### PR TITLE
Configuration Files

### DIFF
--- a/glue/__init__.py
+++ b/glue/__init__.py
@@ -12,3 +12,7 @@ from data_collection import DataCollection
 from link_manager import LinkManager
 from component_link import ComponentLink
 import qt
+
+# Set up configuration variables
+from .config import load_configuration
+env = load_configuration()

--- a/glue/config.py
+++ b/glue/config.py
@@ -1,0 +1,29 @@
+import os
+import imp
+
+# Set the list of configuration keys that we expect
+CONFIG_KEYS = ['extra_clients']
+
+def load_configuration():
+    '''
+    Read in configuration settings from ~/.glue/config.py
+    '''
+
+    # Find absolute path to configuration file
+    config_file = os.path.expanduser('~/.glue/config.py')
+
+    # Load the file
+    try:
+        config = imp.load_source('config', config_file)
+    except IOError:
+        config = None
+
+    # Populate a configuration dictionary
+    config_dict = {}
+    for key in CONFIG_KEYS:
+        try:
+            config_dict[key] = getattr(config, key)
+        except AttributeError:
+            config_dict[key] = None
+
+    return config_dict


### PR DESCRIPTION
We should set up a mechanism that allows users to customize glue. The most important reason to do this is to allow others to specify custom plug-ins (e.g. extra visualization modules or data linking logic) that glue can use.  Other reasons include custom keyboard shortcuts, etc.

My inclination is to aim for a simplified version of what matplotlib uses:
- A configuration file stored in ~/.glue/config.py
- Code in glue's `__init__.py` to build a global `glue.env` dictionary for these settings

It seems easier if the configuration file is a python file, so we don't need the overhead of parsing the config file (see all the extra code in matplotlib's rcsetup.py file). Django takes this approach. However, I don't have any experience writing files like this -- I may be missing something about the flexibility of plaintext config files.

Do you have any thoughts on this, @astrofrog ?
