### PR TITLE
Improve selection of component for y axis in scatter plots

### DIFF
--- a/glue/qt/widgets/scatter_widget.py
+++ b/glue/qt/widgets/scatter_widget.py
@@ -120,6 +120,12 @@ class ScatterWidget(DataViewer):
             self.update_xatt(None)
             self.update_yatt(None)
 
+        self.ui.xAxisComboBox.setCurrentIndex(0)
+        if len(data.visible_components) > 1:
+            self.ui.yAxisComboBox.setCurrentIndex(1)
+        else:
+            self.ui.yAxisComboBox.setCurrentIndex(0)
+
         self._update_window_title()
 
     def register_to_hub(self, hub):


### PR DESCRIPTION
If more than one component is present in data, scatter plot defaults to using the first two components (rather than using the first component only). I added a special case if there is only one component.
