### PR TITLE
Enabling user-supplied matplotlib colormaps

### DIFF
--- a/glue/config.py
+++ b/glue/config.py
@@ -72,6 +72,12 @@ class ColormapRegistry(Registry):
         members.append(['Purple-Green', cm.PRGn])
         return members
 
+    def add(self, label, cmap):
+        """
+        Add colormap *cmap* with label *label*.
+        """
+        self.members.append([label,cmap])
+        
 class DataFactoryRegistry(Registry):
     """Stores data factories. Data factories take filenames as input,
     and return :class:`~glue.core.Data` instances

--- a/glue/qt/widgets/image_widget.py
+++ b/glue/qt/widgets/image_widget.py
@@ -62,8 +62,8 @@ class ImageWidget(DataViewer):
             return a
 
         self._cmaps = []
-        for cmap in config.colormaps:
-            self._cmaps.append(act(cmap[0],cmap[1]))
+        for label, cmap in config.colormaps:
+            self._cmaps.append(act(label,cmap))
         self._rgb_add = QAction('RGB', self)
         self._rgb_add.triggered.connect(self._add_rgb)
 


### PR DESCRIPTION
Adding a configurable ColormapRegistry which allows the user to supply
their own matplotlib colormaps for the Image Viewer in the config.py
file. The already existing colormaps are loaded in by default.

Example config.py:

``` python
from yt.mods import *
from yt.visualization.color_maps import yt_colormaps
from glue.config import colormaps

# This is a standard matplotlib colormap
colormaps.add("Jet",cm.jet)

# These are yt-based matplotlib colormaps
colormaps.add("Algae",yt_colormaps["algae"])
colormaps.add("idl29",yt_colormaps["idl29"])
```
