### PR TITLE
Added a test to make sure the .xatt and .yatt are ComponentID's

### DIFF
--- a/glue/clients/scatter_client.py
+++ b/glue/clients/scatter_client.py
@@ -207,7 +207,7 @@ class ScatterClient(Client):
            Which axis to reassign
         :param attribute:
            Which attribute of the data to use.
-        :type attribute: str
+        :type attribute: core.data.ComponentID or None
         :param snap:
            If True, will rescale x/y axes to fit the data
         :type snap: bool
@@ -215,7 +215,8 @@ class ScatterClient(Client):
 
         if coord not in ('x', 'y'):
             raise TypeError("coord must be one of x,y")
-        if not isinstance(attribute, ComponentID):
+        if (attribute is not None) and not isinstance(attribute, ComponentID):
+            self._set_xydata(coord, None)
             raise TypeError("attribute must be a ComponentID")
 
         #update coordinates of data and subsets

--- a/glue/clients/tests/test_scatter_client.py
+++ b/glue/clients/tests/test_scatter_client.py
@@ -148,6 +148,11 @@ class TestScatterClient(object):
         self.client.yatt = self.ids[0]
         assert self.client.axes.get_ylabel() == self.ids[0].label
 
+    def test_setters_require_componentID(self):
+        layer = self.add_data()
+        with pytest.raises(TypeError):
+            self.client.xatt = self.ids[1]._label
+
     def test_logs(self):
         layer = self.add_data()
         self.client.xlog = True


### PR DESCRIPTION
For issue #214. Adds a test to `TestScatterClient.assert_properties_correct` to make sure the `client.xatt` and `client.yatt` are `None` or `ComponentID`
