### PR TITLE
Raise startup error dialog

### DIFF
--- a/glue/main.py
+++ b/glue/main.py
@@ -101,6 +101,8 @@ def die_on_error(msg):
 
                 qmb = QMessageBox(QMessageBox.Critical, "Error", m)
                 qmb.setDetailedText(detail)
+                qmb.show()
+                qmb.raise_()
                 qmb.exec_()
                 sys.exit(1)
         return wrapper


### PR DESCRIPTION
If an error is generated when starting Glue from the command line, this raises the error dialog above all other windows
