### PR TITLE
Update histogram_client.py

### DIFF
--- a/glue/clients/histogram_client.py
+++ b/glue/clients/histogram_client.py
@@ -220,8 +220,10 @@ class HistogramClient(Client):
         data = set(a.layer.data for a in self._artists)
         if len(data) == 0:
             return
-        dx = np.mean([d.size for d in data])
-        val = min(max(5, (dx / 1000) ** (1. / 3.) * 30), 100)
+        # dx = np.mean([d.size for d in data])
+        # val = min(max(5, (dx / 1000) ** (1. / 3.) * 30), 100)
+        # from http://www.fmrib.ox.ac.uk/analysis/techrep/tr00mj2/tr00mj2/node24.html
+        val = np.mean ([(np.max(d)-np.min(d))/(2*( np.percentile(d,75)-np.percentile(d,25) )*( d.size**(-1/3.) )) for d in data])
         if not calculate_only:
             self.nbins = val
         return val


### PR DESCRIPTION
Hi,
this should do the trick, calculating the initial bin size based on [this](http://www.fmrib.ox.ac.uk/analysis/techrep/tr00mj2/tr00mj2/node24.html).

I follow your example, extracting the mean bin size for all the `data`, but I would better have an array of binsize, because in my approach it depends on the single data distribution.

Anyway,  the `auto_nbin` is not set initially to the value from the `_auto_nbin` function, any idea?

Cheers,
Mario.
