### PR TITLE
Use Numpy percentile instead of scipy's scoreatpercentile

### DIFF
--- a/glue/clients/util.py
+++ b/glue/clients/util.py
@@ -67,7 +67,7 @@ def small_view_array(data):
 def _scoreatpercentile(values, percentile, limit=None):
     # Avoid using the scipy version since it is available in Numpy
     if limit is not None:
-        values = (values >= limit[0]) & (values <= limit[1])
+        values = values[(values >= limit[0]) & (values <= limit[1])]
     return np.percentile(values, percentile)
 
 


### PR DESCRIPTION
Allows the image client to be used without scipy being installed, and only a couple of lines more code. Requires #467 to be merged first, after which this will be rebased.
