### PR TITLE
Remove ``load_settings`` from base Application class

### DIFF
--- a/glue/core/application_base.py
+++ b/glue/core/application_base.py
@@ -51,7 +51,6 @@ class Application(HubListener):
         self._settings = {}
         for key, value, validator in settings:
             self._settings[key] = [value, validator]
-        self._load_settings()
 
     @property
     def session(self):
@@ -124,9 +123,6 @@ class Application(HubListener):
         """Iterate over settings"""
         for key, (value, _) in self._settings.items():
             yield key, value
-
-    def _load_settings(self, path=None):
-        raise NotImplementedError()
 
     @catch_error("Could not load data")
     def load_data(self, path):

--- a/glue/qt/glue_application.py
+++ b/glue/qt/glue_application.py
@@ -202,6 +202,8 @@ class GlueApplication(Application, QMainWindow):
         self._create_terminal()
         self._update_plot_dashboard(None)
 
+        self._load_settings()
+
     def _setup_ui(self):
         self._ui = load_ui('glue_application', None)
         self.setCentralWidget(self._ui)


### PR DESCRIPTION
@ChrisBeaumont - just a small suggested change - at the moment having `load_settings` in the base class means that any application that wants to inherit from it needs to implement `load_settings`, but this isn't always needed. Another option would be to simply pass instead of raising the `NotImplementedError`.
