### PR TITLE
Prevent IPython from hijacking REPL.

### DIFF
--- a/glue/qt/glue_application.py
+++ b/glue/qt/glue_application.py
@@ -199,7 +199,6 @@ class GlueApplication(Application, QMainWindow):
         self._create_menu()
         self._connect()
         self.new_tab()
-        self._create_terminal()
         self._update_plot_dashboard(None)
 
         self._load_settings()
@@ -633,11 +632,15 @@ class GlueApplication(Application, QMainWindow):
         """
         Returns True if the IPython terminal is present.
         """
+        self._create_terminal()  # ensure terminal is setup
         return self._terminal is not None
 
     def _create_terminal(self):
-        assert self._terminal is None, \
-            "should only call _create_terminal once"
+        if self._terminal is not None:  # already set up
+            return
+
+        if hasattr(self, '_terminal_exception'):  # already failed to set up
+            return
 
         self._terminal_button = QToolButton(self._ui)
         self._terminal_button.setToolTip("Toggle IPython Prompt")
@@ -698,6 +701,7 @@ class GlueApplication(Application, QMainWindow):
         """
         Show the GUI and start the application.
         """
+        self._create_terminal()
         self.show()
         self.raise_()  # bring window to front
         # at some point during all this, the MPL backend

--- a/glue/qt/tests/test_application.py
+++ b/glue/qt/tests/test_application.py
@@ -28,7 +28,6 @@ from ...external.six import PY3
 from ...tests.helpers import requires_ipython_ge_012
 
 
-
 def tab_count(app):
     return app.tab_bar.count()
 
@@ -37,6 +36,7 @@ class TestGlueApplication(object):
 
     def setup_method(self, method):
         self.app = GlueApplication()
+        self.app._create_terminal()
 
     def teardown_method(self, method):
         self.app.close()
@@ -89,6 +89,7 @@ class TestGlueApplication(object):
         with patch('glue.qt.widgets.terminal.glue_terminal') as terminal:
             terminal.side_effect = Exception("disabled")
             app = GlueApplication()
+            app._create_terminal()
             return app
 
     def test_functional_without_terminal(self):


### PR DESCRIPTION
Still need to figure out how to shutdown IPython functionality when
Glue UI closes, to get REPL back at the end of things.
