### PR TITLE
1D linking does not work both ways

### DIFF
--- a/glue/clients/histogram_client.py
+++ b/glue/clients/histogram_client.py
@@ -277,6 +277,10 @@ class HistogramClient(Client):
     def component(self):
         return self._component
 
+    @component.setter
+    def component(self, value):
+        self.set_component(value)
+
     def set_component(self, component):
         """
         Redefine which component gets plotted
@@ -335,6 +339,10 @@ class HistogramClient(Client):
     def _numerical_data_changed(self, message):
         data = message.sender
         self.sync_all(force=True)
+
+    def _on_component_replaced(self, msg):
+        if self.component is msg.old:
+            self.set_component(msg.new)
 
     def _update_data(self, message):
         self.sync_all()
@@ -404,6 +412,9 @@ class HistogramClient(Client):
         hub.subscribe(self,
                       msg.NumericalDataChangedMessage,
                       handler=self._numerical_data_changed)
+        hub.subscribe(self,
+                      msg.ComponentReplacedMessage,
+                      handler=self._on_component_replaced)
 
     def restore_layers(self, layers, context):
         for layer in layers:

--- a/glue/clients/image_client.py
+++ b/glue/clients/image_client.py
@@ -8,9 +8,10 @@ import numpy as np
 from ..external.modest_image import extract_matched_slices
 from ..core.exceptions import IncompatibleAttribute
 from ..core.data import Data
-from ..core.util import lookup_class, defer
+from ..core.util import lookup_class
 from ..core.subset import Subset, RoiSubsetState
 from ..core.roi import PolygonalROI
+from ..core.message import ComponentReplacedMessage
 from ..core.callback_property import (
     callback_property, CallbackProperty)
 from ..core.edit_subset_mode import EditSubsetMode
@@ -607,6 +608,16 @@ class ImageClient(VizClient):
             else:
                 raise ValueError("Cannot restore layer of type %s" % l)
             l.properties = props
+
+    def _on_component_replace(self, msg):
+        if self.display_attribute is msg.old:
+            self.display_attribute = msg.new
+
+    def register_to_hub(self, hub):
+        super(ImageClient, self).register_to_hub(hub)
+        hub.subscribe(self,
+                      ComponentReplacedMessage,
+                      self._on_component_replace)
 
     # subclasses should override the following methods as appropriate
     def _new_rgb_layer(self, layer):

--- a/glue/clients/scatter_client.py
+++ b/glue/clients/scatter_client.py
@@ -10,6 +10,7 @@ from ..core.subset import RoiSubsetState, RangeSubsetState
 from ..core.roi import PolygonalROI, RangeROI
 from ..core.util import relim, lookup_class
 from ..core.edit_subset_mode import EditSubsetMode
+from ..core.message import ComponentReplacedMessage
 from .viz_client import init_mpl
 from .layer_artist import ScatterLayerArtist, LayerArtistContainer
 from .util import visible_limits, update_ticks
@@ -454,3 +455,16 @@ class ScatterClient(Client):
             self.ymax = max(ylim)
             self.yflip = yflip
             self.ylog = (ysc == 'log')
+
+    def _on_component_replace(self, msg):
+        old = msg.old
+        new = msg.new
+
+        if self.xatt is old:
+            self.xatt = new
+        if self.yatt is old:
+            self.yatt = new
+
+    def register_to_hub(self, hub):
+        super(ScatterClient, self).register_to_hub(hub)
+        hub.subscribe(self, ComponentReplacedMessage, self._on_component_replace)

--- a/glue/clients/tests/test_histogram_client.py
+++ b/glue/clients/tests/test_histogram_client.py
@@ -11,7 +11,7 @@ from ..layer_artist import HistogramLayerArtist
 
 from ...core.data_collection import DataCollection
 from ...core.exceptions import IncompatibleDataException
-from ...core.data import Data, CategoricalComponent
+from ...core.data import Data, CategoricalComponent, ComponentID
 from ...core.subset import RangeSubsetState
 
 from .util import renderless_figure
@@ -316,6 +316,16 @@ class TestHistogramClient(object):
             assert a.get_data()[0].size > 0
             a.clear()
             assert a.get_data()[0].size == 0
+
+    def test_component_replaced(self):
+        # regression test for 508
+        self.client.register_to_hub(self.collect.hub)
+        self.client.add_layer(self.data)
+        self.client.component = self.data.components[0]
+
+        test = ComponentID('test')
+        self.data.update_id(self.client.component, test)
+        assert self.client.component is test
 
 
 class TestCategoricalHistogram(TestHistogramClient):

--- a/glue/clients/tests/test_image_client.py
+++ b/glue/clients/tests/test_image_client.py
@@ -341,6 +341,19 @@ class _TestImageClientBase(object):
         assert c.is_visible(self.im)
         assert not c.is_visible(s)
 
+    def test_component_replaced(self):
+        # Regression test for #508
+        c = self.create_client_with_image()
+
+        d = c.display_data
+        a = c.display_attribute
+        test = core.ComponentID('test')
+
+        c.register_to_hub(d.hub)
+        d.update_id(a, test)
+
+        assert c.display_attribute is test
+
 
 class TestMplImageClient(_TestImageClientBase):
 

--- a/glue/clients/tests/test_scatter_client.py
+++ b/glue/clients/tests/test_scatter_client.py
@@ -579,6 +579,13 @@ class TestScatterClient(object):
         self.client.apply_roi(roi)
         assert data.edit_subset.subset_state.att == self.client.yatt
 
+    def test_component_replaced(self):
+        # regression test for #508
+        data = self.add_data_and_attributes()
+        test = ComponentID('test')
+        data.update_id(self.client.xatt, test)
+        assert self.client.xatt is test
+
 
 class TestCategoricalScatterClient(TestScatterClient):
 
@@ -662,7 +669,7 @@ class TestCategoricalScatterClient(TestScatterClient):
         card_data = [str(num) for num in range(card)]
         data.add_component(core.Component(np.arange(card * 5)), 'y')
         data.add_component(
-            core.data.CategoricalComponent(np.repeat([card_data],5)), 'xcat')
+            core.data.CategoricalComponent(np.repeat([card_data], 5)), 'xcat')
         self.add_data(data)
         comp = data.find_component_id('xcat')
         timer_func = partial(self.client._set_xydata, 'x', comp)

--- a/glue/core/contracts.py
+++ b/glue/core/contracts.py
@@ -18,11 +18,22 @@ and never directly from the contracts package.
 """
 from ..config import enable_contracts
 
+
+def _build_custom_contracts():
+    """
+    Define some custom contracts if PyContracts is found
+    """
+    pass
+
 try:
     from contracts import contract
+
     if not enable_contracts():
         from contracts import disable_all
         disable_all()
+
+    _build_custom_contracts()
+
 except ImportError:
     # no-op interface if PyContracts isn't installed
 

--- a/glue/core/link_manager.py
+++ b/glue/core/link_manager.py
@@ -1,10 +1,27 @@
 from __future__ import absolute_import, division, print_function
+"""
+The LinkManager class is responsible for maintaining the conistency
+of the "web of links" in a DataCollection. It discovers how to
+combine ComponentLinks together to discover all of the ComponentIDs
+that a Data object can derive,
 
+As a trivial example, imagine a chain of 2 ComponentLinks linking
+ComponentIDs across 3 datasets:
+
+Data:        D1        D2       D3
+ComponentID: x         y        z
+Link:        <---x2y---><--y2z-->
+
+The LinkManager autocreates a link from D1.id['x'] to D3.id['z']
+by chaining x2y and y2z.
+"""
 import logging
 
-from .data import DerivedComponent
+from .data import DerivedComponent, Data, ComponentID
+from .component_link import ComponentLink
 from .link_helpers import LinkCollection
 from ..external import six
+from .contracts import contract
 
 
 def accessible_links(cids, links):
@@ -96,14 +113,24 @@ def find_dependents(data, link):
 
 
 class LinkManager(object):
+
     """A helper class to generate and store ComponentLinks,
     and compute which components are accesible from which data sets
     """
+
     def __init__(self):
         self._links = set()
         self._duplicated_ids = []
 
     def add_link(self, link):
+        """
+        Ingest one or more ComponentLinks to the manager
+
+        Parameters
+        ----------
+        link : ComponentLink, LinkCollection, or list thereof
+           The link(s) to ingest
+        """
         if isinstance(link, (LinkCollection, list)):
             for l in link:
                 self.add_link(l)
@@ -136,10 +163,12 @@ class LinkManager(object):
             if d in data.components:
                 data.update_id(d, o)
 
+    @contract(link=ComponentLink)
     def remove_link(self, link):
         logging.getLogger(__name__).debug('removing link %s', link)
         self._links.remove(link)
 
+    @contract(data=Data)
     def update_data_components(self, data):
         """Update all the DerivedComponents in a data object, based on
         all the Components deriveable based on the links in self.

--- a/glue/core/message.py
+++ b/glue/core/message.py
@@ -127,6 +127,14 @@ class ComponentsChangedMessage(DataMessage):
     pass
 
 
+class ComponentReplacedMessage(ComponentsChangedMessage):
+
+    def __init__(self, sender, old_component, new_component, tag=None):
+        super(ComponentReplacedMessage, self).__init__(sender, old_component)
+        self.old = old_component
+        self.new = new_component
+
+
 class DataUpdateMessage(DataMessage):
 
     def __init__(self, sender, attribute, tag=None):

--- a/glue/core/tests/test_component_link.py
+++ b/glue/core/tests/test_component_link.py
@@ -5,10 +5,13 @@ from __future__ import absolute_import, division, print_function
 import pytest
 
 import numpy as np
+from numpy.testing import assert_array_equal
 
 from ..data import ComponentID, Data, Component
 from ..component_link import ComponentLink, BinaryComponentLink
 from ..subset import InequalitySubsetState
+from ..link_helpers import LinkSame
+from ..data_collection import DataCollection
 
 
 class TestComponentLink(object):
@@ -47,7 +50,7 @@ class TestComponentLink(object):
 
         result = link.compute(data)
         expected = from_.data
-        np.testing.assert_array_equal(result, expected)
+        assert_array_equal(result, expected)
 
     def test_compute_using(self):
         data, from_, to_ = self.toy_data()
@@ -58,7 +61,7 @@ class TestComponentLink(object):
 
         result = link.compute(data)
         expected = from_.data * 3
-        np.testing.assert_array_equal(result, expected)
+        assert_array_equal(result, expected)
 
     def test_getters(self):
         data, from_, to_ = self.toy_data()
@@ -139,44 +142,44 @@ def test_link_bad_input():
 
 def test_arithmetic_id_scalar():
     d = Data(x=[1, 2, 3, 4], y=[10, 20, 10, 20])
-    np.testing.assert_array_equal(d[d.id['x'] + 3], [4, 5, 6, 7])
-    np.testing.assert_array_equal(d[d.id['x'] - 3], [-2, -1, 0, 1])
-    np.testing.assert_array_equal(d[d.id['x'] * 3], [3, 6, 9, 12])
-    np.testing.assert_array_equal(d[d.id['y'] / 10], [1, 2, 1, 2])
-    np.testing.assert_array_equal(d[d.id['x'] ** 2], [1, 4, 9, 16])
+    assert_array_equal(d[d.id['x'] + 3], [4, 5, 6, 7])
+    assert_array_equal(d[d.id['x'] - 3], [-2, -1, 0, 1])
+    assert_array_equal(d[d.id['x'] * 3], [3, 6, 9, 12])
+    assert_array_equal(d[d.id['y'] / 10], [1, 2, 1, 2])
+    assert_array_equal(d[d.id['x'] ** 2], [1, 4, 9, 16])
 
-    np.testing.assert_array_equal(d[3 + d.id['x']], [4, 5, 6, 7])
-    np.testing.assert_array_equal(d[3 - d.id['x']], [2, 1, 0, -1])
-    np.testing.assert_array_equal(d[3 * d.id['x']], [3, 6, 9, 12])
-    np.testing.assert_array_equal(d[24 / d.id['x']], [24, 12, 8, 6])
-    np.testing.assert_array_equal(d[2 ** d.id['x']], [2, 4, 8, 16])
+    assert_array_equal(d[3 + d.id['x']], [4, 5, 6, 7])
+    assert_array_equal(d[3 - d.id['x']], [2, 1, 0, -1])
+    assert_array_equal(d[3 * d.id['x']], [3, 6, 9, 12])
+    assert_array_equal(d[24 / d.id['x']], [24, 12, 8, 6])
+    assert_array_equal(d[2 ** d.id['x']], [2, 4, 8, 16])
 
 
 def test_arithmetic_id_id():
     d = Data(x=[1, 2, 3, 4], y=[10, 20, 10, 20])
-    np.testing.assert_array_equal(d[d.id['x'] + d.id['y']], [11, 22, 13, 24])
-    np.testing.assert_array_equal(d[d.id['x'] - d.id['y']], [-9, -18, -7, -16])
-    np.testing.assert_array_equal(d[d.id['x'] * d.id['y']], [10, 40, 30, 80])
-    np.testing.assert_array_equal(
+    assert_array_equal(d[d.id['x'] + d.id['y']], [11, 22, 13, 24])
+    assert_array_equal(d[d.id['x'] - d.id['y']], [-9, -18, -7, -16])
+    assert_array_equal(d[d.id['x'] * d.id['y']], [10, 40, 30, 80])
+    assert_array_equal(
         d[d.id['y'] / d.id['x']], [10, 10, 10 / 3, 5])
-    np.testing.assert_array_equal(d[d.id['y'] ** d.id['x']],
-                                  [10, 400, 1000, 20 ** 4])
+    assert_array_equal(d[d.id['y'] ** d.id['x']],
+                       [10, 400, 1000, 20 ** 4])
 
 
 def test_arithmetic_id_link():
     d = Data(x=[1, 2, 3, 4], y=[10, 20, 10, 20])
     y10 = d.id['y'] / 10
-    np.testing.assert_array_equal(d[d.id['x'] + y10], [2, 4, 4, 6])
-    np.testing.assert_array_equal(d[d.id['x'] - y10], [0, 0, 2, 2])
-    np.testing.assert_array_equal(d[d.id['x'] * y10], [1, 4, 3, 8])
-    np.testing.assert_array_equal(d[d.id['x'] / y10], [1, 1, 3, 2])
-    np.testing.assert_array_equal(d[d.id['x'] ** y10], [1, 4, 3, 16])
+    assert_array_equal(d[d.id['x'] + y10], [2, 4, 4, 6])
+    assert_array_equal(d[d.id['x'] - y10], [0, 0, 2, 2])
+    assert_array_equal(d[d.id['x'] * y10], [1, 4, 3, 8])
+    assert_array_equal(d[d.id['x'] / y10], [1, 1, 3, 2])
+    assert_array_equal(d[d.id['x'] ** y10], [1, 4, 3, 16])
 
-    np.testing.assert_array_equal(d[y10 + d.id['x']], [2, 4, 4, 6])
-    np.testing.assert_array_equal(d[y10 - d.id['x']], [0, 0, -2, -2])
-    np.testing.assert_array_equal(d[y10 * d.id['x']], [1, 4, 3, 8])
-    np.testing.assert_array_equal(d[y10 / d.id['x']], [1, 1, 1 / 3., 1 / 2.])
-    np.testing.assert_array_equal(d[y10 ** d.id['x']], [1, 4, 1, 16])
+    assert_array_equal(d[y10 + d.id['x']], [2, 4, 4, 6])
+    assert_array_equal(d[y10 - d.id['x']], [0, 0, -2, -2])
+    assert_array_equal(d[y10 * d.id['x']], [1, 4, 3, 8])
+    assert_array_equal(d[y10 / d.id['x']], [1, 1, 1 / 3., 1 / 2.])
+    assert_array_equal(d[y10 ** d.id['x']], [1, 4, 1, 16])
 
 
 def test_arithmetic_link_link():
@@ -185,11 +188,11 @@ def test_arithmetic_link_link():
     y = d[d.id['y']]
     xpy = d.id['x'] + d.id['y']
     xt3 = d.id['x'] * 3
-    np.testing.assert_array_equal(d[xpy + xt3], x + y + x * 3)
-    np.testing.assert_array_equal(d[xpy - xt3], x + y - x * 3)
-    np.testing.assert_array_equal(d[xpy * xt3], (x + y) * x * 3)
-    np.testing.assert_array_equal(d[xpy / xt3], (x + y) / (x * 3))
-    np.testing.assert_array_equal(d[xpy ** xt3], (x + y) ** (x * 3))
+    assert_array_equal(d[xpy + xt3], x + y + x * 3)
+    assert_array_equal(d[xpy - xt3], x + y - x * 3)
+    assert_array_equal(d[xpy * xt3], (x + y) * x * 3)
+    assert_array_equal(d[xpy / xt3], (x + y) / (x * 3))
+    assert_array_equal(d[xpy ** xt3], (x + y) ** (x * 3))
 
 
 def test_inequality():
@@ -202,40 +205,40 @@ def test_inequality():
     y = d[d.id['y']]
 
     s.subset_state = xpy < 22
-    np.testing.assert_array_equal(s.to_mask(), (x + y) < 22)
+    assert_array_equal(s.to_mask(), (x + y) < 22)
 
     s.subset_state = xpy <= 22
-    np.testing.assert_array_equal(s.to_mask(), (x + y) <= 22)
+    assert_array_equal(s.to_mask(), (x + y) <= 22)
 
     s.subset_state = xpy >= 22
-    np.testing.assert_array_equal(s.to_mask(), (x + y) >= 22)
+    assert_array_equal(s.to_mask(), (x + y) >= 22)
 
     s.subset_state = xpy > 22
-    np.testing.assert_array_equal(s.to_mask(), (x + y) > 22)
+    assert_array_equal(s.to_mask(), (x + y) > 22)
 
     s.subset_state = 22 < xpy
-    np.testing.assert_array_equal(s.to_mask(), 22 < (x + y))
+    assert_array_equal(s.to_mask(), 22 < (x + y))
 
     s.subset_state = 22 <= xpy
-    np.testing.assert_array_equal(s.to_mask(), 22 <= (x + y))
+    assert_array_equal(s.to_mask(), 22 <= (x + y))
 
     s.subset_state = 22 > xpy
-    np.testing.assert_array_equal(s.to_mask(), 22 > (x + y))
+    assert_array_equal(s.to_mask(), 22 > (x + y))
 
     s.subset_state = 22 >= xpy
-    np.testing.assert_array_equal(s.to_mask(), 22 >= (x + y))
+    assert_array_equal(s.to_mask(), 22 >= (x + y))
 
     s.subset_state = twentytwo < xpy
-    np.testing.assert_array_equal(s.to_mask(), 22 < (x + y))
+    assert_array_equal(s.to_mask(), 22 < (x + y))
 
     s.subset_state = twentytwo <= xpy
-    np.testing.assert_array_equal(s.to_mask(), 22 <= (x + y))
+    assert_array_equal(s.to_mask(), 22 <= (x + y))
 
     s.subset_state = twentytwo > xpy
-    np.testing.assert_array_equal(s.to_mask(), 22 > (x + y))
+    assert_array_equal(s.to_mask(), 22 > (x + y))
 
     s.subset_state = twentytwo >= xpy
-    np.testing.assert_array_equal(s.to_mask(), 22 >= (x + y))
+    assert_array_equal(s.to_mask(), 22 >= (x + y))
 
 
 def test_link_fixes_shape():
@@ -245,7 +248,7 @@ def test_link_fixes_shape():
     d = Data(x=[1, 2, 3, 4])
     y = ComponentID('y')
     link = ComponentLink([d.id['x']], y, using=double)
-    np.testing.assert_array_equal(d[link], [2, 4, 6, 8])
+    assert_array_equal(d[link], [2, 4, 6, 8])
 
 
 def test_link_str():
@@ -264,3 +267,23 @@ def test_link_str():
     assert str(x + x + y) == ('((x + x) + y)')
 
     assert repr(x + y) == '<BinaryComponentLink: (x + y)>'
+
+
+def test_duplicated_links_remove_first_input():
+    """
+    # test changes introduced for #508
+    """
+
+    d1 = Data(x=[1, 2, 3])
+    d2 = Data(y=[2, 4, 6])
+
+    x = d1.id['x']
+    y = d2.id['y']
+
+    dc = DataCollection([d1, d2])
+
+    dc.add_link(LinkSame(x, y))
+    assert y not in d2.components
+    assert y not in d1.components
+    assert x in d2.components
+    assert x in d2.components

--- a/glue/core/tests/test_data_collection.py
+++ b/glue/core/tests/test_data_collection.py
@@ -32,7 +32,7 @@ class TestDataCollection(object):
 
     def setup_method(self, method):
         self.dc = DataCollection()
-        self.data = MagicMock()
+        self.data = MagicMock(spec_set=Data)
         self.hub = self.dc.hub
         self.log = HubLog()
         self.log.register_to_hub(self.hub)
@@ -219,7 +219,7 @@ class TestDataCollection(object):
 
         assert d1.id['x'] is d2.id['x']
         assert d1.id['x'] is not duplicated_id
-        assert duplicated_id.hidden
+        assert duplicated_id not in d2.components
 
         assert_array_equal(d1[d1.id['x']], [1, 2, 3])
         assert_array_equal(d2[d1.id['x']], [2, 3, 4])

--- a/glue/core/tests/test_link_manager.py
+++ b/glue/core/tests/test_link_manager.py
@@ -221,7 +221,6 @@ class TestLinkManager(object):
 
         dc = DataCollection([d1, d2])
         dc.add_link(LinkSame(d2.id['u'], d1.id['x']))
-        assert d1.find_component_id('x').hidden
 
         np.testing.assert_array_equal(d1['z'], [3, 5, 7])
 
@@ -237,6 +236,5 @@ class TestLinkManager(object):
 
         dc = DataCollection([d1, d2])
         dc.add_link(LinkSame(d2.id['u'], d1.id['x']))
-        assert d1.find_component_id('x').hidden
 
         np.testing.assert_array_equal(d1['z'], [8, 10, 12])

--- a/glue/qt/layer_artist_model.py
+++ b/glue/qt/layer_artist_model.py
@@ -18,7 +18,7 @@ from ..external.qt.QtGui import (QColor,
 from ..external.qt.QtCore import (Qt, QAbstractListModel, QModelIndex,
                                   QSize, QTimer)
 
-from .qtutil import (layer_artist_icon, nonpartial)
+from .qtutil import (layer_artist_icon, nonpartial, PythonListModel)
 
 from .mime import PyMimeData, LAYERS_MIME_TYPE
 from ..clients.layer_artist import LayerArtist, LayerArtistContainer
@@ -26,7 +26,7 @@ from ..clients.layer_artist import LayerArtist, LayerArtistContainer
 from .widgets.style_dialog import StyleDialog
 
 
-class LayerArtistModel(QAbstractListModel):
+class LayerArtistModel(PythonListModel):
 
     """A Qt model to manage a list of LayerArtists. Multiple
     views into this model should stay in sync, thanks to Qt.
@@ -38,25 +38,13 @@ class LayerArtistModel(QAbstractListModel):
     """
 
     def __init__(self, artists, parent=None):
-        super(LayerArtistModel, self).__init__(parent)
+        super(LayerArtistModel, self).__init__(artists, parent)
         self.artists = artists
-
-    def rowCount(self, parent=None):
-        """Number of rows"""
-        return len(self.artists)
-
-    def headerData(self, section, orientation, role):
-        """Column labels"""
-        if role != Qt.DisplayRole:
-            return None
-        return "%i" % section
 
     def data(self, index, role):
         """Retrieve data at each index"""
         if not index.isValid():
             return None
-        if role == Qt.DisplayRole or role == Qt.EditRole:
-            return self.row_label(index.row())
         if role == Qt.DecorationRole:
             art = self.artists[index.row()]
             result = layer_artist_icon(art)
@@ -69,6 +57,8 @@ class LayerArtistModel(QAbstractListModel):
             art = self.artists[index.row()]
             if not art.enabled:
                 return art.disabled_message
+
+        return super(LayerArtistModel, self).data(index, role)
 
     def flags(self, index):
         result = super(LayerArtistModel, self).flags(index)
@@ -93,16 +83,10 @@ class LayerArtistModel(QAbstractListModel):
         self.dataChanged.emit(index, index)
         return True
 
-    def removeRow(self, row, parent=None):
-        if row < 0 or row >= len(self.artists):
-            return False
-
-        self.beginRemoveRows(QModelIndex(), row, row)
+    def _remove_row(self, row):
         art = self.artists.pop(row)
         art.clear()
         art.redraw()
-        self.endRemoveRows()
-        return True
 
     def mimeTypes(self):
         return [PyMimeData.MIME_TYPE, LAYERS_MIME_TYPE]

--- a/glue/qt/qtutil.py
+++ b/glue/qt/qtutil.py
@@ -14,7 +14,7 @@ import numpy as np
 
 from ..external.axescache import AxesCache
 from ..external.qt import QtGui
-from ..external.qt.QtCore import Qt, QThread
+from ..external.qt.QtCore import (Qt, QThread, QAbstractListModel, QModelIndex)
 from ..external.qt.QtGui import (QColor, QInputDialog, QColorDialog,
                                  QListWidget, QTreeWidget, QPushButton,
                                  QMessageBox,
@@ -1006,3 +1006,150 @@ def update_combobox(combo, labeldata):
     combo.setCurrentIndex(index)
 
     return combo
+
+
+class PythonListModel(QAbstractListModel):
+
+    """
+    A Qt Model that wraps a python list, and exposes a list-like interface
+
+    This can be connected directly to multiple QListViews, which will
+    stay in sync with the state of the container.
+    """
+
+    def __init__(self, items, parent=None):
+        """
+        Create a new model
+
+        Parameters
+        ----------
+        items : list
+            The initial list to wrap
+        parent : QObject
+            The model parent
+        """
+        super(PythonListModel, self).__init__(parent)
+        self.items = items
+
+    def rowCount(self, parent=None):
+        """Number of rows"""
+        return len(self.items)
+
+    def headerData(self, section, orientation, role):
+        """Column labels"""
+        if role != Qt.DisplayRole:
+            return None
+        return "%i" % section
+
+    def row_label(self, row):
+        """ The textual label for the row"""
+        return str(self.items[row])
+
+    def data(self, index, role):
+        """Retrieve data at each index"""
+        if not index.isValid():
+            return None
+        if role == Qt.DisplayRole or role == Qt.EditRole:
+            return self.row_label(index.row())
+        if role == Qt.UserRole:
+            return self.items[index.row()]
+
+    def setData(self, index, value, role):
+        """
+        Update the data in-place
+
+        Parameters
+        ----------
+        index : QModelIndex
+            The location of the change
+        value : object
+            The new value
+        role : QEditRole
+            Which aspect of the model to update
+        """
+        if not index.isValid():
+            return False
+
+        if role == Qt.UserRole:
+            row = index.row()
+            self.items[row] = value
+            self.dataChanged.emit(index, index)
+            return True
+
+        return super(PythonListModel, self).setDdata(index, value, role)
+
+    def removeRow(self, row, parent=None):
+        """
+        Remove a row from the table
+
+        Parameters
+        ----------
+        row : int
+            Row to remove
+
+        Returns
+        -------
+        successful : bool
+        """
+        if row < 0 or row >= len(self.items):
+            return False
+
+        self.beginRemoveRows(QModelIndex(), row, row)
+        self._remove_row(row)
+        self.endRemoveRows()
+        return True
+
+    def pop(self, row=None):
+        """
+        Remove and return an item (default last item)
+
+        Parameters
+        ----------
+        row : int (optional)
+            Which row to remove. Default=last
+
+        Returns
+        --------
+        popped : object
+        """
+        if row is None:
+            row = len(self) - 1
+        result = self[row]
+        self.removeRow(row)
+        return result
+
+    def _remove_row(self, row):
+        # actually remove data. Subclasses can override this as needed
+        self.items.pop(row)
+
+    def __getitem__(self, row):
+        return self.items[row]
+
+    def __setitem__(self, row, value):
+        index = self.index(row)
+        self.setData(index, value, role=Qt.UserRole)
+
+    def __len__(self):
+        return len(self.items)
+
+    def insert(self, row, value):
+        self.beginInsertRows(QModelIndex(), row, row)
+        self.items.insert(row, value)
+        self.endInsertRows()
+        self.rowsInserted.emit(self.index(row), row, row)
+
+    def append(self, value):
+        row = len(self)
+        self.insert(row, value)
+
+    def extend(self, values):
+        for v in values:
+            self.append(v)
+
+    def set_list(self, values):
+        """
+        Set the model to a new list
+        """
+        self.beginResetModel()
+        self.items = values
+        self.endResetModel()

--- a/glue/qt/tests/test_qtutil.py
+++ b/glue/qt/tests/test_qtutil.py
@@ -1,13 +1,14 @@
 # pylint: disable=I0011,W0613,W0201,W0212,E1101,E1103
 
 from __future__ import absolute_import, division, print_function
+import pytest
 
 from .. import qtutil
 from ...external.qt import QtGui
 from ...external.qt.QtCore import Qt
 from mock import MagicMock, patch
 from ..qtutil import GlueDataDialog
-from ..qtutil import pretty_number, GlueComboBox
+from ..qtutil import pretty_number, GlueComboBox, PythonListModel
 
 from glue.config import data_factory
 from glue.core import Subset
@@ -372,3 +373,82 @@ class TestRGBEdit(object):
         for color in ['red', 'green', 'blue']:
             self.w.current[color].click()
             assert self.artist.contrast_layer == color
+
+
+class TestListModel(object):
+
+    def test_row_count(self):
+        assert PythonListModel([]).rowCount() == 0
+        assert PythonListModel([1]).rowCount() == 1
+        assert PythonListModel([1, 2]).rowCount() == 2
+
+    def test_data_display(self):
+        m = PythonListModel([1, 'a'])
+        i = m.index(0)
+        assert m.data(i, role=Qt.DisplayRole) == '1'
+
+        i = m.index(1)
+        assert m.data(i, role=Qt.DisplayRole) == 'a'
+
+    def test_data_edit(self):
+        m = PythonListModel([1, 'a'])
+        i = m.index(0)
+        assert m.data(i, role=Qt.EditRole) == '1'
+
+        i = m.index(1)
+        assert m.data(i, role=Qt.EditRole) == 'a'
+
+    def test_data_user(self):
+        m = PythonListModel([1, 'a'])
+        i = m.index(0)
+        assert m.data(i, role=Qt.UserRole) == 1
+
+        i = m.index(1)
+        assert m.data(i, role=Qt.UserRole) == 'a'
+
+    def test_itemget(self):
+        m = PythonListModel([1, 'a'])
+        assert m[0] == 1
+        assert m[1] == 'a'
+
+    def test_itemset(self):
+        m = PythonListModel([1, 'a'])
+        m[0] = 'b'
+        assert m[0] == 'b'
+
+    @pytest.mark.parametrize('items', ([], [1, 2, 3], [1]))
+    def test_len(self, items):
+        assert len(PythonListModel(items)) == len(items)
+
+    def test_pop(self):
+        m = PythonListModel([1, 2, 3])
+        assert m.pop() == 3
+        assert len(m) == 2
+        assert m.pop(0) == 1
+        assert len(m) == 1
+        assert m[0] == 2
+
+    def test_append(self):
+        m = PythonListModel([])
+        m.append(2)
+        assert m[0] == 2
+        m.append(3)
+        assert m[1] == 3
+        m.pop()
+        m.append(4)
+        assert m[1] == 4
+
+    def test_extend(self):
+        m = PythonListModel([])
+        m.extend([2, 3])
+        assert m[0] == 2
+        assert m[1] == 3
+
+    def test_insert(self):
+        m = PythonListModel([1, 2, 3])
+        m.insert(1, 5)
+        assert m[1] == 5
+
+    def test_iter(self):
+        m = PythonListModel([1, 2, 3])
+        assert list(m) == [1, 2, 3]

--- a/glue/qt/widgets/histogram_widget.py
+++ b/glue/qt/widgets/histogram_widget.py
@@ -121,6 +121,8 @@ class HistogramWidget(DataViewer):
         """Repopulate the combo box that selects the quantity to plot"""
         combo = self.ui.attributeCombo
         component = self.component
+        new = self.client.component or component
+
         combo.blockSignals(True)
         combo.clear()
 
@@ -132,6 +134,7 @@ class HistogramWidget(DataViewer):
         self._component_hashes = dict((_hash(c), c) for d in self._data
                                       for c in d.components)
 
+        found = False
         for d in self._data:
             if d not in self._container:
                 continue
@@ -143,6 +146,8 @@ class HistogramWidget(DataViewer):
             for c in d.visible_components:
                 if not d.get_component(c).numeric:
                     continue
+                if c is new:
+                    found = True
                 item = QtGui.QStandardItem(c.label)
                 item.setData(_hash(c), role=Qt.UserRole)
                 model.appendRow(item)
@@ -155,8 +160,8 @@ class HistogramWidget(DataViewer):
 
         combo.blockSignals(False)
 
-        if component is not None:
-            self.component = component
+        if found:
+            self.component = new
         else:
             combo.setCurrentIndex(2)  # skip first data + separator
         self._set_attribute_from_combo()


### PR DESCRIPTION
Scenario:
- Read in two one-dimensional datasets.
- Display the data sets.
- Link the x axis components
- Using the range tool, choose a range in the first dataset. Linked range in the second dataset highlights.
- Using the range tool, choose a range in the second dataset. Original linked range disappears in first dataset and no corresponding range appears.
- In general, the effect is as if the link is only one-way.

Auxiliary information:
- After the linking, for the second dataset, the plot options often shows both x and y axis as belonging to original y axis component.
- For the second dataset, if the original x-axis component label was different than the first datasets x-axis component label, the second dataset component no longer appears as an option in the plot options for the x/y-axis
- Through examination of the datacollection instance using the python console, the second dataset will gain a new componenet, either named the same as the linked component from the first dataset, or if there is a name clash, the name has an underscore prepended.
