### PR TITLE
Add header to pytest to show package versions

### DIFF
--- a/glue/_deps.py
+++ b/glue/_deps.py
@@ -37,7 +37,7 @@ class Dependency(object):
             module = __import__(self.module)
             return module.__version__
         except (ImportError, AttributeError):
-            return 'unknown'
+            return 'unknown version'
 
     def install(self):
         if self.installed:

--- a/glue/_deps.py
+++ b/glue/_deps.py
@@ -5,6 +5,8 @@ Guide users through installing Glue's dependencies
 
 from __future__ import absolute_import, division, print_function
 
+import os
+
 # Unfortunately, we can't rely on setuptools' install_requires
 # keyword, because matplotlib doesn't properly install its dependencies
 from subprocess import check_call, CalledProcessError
@@ -29,6 +31,14 @@ class Dependency(object):
         except ImportError:
             return False
 
+    @property
+    def version(self):
+        try:
+            module = __import__(self.module)
+            return module.__version__
+        except (ImportError, AttributeError):
+            return 'unknown'
+
     def install(self):
         if self.installed:
             return
@@ -52,7 +62,7 @@ PIP package name:
 
     def __str__(self):
         if self.installed:
-            status = 'INSTALLED'
+            status = 'INSTALLED (%s)' % self.version
         elif self.failed:
             status = 'FAILED (%s)' % self.info
         else:
@@ -136,12 +146,18 @@ categories = (('required', required),
 dependencies = dict((d.module, d) for c in categories for d in c[1])
 
 
-def show_status():
+def get_status():
+    s = ""
     for category, deps in categories:
-        print("%21s" % category.upper())
+        s += "%21s" % category.upper() + os.linesep
         for dep in deps:
-            print(dep)
-        print('\n')
+            s += str(dep) + os.linesep
+        s += os.linesep
+    return s
+    
+
+def show_status():
+    print(get_status())
 
 
 def install_all():

--- a/glue/conftest.py
+++ b/glue/conftest.py
@@ -1,3 +1,5 @@
+import os
+
 def pytest_addoption(parser):
     parser.addoption("--no-optional-skip", action="store_true",
                      help="don't skip any tests with optional dependencies")
@@ -11,3 +13,10 @@ def pytest_configure(config):
                 # The following line replaces the decorators with a function
                 # that does noting, effectively disabling it.
                 setattr(helpers, attr, lambda f: f)
+
+
+def pytest_report_header(config):
+    from . import __version__
+    glue_version = "%20s:\t%s" % ("glue", __version__)
+    from ._deps import get_status
+    return os.linesep + glue_version + os.linesep + os.linesep + get_status()

--- a/glue/tests/test_deps.py
+++ b/glue/tests/test_deps.py
@@ -42,7 +42,7 @@ class TestDependency(object):
 
     def test_installed_str(self):
         d = Dependency('math', 'info')
-        assert str(d) == "                math:\tINSTALLED"
+        assert str(d) == "                math:\tINSTALLED (unknown version)"
 
     def test_noinstalled_str(self):
         d = Dependency('asdf', 'info')


### PR DESCRIPTION
It is possible to configure the header of the pytest output to include versions of all the dependencies (we do this in astropy). This is done by adding a function to ``glue/conftest.py``. Presumably some code can be shared between this and ``glue-deps``