### PR TITLE
Add astropy_helpers to be able to build the docs locally

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "astropy_helpers"]
+	path = astropy_helpers
+	url = http://github.com/astropy/astropy-helpers.git

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -11,9 +11,6 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
-import os
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -28,10 +25,11 @@ import os
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.todo', 'sphinx.ext.coverage',
               'sphinx.ext.mathjax', 'sphinx.ext.viewcode',
-              'astropy.sphinx.ext.astropyautosummary',
-              'astropy.sphinx.ext.automodapi',
-              'astropy.sphinx.ext.numpydoc',
-              'astropy.sphinx.ext.automodsumm', 'sphinx.ext.intersphinx']
+              'astropy_helpers.sphinx.ext.astropyautosummary',
+              'astropy_helpers.sphinx.ext.automodapi',
+              'astropy_helpers.sphinx.ext.numpydoc',
+              'astropy_helpers.sphinx.ext.automodsumm',
+              'sphinx.ext.intersphinx']
 
 intersphinx_cache_limit = 10     # days to keep the cached inventories
 intersphinx_mapping = {


### PR DESCRIPTION
I could not build the docs as it uses  modules from ``astropy.sphinx.ext`` that doesn't exist any more in the latest astropy. Let alone astropy is an optional dependency only.

In this PR I suggest to use ``astropy_helpers`` in the same way as in other affiliated packages.