### PR TITLE
Docs: move generated dirs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "astropy_helpers"]
+	path = astropy_helpers
+	url = http://github.com/astropy/astropy-helpers.git

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -11,9 +11,6 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
-import os
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -28,10 +25,11 @@ import os
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.todo', 'sphinx.ext.coverage',
               'sphinx.ext.mathjax', 'sphinx.ext.viewcode',
-              'astropy.sphinx.ext.astropyautosummary',
-              'astropy.sphinx.ext.automodapi',
-              'astropy.sphinx.ext.numpydoc',
-              'astropy.sphinx.ext.automodsumm', 'sphinx.ext.intersphinx']
+              'astropy_helpers.sphinx.ext.astropyautosummary',
+              'astropy_helpers.sphinx.ext.automodapi',
+              'astropy_helpers.sphinx.ext.numpydoc',
+              'astropy_helpers.sphinx.ext.automodsumm',
+              'sphinx.ext.intersphinx']
 
 intersphinx_cache_limit = 10     # days to keep the cached inventories
 intersphinx_mapping = {

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,5 @@ all_files = 1
 [ah_bootstrap]
 auto_use = True
 
+[metadata]
+package_name = glueviz

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,8 @@
+[build_sphinx]
+source-dir = doc
+build-dir = doc/_build
+all_files = 1
+
+[ah_bootstrap]
+auto_use = True
+

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,23 @@
 #!/usr/bin/env python
 from __future__ import print_function
 
-from setuptools import setup, Command, find_packages
+from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 
 import os
 import sys
 import subprocess
+
+import ah_bootstrap
+
+# A dirty hack to get around some early import/configurations ambiguities
+if sys.version_info[0] >= 3:
+    import builtins
+else:
+    import __builtin__ as builtins
+builtins._ASTROPY_SETUP_ = True
+
+from astropy_helpers.setup_helpers import register_commands
 
 # Generate version.py
 
@@ -36,7 +47,23 @@ except (IOError, ImportError):
     with open('README.md') as infile:
         LONG_DESCRIPTION=infile.read()
 
-cmdclass = {}
+# Get some values from the setup.cfg
+from distutils import config
+conf = config.ConfigParser()
+conf.read(['setup.cfg'])
+metadata = dict(conf.items('metadata'))
+
+PACKAGENAME = metadata.get('package_name', 'packagename')
+VERSION = __version__
+
+# Indicates if this version is a release version
+RELEASE = 'dev' not in VERSION
+
+# Populate the dict of setup command overrides; this should be done before
+# invoking any other functionality from distutils since it can potentially
+# modify distutils' behavior.
+cmdclassd = register_commands(PACKAGENAME, VERSION, RELEASE)
+
 
 class PyTest(TestCommand):
     user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
@@ -51,12 +78,12 @@ class PyTest(TestCommand):
         self.test_suite = True
 
     def run_tests(self):
-        #import here, cause outside the eggs aren't loaded
+        # import here, cause outside the eggs aren't loaded
         import pytest
         errno = pytest.main(self.pytest_args + ['glue'])
         sys.exit(errno)
 
-cmdclass['test'] = PyTest
+cmdclassd['test'] = PyTest
 
 
 console_scripts = ['glue = glue.main:main',
@@ -64,9 +91,9 @@ console_scripts = ['glue = glue.main:main',
                    'glue-deps = glue._deps:main',
                    ]
 
-setup(name='glueviz',
+setup(name='PACKAGENAME',
       version=__version__,
-      description = 'Multidimensional data visualzation across files',
+      description='Multidimensional data visualzation across files',
       long_description=LONG_DESCRIPTION,
       author='Chris Beaumont, Thomas Robitaille',
       author_email='glueviz@gmail.com',
@@ -79,8 +106,8 @@ setup(name='glueviz',
           'Topic :: Scientific/Engineering :: Visualization',
           'License :: OSI Approved :: BSD License'
           ],
-      packages = find_packages(),
-      entry_points={'console_scripts' : console_scripts},
-      cmdclass=cmdclass,
+      packages=find_packages(),
+      entry_points={'console_scripts': console_scripts},
+      cmdclass=cmdclassd,
       package_data={'': ['*.png', '*.ui']}
-    )
+      )


### PR DESCRIPTION
This PR moves the ``build_sphinx`` generated directories under ``doc``. 
I tried to keep the changes to ``setup.py`` minimal (copied from astropy's package template), but some may still be superfluous.  With these changes the number of warnings significantly decreased (thus this picks the lowest hanging part of #544). 

This PR depends on #555.

Edit: not sure that it needs the ``astropy-helpers``, but I couldn't make the ``api/ --> doc/api`` move without it.