### PR TITLE
Fix glue.test() to work in MacOS X app

### DIFF
--- a/glue/__init__.py
+++ b/glue/__init__.py
@@ -128,6 +128,8 @@ def test(no_optional_skip=False):
     import os
     from pytest import main
     root = os.path.abspath(os.path.dirname(__file__))
+    if 'site-packages.zip' in root:
+        root = root.replace('site-packages.zip', 'glue')
     args = [root]
     if no_optional_skip:
         args.append('--no-optional-skip')


### PR DESCRIPTION
@ChrisBeaumont - I think this will allow us to run the tests in the MacOS X app. I'm building the app to test.