### PR TITLE
Add a menu item 'Console Log' to make log more easily discoverable

### DIFF
--- a/glue/qt/glue_application.py
+++ b/glue/qt/glue_application.py
@@ -426,6 +426,14 @@ class GlueApplication(Application, QMainWindow):
         mbar.addMenu(menu)
 
         menu = QMenu(mbar)
+        menu.setTitle("&View ")
+
+        a = QAction("&Console Log", menu)
+        a.triggered.connect(self._ui.log._show)
+        menu.addAction(a)
+        mbar.addMenu(menu)
+
+        menu = QMenu(mbar)
         menu.setTitle("&Canvas")
         menu.addAction(self._actions['tab_new'])
         menu.addAction(self._actions['viewer_new'])


### PR DESCRIPTION
We should have a Window/Windows menu in the menubar that has e.g. Main Window and Console Log so that users can easily discover the console log (at the moment it is not obvious that one can click on the red square in the bottom right).