### PR TITLE
Date-Time Support for Scatter Plot

### DIFF
--- a/glue/clients/layer_artist.py
+++ b/glue/clients/layer_artist.py
@@ -17,6 +17,7 @@ from contextlib import contextmanager
 from abc import ABCMeta, abstractproperty, abstractmethod
 
 import numpy as np
+
 from matplotlib.cm import gray
 from ..external import six
 from ..core.exceptions import IncompatibleAttribute
@@ -703,6 +704,7 @@ class ScatterLayerArtist(LayerArtist, ScatterLayerBase):
             return False
 
         self.artists = self._axes.plot(x, y)
+
         return True
 
     def update(self, view=None, transpose=False):

--- a/glue/clients/layer_artist.py
+++ b/glue/clients/layer_artist.py
@@ -13,6 +13,8 @@ LayerArtists contain the bulk of the logic for actually rendering things
 from __future__ import absolute_import, division, print_function
 
 import logging
+import numpy as np
+from pandas import DataFrame, groupby
 from contextlib import contextmanager
 from abc import ABCMeta, abstractproperty, abstractmethod
 
@@ -708,16 +710,12 @@ class ScatterLayerArtist(LayerArtist, ScatterLayerBase):
             return False
         self.artists = self._axes.plot(x, y, 'k.')
 
-        gu = np.unique(g)
-        colors = get_colors(len(gu))
-
-        if len(gu) is not len(g):
-            for elem, c in zip(gu, colors):
-                xg = x[g == elem]
-                yg = y[g == elem]
-                i = np.argsort(xg)
-                art = self._axes.plot(xg[i], yg[i], '.-', color=c)
-                self.artists.extend(art)
+        df = DataFrame({'g': g, 'x': x, 'y': y})
+        groups = df.groupby('g')
+        colors = get_colors(len(groups))
+        for grp, c in zip(groups, colors):
+            art = self._axes.plot(grp[1]['x'], grp[1]['y'], '.-', color=c)
+            self.artists.extend(art)
 
         return True
 

--- a/glue/clients/scatter_client.py
+++ b/glue/clients/scatter_client.py
@@ -35,6 +35,7 @@ class ScatterClient(Client):
     xflip = CallbackProperty(False)
     xatt = CallbackProperty()
     yatt = CallbackProperty()
+    group = CallbackProperty()
     jitter = CallbackProperty()
 
     def __init__(self, data=None, figure=None, axes=None,
@@ -60,6 +61,7 @@ class ScatterClient(Client):
         self._layer_updated = False  # debugging
         self._xset = False
         self._yset = False
+        self._gset = False
         self.axes = axes
 
         self._connect()
@@ -94,6 +96,7 @@ class ScatterClient(Client):
         add_callback(self, 'ymax', self._set_limits)
         add_callback(self, 'xatt', partial(self._set_xydata, 'x'))
         add_callback(self, 'yatt', partial(self._set_xydata, 'y'))
+        add_callback(self, 'group', partial(self._set_xydata, 'group'))
         add_callback(self, 'jitter', self._jitter)
         self.axes.figure.canvas.mpl_connect('draw_event',
                                             lambda x: self._pull_properties())
@@ -220,7 +223,7 @@ class ScatterClient(Client):
            If True, will rescale x/y axes to fit the data
         :type snap: bool
         """
-        if coord not in ('x', 'y'):
+        if coord not in ('x', 'y', 'group'):
             raise TypeError("coord must be one of x,y")
         if not isinstance(attribute, ComponentID):
             raise TypeError("attribute must be a ComponentID")
@@ -234,6 +237,9 @@ class ScatterClient(Client):
             new_add = not self._yset
             self.yatt = attribute
             self._yset = self.yatt is not None
+        elif coord == 'group':
+            self.group = attribute
+            self._gset = self.group is not None
 
         # update plots
         list(map(self._update_layer, self.artists.layers))

--- a/glue/clients/scatter_client.py
+++ b/glue/clients/scatter_client.py
@@ -407,6 +407,19 @@ class ScatterClient(Client):
                 pass
         return False
 
+    def _check_if_date(self, attribute):
+        """ A function to check if an attribute has date formatted information.
+        :param attribute: core.Data.ComponentID
+        :return: True iff Data is Date
+        """
+        for data in self._data:
+            try:
+                if data.get_component(attribute).datetime:
+                    return True
+            except IncompatibleAttribute:
+                pass
+        return False
+
     def _update_subset(self, message):
         self._update_layer(message.sender)
 

--- a/glue/clients/scatter_client.py
+++ b/glue/clients/scatter_client.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
 from functools import partial
-
 import numpy as np
 from matplotlib.dates import num2date
 

--- a/glue/clients/tests/test_scatter_client.py
+++ b/glue/clients/tests/test_scatter_client.py
@@ -5,6 +5,9 @@ from __future__ import absolute_import, division, print_function
 import pytest
 
 import numpy as np
+import pandas as pd
+from matplotlib.dates import date2num, AutoDateLocator, AutoDateFormatter
+
 from matplotlib.ticker import AutoLocator, MaxNLocator, LogLocator
 from matplotlib.ticker import LogFormatterMathtext, ScalarFormatter, FuncFormatter
 from mock import MagicMock
@@ -65,7 +68,7 @@ class TestScatterClient(object):
         assert (self.client.yatt is None) or isinstance(
             self.client.yatt, ComponentID)
 
-    def check_ticks(self, axis, is_log, is_cat):
+    def check_ticks(self, axis, is_log, is_cat, is_date):
         locator = axis.get_major_locator()
         formatter = axis.get_major_formatter()
         if is_log:
@@ -74,6 +77,9 @@ class TestScatterClient(object):
         elif is_cat:
             assert isinstance(locator, MaxNLocator)
             assert isinstance(formatter, FuncFormatter)
+        elif is_date:
+            assert isinstance(locator, AutoDateLocator)
+            assert isinstance(formatter, AutoDateFormatter)
         else:
             assert isinstance(locator, AutoLocator)
             assert isinstance(formatter, ScalarFormatter)
@@ -84,11 +90,13 @@ class TestScatterClient(object):
         if client.xatt is not None:
             self.check_ticks(ax.xaxis,
                              client.xlog,
-                             client._check_categorical(client.xatt))
+                             client._check_categorical(client.xatt),
+                             client._check_if_date(client.xatt))
         if client.yatt is not None:
             self.check_ticks(ax.yaxis,
                              client.ylog,
-                             client._check_categorical(client.yatt))
+                             client._check_categorical(client.yatt),
+                             client._check_if_date(client.yatt))
 
     def plot_data(self, layer):
         """ Return the data bounds for a given layer (data or subset)
@@ -655,12 +663,12 @@ class TestCategoricalScatterClient(TestScatterClient):
         self.add_data(data=data)
         self.client.yatt = data.find_component_id('y')
         self.client.xatt = data.find_component_id('xcat')
-        self.check_ticks(self.client.axes.xaxis, False, True)
-        self.check_ticks(self.client.axes.yaxis, False, False)
+        self.check_ticks(self.client.axes.xaxis, False, True, False)
+        self.check_ticks(self.client.axes.yaxis, False, False, False)
 
         self.client.xatt = data.find_component_id('xcont')
-        self.check_ticks(self.client.axes.yaxis, False, False)
-        self.check_ticks(self.client.axes.xaxis, False, False)
+        self.check_ticks(self.client.axes.yaxis, False, False, False)
+        self.check_ticks(self.client.axes.xaxis, False, False, False)
 
     def test_high_cardinatility_timing(self):
 
@@ -700,7 +708,7 @@ class TestCategoricalScatterClient(TestScatterClient):
         """ Log-based tests don't make sense here."""
         pass
 
-'''
+
 class TestDateScatterClient(TestScatterClient):
     def setup_method(self, method):
         self.data = example_data.test_date_data()
@@ -708,8 +716,8 @@ class TestDateScatterClient(TestScatterClient):
                     self.data[0].find_component_id('y1'),
                     self.data[1].find_component_id('dates2'),
                     self.data[1].find_component_id('y2')]
-        self.roi_limits = (np.datetime64('2007-01-01'), 2.5, np.datetime64('2011-01-01'), 6.5)
-        self.roi_points = (np.array(['2010-12-14']), np.array([2]))
+        self.roi_limits = (732677.0, 2.5, 733773.0, 6.5)
+        self.roi_points = (np.array(['2007-07-13'], dtype='datetime64'), np.array([3]))
         self.collect = core.data_collection.DataCollection()
         self.hub = self.collect.hub
         FIGURE.clf()
@@ -724,77 +732,99 @@ class TestDateScatterClient(TestScatterClient):
         self.client.yatt = self.ids[1]
         assert self.client.axes.get_ylabel() == self.ids[1].label
 
+    def test_range_rois_preserved(self):
+        data = self.add_data_and_attributes()
+        assert self.client.xatt is not self.client.yatt
 
-    def test_get_category_tick(self):
+        roi = core.roi.XRangeROI()
+        roi.set_range(732678.0, 733408.0)
+        self.client.apply_roi(roi)
+        assert isinstance(data.edit_subset.subset_state,
+                          core.subset.RangeSubsetState)
+        assert data.edit_subset.subset_state.att == self.client.xatt
+
+        roi = core.roi.YRangeROI()
+        roi.set_range(2, 5)
+        self.client.apply_roi(roi)
+        assert data.edit_subset.subset_state.att == self.client.yatt
+
+    def test_apply_roi(self):
+        data = self.add_data_and_attributes()
+        roi = core.roi.RectangularROI()
+        roi.update_limits(*self.roi_limits)
+        x, y = self.roi_points
+        self.client.apply_roi(roi)
+        assert self.layer_data_correct(data.edit_subset, x, y)
+
+    def test_apply_roi_adds_on_empty(self):
+        data = self.add_data_and_attributes()
+        data._subsets = []
+        data.edit_subset = None
+        roi = core.roi.RectangularROI()
+        roi.update_limits(*self.roi_limits)
+        x, y = self.roi_points
+        self.client.apply_roi(roi)
+        assert data.edit_subset is not None
+
+    def test_apply_roi_applies_to_all_editable_subsets(self):
+        d1 = self.add_data_and_attributes()
+        d2 = self.add_data()
+        state1 = d1.edit_subset.subset_state
+        state2 = d2.edit_subset.subset_state
+        roi = core.roi.RectangularROI()
+        roi.update_limits(*self.roi_limits)
+        x, y = self.roi_points
+        self.client.apply_roi(roi)
+        assert d1.edit_subset.subset_state is not state1
+        assert d1.edit_subset.subset_state is not state2
+
+    def test_apply_roi_doesnt_add_if_any_selection(self):
+        d1 = self.add_data_and_attributes()
+        d2 = self.add_data()
+        d1.edit_subset = None
+        d2.edit_subset = d2.new_subset()
+        ct = len(d1.subsets)
+        roi = core.roi.RectangularROI()
+        roi.update_limits(*self.roi_limits)
+        x, y = self.roi_points
+        self.client.apply_roi(roi)
+        assert len(d1.subsets) == ct
+
+    def test_check_formatter(self):
         self.add_data()
         self.client.xatt = self.ids[0]
         self.client.yatt = self.ids[0]
         axes = self.client.axes
         xformat = axes.xaxis.get_major_formatter()
-        yformat = axes.yaxis.get_major_formatter()
-        xlabels = [xformat.format_data(pos) for pos in range(2)]
-        ylabels = [yformat.format_data(pos) for pos in range(2)]
-        assert xlabels == ['a', 'b']
-        assert ylabels == ['a', 'b']
+        assert isinstance(xformat, AutoDateFormatter)
 
-    def test_jitter_with_setter_change(self):
-        grab_data = lambda client: client.data[0][client.xatt].copy()
-        layer = self.add_data()
+    def test_check_locator(self):
+        self.add_data()
         self.client.xatt = self.ids[0]
-        self.client.yatt = self.ids[1]
-        orig_data = grab_data(self.client)
-        self.client.jitter = None
-        np.testing.assert_equal(orig_data, grab_data(self.client))
-        self.client.jitter = 'uniform'
-        delta = np.abs(orig_data - grab_data(self.client))
-        assert np.all((delta > 0) & (delta < 1))
-        self.client.jitter = None
-        np.testing.assert_equal(orig_data, grab_data(self.client))
-    def test_ticks_go_back_after_changing(self):
-        """ If you change to a categorical axis and then change back
-        to a numeric, the axis ticks should fix themselves properly.
-        """
-        data = core.Data()
-        data.add_component(core.Component(np.arange(100)), 'y')
-        data.add_component(
-            core.data.CategoricalComponent(['a'] * 50 + ['b'] * 50), 'xcat')
-        data.add_component(core.Component(2 * np.arange(100)), 'xcont')
-        self.add_data(data=data)
-        self.client.yatt = data.find_component_id('y')
-        self.client.xatt = data.find_component_id('xcat')
-        self.check_ticks(self.client.axes.xaxis, False, True)
-        self.check_ticks(self.client.axes.yaxis, False, False)
-        self.client.xatt = data.find_component_id('xcont')
-        self.check_ticks(self.client.axes.yaxis, False, False)
-        self.check_ticks(self.client.axes.xaxis, False, False)
-    def test_high_cardinatility_timing(self):
-        card = 50000
-        data = core.Data()
-        card_data = [str(num) for num in range(card)]
-        data.add_component(core.Component(np.arange(card * 5)), 'y')
-        data.add_component(
-            core.data.CategoricalComponent(np.repeat([card_data], 5)), 'xcat')
-        self.add_data(data)
-        comp = data.find_component_id('xcat')
-        timer_func = partial(self.client._set_xydata, 'x', comp)
-        timer = timeit(timer_func, number=1)
-        assert timer < 3  # this is set for Travis speed
+        self.client.yatt = self.ids[0]
+        axes = self.client.axes
+        xformat = axes.xaxis.get_major_locator()
+        assert isinstance(xformat, AutoDateLocator)
+
     # REMOVED TESTS
     def test_invalid_plot(self):
         """ This fails because the axis ticks shouldn't reset after
         invalid plot. Current testing logic can't cope with this."""
         pass
+
     def test_redraw_called_on_invalid_plot(self):
         """ This fails because the axis ticks shouldn't reset after
         invalid plot. Current testing logic can't cope with this."""
         pass
+
     def test_xlog_relimits_if_negative(self):
         """ Log-based tests don't make sense here."""
         pass
+
     def test_log_sticky(self):
         """ Log-based tests don't make sense here."""
         pass
+
     def test_logs(self):
         """ Log-based tests don't make sense here."""
         pass
-'''

--- a/glue/clients/tests/test_scatter_client.py
+++ b/glue/clients/tests/test_scatter_client.py
@@ -699,3 +699,102 @@ class TestCategoricalScatterClient(TestScatterClient):
     def test_logs(self):
         """ Log-based tests don't make sense here."""
         pass
+
+'''
+class TestDateScatterClient(TestScatterClient):
+    def setup_method(self, method):
+        self.data = example_data.test_date_data()
+        self.ids = [self.data[0].find_component_id('dates1'),
+                    self.data[0].find_component_id('y1'),
+                    self.data[1].find_component_id('dates2'),
+                    self.data[1].find_component_id('y2')]
+        self.roi_limits = (np.datetime64('2007-01-01'), 2.5, np.datetime64('2011-01-01'), 6.5)
+        self.roi_points = (np.array(['2010-12-14']), np.array([2]))
+        self.collect = core.data_collection.DataCollection()
+        self.hub = self.collect.hub
+        FIGURE.clf()
+        axes = FIGURE.add_subplot(111)
+        self.client = ScatterClient(self.collect, axes=axes)
+        self.connect()
+
+    def test_axis_labels_sync_with_setters(self):
+        self.add_data()
+        self.client.xatt = self.ids[0]
+        assert self.client.axes.get_xlabel() == self.ids[0].label
+        self.client.yatt = self.ids[1]
+        assert self.client.axes.get_ylabel() == self.ids[1].label
+
+
+    def test_get_category_tick(self):
+        self.add_data()
+        self.client.xatt = self.ids[0]
+        self.client.yatt = self.ids[0]
+        axes = self.client.axes
+        xformat = axes.xaxis.get_major_formatter()
+        yformat = axes.yaxis.get_major_formatter()
+        xlabels = [xformat.format_data(pos) for pos in range(2)]
+        ylabels = [yformat.format_data(pos) for pos in range(2)]
+        assert xlabels == ['a', 'b']
+        assert ylabels == ['a', 'b']
+
+    def test_jitter_with_setter_change(self):
+        grab_data = lambda client: client.data[0][client.xatt].copy()
+        layer = self.add_data()
+        self.client.xatt = self.ids[0]
+        self.client.yatt = self.ids[1]
+        orig_data = grab_data(self.client)
+        self.client.jitter = None
+        np.testing.assert_equal(orig_data, grab_data(self.client))
+        self.client.jitter = 'uniform'
+        delta = np.abs(orig_data - grab_data(self.client))
+        assert np.all((delta > 0) & (delta < 1))
+        self.client.jitter = None
+        np.testing.assert_equal(orig_data, grab_data(self.client))
+    def test_ticks_go_back_after_changing(self):
+        """ If you change to a categorical axis and then change back
+        to a numeric, the axis ticks should fix themselves properly.
+        """
+        data = core.Data()
+        data.add_component(core.Component(np.arange(100)), 'y')
+        data.add_component(
+            core.data.CategoricalComponent(['a'] * 50 + ['b'] * 50), 'xcat')
+        data.add_component(core.Component(2 * np.arange(100)), 'xcont')
+        self.add_data(data=data)
+        self.client.yatt = data.find_component_id('y')
+        self.client.xatt = data.find_component_id('xcat')
+        self.check_ticks(self.client.axes.xaxis, False, True)
+        self.check_ticks(self.client.axes.yaxis, False, False)
+        self.client.xatt = data.find_component_id('xcont')
+        self.check_ticks(self.client.axes.yaxis, False, False)
+        self.check_ticks(self.client.axes.xaxis, False, False)
+    def test_high_cardinatility_timing(self):
+        card = 50000
+        data = core.Data()
+        card_data = [str(num) for num in range(card)]
+        data.add_component(core.Component(np.arange(card * 5)), 'y')
+        data.add_component(
+            core.data.CategoricalComponent(np.repeat([card_data], 5)), 'xcat')
+        self.add_data(data)
+        comp = data.find_component_id('xcat')
+        timer_func = partial(self.client._set_xydata, 'x', comp)
+        timer = timeit(timer_func, number=1)
+        assert timer < 3  # this is set for Travis speed
+    # REMOVED TESTS
+    def test_invalid_plot(self):
+        """ This fails because the axis ticks shouldn't reset after
+        invalid plot. Current testing logic can't cope with this."""
+        pass
+    def test_redraw_called_on_invalid_plot(self):
+        """ This fails because the axis ticks shouldn't reset after
+        invalid plot. Current testing logic can't cope with this."""
+        pass
+    def test_xlog_relimits_if_negative(self):
+        """ Log-based tests don't make sense here."""
+        pass
+    def test_log_sticky(self):
+        """ Log-based tests don't make sense here."""
+        pass
+    def test_logs(self):
+        """ Log-based tests don't make sense here."""
+        pass
+'''

--- a/glue/clients/tests/test_scatter_client.py
+++ b/glue/clients/tests/test_scatter_client.py
@@ -5,9 +5,7 @@ from __future__ import absolute_import, division, print_function
 import pytest
 
 import numpy as np
-import pandas as pd
 from matplotlib.dates import date2num, AutoDateLocator, AutoDateFormatter
-
 from matplotlib.ticker import AutoLocator, MaxNLocator, LogLocator
 from matplotlib.ticker import LogFormatterMathtext, ScalarFormatter, FuncFormatter
 from mock import MagicMock

--- a/glue/clients/util.py
+++ b/glue/clients/util.py
@@ -1,17 +1,16 @@
 from __future__ import absolute_import, division, print_function
 
-from functools import partial
-
 import numpy as np
 import pandas as pd
-from matplotlib.dates import date2num, AutoDateLocator, AutoDateFormatter
 import datetime
+from functools import partial
+from colorsys import hls_to_rgb
+
+from matplotlib.dates import date2num, AutoDateLocator, AutoDateFormatter
 from matplotlib.ticker import AutoLocator, MaxNLocator, LogLocator
 from matplotlib.ticker import (LogFormatterMathtext, ScalarFormatter,
                                FuncFormatter)
 from ..core.data import CategoricalComponent
-from colorsys import hls_to_rgb
-
 
 def small_view(data, attribute):
     """
@@ -61,9 +60,8 @@ def visible_limits(artists, axis):
     if data.size == 0:
         return
 
-    if isinstance(data[0], np.datetime64) \
-            or 'datetime64' in str(type(data[0])) \
-            or isinstance(data[0], datetime.date):
+    if isinstance(data[0], (np.datetime64, datetime.date)) \
+            or 'datetime64' in str(type(data[0])):
         data = pd.to_datetime(data)
         dt = data[pd.notnull(data)]
         if len(dt) == 0:

--- a/glue/clients/util.py
+++ b/glue/clients/util.py
@@ -10,6 +10,7 @@ from matplotlib.ticker import AutoLocator, MaxNLocator, LogLocator
 from matplotlib.ticker import (LogFormatterMathtext, ScalarFormatter,
                                FuncFormatter)
 from ..core.data import CategoricalComponent
+from colorsys import hls_to_rgb
 
 
 def small_view(data, attribute):
@@ -136,3 +137,20 @@ def update_ticks(axes, coord, components, is_log):
     else:
         axis.set_major_locator(AutoLocator())
         axis.set_major_formatter(ScalarFormatter())
+
+
+def get_colors(num_colors):
+    """
+    Taken from: http://stackoverflow.com/questions/470690/how-to-automatically-generate-n-distinct-colors
+    Creates a list of distinct colors to plot with
+    :param num_colors: number of colors to generate
+    :return: list of colors
+    """
+    colors = []
+    if num_colors:
+        for i in np.arange(0., 360., 360. / num_colors):
+            hue = i / 360.
+            lightness = (50 + np.random.rand() * 10) / 100.
+            saturation = (90 + np.random.rand() * 10) / 100.
+            colors.append(hls_to_rgb(hue, lightness, saturation))
+    return colors

--- a/glue/clients/util.py
+++ b/glue/clients/util.py
@@ -3,6 +3,9 @@ from __future__ import absolute_import, division, print_function
 from functools import partial
 
 import numpy as np
+import pandas as pd
+import matplotlib.dates as mdate
+import datetime
 from matplotlib.ticker import AutoLocator, MaxNLocator, LogLocator
 from matplotlib.ticker import (LogFormatterMathtext, ScalarFormatter,
                                FuncFormatter)
@@ -57,13 +60,22 @@ def visible_limits(artists, axis):
     if data.size == 0:
         return
 
-    data = data[np.isfinite(data)]
-    if data.size == 0:
-        return
+    print(type(data[0]))
+    if isinstance(data[0], np.datetime64) or isinstance(data[0], datetime.date):
+        data = pd.to_datetime(data)
+        dt = data[pd.notnull(data)]
+        if len(dt) == 0:
+            return
+        lo, hi = mdate.date2num(min(data)), mdate.date2num(max(data))
 
-    lo, hi = np.nanmin(data), np.nanmax(data)
-    if not np.isfinite(lo):
-        return
+    else:
+        data = data[np.isfinite(data)]
+        if data.size == 0:
+            return
+
+        lo, hi = np.nanmin(data), np.nanmax(data)
+        if not np.isfinite(lo):
+            return
 
     return lo, hi
 

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -227,6 +227,15 @@ class Component(object):
         dt = isinstance(self.data.dtype, datetime.date)
         return dt64 or dt
 
+    @property
+    def group(self):
+        """
+        Whether or not the datatype can be considered a grouping identifier
+        """
+        elems = len(self.data[:])
+        groups = len(np.unique(self.data[:]))
+        return (elems / groups) > 2 and groups < 1001
+
     def __str__(self):
         return "Component with shape %s" % shape_to_string(self.shape)
 

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -4,6 +4,7 @@ import operator
 import logging
 
 import numpy as np
+import datetime
 import pandas as pd
 
 from .contracts import contract
@@ -216,6 +217,15 @@ class Component(object):
         Whether or not the datatype is numeric
         """
         return np.can_cast(self.data[0], np.complex)
+
+    @property
+    def datetime(self):
+        """
+        Whether or not the datatype is date
+        """
+        dt64 = isinstance(self.data.dtype, np.datetime64) or 'datetime64' in str(self.data.dtype)
+        dt = isinstance(self.data.dtype, datetime.date)
+        return dt64 or dt
 
     def __str__(self):
         return "Component with shape %s" % shape_to_string(self.shape)

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -2,9 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import operator
 import logging
-
 import numpy as np
-import datetime
 import pandas as pd
 
 from .contracts import contract
@@ -223,9 +221,7 @@ class Component(object):
         """
         Whether or not the datatype is date
         """
-        dt64 = isinstance(self.data.dtype, np.datetime64) or 'datetime64' in str(self.data.dtype)
-        dt = isinstance(self.data.dtype, datetime.date)
-        return dt64 or dt
+        return isinstance(self.data.dtype, np.datetime64) or 'datetime64' in str(self.data.dtype)
 
     @property
     def group(self):

--- a/glue/core/roi.py
+++ b/glue/core/roi.py
@@ -1,9 +1,12 @@
 from __future__ import absolute_import, division, print_function
 
 import numpy as np
+import pandas as pd
+import datetime
 from matplotlib.patches import Polygon, Rectangle, Ellipse, PathPatch
 from matplotlib.patches import Path as mplPath
 from matplotlib.transforms import IdentityTransform, blended_transform_factory
+import matplotlib.dates as mdate
 import copy
 
 np.seterr(all='ignore')
@@ -493,7 +496,9 @@ class PolygonalROI(VertexROIBase):
             x = np.asarray(x)
         if not isinstance(y, np.ndarray):
             y = np.asarray(y)
-
+        if isinstance(x[0], np.datetime64) or isinstance(x[0], datetime.date):
+            x = pd.to_datetime(x)
+            x = mdate.date2num(x)
         xypts = np.column_stack((x.flat, y.flat))
         xyvts = np.column_stack((self.vx, self.vy))
         result = points_inside_poly(xypts, xyvts)

--- a/glue/core/roi.py
+++ b/glue/core/roi.py
@@ -496,11 +496,17 @@ class PolygonalROI(VertexROIBase):
             x = np.asarray(x)
         if not isinstance(y, np.ndarray):
             y = np.asarray(y)
-        if isinstance(x[0], np.datetime64) or isinstance(x[0], datetime.date):
+        if isinstance(x[0], np.datetime64)\
+                or 'datetime64' in str(type(x[0]))\
+                or isinstance(x[0], datetime.date):
             x = pd.to_datetime(x)
             x = mdate.date2num(x)
+            vx = pd.to_datetime(self.vx)
+            vx = mdate.date2num(vx)
+        else:
+            vx = self.vx
         xypts = np.column_stack((x.flat, y.flat))
-        xyvts = np.column_stack((self.vx, self.vy))
+        xyvts = np.column_stack((vx, self.vy))
         result = points_inside_poly(xypts, xyvts)
         good = np.isfinite(xypts).all(axis=1)
         result[~good] = False

--- a/glue/core/roi.py
+++ b/glue/core/roi.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import, division, print_function
-
 import numpy as np
 import pandas as pd
 import datetime

--- a/glue/qt/qtutil.py
+++ b/glue/qt/qtutil.py
@@ -10,6 +10,7 @@ import os
 import pkg_resources
 from matplotlib.colors import ColorConverter
 from matplotlib import cm
+from matplotlib.dates import num2date
 import numpy as np
 
 from ..external.axescache import AxesCache
@@ -493,6 +494,35 @@ def pretty_number(numbers):
         result = "%0.3f" % n
     if result.find('.') != -1:
         result = result.rstrip('0')
+
+    return result
+
+
+def pretty_date(dates):
+    """Convert a list of numbers into a nice list of date(time)s
+
+    :param dates: Numbers to convert
+    :type dates: List or other iterable of numbers
+
+    :rtype: A list of strings
+    """
+    try:
+        return [pretty_date(d) for d in dates]
+    except TypeError:
+        pass
+
+    d = num2date(dates)
+    t = [d.hour, d.minute, d.second, d.microsecond]
+    result = "%i/%02d/%04d" % (d.month, d.day, d.year)
+
+    if t[3] is not 0:
+        result += " %i:%02d:%02d:%i" % (d.hour, d.minute, d.second, d.microsecond)
+    elif t[2] is not 0:
+        result += " %i:%02d:%02d" % (d.hour, d.minute, d.second)
+    elif t[1] is not 0:
+        result += " %i:%02d" % (d.hour, d.minute)
+    elif t[0] is not 0:
+        result += " %i" % d.hour
 
     return result
 

--- a/glue/qt/ui/scatterwidget.ui
+++ b/glue/qt/ui/scatterwidget.ui
@@ -322,6 +322,45 @@
        </layout>
       </item>
       <item>
+       <widget class="Line" name="line">
+        <property name="frameShadow">
+         <enum>QFrame::Sunken</enum>
+        </property>
+        <property name="lineWidth">
+         <number>2</number>
+        </property>
+        <property name="midLineWidth">
+         <number>0</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="group">
+        <property name="text">
+         <string>Group Time Series by:</string>
+        </property>
+       </widget>
+      </item>z
+      <item>
+       <widget class="QComboBox" name="groupComboBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>Select a field to group time series information by. (ex. Patient ID)</string>
+        </property>
+        <property name="sizeAdjustPolicy">
+         <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
        <spacer name="verticalSpacer">
         <property name="orientation">
          <enum>Qt::Vertical</enum>

--- a/glue/qt/ui/scatterwidget.ui
+++ b/glue/qt/ui/scatterwidget.ui
@@ -340,7 +340,7 @@
       <item>
        <widget class="QLabel" name="group">
         <property name="text">
-         <string>Group Time Series by:</string>
+         <string>Group by:</string>
         </property>
        </widget>
       </item>z

--- a/glue/qt/widget_properties.py
+++ b/glue/qt/widget_properties.py
@@ -20,14 +20,14 @@ Example Use::
 from __future__ import absolute_import, division, print_function
 
 from functools import partial
+from matplotlib.dates import date2num
+import datetime as dt
+import re
 
 from .qtutil import pretty_number, pretty_date
 from ..external.qt import QtGui, QtCore
 from ..external.six.moves import reduce
 from ..core.callback_property import add_callback
-from matplotlib.dates import date2num
-import datetime as dt
-import re
 
 
 class WidgetProperty(object):
@@ -192,7 +192,6 @@ def connect_current_combo(client, prop, widget):
     """
 
     def _push_combo(value):
-        print(value)
         try:
             idx = _find_combo_data(widget, value)
         except ValueError:  # not found. Punt instead of failing
@@ -262,7 +261,6 @@ def connect_date_edit(client, prop, widget):
                 while i < len(flds) and str.isdigit(str(flds[i])):
                     rest[i - 3] = int(flds[i])
                     i += 1
-
                 if str(flds[-1]) in ['PM', 'pm'] and rest[0] < 12:
                         rest[0] += 12
                 [h, m, s, ms] = rest[:]

--- a/glue/qt/widgets/scatter_widget.py
+++ b/glue/qt/widgets/scatter_widget.py
@@ -18,7 +18,6 @@ from ..widget_properties import (ButtonProperty, FloatLineProperty,
 
 from ..qtutil import load_ui, cache_axes, nonpartial
 
-from matplotlib.dates import num2date
 
 __all__ = ['ScatterWidget']
 

--- a/glue/qt/widgets/scatter_widget.py
+++ b/glue/qt/widgets/scatter_widget.py
@@ -175,13 +175,6 @@ class ScatterWidget(DataViewer):
         self.client.xatt = self.xatt
         self.client.yatt = self.yatt
         self.client.group = self.group
-        # print(self.xatt)
-        # print(self.yatt)
-
-        # print(self.yatt)
-        # print(self._data[0].get_component(self._data[0].find_component_id(self.yatt)))
-        # print(self._data[0].get_component(self._data[0].find_component_id(self.yatt)).data)
-        # print(self._data[0].get_component(self._data[0].find_component_id(self.yatt)).datetime)
 
     @defer_draw
     def add_data(self, data):

--- a/glue/qt/widgets/style_dialog.py
+++ b/glue/qt/widgets/style_dialog.py
@@ -63,6 +63,11 @@ class StyleDialog(QDialog):
         color = mpl_to_qt4_color(color, alpha=self.layer.style.alpha)
         self.set_color(color)
 
+        self.linewidth_widget = QSpinBox()
+        self.linewidth_widget.setMinimum(1)
+        self.linewidth_widget.setMaximum(10)
+        self.linewidth_widget.setValue(self.layer.style.linewidth)
+
         self.okcancel = QDialogButtonBox(QDialogButtonBox.Ok |
                                          QDialogButtonBox.Cancel)
 
@@ -71,6 +76,7 @@ class StyleDialog(QDialog):
         self.layout.addRow("Symbol", self.symbol_widget)
         self.layout.addRow("Color", self.color_widget)
         self.layout.addRow("Size", self.size_widget)
+        self.layout.addRow("Line", self.linewidth_widget)
 
         self.layout.addWidget(self.okcancel)
 
@@ -109,6 +115,9 @@ class StyleDialog(QDialog):
     def symbol(self):
         return self._symbols[self.symbol_widget.currentIndex()]
 
+    def linewidth(self):
+        return self.linewidth_widget.value()
+
     def update_style(self):
         if self._edit_label:
             self.layer.label = self.label()
@@ -116,6 +125,7 @@ class StyleDialog(QDialog):
         self.layer.style.alpha = self.color().alpha() / 255.
         self.layer.style.marker = self.symbol()
         self.layer.style.markersize = self.size()
+        self.layer.style.linewidth = self.linewidth()
 
     @classmethod
     def edit_style(cls, layer):
@@ -155,4 +165,5 @@ if __name__ == "__main__":
     print('color: ', d.style.color)
     print('marker: ', d.style.marker)
     print('marker size: ', d.style.markersize)
+    print('line width: ', d.style.linewidth)
     print('alpha ', d.style.alpha)

--- a/glue/tests/example_data.py
+++ b/glue/tests/example_data.py
@@ -18,7 +18,7 @@ def test_histogram_data():
 
 def test_data():
     data = glue.core.data.Data(label="Test Data 1")
-    data2 = glue.core.data.Data(label="Teset Data 2")
+    data2 = glue.core.data.Data(label="Test Data 2")
 
     comp_a = glue.core.data.Component(np.array([1, 2, 3]))
     comp_b = glue.core.data.Component(np.array([1, 2, 3]))
@@ -34,7 +34,7 @@ def test_data():
 def test_categorical_data():
 
     data = glue.core.data.Data(label="Test Cat Data 1")
-    data2 = glue.core.data.Data(label="Teset Cat Data 2")
+    data2 = glue.core.data.Data(label="Test Cat Data 2")
 
     comp_x1 = glue.core.data.CategoricalComponent(np.array(['a', 'a', 'b']))
     comp_y1 = glue.core.data.Component(np.array([1, 2, 3]))
@@ -46,6 +46,24 @@ def test_categorical_data():
     data2.add_component(comp_y2, 'y2')
     return data, data2
 
+
+def test_date_data():
+    data = glue.core.data.Data(label="Test Time Data 1")
+    data2 = glue.core.data.Data(label="Test Time Data 2")
+
+    dates1 = np.array(['2006-01-13', '2007-07-13', '2010-08-13'], dtype='datetime64')
+    dates2 = np.array(['2010-12-14', '2013-11-20', '2014-12-25'], dtype='datetime64')
+
+    comp_dates1 = glue.core.data.Component(dates1)
+    comp_y1 = glue.core.data.Component(np.array([1, 3, 9]))
+    comp_dates2 = glue.core.data.Component(dates2)
+    comp_y2 = glue.core.data.Component(np.array([2, 4, 8]))
+
+    data.add_component(comp_dates1, 'dates1')
+    data.add_component(comp_y1, 'y1')
+    data2.add_component(comp_dates2, 'dates2')
+    data2.add_component(comp_y2, 'y2')
+    return data, data2
 
 def test_image():
     data = glue.core.data.Data(label="Test Image")


### PR DESCRIPTION
Hi all, my name is Alex Koszycki and I'm a MS student working under Dr. William Dampier at Drexel. I'm helping to extend Glue's functionality to biological data-types. I haven't done an open-source project before so I welcome any advice and ask for patience if I don't get something right.

This pull request is for adding datetime support for scatter plots. A lot of biological data is taken over time, especially with clinical information. Having a way to explore a time series is quite useful.

Here is what I've implemented:
Plotting - the backend still does everything with numbers (seconds since 0001-01-01 00:00:00 UTC, plus one)
Axes label formatting for dates
ROI support
Date-formatted X and Y limits in the GUI
A "grouping" combo box that allows you to draw a line based on another field (ex. Patient ID)

What's Incomplete:
I haven't gone through the testing for the GUI end of things
I haven't figured out how to use the "Edit Style" box to change the width of the lines
The plot doesn't react well to the log and flip checkboxes

Thanks,
Alex
