### PR TITLE
Always delete old files when syncing to S3

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -154,7 +154,7 @@ doctest:
 	      "results in $(BUILDDIR)/doctest/output.txt."
 
 s3:
-	aws s3 sync _build/html s3://www.glueviz.org/en/$(TRAVIS_BRANCH)
+	aws s3 sync _build/html s3://www.glueviz.org/en/$(TRAVIS_BRANCH) --delete
 
 s3latest:
-	aws s3 sync _build/html s3://www.glueviz.org/en/latest
+	aws s3 sync _build/html s3://www.glueviz.org/en/latest --delete


### PR DESCRIPTION
@ChrisBeaumont - very minor, but just wanted to check if you agree. This will avoid accumulating stale files over time.