### PR TITLE
Fix StyleDialog in Python 3

### DIFF
--- a/glue/qt/widgets/style_dialog.py
+++ b/glue/qt/widgets/style_dialog.py
@@ -31,7 +31,7 @@ class StyleDialog(QDialog):
         self.setWindowTitle("Style Editor")
         self.layer = layer
         self._edit_label = edit_label
-        self._symbols = POINT_ICONS.keys()
+        self._symbols = list(POINT_ICONS.keys())
 
         self._setup_widgets()
         self._connect()

--- a/glue/qt/widgets/tests/test_style_dialog.py
+++ b/glue/qt/widgets/tests/test_style_dialog.py
@@ -1,0 +1,28 @@
+from ....external.qt.QtCore import QPoint
+from ....external.qt.QtGui import QMainWindow
+from ....core import Data
+
+from . import simple_session
+from ..style_dialog import StyleDialog
+
+
+class NonBlockingStyleDialog(StyleDialog):
+    def exec_(self, *args):
+        self.show()
+
+
+def test_style_dialog():
+
+    # This is in part a regression test for a bug in Python 3. It is not a
+    # full test of StyleDialog.
+
+    session = simple_session()
+    hub = session.hub
+    collect = session.data_collection
+
+    image = Data(label='im',
+                 x=[[1, 2], [3, 4]],
+                 y=[[2, 3], [4, 5]])
+
+    pos = QPoint(10, 10)
+    st = NonBlockingStyleDialog.dropdown_editor(image, pos)


### PR DESCRIPTION
@ChrisBeaumont - quick question, is what I am doing here the best way to make sure the style dialog becomes non-blocking when testing, or is there an easier way?