### PR TITLE
Workaround for non-working import in glue.qt.widgets.__init__.py

### DIFF
--- a/glue/config.py
+++ b/glue/config.py
@@ -222,9 +222,17 @@ class QtClientRegistry(Registry):
     def default_members(self):
         try:
             from .qt.widgets import default_widgets
+            # NOTE: necessary because somehow default_widgets does not
+            # include ginga even though the same import statement as
+            # below is done in .qt.widgets.__init__.py
+            try:
+                from .qt.widgets.ginga_widget import GingaWidget
+                default_widgets.append(GingaWidget)
+            except ImportError as e:
+                pass
             from .qt.custom_viewer import CUSTOM_WIDGETS
             return default_widgets + CUSTOM_WIDGETS
-        except ImportError:
+        except ImportError as e:
             logging.getLogger(__name__).warning(
                 "could not import glue.qt in ConfigObject")
             return []


### PR DESCRIPTION
- glue.config imports default_widgets from glue.qt.widgets, but
  this fails to import ginga correctly, even though later imports
  (from other modules) of default_widgets correctly imports ginga.
  Therefore the Ginga viewer doesn't show up in the list of possible
  viewers.  This workaround in config fixes the issue.