### PR TITLE
Generalize data sources/importers

### DIFF
--- a/doc/python_guide/customization.rst
+++ b/doc/python_guide/customization.rst
@@ -113,6 +113,31 @@ this file to your function, and use the resulting Data object.
 For more examples of custom data loaders, see the `example repository
 <https://github.com/glue-viz/glue-data-loaders>`_.
 
+Custom importers
+----------------
+
+The `Custom Data Loaders`_ described above allow Glue to recognize more file
+formats than originally implemented, but it is also possible to write entire
+new ways of importing data, including new GUI dialogs. An example would be a
+dialog that allows the user to query and download online data.
+
+Currently, an importer should be defined as a function that returns a list of
+:class:`~glue.core.data.Data` objects. In future we may relax this latter
+requirement and allow existing tools in Glue to interpret the data.
+
+An importer can be defined using the ``@importer`` decorator::
+
+    from glue.config import importer
+    from glue.core import Data
+
+    @importer("Import from custom source")
+    def my_importer():
+        # Main code here
+        return [Data(...), Data(...)]
+
+The label in the ``@importer`` decorator is the text that will appear in the
+``Import`` menu in Glue.
+
 Custom Colormaps
 ----------------
 

--- a/glue/config.py
+++ b/glue/config.py
@@ -15,7 +15,7 @@ __all__ = ['Registry', 'SettingRegistry', 'ExporterRegistry',
            'SingleSubsetLayerActionRegistry', 'ProfileFitterRegistry',
            'qt_client', 'data_factory', 'link_function', 'link_helper',
            'colormaps', 'exporters', 'settings', 'fit_plugin',
-           'auto_refresh', 'importers']
+           'auto_refresh', 'importer']
 
 
 class Registry(object):
@@ -132,6 +132,12 @@ class DataImportRegistry(Registry):
         :type importer: function()
         """
         self.members.append((label, importer))
+
+    def __call__(self, label):
+        def adder(func):
+            self.add(label, func)
+            return func
+        return adder
 
 
 class ExporterRegistry(Registry):
@@ -433,7 +439,7 @@ data_factory = DataFactoryRegistry()
 link_function = LinkFunctionRegistry()
 link_helper = LinkHelperRegistry()
 colormaps = ColormapRegistry()
-importers = DataImportRegistry()
+importer = DataImportRegistry()
 exporters = ExporterRegistry()
 settings = SettingRegistry()
 fit_plugin = ProfileFitterRegistry()

--- a/glue/config.py
+++ b/glue/config.py
@@ -14,7 +14,8 @@ __all__ = ['Registry', 'SettingRegistry', 'ExporterRegistry',
            'LinkFunctionRegistry', 'LinkHelperRegistry', 'QtToolRegistry',
            'SingleSubsetLayerActionRegistry', 'ProfileFitterRegistry',
            'qt_client', 'data_factory', 'link_function', 'link_helper',
-           'colormaps', 'exporters', 'settings', 'fit_plugin', 'auto_refresh']
+           'colormaps', 'exporters', 'settings', 'fit_plugin',
+           'auto_refresh', 'importers']
 
 
 class Registry(object):
@@ -107,6 +108,30 @@ class SettingRegistry(Registry):
     def default_members(self):
         import glue.plugins  # plugins will populate this registry
         return []
+
+
+class DataImportRegistry(Registry):
+    """
+    Stores functions which can import data.
+
+    The members property is a list of importers, each represented as a
+    ``(label, load_function)`` tuple. The ``load_function`` should take no
+    arguments and return a :class:`~glue.core.data.Data` object.
+    """
+
+    def default_members(self):
+        return []
+
+    def add(self, label, importer):
+        """
+        Add a new importer
+        :param label: Short label for the importer
+        :type label: str
+
+        :param importer: importer function
+        :type importer: function()
+        """
+        self.members.append((label, importer))
 
 
 class ExporterRegistry(Registry):
@@ -408,6 +433,7 @@ data_factory = DataFactoryRegistry()
 link_function = LinkFunctionRegistry()
 link_helper = LinkHelperRegistry()
 colormaps = ColormapRegistry()
+importers = DataImportRegistry()
 exporters = ExporterRegistry()
 settings = SettingRegistry()
 fit_plugin = ProfileFitterRegistry()

--- a/glue/config.py
+++ b/glue/config.py
@@ -116,7 +116,7 @@ class DataImportRegistry(Registry):
 
     The members property is a list of importers, each represented as a
     ``(label, load_function)`` tuple. The ``load_function`` should take no
-    arguments and return a :class:`~glue.core.data.Data` object.
+    arguments and return a list of :class:`~glue.core.data.Data` objects.
     """
 
     def default_members(self):

--- a/glue/qt/glue_application.py
+++ b/glue/qt/glue_application.py
@@ -525,24 +525,23 @@ class GlueApplication(Application, QMainWindow):
         self._actions['session_save'] = a
 
         from glue.config import importers
-        if len(importers) > 0:
 
-            acts = []
+        acts = []
 
-            # Add default file loader (later we can add this to the registry)
-            a = act("Load from file", self, tip="Load from file", shortcut=QKeySequence.Open)
+        # Add default file loader (later we can add this to the registry)
+        a = act("Load from file", self, tip="Load from file", shortcut=QKeySequence.Open)
+        a.triggered.connect(nonpartial(self._choose_load_data,
+                                       data_wizard))
+        acts.append(a)
+
+        for i in importers:
+            label, data_importer = i
+            a = act(label, self, tip=label)
             a.triggered.connect(nonpartial(self._choose_load_data,
-                                           data_wizard))
+                                           data_importer))
             acts.append(a)
 
-            for i in importers:
-                label, data_importer = i
-                a = act(label, self, tip=label)
-                a.triggered.connect(nonpartial(self._choose_load_data,
-                                               data_importer))
-                acts.append(a)
-
-            self._actions['data_importers'] = acts
+        self._actions['data_importers'] = acts
 
 
         from glue.config import exporters

--- a/glue/qt/glue_application.py
+++ b/glue/qt/glue_application.py
@@ -406,9 +406,8 @@ class GlueApplication(Application, QMainWindow):
         menu = QMenu(mbar)
         menu.setTitle("&File")
 
-        menu.addAction(self._actions['data_new'])
         if 'data_importers' in self._actions:
-            submenu = menu.addMenu("I&mport")
+            submenu = menu.addMenu("I&mport data")
             for a in self._actions['data_importers']:
                 submenu.addAction(a)
         # menu.addAction(self._actions['data_save'])  # XXX add this
@@ -495,12 +494,6 @@ class GlueApplication(Application, QMainWindow):
         """ Create and connect actions, store in _actions dict """
         self._actions = {}
 
-        a = act("&Open Data Set", self,
-                tip="Open a new data set",
-                shortcut=QKeySequence.Open)
-        a.triggered.connect(nonpartial(self._choose_load_data))
-        self._actions['data_new'] = a
-
         a = act("&New Data Viewer", self,
                 tip="Open a new visualization window in the current tab",
                 shortcut=QKeySequence.New
@@ -537,7 +530,7 @@ class GlueApplication(Application, QMainWindow):
             acts = []
 
             # Add default file loader (later we can add this to the registry)
-            a = act("Load from file", self, tip="Load from file")
+            a = act("Load from file", self, tip="Load from file", shortcut=QKeySequence.Open)
             a.triggered.connect(nonpartial(self._choose_load_data,
                                            data_wizard))
             acts.append(a)

--- a/glue/qt/glue_application.py
+++ b/glue/qt/glue_application.py
@@ -524,7 +524,7 @@ class GlueApplication(Application, QMainWindow):
         a.triggered.connect(nonpartial(self._choose_save_session))
         self._actions['session_save'] = a
 
-        from glue.config import importers
+        from glue.config import importer
 
         acts = []
 
@@ -534,7 +534,7 @@ class GlueApplication(Application, QMainWindow):
                                        data_wizard))
         acts.append(a)
 
-        for i in importers:
+        for i in importer:
             label, data_importer = i
             a = act(label, self, tip=label)
             a.triggered.connect(nonpartial(self._choose_load_data,

--- a/glue/qt/glue_application.py
+++ b/glue/qt/glue_application.py
@@ -406,6 +406,7 @@ class GlueApplication(Application, QMainWindow):
         menu = QMenu(mbar)
         menu.setTitle("&File")
 
+        menu.addAction(self._actions['data_new'])
         if 'data_importers' in self._actions:
             submenu = menu.addMenu("I&mport data")
             for a in self._actions['data_importers']:
@@ -524,12 +525,21 @@ class GlueApplication(Application, QMainWindow):
         a.triggered.connect(nonpartial(self._choose_save_session))
         self._actions['session_save'] = a
 
+        # Add file loader as first item in File menu for convenience. We then
+        # also add it again below in the Import menu for consistency.
+        a = act("&Open Data Set", self, tip="Open a new data set",
+                shortcut=QKeySequence.Open)
+        a.triggered.connect(nonpartial(self._choose_load_data,
+                                       data_wizard))
+        self._actions['data_new'] = a
+
+        # We now populate the "Import data" menu
         from glue.config import importer
 
         acts = []
 
         # Add default file loader (later we can add this to the registry)
-        a = act("Load from file", self, tip="Load from file", shortcut=QKeySequence.Open)
+        a = act("Import from file", self, tip="Import from file")
         a.triggered.connect(nonpartial(self._choose_load_data,
                                        data_wizard))
         acts.append(a)
@@ -542,7 +552,6 @@ class GlueApplication(Application, QMainWindow):
             acts.append(a)
 
         self._actions['data_importers'] = acts
-
 
         from glue.config import exporters
         if len(exporters) > 0:


### PR DESCRIPTION
In the same way that we can have plug-in exporters, it would be nice to have plug-in imports that can bring up different or additional dialogs. Examples include:

* An additional dialog for e.g. FITS files which can allow one to select the HDU
* A dialog instead of the 'open file' which could get data from online sources (e.g. dataverse, Vizier, etc)

This would open up all kinds of new fun ways to bring data into glue. All these could be developed as plugins of course, and wouldn't clutter up the main code base.