### PR TITLE
Parse HDUList objects from qglue

### DIFF
--- a/glue/core/io.py
+++ b/glue/core/io.py
@@ -1,18 +1,21 @@
 from __future__ import absolute_import, division, print_function
 
 
-def extract_data_fits(filename, use_hdu='all'):
-    '''
-    Extract non-tabular HDUs from a FITS file. If `use_hdu` is 'all', then
-    all non-tabular HDUs are extracted, otherwise only the ones specified
-    by `use_hdu` are extracted (`use_hdu` should then contain a list of
-    integers). If the requested HDUs do not have the same dimensions, an
-    Exception is raised.
-    '''
-    from ..external.astro import fits
+def filter_hdulist_by_shape(hdulist, use_hdu='all'):
+    """
+    Remove empty HDUs, and ensure that all HDUs can be
+    packed into a single Data object (ie have the same shape)
 
-    # Read in all HDUs
-    hdulist = fits.open(filename, ignore_blank=True)
+    Parameters
+    ----------
+    use_hdu : 'all' or list of integers (optional)
+        Which HDUs to use
+
+    Returns
+    -------
+    a new HDUList
+    """
+    from ..external.astro import fits
 
     # If only a subset are requested, extract those
     if use_hdu != 'all':
@@ -29,6 +32,23 @@ def extract_data_fits(filename, use_hdu='all'):
     for hdu in hdulist:
         if hdu.data.shape != reference_shape:
             raise Exception("HDUs are not all the same dimensions")
+
+    return hdulist
+
+
+def extract_data_fits(filename, use_hdu='all'):
+    '''
+    Extract non-tabular HDUs from a FITS file. If `use_hdu` is 'all', then
+    all non-tabular HDUs are extracted, otherwise only the ones specified
+    by `use_hdu` are extracted (`use_hdu` should then contain a list of
+    integers). If the requested HDUs do not have the same dimensions, an
+    Exception is raised.
+    '''
+    from ..external.astro import fits
+
+    # Read in all HDUs
+    hdulist = fits.open(filename, ignore_blank=True)
+    hdulist = filter_hdulist_by_shape(hdulist)
 
     # Extract data
     arrays = {}

--- a/glue/tests/test_qglue.py
+++ b/glue/tests/test_qglue.py
@@ -21,6 +21,7 @@ class TestQGlue(object):
     def setup_method(self, method):
 
         from astropy.table import Table
+        from astropy.io.fits import HDUList, ImageHDU
 
         Registry().clear()
 
@@ -36,6 +37,7 @@ class TestQGlue(object):
                                           dtype=[(str('a'), int), (str('b'), int)])
         self.astropy_table = Table({'x': x, 'y': y})
         self.bad_data = {'x': x, 'u': u}
+        self.hdulist = HDUList([ImageHDU(x, name='PRIMARY')])
 
         self.x = np.array(x)
         self.y = np.array(y)
@@ -97,6 +99,10 @@ class TestQGlue(object):
         dc = qglue(data1=self.dict_data, data2=self.xy).data_collection
         self.check_setup(dc, {'data1': ['u', 'v'],
                               'data2': ['x', 'y']})
+
+    def test_hdulist(self):
+        dc = qglue(data1=self.hdulist).data_collection
+        self.check_setup(dc, {'data1': ['PRIMARY']})
 
     def test_glue_data(self):
         d = Data(x=[1, 2, 3])


### PR DESCRIPTION
Closes #532. This allows users to pass HDUList objects into qglue, which will be packed into data objects (with WCS-parsed coordinate information). This also allows data factories to return HDUList objects, since they are parsed using the same logic.