### PR TITLE
Re-factoring Categorical ROI

### DIFF
--- a/glue/clients/histogram_client.py
+++ b/glue/clients/histogram_client.py
@@ -379,17 +379,19 @@ class HistogramClient(Client):
             lo = 10 ** lo
             hi = 10 ** hi
 
-        comp = self._get_data_components('x').next()
-        if comp.categorical:
-            state = CategoricalRoiSubsetState.from_range(comp, self.component,
-                                                         lo, hi)
-        else:
-            state = RangeSubsetState(lo, hi)
-            state.att = self.component
-        mode = EditSubsetMode()
-        visible = [d for d in self.data if self.is_layer_visible(d)]
-        focus = visible[0] if len(visible) > 0 else None
-        mode.update(self.data, state, focus_data=focus)
+        comp = list(self._get_data_components('x'))
+        if comp:
+            comp = comp[0]
+            if comp.categorical:
+                state = CategoricalRoiSubsetState.from_range(comp, self.component,
+                                                             lo, hi)
+            else:
+                state = RangeSubsetState(lo, hi)
+                state.att = self.component
+            mode = EditSubsetMode()
+            visible = [d for d in self.data if self.is_layer_visible(d)]
+            focus = visible[0] if len(visible) > 0 else None
+            mode.update(self.data, state, focus_data=focus)
 
     def register_to_hub(self, hub):
         dfilter = lambda x: x.sender.data in self._artists

--- a/glue/clients/histogram_client.py
+++ b/glue/clients/histogram_client.py
@@ -5,7 +5,7 @@ import numpy as np
 from ..core.client import Client
 from ..core import message as msg
 from ..core.data import Data, CategoricalComponent
-from ..core.subset import RangeSubsetState
+from ..core.subset import RangeSubsetState, CategoricalRoiSubsetState
 from ..core.exceptions import IncompatibleDataException, IncompatibleAttribute
 from ..core.edit_subset_mode import EditSubsetMode
 from .layer_artist import HistogramLayerArtist, LayerArtistContainer
@@ -379,8 +379,13 @@ class HistogramClient(Client):
             lo = 10 ** lo
             hi = 10 ** hi
 
-        state = RangeSubsetState(lo, hi)
-        state.att = self.component
+        comp = self._get_data_components('x').next()
+        if comp.categorical:
+            state = CategoricalRoiSubsetState.from_range(comp, self.component,
+                                                         lo, hi)
+        else:
+            state = RangeSubsetState(lo, hi)
+            state.att = self.component
         mode = EditSubsetMode()
         visible = [d for d in self.data if self.is_layer_visible(d)]
         focus = visible[0] if len(visible) > 0 else None

--- a/glue/clients/scatter_client.py
+++ b/glue/clients/scatter_client.py
@@ -258,18 +258,24 @@ class ScatterClient(Client):
         if isinstance(roi, RectangularROI):
 
             lo, hi = roi.xmin, roi.xmax
-            xcomp = self._get_data_components('x').next()
-            if self._check_categorical(self.xatt):
-                x_subset = CategoricalRoiSubsetState.from_range(xcomp, self.xatt, lo, hi)
+            xcomp = list(self._get_data_components('x'))
+            if xcomp:
+                if self._check_categorical(self.xatt):
+                    x_subset = CategoricalRoiSubsetState.from_range(xcomp[0], self.xatt, lo, hi)
+                else:
+                    x_subset = RangeSubsetState(lo, hi, self.xatt)
             else:
-                x_subset = RangeSubsetState(lo, hi, self.xatt)
+                x_subset = None
 
             lo, hi = roi.ymin, roi.ymax
-            ycomp = self._get_data_components('y').next()
-            if self._check_categorical(self.yatt):
-                y_subset = CategoricalRoiSubsetState.from_range(ycomp, self.yatt, lo, hi)
+            ycomp = list(self._get_data_components('y'))
+            if ycomp:
+                if self._check_categorical(self.yatt):
+                    y_subset = CategoricalRoiSubsetState.from_range(ycomp[0], self.yatt, lo, hi)
+                else:
+                    y_subset = RangeSubsetState(lo, hi, self.yatt)
             else:
-                y_subset = RangeSubsetState(lo, hi, self.yatt)
+                y_subset = None
         else:
             raise AssertionError
 
@@ -283,8 +289,11 @@ class ScatterClient(Client):
             lo, hi = roi.range()
             att = self.xatt if roi.ori == 'x' else self.yatt
             if self._check_categorical(att):
-                comp = self._get_data_components(roi.ori).next()
-                subset_state = CategoricalRoiSubsetState.from_range(comp, att, lo, hi)
+                comp = list(self._get_data_components(roi.ori))
+                if comp:
+                    subset_state = CategoricalRoiSubsetState.from_range(comp[0], att, lo, hi)
+                else:
+                    subset_state = None
             else:
                 subset_state = RangeSubsetState(lo, hi, att)
         else:

--- a/glue/clients/scatter_client.py
+++ b/glue/clients/scatter_client.py
@@ -256,30 +256,22 @@ class ScatterClient(Client):
         """
 
         if isinstance(roi, RectangularROI):
-
-            lo, hi = roi.xmin, roi.xmax
-            xcomp = list(self._get_data_components('x'))
-            if xcomp:
-                if self._check_categorical(self.xatt):
-                    x_subset = CategoricalRoiSubsetState.from_range(xcomp[0], self.xatt, lo, hi)
+            subsets = []
+            axes = [('x', roi.xmin, roi.xmax),
+                    ('y', roi.ymin, roi.ymax)]
+            for coord, lo, hi in axes:
+                comp = list(self._get_data_components(coord))
+                if comp:
+                    if comp[0].categorical:
+                        subset = CategoricalRoiSubsetState.from_range(comp[0], self.xatt, lo, hi)
+                    else:
+                        subset = RangeSubsetState(lo, hi, self.xatt)
                 else:
-                    x_subset = RangeSubsetState(lo, hi, self.xatt)
-            else:
-                x_subset = None
-
-            lo, hi = roi.ymin, roi.ymax
-            ycomp = list(self._get_data_components('y'))
-            if ycomp:
-                if self._check_categorical(self.yatt):
-                    y_subset = CategoricalRoiSubsetState.from_range(ycomp[0], self.yatt, lo, hi)
-                else:
-                    y_subset = RangeSubsetState(lo, hi, self.yatt)
-            else:
-                y_subset = None
+                    subset = None
+                subsets.append(subset)
         else:
             raise AssertionError
-
-        return AndState(x_subset, y_subset)
+        return AndState(*subsets)
 
     def apply_roi(self, roi):
         # every editable subset is updated

--- a/glue/clients/tests/test_scatter_client.py
+++ b/glue/clients/tests/test_scatter_client.py
@@ -677,6 +677,36 @@ class TestCategoricalScatterClient(TestScatterClient):
         timer = timeit(timer_func, number=1)
         assert timer < 3  # this is set for Travis speed
 
+    def test_apply_roi(self):
+        data = self.add_data_and_attributes()
+        roi = core.roi.RectangularROI()
+        roi.update_limits(*self.roi_limits)
+        x, y = self.roi_points
+        self.client.apply_roi(roi)
+
+    def test_range_rois_preserved(self):
+        data = self.add_data_and_attributes()
+        assert self.client.xatt is not self.client.yatt
+
+        roi = core.roi.XRangeROI()
+        roi.set_range(1, 2)
+        self.client.apply_roi(roi)
+        assert isinstance(data.edit_subset.subset_state,
+                          core.subset.CategoricalRoiSubsetState)
+        assert data.edit_subset.subset_state.att == self.client.xatt
+
+        roi = core.roi.YRangeROI()
+        roi.set_range(1, 2)
+        self.client.apply_roi(roi)
+        assert isinstance(data.edit_subset.subset_state,
+                          core.subset.RangeSubsetState)
+        assert data.edit_subset.subset_state.att == self.client.yatt
+        roi = core.roi.RectangularROI(xmin=1, xmax=2, ymin=1, ymax=2)
+
+        self.client.apply_roi(roi)
+        assert isinstance(data.edit_subset.subset_state,
+                          core.subset.AndState)
+
     # REMOVED TESTS
     def test_invalid_plot(self):
         """ This fails because the axis ticks shouldn't reset after

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -217,6 +217,13 @@ class Component(object):
         """
         return np.can_cast(self.data[0], np.complex)
 
+    @property
+    def categorical(self):
+        """
+        Whether or not the datatype is categorical
+        """
+        return False
+
     def __str__(self):
         return "Component with shape %s" % shape_to_string(self.shape)
 
@@ -388,6 +395,10 @@ class CategoricalComponent(Component):
             self._update_categories()
         else:
             self._update_data()
+
+    @property
+    def categorical(self):
+        return True
 
     def _update_categories(self, categories=None):
         """

--- a/glue/core/roi.py
+++ b/glue/core/roi.py
@@ -1106,12 +1106,8 @@ class MplPathROI(MplPolygonalROI):
 
 class CategoricalRoi(Roi):
 
-    def __init__(self, orientation=None, categories=None):
+    def __init__(self, categories=None):
         self.categories = np.unique(categories)
-        if orientation not in ['x', 'y', None]:
-            raise TypeError("Orientation must be one of 'x', 'y'")
-
-        self.orientation = orientation
 
     def _categorical_helper(self, indata):
         """
@@ -1131,11 +1127,7 @@ class CategoricalRoi(Roi):
 
     def contains(self, x, y):
 
-        if self.orientation == 'x':
-            check = self._categorical_helper(x)
-        else:
-            check = self._categorical_helper(y)
-
+        check = self._categorical_helper(x)
         index = np.minimum(np.searchsorted(self.categories, check),
                            len(self.categories)-1)
         return self.categories[index] == check
@@ -1146,10 +1138,7 @@ class CategoricalRoi(Roi):
 
     def defined(self):
         """ Returns True if the ROI is defined """
-        return self.categories is not None and \
-            self.orientation is not None
+        return self.categories is not None
 
     def reset(self):
-
-        self.orientation = None
         self.categories = None

--- a/glue/core/roi.py
+++ b/glue/core/roi.py
@@ -1142,3 +1142,19 @@ class CategoricalRoi(Roi):
 
     def reset(self):
         self.categories = None
+
+    @staticmethod
+    def from_range(cat_comp, lo, hi):
+        """
+        Utility function to help contruct the Roi from a range.
+
+        :param cat_comp: Anything understood by ._categorical_helper ... array, list or component
+        :param lo: lower bound of the range
+        :param hi: upper bound of the range
+        :return: CategoricalRoi object
+        """
+
+        roi = CategoricalRoi()
+        cat_data = cat_comp._categories
+        roi.update_categories(cat_data[np.floor(lo):np.ceil(hi)])
+        return roi

--- a/glue/core/roi.py
+++ b/glue/core/roi.py
@@ -1111,7 +1111,10 @@ class CategoricalRoi(Roi):
     """
 
     def __init__(self, categories=None):
-        self.categories = np.unique(categories)
+        if categories is None:
+            self.categories = None
+        else:
+            self.update_categories(categories)
 
     def _categorical_helper(self, indata):
         """

--- a/glue/core/roi.py
+++ b/glue/core/roi.py
@@ -1106,6 +1106,10 @@ class MplPathROI(MplPolygonalROI):
 
 class CategoricalRoi(Roi):
 
+    """
+    A ROI abstraction to represent selections of categorical data.
+    """
+
     def __init__(self, categories=None):
         self.categories = np.unique(categories)
 
@@ -1126,6 +1130,20 @@ class CategoricalRoi(Roi):
             return np.asarray(indata)
 
     def contains(self, x, y):
+        """
+        Test whether a set categorical elements fall within
+        the region of interest
+
+        :param x: Any array-like object of categories
+                 (includes CategoricalComponenets)
+        :param y: Unused but required for compatibility
+
+        *Returns*
+
+           A list of True/False values, for whether each x value falls
+           within the ROI
+
+        """
 
         check = self._categorical_helper(x)
         index = np.minimum(np.searchsorted(self.categories, check),
@@ -1146,7 +1164,7 @@ class CategoricalRoi(Roi):
     @staticmethod
     def from_range(cat_comp, lo, hi):
         """
-        Utility function to help contruct the Roi from a range.
+        Utility function to help construct the Roi from a range.
 
         :param cat_comp: Anything understood by ._categorical_helper ... array, list or component
         :param lo: lower bound of the range

--- a/glue/core/subset.py
+++ b/glue/core/subset.py
@@ -14,6 +14,7 @@ from .util import split_component_view
 from ..utils import view_shape
 from ..external.six import PY3
 from .contracts import contract
+from .roi import CategoricalRoi
 
 __all__ = ['Subset', 'SubsetState', 'RoiSubsetState', 'CompositeSubsetState',
            'OrState', 'AndState', 'XorState', 'InvertState',
@@ -460,10 +461,10 @@ class CategoricalRoiSubsetState(SubsetState):
     @memoize
     @contract(data='isinstance(Data)', view='array_view')
     def to_mask(self, data, view=None):
-        x = data[self.att, view]
+        x = data.get_component(self.att)._categorical_data[view]
         result = self.roi.contains(x, None)
         assert x.shape == result.shape
-        return result
+        return result.ravel()
 
     def copy(self):
         result = CategoricalRoiSubsetState()
@@ -471,6 +472,13 @@ class CategoricalRoiSubsetState(SubsetState):
         result.roi = self.roi
         return result
 
+    @staticmethod
+    def from_range(component, att, lo, hi):
+
+        roi = CategoricalRoi.from_range(component, lo, hi)
+        subset = CategoricalRoiSubsetState(roi=roi,
+                                           att=att)
+        return subset
 
 
 class RangeSubsetState(SubsetState):

--- a/glue/core/subset.py
+++ b/glue/core/subset.py
@@ -446,6 +446,33 @@ class RoiSubsetState(SubsetState):
         return result
 
 
+class CategoricalRoiSubsetState(SubsetState):
+
+    def __init__(self, att=None, roi=None):
+        super(CategoricalRoiSubsetState, self).__init__()
+        self.att = att
+        self.roi = roi
+
+    @property
+    def attributes(self):
+        return self.att,
+
+    @memoize
+    @contract(data='isinstance(Data)', view='array_view')
+    def to_mask(self, data, view=None):
+        x = data[self.att, view]
+        result = self.roi.contains(x, None)
+        assert x.shape == result.shape
+        return result
+
+    def copy(self):
+        result = CategoricalRoiSubsetState()
+        result.att = self.att
+        result.roi = self.roi
+        return result
+
+
+
 class RangeSubsetState(SubsetState):
 
     def __init__(self, lo, hi, att=None):

--- a/glue/core/tests/test_roi.py
+++ b/glue/core/tests/test_roi.py
@@ -7,10 +7,10 @@ import pytest
 import numpy as np
 from numpy.testing import assert_almost_equal
 from matplotlib.figure import Figure
+from glue.core.data import CategoricalComponent
 from mock import MagicMock
 
-from ..roi import (RectangularROI, UndefinedROI, CircularROI, PolygonalROI,
-                   PointROI, MplPickROI,
+from ..roi import (RectangularROI, UndefinedROI, CircularROI, PolygonalROI, CategoricalRoi,
                    MplCircularROI, MplRectangularROI, MplPolygonalROI,
                    XRangeROI, MplXRangeROI, YRangeROI, MplYRangeROI)
 
@@ -339,6 +339,39 @@ class TestPolygon(object):
     def test_str(self):
         """ __str__ returns a string """
         assert type(str(self.roi)) == str
+
+
+class TestCategorical(object):
+
+    def setup_method(self, method):
+        self.roi = CategoricalRoi()
+
+    def test_defined(self):
+
+        assert not self.roi.defined()
+        nroi = CategoricalRoi(orientation='x',
+                              categories=['a', 'b', 'c'])
+        assert nroi.defined()
+        nroi.reset()
+        assert not nroi.defined()
+
+    def test_loads_from_components(self):
+
+        comp = CategoricalComponent(np.array(['a', 'a', 'b']))
+        self.roi.update_categories(comp)
+
+        np.testing.assert_array_equal(self.roi.categories,
+                                      np.array(['a', 'b']))
+
+    def test_applies_components(self):
+
+        comp = CategoricalComponent(np.array(['a', 'b', 'c']))
+        self.roi.update_categories(CategoricalComponent(np.array(['a', 'b'])))
+        self.roi.orientation = 'x'
+        contained = self.roi.contains(comp, None)
+        np.testing.assert_array_equal(contained,
+                                      np.array([True, True, False]))
+
 
     def test_move(self):
         """Move polygon"""

--- a/glue/core/tests/test_roi.py
+++ b/glue/core/tests/test_roi.py
@@ -348,9 +348,7 @@ class TestCategorical(object):
 
     def test_defined(self):
 
-        assert not self.roi.defined()
-        nroi = CategoricalRoi(orientation='x',
-                              categories=['a', 'b', 'c'])
+        nroi = CategoricalRoi(categories=['a', 'b', 'c'])
         assert nroi.defined()
         nroi.reset()
         assert not nroi.defined()
@@ -367,7 +365,6 @@ class TestCategorical(object):
 
         comp = CategoricalComponent(np.array(['a', 'b', 'c']))
         self.roi.update_categories(CategoricalComponent(np.array(['a', 'b'])))
-        self.roi.orientation = 'x'
         contained = self.roi.contains(comp, None)
         np.testing.assert_array_equal(contained,
                                       np.array([True, True, False]))

--- a/glue/core/tests/test_roi.py
+++ b/glue/core/tests/test_roi.py
@@ -11,7 +11,7 @@ from glue.core.data import CategoricalComponent
 from mock import MagicMock
 
 from ..roi import (RectangularROI, UndefinedROI, CircularROI, PolygonalROI, CategoricalRoi,
-                   MplCircularROI, MplRectangularROI, MplPolygonalROI,
+                   MplCircularROI, MplRectangularROI, MplPolygonalROI, MplPickROI, PointROI,
                    XRangeROI, MplXRangeROI, YRangeROI, MplYRangeROI)
 
 from .. import roi as r
@@ -377,17 +377,6 @@ class TestCategorical(object):
         np.testing.assert_array_equal(roi.categories,
                                       np.array(list('ghij')))
 
-
-    def test_move(self):
-        """Move polygon"""
-        self.define_as_square()
-        vx = list(self.roi.vx)
-        vy = list(self.roi.vy)
-        self.roi.move_to(1, 1)
-        assert type(self.roi.vx) == list
-        assert type(self.roi.vy) == list
-        assert self.roi.vx[0] - vx[0] == 1
-        assert self.roi.vy[0] - vy[0] == 1
 
 
 class DummyEvent(object):

--- a/glue/core/tests/test_roi.py
+++ b/glue/core/tests/test_roi.py
@@ -369,6 +369,14 @@ class TestCategorical(object):
         np.testing.assert_array_equal(contained,
                                       np.array([True, True, False]))
 
+    def test_from_range(self):
+
+        comp = CategoricalComponent(np.array(list('abcdefghijklmnopqrstuvwxyz')*2))
+
+        roi = CategoricalRoi.from_range(comp, 6, 10)
+        np.testing.assert_array_equal(roi.categories,
+                                      np.array(list('ghij')))
+
 
     def test_move(self):
         """Move polygon"""

--- a/glue/core/tests/test_roi.py
+++ b/glue/core/tests/test_roi.py
@@ -343,8 +343,10 @@ class TestPolygon(object):
 
 class TestCategorical(object):
 
-    def setup_method(self, method):
-        self.roi = CategoricalRoi()
+    def test_empty(self):
+
+        roi = CategoricalRoi()
+        assert not roi.defined()
 
     def test_defined(self):
 
@@ -355,17 +357,24 @@ class TestCategorical(object):
 
     def test_loads_from_components(self):
 
+        roi = CategoricalRoi()
         comp = CategoricalComponent(np.array(['a', 'a', 'b']))
-        self.roi.update_categories(comp)
+        roi.update_categories(comp)
 
-        np.testing.assert_array_equal(self.roi.categories,
+        np.testing.assert_array_equal(roi.categories,
                                       np.array(['a', 'b']))
+
+        roi = CategoricalRoi(categories=comp)
+        np.testing.assert_array_equal(roi.categories,
+                                      np.array(['a', 'b']))
+
 
     def test_applies_components(self):
 
+        roi = CategoricalRoi()
         comp = CategoricalComponent(np.array(['a', 'b', 'c']))
-        self.roi.update_categories(CategoricalComponent(np.array(['a', 'b'])))
-        contained = self.roi.contains(comp, None)
+        roi.update_categories(CategoricalComponent(np.array(['a', 'b'])))
+        contained = roi.contains(comp, None)
         np.testing.assert_array_equal(contained,
                                       np.array([True, True, False]))
 


### PR DESCRIPTION
As part of the effort @aak65 is doing implementing some Bio-glue features he's going to need a more robust ability to pass around ROIs and subsets that are based on categorical data in a way that's more robust then my approach before ... which was basically convert everything to numbers and hope it all worked out.

This has all of the backings for the new ROI/Subset but I can't quite figure out where to fold it into the Historgram & Scatter viewers. My ideal situation would be after the user uses a Range-selector on an axis defined by a categorical component it would adjust the returned ROI accordingly. Any ideas on where I would find that logic? @ChrisBeaumont  or @astrofrog

