### PR TITLE
Zoom to rectangle button is not updating

### DIFF
--- a/glue/qt/glue_application.py
+++ b/glue/qt/glue_application.py
@@ -43,10 +43,15 @@ def _fix_ipython_pylab():
     shell = get_ipython()
     if shell is None:
         return
+
+    from IPython.core.error import UsageError
+
     try:
         shell.enable_pylab('inline', import_all=True)
     except ValueError:
         # if the shell is a normal terminal shell, we get here
+        pass
+    except UsageError:
         pass
 
 


### PR DESCRIPTION
After using the zoom to rectangle button and letting go of the mouse button, my display doesn't update:

![image](https://cloud.githubusercontent.com/assets/796752/7185622/b2974c68-e418-11e4-9c2a-a61adf610b1a.png)

As soon as I pan around a bit to force a display refresh, the zoom region looks correct

![image](https://cloud.githubusercontent.com/assets/796752/7185637/c7a5503c-e418-11e4-9106-44fe53990463.png)

I suspect that we aren't properly calling ``figure.canvas.draw`` in this situation

@astrofrog can you reproduce?


Platform: darwin
Version: 2.7.9 |Anaconda 2.1.0 (x86_64)| (default, Dec 15 2014, 10:37:34) 
[GCC 4.2.1 (Apple Inc. build 5577)]
Qt Binding: PyQt4
Matplotlib version: 1.4.2
Numpy version: 1.9.1
AstroPy version: 0.4.2