### PR TITLE
WIP: Make Qt viewer widgets usable outside glue

### DIFF
--- a/glue/core/application_base.py
+++ b/glue/core/application_base.py
@@ -69,7 +69,7 @@ class Application(HubListener):
         if viewer_class is None:
             return
 
-        c = viewer_class(self._session)
+        c = viewer_class(session=self._session)
         c.register_to_hub(self._session.hub)
 
         if data and not c.add_data(data):
@@ -385,7 +385,7 @@ class ViewerBase(HubListener, PropertySetMixin):
     @classmethod
     def __setgluestate__(cls, rec, context):
         session = context.object(rec['session'])
-        result = cls(session)
+        result = cls(session=session)
         result.register_to_hub(session.hub)
         result.viewer_size = rec['size']
         x, y = rec['pos']

--- a/glue/plugins/ginga_viewer/qt_widget.py
+++ b/glue/plugins/ginga_viewer/qt_widget.py
@@ -42,7 +42,7 @@ class GingaWidget(ImageWidgetBase):
 
     LABEL = "Ginga Viewer"
 
-    def __init__(self, session, parent=None):
+    def __init__(self, session=None, parent=None):
 
         self.logger = log.get_logger(name='ginga', log_stderr=True)
 
@@ -85,7 +85,7 @@ class GingaWidget(ImageWidgetBase):
         self.readout = Readout.Readout(-1, -1)
         self.roi_tag = None
 
-        super(GingaWidget, self).__init__(session, parent)
+        super(GingaWidget, self).__init__(session=session, parent=parent)
 
     @staticmethod
     def _get_default_tools():

--- a/glue/qt/custom_viewer.py
+++ b/glue/qt/custom_viewer.py
@@ -853,8 +853,8 @@ class CustomWidgetBase(DataViewer):
 
     coordinator_cls = None
 
-    def __init__(self, session, parent=None):
-        super(CustomWidgetBase, self).__init__(session, parent)
+    def __init__(self, session=None, parent=None):
+        super(CustomWidgetBase, self).__init__(session=session, parent=parent)
         self.central_widget = MplWidget()
         self.setCentralWidget(self.central_widget)
 

--- a/glue/qt/glue_application.py
+++ b/glue/qt/glue_application.py
@@ -26,7 +26,7 @@ from .qtutil import (pick_class, data_wizard,
 from .widgets.glue_mdi_area import GlueMdiArea, GlueMdiSubWindow
 from .widgets.edit_subset_mode_toolbar import EditSubsetModeToolBar
 from .widgets.layer_tree_widget import PlotAction, LayerTreeWidget
-from .widgets.data_viewer import DataViewer
+from .widgets.data_viewer import DataViewer, DataViewerMixin
 from .widgets.settings_editor import SettingsEditor
 from .widgets.mpl_widget import defer_draw
 from .feedback import submit_bug_report
@@ -347,7 +347,7 @@ class GlueApplication(Application, QMainWindow):
             return QWidget(), QWidget(), ""
 
         widget = sub_window.widget()
-        if not isinstance(widget, DataViewer):
+        if not isinstance(widget, (DataViewerMixin, DataViewer)):
             return QWidget(), QWidget(), ""
 
         return widget.layer_view(), widget.options_widget(), str(widget)

--- a/glue/qt/widgets/data_viewer.py
+++ b/glue/qt/widgets/data_viewer.py
@@ -30,7 +30,7 @@ class DataViewer(QMainWindow, ViewerBase):
     _container_cls = QtLayerArtistContainer
     LABEL = 'Override this'
 
-    def __init__(self, session, parent=None):
+    def __init__(self, session=None, parent=None):
         """
         :type session: :class:`~glue.core.Session`
         """

--- a/glue/qt/widgets/data_viewer.py
+++ b/glue/qt/widgets/data_viewer.py
@@ -15,26 +15,28 @@ from .. import get_qapp
 from ..mime import LAYERS_MIME_TYPE, LAYER_MIME_TYPE
 from .glue_mdi_area import GlueMdiSubWindow
 
-__all__ = ['DataViewer']
+__all__ = ['DataViewer', 'DataViewerMixin']
 
 
-class DataViewer(QMainWindow, ViewerBase):
+class DataViewerMixin(ViewerBase):
+    """
+    Mix-in class for all Qt DataViewer widgets.
 
-    """Base class for all Qt DataViewer widgets.
-
-    This defines a minimal interface, and implemlements the following::
+    This defines a minimal interface, and implements the following::
 
        * An automatic call to unregister on window close
        * Drag and drop support for adding data
     """
+
     _container_cls = QtLayerArtistContainer
     LABEL = 'Override this'
 
-    def __init__(self, session=None, parent=None):
+
+
+    def __init__(self, session=None):
         """
         :type session: :class:`~glue.core.Session`
         """
-        QMainWindow.__init__(self, parent)
         ViewerBase.__init__(self, session)
         self.setWindowIcon(get_qapp().windowIcon())
         self._view = LayerArtistView()
@@ -42,16 +44,18 @@ class DataViewer(QMainWindow, ViewerBase):
         self._tb_vis = {}  # store whether toolbars are enabled
         self.setAttribute(Qt.WA_DeleteOnClose)
         self.setAcceptDrops(True)
-        self.setAnimated(False)
         self._toolbars = []
         self._warn_close = True
         self.setContentsMargins(2, 2, 2, 2)
         self._mdi_wrapper = None  # GlueMdiSubWindow that self is embedded in
-        self.statusBar().setStyleSheet("QStatusBar{font-size:10px}")
 
         # close window when last plot layer deleted
         self._container.on_empty(lambda: self.close(warn=False))
         self._container.on_changed(self.update_window_title)
+
+        if isinstance(self, QMainWindow):
+            self.setAnimated(False)
+            self.statusBar().setStyleSheet("QStatusBar{font-size:10px}")
 
     def remove_layer(self, layer):
         self._container.pop(layer)
@@ -86,7 +90,7 @@ class DataViewer(QMainWindow, ViewerBase):
 
     def close(self, warn=True):
         self._warn_close = warn
-        super(DataViewer, self).close()
+        super(DataViewerMixin, self).close()
         self._warn_close = True
 
     def mdi_wrap(self):
@@ -153,7 +157,7 @@ class DataViewer(QMainWindow, ViewerBase):
 
         if self._hub is not None:
             self.unregister(self._hub)
-        super(DataViewer, self).closeEvent(event)
+        super(DataViewerMixin, self).closeEvent(event)
         event.accept()
 
     def _confirm_close(self):
@@ -189,7 +193,7 @@ class DataViewer(QMainWindow, ViewerBase):
         return QWidget()
 
     def addToolBar(self, tb):
-        super(DataViewer, self).addToolBar(tb)
+        super(DataViewerMixin, self).addToolBar(tb)
         self._toolbars.append(tb)
         self._tb_vis[tb] = True
 
@@ -247,3 +251,17 @@ class DataViewer(QMainWindow, ViewerBase):
 
     def update_window_title(self):
         self.setWindowTitle(self.window_title)
+
+
+class DataViewer(DataViewerMixin, QMainWindow):
+    """
+    Base class for all Qt DataViewer widgets.
+
+    This defines a minimal interface, and implements the following::
+
+       * An automatic call to unregister on window close
+       * Drag and drop support for adding data
+    """
+    def __init__(self, session=None, parent=None):
+        QMainWindow.__init__(self, parent=parent)
+        DataViewerMixin.__init__(self, session=session)

--- a/glue/qt/widgets/dendro_widget.py
+++ b/glue/qt/widgets/dendro_widget.py
@@ -28,8 +28,8 @@ class DendroWidget(DataViewer):
     parent = CurrentComboProperty('ui.parentCombo', 'parent attribute')
     order = CurrentComboProperty('ui.orderCombo', 'layout sorter attribute')
 
-    def __init__(self, session, parent=None):
-        super(DendroWidget, self).__init__(session, parent)
+    def __init__(self, session=None, parent=None):
+        super(DendroWidget, self).__init__(session=session, parent=parent)
 
         self.central_widget = MplWidget()
         self.option_widget = QtGui.QWidget()

--- a/glue/qt/widgets/histogram_widget.py
+++ b/glue/qt/widgets/histogram_widget.py
@@ -42,8 +42,8 @@ class HistogramWidget(DataViewer):
     xlog = ButtonProperty('ui.xlog_box', 'Log-scale the x axis?')
     ylog = ButtonProperty('ui.ylog_box', 'Log-scale the y axis?')
 
-    def __init__(self, session, parent=None):
-        super(HistogramWidget, self).__init__(session, parent)
+    def __init__(self, session=None, parent=None):
+        super(HistogramWidget, self).__init__(session=session, parent=parent)
 
         self.central_widget = MplWidget()
         self.setCentralWidget(self.central_widget)

--- a/glue/qt/widgets/image_widget.py
+++ b/glue/qt/widgets/image_widget.py
@@ -52,8 +52,8 @@ class ImageWidgetBase(DataViewer):
                               'RGB Mode?')
     rgb_viz = Pointer('ui.rgb_options.rgb_visible')
 
-    def __init__(self, session, parent=None):
-        super(ImageWidgetBase, self).__init__(session, parent)
+    def __init__(self, session=None, parent=None):
+        super(ImageWidgetBase, self).__init__(session=session, parent=parent)
         self._setup_widgets()
         self.client = self.make_client()
 

--- a/glue/qt/widgets/scatter_widget.py
+++ b/glue/qt/widgets/scatter_widget.py
@@ -46,8 +46,8 @@ class ScatterWidget(DataViewer):
     yatt = CurrentComboProperty('ui.yAxisComboBox',
                                 'Attribute to plot on y axis')
 
-    def __init__(self, session, parent=None):
-        super(ScatterWidget, self).__init__(session, parent)
+    def __init__(self, session=None, parent=None):
+        super(ScatterWidget, self).__init__(session=session, parent=parent)
         self.central_widget = MplWidget()
         self.option_widget = QtGui.QWidget()
 

--- a/glue/qt/widgets/table_widget.py
+++ b/glue/qt/widgets/table_widget.py
@@ -48,8 +48,8 @@ class DataTableModel(QAbstractTableModel):
 
 
 class TableWidget(DataViewer):
-    def __init__(self, session, parent=None):
-        super(TableWidget, self).__init__(session, parent)
+    def __init__(self, session=None, parent=None):
+        super(TableWidget, self).__init__(session=session, parent=parent)
         self.widget = QTableView()
         self.setCentralWidget(self.widget)
 


### PR DESCRIPTION
I have been trying to think of the cleanest way to make Qt viewer widgets usable outside glue as if they were a normal Qt widget, or conversely, making an existing Qt widget usable in glue. There are several things I think we can do to make this easier:

* At the moment Qt data viewers have a different function signature than normal Qt widgets, because they have a non-optional ``session`` parameter. This PR currently changes ``session`` to no longer be a required positional argument but a keyword argument. Note that this preserves backward compatibility because I left it as the first argument. This is a minor change, but I think it would be cleaner this way since it means that if a widget class is used outside glue we don't have to initialize it with ``(None, parent)``.

* Currently ``DataViewer`` inherits from ``QMainWindow`` and ``ViewerBase``. Now let's say that I have an existing ``QWidget`` class that I want to use in glue, call it ``MyWidget``. Let's say I can't modify the code for ``MyWidget`` code. What would be useful is to then be able to create a sub-class where we add the wrapping code necessary for glue:

```python
from somewhere import MyWidget

class MyGlueWidget(MyWidget)
    ...
```

However, the issue with that is that I can't re-use the stuff in ``DataViewer`` because ``DataViewer`` inherits from ``QMainWindow`` so I can't make ``MyGlueWidget`` inherit from ``DataViewer`` because ``MyGlueWidget`` already inherits from ``MyWidget`` which inherits from ``QWidget``.

For this reason, I would like to propose that we actually take a lot of the methods/properties from ``DataViewer`` and make them into a mix-in class that can work with both ``QMainWindow`` or ``QWidget`` (and subclasses). That way, we could do:

```python
class MyGlueWidget(MyWidget, DataViewerMixin):
    ...
```

and this will add all the conveniences that ``DataViewer`` adds. Of course, for now, we could still provide:

```python
class DataViewer(QMainWindow, DataViewerMixin):
    ...
```

for backward-compatibility in glue. We could even call the mix-in class ``GlueViewerMixin`` which highlights that it is making it glue-compatible.

Note that of course there are still some methods the user would have to define, so something like:

```python
class MyGlueViewer(QMainWindow, DataViewerMixin):
    LABEL = "Camembert Viewer"
    def add_data(self, data):
        ...
       return True
```

@ChrisBeaumont - what do you think? If you think this would make sense, I can make the changes and start writing up some docs on making QWidgets that can be used in and out of glue.