### PR TITLE
Bug in tab name when creating new tab

### DIFF
--- a/glue/qt/glue_application.py
+++ b/glue/qt/glue_application.py
@@ -194,6 +194,11 @@ class GlueApplication(Application, QMainWindow):
         self.tab_widget.setMovable(True)
         self.tab_widget.setTabsClosable(True)
 
+        # The following is a counter that never goes down, even if tabs are
+        # deleted (this is by design, to avoid having two tabs called the
+        # same if a tab is removed then a new one added again)
+        self._total_tab_count = 0
+
         lwidget = self._ui.layerWidget
         a = PlotAction(lwidget, self)
         lwidget.layerTree.addAction(a)
@@ -268,7 +273,8 @@ class GlueApplication(Application, QMainWindow):
         widget = GlueMdiArea(self)
         widget.setLayout(layout)
         tab = self.tab_widget
-        tab.addTab(widget, str("Tab %i" % (tab.count() + 1)))
+        self._total_tab_count += 1
+        tab.addTab(widget, str("Tab %i" % self._total_tab_count))
         tab.setCurrentWidget(widget)
         widget.subWindowActivated.connect(self._update_plot_dashboard)
 

--- a/glue/qt/tests/test_application.py
+++ b/glue/qt/tests/test_application.py
@@ -124,14 +124,27 @@ class TestGlueApplication(object):
         assert term.hide.call_count == 1
 
     def test_close_tab(self):
+
         assert self.app.tab_widget.count() == 1
+        assert self.app.tab_bar.tabText(0) == 'Tab 1'
+
         self.app.new_tab()
         assert self.app.tab_widget.count() == 2
+        assert self.app.tab_bar.tabText(0) == 'Tab 1'
+        assert self.app.tab_bar.tabText(1) == 'Tab 2'
+
         self.app.close_tab(0)
         assert self.app.tab_widget.count() == 1
+        assert self.app.tab_bar.tabText(0) == 'Tab 2'
+
         # do not delete last tab
         self.app.close_tab(0)
         assert self.app.tab_widget.count() == 1
+
+        # check that counter always goes up
+        self.app.new_tab()
+        assert self.app.tab_bar.tabText(0) == 'Tab 2'
+        assert self.app.tab_bar.tabText(1) == 'Tab 3'
 
     def test_new_data_viewer_cancel(self):
         with patch('glue.qt.glue_application.pick_class') as pc:


### PR DESCRIPTION
To reproduce issue:

* Open glue
* Create extra tab
* Go to tab 2
* Remove tab 1
* Create new tab, which is now called Tab 2

Result: two tabs are called Tab 2