### PR TITLE
Added the ability to register menubar plugins

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Changelog
 v0.5 (Unreleased)
 -----------------
 
+* Added a ``menu_plugin`` registry to add custom tools to the registry
 * Support for 'lazy-loading' plugins which means their import is deferred until they are needed
 * Support for connecting custom importers
 * ``qglue`` now correctly interprets HDUList objects 

--- a/doc/python_guide/customization.rst
+++ b/doc/python_guide/customization.rst
@@ -138,6 +138,27 @@ An importer can be defined using the ``@importer`` decorator::
 The label in the ``@importer`` decorator is the text that will appear in the
 ``Import`` menu in Glue.
 
+Custom menubar tools
+--------------------
+
+In some cases, it might be desirable to add tools to Glue that can operate on
+any aspects of the data or subsets, and can be accessed from the menubar. To
+do this, you can define a function that takes two arguments (the session
+object, and the data collection object), and decorate it with the
+``@menubar_plugin`` decorator, giving it the label that will appear in the
+**Tools** menubar::
+
+    from glue.config import menubar_plugin
+
+    @menubar_plugin("Do something")
+    def my_plugin(session, data_collection):
+        # do anything here
+        return
+
+The function can do anything, such as launch a QWidget, or anything else
+(such as a web browser, etc.), and does not need to return anything (instead
+it can operate by directly modifying the data collection or subsets).
+
 Custom Colormaps
 ----------------
 

--- a/glue/config.py
+++ b/glue/config.py
@@ -140,6 +140,36 @@ class DataImportRegistry(Registry):
         return adder
 
 
+class MenubarPluginRegistry(Registry):
+    """
+    Stores menubar plugins.
+
+    The members property is a list of menubar plugins, each represented as a
+    ``(label, function)`` tuple. The ``function`` should take two item which
+    are a reference to the session and to the data collection.
+    """
+
+    def default_members(self):
+        return []
+
+    def add(self, label, function):
+        """
+        Add a new menubar plugin
+        :param label: Short label for the plugin
+        :type label: str
+
+        :param function: function
+        :type function: function()
+        """
+        self.members.append((label, function))
+
+    def __call__(self, label):
+        def adder(func):
+            self.add(label, func)
+            return func
+        return adder
+
+
 class ExporterRegistry(Registry):
 
     """Stores functions which can export an applocation to an output file
@@ -444,6 +474,7 @@ exporters = ExporterRegistry()
 settings = SettingRegistry()
 fit_plugin = ProfileFitterRegistry()
 single_subset_action = SingleSubsetLayerActionRegistry()
+menubar_plugin = MenubarPluginRegistry()
 
 # watch loaded data files for changes?
 auto_refresh = BooleanSetting(False)

--- a/glue/config.py
+++ b/glue/config.py
@@ -145,8 +145,8 @@ class MenubarPluginRegistry(Registry):
     Stores menubar plugins.
 
     The members property is a list of menubar plugins, each represented as a
-    ``(label, function)`` tuple. The ``function`` should take two item which
-    are a reference to the session and to the data collection.
+    ``(label, function)`` tuple. The ``function`` should take two items which
+    are a reference to the session and to the data collection respectively.
     """
 
     def default_members(self):

--- a/glue/qt/glue_application.py
+++ b/glue/qt/glue_application.py
@@ -474,6 +474,15 @@ class GlueApplication(Application, QMainWindow):
         menu.addActions(tbar.actions())
         mbar.addMenu(menu)
 
+        menu = QMenu(mbar)
+        menu.setTitle("&Tools")
+
+        if 'plugins' in self._actions:
+            for plugin in self._actions['plugins']:
+                menu.addAction(plugin)
+
+        mbar.addMenu(menu)
+
         # trigger inclusion of Mac Native "Help" tool
         menu = mbar.addMenu("&Help")
         a = QAction("&Online Documentation", menu)
@@ -590,6 +599,17 @@ class GlueApplication(Application, QMainWindow):
         a.triggered.connect(nonpartial(self.redo))
         a.setEnabled(False)
         self._actions['redo'] = a
+
+        # Create actions for menubar plugins
+        from glue.config import menubar_plugin
+        acts = []
+        for label, function in menubar_plugin:
+            a = act(label, self, tip=label)
+            a.triggered.connect(nonpartial(function,
+                                           self.session,
+                                           self.data_collection))
+            acts.append(a)
+        self._actions['plugins'] = acts
 
     def choose_new_data_viewer(self, data=None):
         """ Create a new visualization window in the current tab


### PR DESCRIPTION
In some cases we might want to create plugins that are not tied to a specific GUI action. For instance, I am writing a small plugin that can be used to reorder components in a categorical component. Another example would be a plugin to edit data types of components. This sets up the framework to register plugins in a 'Tools' menu. We could also allow plugins to be added to any existing menu rather than defining a new one. @ChrisBeaumont - what do you think?

![screen shot 2015-05-28 at 3 33 11 pm](https://cloud.githubusercontent.com/assets/314716/7862596/e21d04a8-054e-11e5-9de7-1bf25e1e67ca.png)
