### PR TITLE
Drag other selections

### DIFF
--- a/glue/core/data_factories/io.py
+++ b/glue/core/data_factories/io.py
@@ -21,19 +21,22 @@ def filter_hdulist_by_shape(hdulist, use_hdu='all'):
     if use_hdu != 'all':
         hdulist = [hdulist[hdu] for hdu in use_hdu]
 
-    # Now only keep HDUs that are not tables
+    # Now only keep HDUs that are not tables or empty.
+    valid_hdus = []
     for hdu in hdulist:
-        if not isinstance(hdu, fits.PrimaryHDU) and \
-                not isinstance(hdu, fits.ImageHDU):
-            hdulist.remove(hdu)
+        if (isinstance(hdu, fits.PrimaryHDU) or \
+            isinstance(hdu, fits.ImageHDU)) and \
+            hdu.data is not None:
+            valid_hdus.append(hdu)
 
     # Check that dimensions of all HDU are the same
-    reference_shape = hdulist[0].data.shape
-    for hdu in hdulist:
+    # Allow for HDU's that have no data.
+    reference_shape = valid_hdus[0].data.shape
+    for hdu in valid_hdus:
         if hdu.data.shape != reference_shape:
             raise Exception("HDUs are not all the same dimensions")
 
-    return hdulist
+    return valid_hdus
 
 
 def extract_data_fits(filename, use_hdu='all'):

--- a/glue/core/roi.py
+++ b/glue/core/roi.py
@@ -513,8 +513,8 @@ class PolygonalROI(VertexROIBase):
         return result
 
     def move_to(self, xdelta, ydelta):
-        self.vx = map(lambda x: x + xdelta, self.vx)
-        self.vy = map(lambda y: y + ydelta, self.vy)
+        self.vx = list(map(lambda x: x + xdelta, self.vx))
+        self.vy = list(map(lambda y: y + ydelta, self.vy))
 
 
 class Path(VertexROIBase):
@@ -573,7 +573,9 @@ class AbstractMplRoi(object):  # pragma: no cover
         raise NotImplementedError()
 
     def abort_selection(self, event):
-        raise NotImplementedError()
+        if self._mid_selection:
+            self._roi_restore()
+        self.reset(include_roi=False)
 
     def _sync_patch(self):
         raise NotImplementedError()
@@ -690,10 +692,6 @@ class MplRectangularROI(AbstractMplRoi):
         self._patch.set_visible(False)
         self._draw()
 
-    def abort_selection(self, event):
-        self._roi_restore()
-        self.reset(include_roi=False)
-
     def _sync_patch(self):
         if self._roi.defined():
             corner = self._roi.corner()
@@ -773,10 +771,6 @@ class MplXRangeROI(AbstractMplRoi):
         self._patch.set_visible(False)
         self._draw()
 
-    def abort_selection(self, event):
-        self._roi_restore()
-        self.reset(include_roi=False)
-
     def _sync_patch(self):
         if self._roi.defined():
             rng = self._roi.range()
@@ -850,10 +844,6 @@ class MplYRangeROI(AbstractMplRoi):
         self._mid_selection = False
         self._patch.set_visible(False)
         self._draw()
-
-    def abort_selection(self, event):
-        self._roi_restore()
-        self.reset(include_roi=False)
 
     def _sync_patch(self):
         if self._roi.defined():
@@ -990,10 +980,6 @@ class MplCircularROI(AbstractMplRoi):
         self._patch.set_visible(False)
         self._axes.figure.canvas.draw()
 
-    def abort_selection(self, event):
-        self._roi_restore()
-        self.reset(include_roi=False)
-
 
 class MplPolygonalROI(AbstractMplRoi):
 
@@ -1081,10 +1067,6 @@ class MplPolygonalROI(AbstractMplRoi):
         self._mid_selection = False
         self._patch.set_visible(False)
         self._axes.figure.canvas.draw()
-
-    def abort_selection(self, event):
-        self._roi_restore()
-        self.reset(include_roi=False)
 
 
 class MplPathROI(MplPolygonalROI):

--- a/glue/core/roi.py
+++ b/glue/core/roi.py
@@ -513,8 +513,8 @@ class PolygonalROI(VertexROIBase):
         return result
 
     def move_to(self, xdelta, ydelta):
-        self.vx = list(map(lambda x: x + xdelta, self.vx))
-        self.vy = list(map(lambda y: y + ydelta, self.vy))
+        self.vx = map(lambda x: x + xdelta, self.vx)
+        self.vy = map(lambda y: y + ydelta, self.vy)
 
 
 class Path(VertexROIBase):
@@ -573,9 +573,7 @@ class AbstractMplRoi(object):  # pragma: no cover
         raise NotImplementedError()
 
     def abort_selection(self, event):
-        if self._mid_selection:
-            self._roi_restore()
-        self.reset(include_roi=False)
+        raise NotImplementedError()
 
     def _sync_patch(self):
         raise NotImplementedError()
@@ -692,6 +690,10 @@ class MplRectangularROI(AbstractMplRoi):
         self._patch.set_visible(False)
         self._draw()
 
+    def abort_selection(self, event):
+        self._roi_restore()
+        self.reset(include_roi=False)
+
     def _sync_patch(self):
         if self._roi.defined():
             corner = self._roi.corner()
@@ -771,6 +773,10 @@ class MplXRangeROI(AbstractMplRoi):
         self._patch.set_visible(False)
         self._draw()
 
+    def abort_selection(self, event):
+        self._roi_restore()
+        self.reset(include_roi=False)
+
     def _sync_patch(self):
         if self._roi.defined():
             rng = self._roi.range()
@@ -844,6 +850,10 @@ class MplYRangeROI(AbstractMplRoi):
         self._mid_selection = False
         self._patch.set_visible(False)
         self._draw()
+
+    def abort_selection(self, event):
+        self._roi_restore()
+        self.reset(include_roi=False)
 
     def _sync_patch(self):
         if self._roi.defined():
@@ -929,9 +939,6 @@ class MplCircularROI(AbstractMplRoi):
         if self._roi.defined() and \
            self._roi.contains(xi, yi):
             self._scrubbing = True
-            (xc, yc) = self._roi.get_center()
-            self._dx = xc - xi
-            self._dy = yc - yi
         else:
             self.reset()
             self._roi.set_center(xi, yi)
@@ -951,7 +958,7 @@ class MplCircularROI(AbstractMplRoi):
         yi = xy[0, 1]
 
         if self._scrubbing:
-            self._roi.set_center(xi + self._dx, yi + self._dy)
+            self._roi.set_center(xi, yi)
         else:
             dx = xy[0, 0] - self._xi
             dy = xy[0, 1] - self._yi
@@ -979,6 +986,10 @@ class MplCircularROI(AbstractMplRoi):
         self._mid_selection = False
         self._patch.set_visible(False)
         self._axes.figure.canvas.draw()
+
+    def abort_selection(self, event):
+        self._roi_restore()
+        self.reset(include_roi=False)
 
 
 class MplPolygonalROI(AbstractMplRoi):
@@ -1067,6 +1078,10 @@ class MplPolygonalROI(AbstractMplRoi):
         self._mid_selection = False
         self._patch.set_visible(False)
         self._axes.figure.canvas.draw()
+
+    def abort_selection(self, event):
+        self._roi_restore()
+        self.reset(include_roi=False)
 
 
 class MplPathROI(MplPolygonalROI):

--- a/glue/core/roi.py
+++ b/glue/core/roi.py
@@ -663,8 +663,7 @@ class MplRectangularROI(AbstractMplRoi):
             self._scrubbing = True
             self._cx, self._cy = self._roi.center()
         else:
-            self._scrubbing = False
-            self._roi.reset()
+            self.reset()
             self._roi.update_limits(event.xdata, event.ydata,
                                     event.xdata, event.ydata)
 
@@ -754,8 +753,8 @@ class MplXRangeROI(AbstractMplRoi):
             self.reset()
             self._roi.set_range(event.xdata, event.xdata)
             self._xi = event.xdata
-            self._mid_selection = True
-            self._sync_patch()
+        self._mid_selection = True
+        self._sync_patch()
 
     def update_selection(self, event):
         if not self._mid_selection or event.inaxes != self._axes:
@@ -832,8 +831,8 @@ class MplYRangeROI(AbstractMplRoi):
             self.reset()
             self._roi.set_range(event.ydata, event.ydata)
             self._xi = event.ydata
-            self._mid_selection = True
-            self._sync_patch()
+        self._mid_selection = True
+        self._sync_patch()
 
     def update_selection(self, event):
         if not self._mid_selection or event.inaxes != self._axes:
@@ -944,7 +943,7 @@ class MplCircularROI(AbstractMplRoi):
             self._dx = xc - xi
             self._dy = yc - yi
         else:
-            self._scrubbing = False
+            self.reset()
             self._roi.set_center(xi, yi)
             self._roi.set_radius(0.)
             self._xi = xi
@@ -1057,8 +1056,7 @@ class MplPolygonalROI(AbstractMplRoi):
             self._cx = event.xdata
             self._cy = event.ydata
         else:
-            self._scrubbing = False
-            self._roi.reset()
+            self.reset()
             self._roi.add_point(event.xdata, event.ydata)
 
         self._mid_selection = True

--- a/glue/core/roi.py
+++ b/glue/core/roi.py
@@ -513,8 +513,8 @@ class PolygonalROI(VertexROIBase):
         return result
 
     def move_to(self, xdelta, ydelta):
-        self.vx = map(lambda x: x + xdelta, self.vx)
-        self.vy = map(lambda y: y + ydelta, self.vy)
+        self.vx = list(map(lambda x: x + xdelta, self.vx))
+        self.vy = list(map(lambda y: y + ydelta, self.vy))
 
 
 class Path(VertexROIBase):
@@ -573,7 +573,9 @@ class AbstractMplRoi(object):  # pragma: no cover
         raise NotImplementedError()
 
     def abort_selection(self, event):
-        raise NotImplementedError()
+        if self._mid_selection:
+            self._roi_restore()
+        self.reset(include_roi=False)
 
     def _sync_patch(self):
         raise NotImplementedError()
@@ -690,10 +692,6 @@ class MplRectangularROI(AbstractMplRoi):
         self._patch.set_visible(False)
         self._draw()
 
-    def abort_selection(self, event):
-        self._roi_restore()
-        self.reset(include_roi=False)
-
     def _sync_patch(self):
         if self._roi.defined():
             corner = self._roi.corner()
@@ -773,10 +771,6 @@ class MplXRangeROI(AbstractMplRoi):
         self._patch.set_visible(False)
         self._draw()
 
-    def abort_selection(self, event):
-        self._roi_restore()
-        self.reset(include_roi=False)
-
     def _sync_patch(self):
         if self._roi.defined():
             rng = self._roi.range()
@@ -850,10 +844,6 @@ class MplYRangeROI(AbstractMplRoi):
         self._mid_selection = False
         self._patch.set_visible(False)
         self._draw()
-
-    def abort_selection(self, event):
-        self._roi_restore()
-        self.reset(include_roi=False)
 
     def _sync_patch(self):
         if self._roi.defined():
@@ -939,6 +929,9 @@ class MplCircularROI(AbstractMplRoi):
         if self._roi.defined() and \
            self._roi.contains(xi, yi):
             self._scrubbing = True
+            (xc, yc) = self._roi.get_center()
+            self._dx = xc - xi
+            self._dy = yc - yi
         else:
             self.reset()
             self._roi.set_center(xi, yi)
@@ -958,7 +951,7 @@ class MplCircularROI(AbstractMplRoi):
         yi = xy[0, 1]
 
         if self._scrubbing:
-            self._roi.set_center(xi, yi)
+            self._roi.set_center(xi + self._dx, yi + self._dy)
         else:
             dx = xy[0, 0] - self._xi
             dy = xy[0, 1] - self._yi
@@ -986,10 +979,6 @@ class MplCircularROI(AbstractMplRoi):
         self._mid_selection = False
         self._patch.set_visible(False)
         self._axes.figure.canvas.draw()
-
-    def abort_selection(self, event):
-        self._roi_restore()
-        self.reset(include_roi=False)
 
 
 class MplPolygonalROI(AbstractMplRoi):
@@ -1078,10 +1067,6 @@ class MplPolygonalROI(AbstractMplRoi):
         self._mid_selection = False
         self._patch.set_visible(False)
         self._axes.figure.canvas.draw()
-
-    def abort_selection(self, event):
-        self._roi_restore()
-        self.reset(include_roi=False)
 
 
 class MplPathROI(MplPolygonalROI):

--- a/glue/core/roi.py
+++ b/glue/core/roi.py
@@ -832,6 +832,7 @@ class MplCircularROI(AbstractMplRoi):
 
         self._xi = None
         self._yi = None
+        self._scrubbing = False
         self._setup_patch()
 
     def _setup_patch(self):
@@ -869,10 +870,19 @@ class MplCircularROI(AbstractMplRoi):
             return
 
         xy = data_to_pixel(self._axes, [event.xdata], [event.ydata])
-        self._roi.set_center(xy[0, 0], xy[0, 1])
-        self._roi.set_radius(0.)
-        self._xi = xy[0, 0]
-        self._yi = xy[0, 1]
+        xi = xy[0, 0]
+        yi = xy[0, 1]
+
+        if self._roi.defined() and \
+           self._roi.contains(xi, yi):
+            self._scrubbing = True
+        else:
+            self._scrubbing = False
+            self._roi.set_center(xi, yi)
+            self._roi.set_radius(0.)
+            self._xi = xi
+            self._yi = yi
+
         self._mid_selection = True
         self._sync_patch()
 
@@ -881,9 +891,16 @@ class MplCircularROI(AbstractMplRoi):
             return
 
         xy = data_to_pixel(self._axes, [event.xdata], [event.ydata])
-        dx = xy[0, 0] - self._xi
-        dy = xy[0, 1] - self._yi
-        self._roi.set_radius(np.hypot(dx, dy))
+        xi = xy[0, 0]
+        yi = xy[0, 1]
+
+        if self._scrubbing:
+            self._roi.set_center(xi, yi)
+        else:
+            dx = xy[0, 0] - self._xi
+            dy = xy[0, 1] - self._yi
+            self._roi.set_radius(np.hypot(dx, dy))
+
         self._sync_patch()
 
     def roi(self):

--- a/glue/core/roi.py
+++ b/glue/core/roi.py
@@ -881,6 +881,9 @@ class MplCircularROI(AbstractMplRoi):
         if self._roi.defined() and \
            self._roi.contains(xi, yi):
             self._scrubbing = True
+            (xc, yc) = self._roi.get_center()
+            self._dx = xc - xi
+            self._dy = yc - yi
         else:
             self._scrubbing = False
             self._roi.set_center(xi, yi)
@@ -900,7 +903,7 @@ class MplCircularROI(AbstractMplRoi):
         yi = xy[0, 1]
 
         if self._scrubbing:
-            self._roi.set_center(xi, yi)
+            self._roi.set_center(xi + self._dx, yi + self._dy)
         else:
             dx = xy[0, 0] - self._xi
             dy = xy[0, 1] - self._yi

--- a/glue/core/roi.py
+++ b/glue/core/roi.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-from functools import wraps
-
 import numpy as np
 from matplotlib.patches import Polygon, Rectangle, Ellipse, PathPatch
 from matplotlib.patches import Path as mplPath
@@ -252,16 +250,8 @@ class RangeROI(Roi):
     def range(self):
         return self.min, self.max
 
-    def center(self):
-        return (self.min + self.max) / 2
-
     def set_range(self, lo, hi):
         self.min, self.max = lo, hi
-
-    def move_to(self, center):
-        delta = center - self.center()
-        self.min += delta
-        self.max += delta
 
     def contains(self, x, y):
         if not self.defined():
@@ -512,10 +502,6 @@ class PolygonalROI(VertexROIBase):
         result.shape = x.shape
         return result
 
-    def move_to(self, xdelta, ydelta):
-        self.vx = map(lambda x: x + xdelta, self.vx)
-        self.vy = map(lambda y: y + ydelta, self.vy)
-
 
 class Path(VertexROIBase):
 
@@ -540,9 +526,7 @@ class AbstractMplRoi(object):  # pragma: no cover
 
         self._axes = axes
         self._roi = self._roi_factory()
-        self._previous_roi = None
         self._mid_selection = False
-        self._scrubbing = False
 
     def _draw(self):
         self._axes.figure.canvas.draw()
@@ -553,11 +537,9 @@ class AbstractMplRoi(object):  # pragma: no cover
     def roi(self):
         return self._roi.copy()
 
-    def reset(self, include_roi=True):
+    def reset(self):
+        self._roi.reset()
         self._mid_selection = False
-        self._scrubbing = False
-        if include_roi:
-            self._roi.reset()
         self._sync_patch()
 
     def active(self):
@@ -572,17 +554,8 @@ class AbstractMplRoi(object):  # pragma: no cover
     def finalize_selection(self, event):
         raise NotImplementedError()
 
-    def abort_selection(self, event):
-        raise NotImplementedError()
-
     def _sync_patch(self):
         raise NotImplementedError()
-
-    def _roi_store(self):
-        self._previous_roi = self._roi.copy()
-
-    def _roi_restore(self):
-        self._roi = self._previous_roi
 
 
 class MplPickROI(AbstractMplRoi):
@@ -633,6 +606,7 @@ class MplRectangularROI(AbstractMplRoi):
 
         self._xi = None
         self._yi = None
+        self._scrubbing = False
 
         self.plot_opts = {'edgecolor': PATCH_COLOR, 'facecolor': PATCH_COLOR,
                           'alpha': 0.3}
@@ -654,12 +628,11 @@ class MplRectangularROI(AbstractMplRoi):
         if event.inaxes != self._axes:
             return
 
-        self._roi_store()
         self._xi = event.xdata
         self._yi = event.ydata
 
         if self._roi.defined() and \
-           self._roi.contains(event.xdata, event.ydata):
+                self._roi.contains(event.xdata, event.ydata):
             self._scrubbing = True
             self._cx, self._cy = self._roi.center()
         else:
@@ -686,14 +659,9 @@ class MplRectangularROI(AbstractMplRoi):
         self._sync_patch()
 
     def finalize_selection(self, event):
-        self._scrubbing = False
         self._mid_selection = False
         self._patch.set_visible(False)
         self._draw()
-
-    def abort_selection(self, event):
-        self._roi_restore()
-        self.reset(include_roi=False)
 
     def _sync_patch(self):
         if self._roi.defined():
@@ -744,39 +712,23 @@ class MplXRangeROI(AbstractMplRoi):
         if event.inaxes != self._axes:
             return
 
-        self._roi_store()
-
-        if self._roi.defined() and \
-           self._roi.contains(event.xdata, event.xdata):
-            self._scrubbing = True
-            self._dx = event.xdata - self._roi.center()
-        else:
-            self.reset()
-            self._roi.set_range(event.xdata, event.xdata)
-            self._xi = event.xdata
-            self._mid_selection = True
-            self._sync_patch()
+        self._roi.reset()
+        self._roi.set_range(event.xdata, event.xdata)
+        self._xi = event.xdata
+        self._mid_selection = True
+        self._sync_patch()
 
     def update_selection(self, event):
         if not self._mid_selection or event.inaxes != self._axes:
             return
-
-        if self._scrubbing:
-            self._roi.move_to(event.xdata + self._dx)
-        else:
-            self._roi.set_range(min(event.xdata, self._xi),
-                                max(event.xdata, self._xi))
+        self._roi.set_range(min(event.xdata, self._xi),
+                            max(event.xdata, self._xi))
         self._sync_patch()
 
     def finalize_selection(self, event):
-        self._scrubbing = False
         self._mid_selection = False
         self._patch.set_visible(False)
         self._draw()
-
-    def abort_selection(self, event):
-        self._roi_restore()
-        self.reset(include_roi=False)
 
     def _sync_patch(self):
         if self._roi.defined():
@@ -822,39 +774,23 @@ class MplYRangeROI(AbstractMplRoi):
         if event.inaxes != self._axes:
             return
 
-        self._roi_store()
-
-        if self._roi.defined() and \
-           self._roi.contains(event.ydata, event.ydata):
-            self._scrubbing = True
-            self._dy = event.ydata - self._roi.center()
-        else:
-            self.reset()
-            self._roi.set_range(event.ydata, event.ydata)
-            self._xi = event.ydata
-            self._mid_selection = True
-            self._sync_patch()
+        self._roi.reset()
+        self._roi.set_range(event.ydata, event.ydata)
+        self._xi = event.ydata
+        self._mid_selection = True
+        self._sync_patch()
 
     def update_selection(self, event):
         if not self._mid_selection or event.inaxes != self._axes:
             return
-
-        if self._scrubbing:
-            self._roi.move_to(event.ydata + self._dy)
-        else:
-            self._roi.set_range(min(event.ydata, self._xi),
-                                max(event.ydata, self._xi))
+        self._roi.set_range(min(event.ydata, self._xi),
+                            max(event.ydata, self._xi))
         self._sync_patch()
 
     def finalize_selection(self, event):
-        self._scrubbing = False
         self._mid_selection = False
         self._patch.set_visible(False)
         self._draw()
-
-    def abort_selection(self, event):
-        self._roi_restore()
-        self.reset(include_roi=False)
 
     def _sync_patch(self):
         if self._roi.defined():
@@ -896,6 +832,7 @@ class MplCircularROI(AbstractMplRoi):
 
         self._xi = None
         self._yi = None
+        self._scrubbing = False
         self._setup_patch()
 
     def _setup_patch(self):
@@ -932,7 +869,6 @@ class MplCircularROI(AbstractMplRoi):
         if event.inaxes != self._axes:
             return
 
-        self._roi_store()
         xy = data_to_pixel(self._axes, [event.xdata], [event.ydata])
         xi = xy[0, 0]
         yi = xy[0, 1]
@@ -940,9 +876,6 @@ class MplCircularROI(AbstractMplRoi):
         if self._roi.defined() and \
            self._roi.contains(xi, yi):
             self._scrubbing = True
-            (xc, yc) = self._roi.get_center()
-            self._dx = xc - xi
-            self._dy = yc - yi
         else:
             self._scrubbing = False
             self._roi.set_center(xi, yi)
@@ -962,7 +895,7 @@ class MplCircularROI(AbstractMplRoi):
         yi = xy[0, 1]
 
         if self._scrubbing:
-            self._roi.set_center(xi + self._dx, yi + self._dy)
+            self._roi.set_center(xi, yi)
         else:
             dx = xy[0, 0] - self._xi
             dy = xy[0, 1] - self._yi
@@ -986,14 +919,9 @@ class MplCircularROI(AbstractMplRoi):
         return result
 
     def finalize_selection(self, event):
-        self._scrubbing = False
         self._mid_selection = False
         self._patch.set_visible(False)
         self._axes.figure.canvas.draw()
-
-    def abort_selection(self, event):
-        self._roi_restore()
-        self.reset(include_roi=False)
 
 
 class MplPolygonalROI(AbstractMplRoi):
@@ -1050,43 +978,21 @@ class MplPolygonalROI(AbstractMplRoi):
         if event.inaxes != self._axes:
             return
 
-        self._roi_store()
-        if self._roi.defined() and \
-           self._roi.contains(event.xdata, event.ydata):
-            self._scrubbing = True
-            self._cx = event.xdata
-            self._cy = event.ydata
-        else:
-            self._scrubbing = False
-            self._roi.reset()
-            self._roi.add_point(event.xdata, event.ydata)
-
+        self._roi.reset()
+        self._roi.add_point(event.xdata, event.ydata)
         self._mid_selection = True
         self._sync_patch()
 
     def update_selection(self, event):
         if not self._mid_selection or event.inaxes != self._axes:
             return
-
-        if self._scrubbing:
-            self._roi.move_to(event.xdata - self._cx,
-                              event.ydata - self._cy)
-            self._cx = event.xdata
-            self._cy = event.ydata
-        else:
-            self._roi.add_point(event.xdata, event.ydata)
-
+        self._roi.add_point(event.xdata, event.ydata)
         self._sync_patch()
 
     def finalize_selection(self, event):
-        self._scrubbing = False
         self._mid_selection = False
         self._patch.set_visible(False)
         self._axes.figure.canvas.draw()
-
-    def abort_selection(self, event):
-        self._roi_restore()
-        self.reset(include_roi=False)
 
 
 class MplPathROI(MplPolygonalROI):

--- a/glue/core/tests/test_roi.py
+++ b/glue/core/tests/test_roi.py
@@ -383,13 +383,13 @@ class TestMpl(object):
         assert self.axes.figure.canvas.draw.call_count == 1
         event = DummyEvent(5, 5, inaxes=self.axes)
         self.roi.start_selection(event)
-        assert self.axes.figure.canvas.draw.call_count == 2
-        self.roi.update_selection(event)
         assert self.axes.figure.canvas.draw.call_count == 3
         self.roi.update_selection(event)
         assert self.axes.figure.canvas.draw.call_count == 4
-        self.roi.finalize_selection(event)
+        self.roi.update_selection(event)
         assert self.axes.figure.canvas.draw.call_count == 5
+        self.roi.finalize_selection(event)
+        assert self.axes.figure.canvas.draw.call_count == 6
 
     def test_patch_shown_on_start(self):
         assert not self.roi._patch.get_visible()

--- a/glue/core/tests/test_roi.py
+++ b/glue/core/tests/test_roi.py
@@ -10,6 +10,7 @@ from matplotlib.figure import Figure
 from mock import MagicMock
 
 from ..roi import (RectangularROI, UndefinedROI, CircularROI, PolygonalROI,
+                   PointROI, MplPickROI,
                    MplCircularROI, MplRectangularROI, MplPolygonalROI,
                    XRangeROI, MplXRangeROI, YRangeROI, MplYRangeROI)
 
@@ -339,6 +340,17 @@ class TestPolygon(object):
         """ __str__ returns a string """
         assert type(str(self.roi)) == str
 
+    def test_move(self):
+        """Move polygon"""
+        self.define_as_square()
+        vx = list(self.roi.vx)
+        vy = list(self.roi.vy)
+        self.roi.move_to(1, 1)
+        assert type(self.roi.vx) == list
+        assert type(self.roi.vy) == list
+        assert self.roi.vx[0] - vx[0] == 1
+        assert self.roi.vy[0] - vy[0] == 1
+
 
 class DummyEvent(object):
     def __init__(self, x, y, inaxes=True):
@@ -419,13 +431,7 @@ class TestMpl(object):
     def test_roi_undefined_before_start(self):
         assert not self.roi._roi.defined()
 
-
-class TestRectangleMpl(TestMpl):
-
-    def _roi_factory(self):
-        return MplRectangularROI(self.axes)
-
-    def test_scrub(self):
+    def scrub(self, assert_final_position):
         roi = self._roi_factory()
 
         event = DummyEvent(5, 5, inaxes=self.axes)
@@ -437,12 +443,49 @@ class TestRectangleMpl(TestMpl):
         roi.start_selection(DummyEvent(6, 6, inaxes=self.axes))
         roi.update_selection(DummyEvent(7, 8, inaxes=self.axes))
 
-        print(roi)
-        print(roi._roi)
-        assert roi._roi.xmin == 6
-        assert roi._roi.xmax == 11
-        assert roi._roi.ymin == 7
-        assert roi._roi.ymax == 12
+        assert_final_position(roi)
+
+    def abort(self, assert_final_position):
+        roi = self._roi_factory()
+
+        event = DummyEvent(5, 5, inaxes=self.axes)
+        roi.start_selection(event)
+        event = DummyEvent(10, 10, inaxes=self.axes)
+        roi.update_selection(event)
+
+        #restart without finalize = scrub
+        roi.start_selection(DummyEvent(6, 6, inaxes=self.axes))
+        roi.update_selection(DummyEvent(7, 8, inaxes=self.axes))
+
+        # Now abort
+        roi.abort_selection(None)
+
+        assert_final_position(roi)
+
+class TestRectangleMpl(TestMpl):
+
+    def _roi_factory(self):
+        return MplRectangularROI(self.axes)
+
+    def test_scrub(self):
+
+        def assert_final_position(roi):
+            assert roi._roi.xmin == 6
+            assert roi._roi.xmax == 11
+            assert roi._roi.ymin == 7
+            assert roi._roi.ymax == 12
+
+        self.scrub(assert_final_position)
+
+    def test_abort(self):
+
+        def assert_final_position(roi):
+            assert roi._roi.xmin == 5
+            assert roi._roi.xmax == 10
+            assert roi._roi.ymin == 5
+            assert roi._roi.ymax == 10
+
+        self.abort(assert_final_position)
 
     def assert_roi_correct(self, x0, x1, y0, y1):
         corner = self.roi.roi().corner()
@@ -547,6 +590,22 @@ class TestXRangeMpl(TestMpl):
 
         assert not self.roi._patch.get_visible()
 
+    def test_scrub(self):
+
+        def assert_final_position(roi):
+            assert_almost_equal(roi._roi.min, 3.0)
+            assert_almost_equal(roi._roi.max, 8.0)
+
+        self.scrub(assert_final_position)
+
+    def test_abort(self):
+
+        def assert_final_position(roi):
+            assert_almost_equal(roi._roi.min, 5.0)
+            assert_almost_equal(roi._roi.max, 10.0)
+
+        self.abort(assert_final_position)
+
 
 class TestYRangeMpl(TestMpl):
     def _roi_factory(self):
@@ -578,6 +637,22 @@ class TestYRangeMpl(TestMpl):
         assert self.roi._roi.range() == (1, 2)
 
         assert not self.roi._patch.get_visible()
+
+    def test_scrub(self):
+
+        def assert_final_position(roi):
+            assert_almost_equal(roi._roi.min, 4.0)
+            assert_almost_equal(roi._roi.max, 9.0)
+
+        self.scrub(assert_final_position)
+
+    def test_abort(self):
+
+        def assert_final_position(roi):
+            assert_almost_equal(roi._roi.min, 5.0)
+            assert_almost_equal(roi._roi.max, 10.0)
+
+        self.abort(assert_final_position)
 
 
 class TestCircleMpl(TestMpl):
@@ -622,6 +697,24 @@ class TestCircleMpl(TestMpl):
         assert not roi.contains(x + 1.05 * r, y)
         assert not roi.contains(x + .8 * r, y + .8 * r)
 
+    def test_scrub(self):
+
+        def assert_final_position(roi):
+            assert roi._roi.xc == 6
+            assert roi._roi.yc == 7
+            assert_almost_equal(roi._roi.radius, 7.0, decimal=0)
+
+        self.scrub(assert_final_position)
+
+    def test_abort(self):
+
+        def assert_final_position(roi):
+            assert roi._roi.xc == 5
+            assert roi._roi.yc == 5
+            assert_almost_equal(roi._roi.radius, 7.0, decimal=0)
+
+        self.abort(assert_final_position)
+
 
 class TestPolyMpl(TestMpl):
     def _roi_factory(self):
@@ -631,10 +724,10 @@ class TestPolyMpl(TestMpl):
         return isinstance(self.roi._roi, PolygonalROI)
 
     def send_events(self):
-        ev0 = DummyEvent(0, 0, inaxes=self.axes)
-        ev1 = DummyEvent(0, 1, inaxes=self.axes)
-        ev2 = DummyEvent(1, 1, inaxes=self.axes)
-        ev3 = DummyEvent(1, 0, inaxes=self.axes)
+        ev0 = DummyEvent(5, 5, inaxes=self.axes)
+        ev1 = DummyEvent(5, 10, inaxes=self.axes)
+        ev2 = DummyEvent(10, 10, inaxes=self.axes)
+        ev3 = DummyEvent(10, 5, inaxes=self.axes)
         self.roi.start_selection(ev0)
         self.roi.update_selection(ev1)
         self.roi.update_selection(ev2)
@@ -643,12 +736,74 @@ class TestPolyMpl(TestMpl):
 
     def assert_roi_correct(self):
         roi = self.roi.roi()
-        assert roi.contains(.5, .5)
-        assert not roi.contains(1.5, .5)
+        assert roi.contains(7.0, 7.0)
+        assert not roi.contains(12, 7.0)
 
     def test_define(self):
         self.send_events()
         self.assert_roi_correct()
+
+    def test_scrub(self):
+        # Define the shape
+        self.send_events()
+
+        # Restart without finalize == scrub
+        self.roi.start_selection(DummyEvent(6, 6, inaxes=self.axes))
+        self.roi.update_selection(DummyEvent(7, 8, inaxes=self.axes))
+
+        assert self.roi._roi.vx[0] == 6
+        assert self.roi._roi.vy[0] == 7
+
+    def test_abort(self):
+        self.send_events()
+
+        # Restart without finalize == scrub
+        self.roi.start_selection(DummyEvent(6, 6, inaxes=self.axes))
+        self.roi.update_selection(DummyEvent(7, 8, inaxes=self.axes))
+
+         # Now abort
+        self.roi.abort_selection(None)
+
+        assert self.roi._roi.vx[0] == 5
+        assert self.roi._roi.vy[0] == 5
+
+
+class TestPickMpl(TestMpl):
+    def _roi_factory(self):
+        return MplPickROI(self.axes)
+
+    def test_proper_roi(self):
+        return isinstance(self.roi._roi, PointROI)
+
+    def test_start_ignored_if_not_inaxes(self):
+        ev = DummyEvent(0, 0, inaxes=None)
+        self.roi.start_selection(ev)
+        assert self.roi._roi.defined()
+
+    def test_update_before_start_ignored(self):
+        ev = DummyEvent(0, 0, inaxes=None)
+        self.roi.update_selection(ev)
+        assert self.roi._roi.defined()
+
+    def test_finalize_before_start_ignored(self):
+        ev = DummyEvent(0, 0, inaxes=None)
+        self.roi.finalize_selection(ev)
+        assert self.roi._roi.defined()
+
+    def test_large_zorder(self):
+        """No patch to test for."""
+
+    def test_patch_shown_on_start(self):
+        """No patch to test for."""
+
+    def test_patch_hidden_on_finalise(self):
+        """No patch to test for."""
+
+    def test_patch_hidden_on_finalise(self):
+        """No patch to test for."""
+
+    def test_canvas_syncs_properly(self):
+        """No patch to test for."""
 
 
 class TestUtil(object):

--- a/glue/qt/glue_application.py
+++ b/glue/qt/glue_application.py
@@ -2,6 +2,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+import os
 import sys
 import webbrowser
 
@@ -280,11 +281,30 @@ class GlueApplication(Application, QMainWindow):
 
     def close_tab(self, index):
         """ Close a tab window and all associated data viewers """
+
         # do not delete the last tab
         if self.tab_widget.count() == 1:
             return
+
+        if not os.environ.get('GLUE_TESTING'):
+            buttons = QMessageBox.Ok | QMessageBox.Cancel
+            dialog = QMessageBox.warning(self, "Confirm Close",
+                                         "Are you sure you want to close this tab? "
+                                         "This will close all data viewers in the tab.",
+                                         buttons=buttons,
+                                         defaultButton=QMessageBox.Cancel)
+            if not dialog == QMessageBox.Ok:
+                return
+
         w = self.tab_widget.widget(index)
+
+        for window in w.subWindowList():
+            widget = window.widget()
+            if isinstance(widget, DataViewer):
+                widget.close(warn=False)
+
         w.close()
+
         self.tab_widget.removeTab(index)
 
     def add_widget(self, new_widget, label=None, tab=None,

--- a/glue/qt/mouse_mode.py
+++ b/glue/qt/mouse_mode.py
@@ -222,6 +222,13 @@ class RoiMode(RoiModeBase):
 
         super(RoiMode, self).release(event)
 
+    def key(self, event):
+        if event.key == 'escape':
+            self._roi_tool.abort_selection(event)
+            self._drag = False
+            self._drawing = False
+            self._start_event  = None
+        super(RoiMode, self).key(event)
 
 class PersistentRoiMode(RoiMode):
 
@@ -269,7 +276,7 @@ class ClickRoiMode(RoiModeBase):
             self._finish_roi(self._last_event)
             self._drawing = False
         elif event.key == 'escape':
-            self._roi_tool.reset()
+            self._roi_tool.abort_selection(event)
             self._drawing = False
         super(ClickRoiMode, self).key(event)
 

--- a/glue/qt/mouse_mode.py
+++ b/glue/qt/mouse_mode.py
@@ -273,6 +273,12 @@ class ClickRoiMode(RoiModeBase):
             self._drawing = False
         super(ClickRoiMode, self).key(event)
 
+    def release(self, event):
+        if getattr(self._roi_tool, '_scrubbing', False):
+            self._finish_roi(event)
+            self._start_event = None
+            super(ClickRoiMode, self).release(event)
+
 
 class RectangleMode(RoiMode):
 

--- a/glue/qt/tests/test_mouse_mode.py
+++ b/glue/qt/tests/test_mouse_mode.py
@@ -170,7 +170,7 @@ class TestClickRoiMode(TestMouseMode):
         self.mode.press(e)
         self.mode.key(e2)
         self.mode.press(e)
-        assert self.mode._roi_tool.reset.call_count == 1
+        assert self.mode._roi_tool.abort_selection.call_count == 1
         assert self.mode._roi_tool.start_selection.call_count == 2
 
 

--- a/glue/qt/tests/test_mouse_mode.py
+++ b/glue/qt/tests/test_mouse_mode.py
@@ -127,6 +127,14 @@ class TestRoiMode(TestMouseMode):
         self.mode.roi()
         self.mode._roi_tool.roi.assert_called_once_with()
 
+    def test_roi_resets_on_escape(self):
+        e = Event(1, 2)
+        e2 = Event(1, 30, key='escape')
+        self.mode.press(e)
+        self.mode.key(e2)
+        self.mode.press(e)
+        assert self.mode._roi_tool.abort_selection.call_count == 1
+
 
 class TestClickRoiMode(TestMouseMode):
 

--- a/glue/qt/widgets/data_viewer.py
+++ b/glue/qt/widgets/data_viewer.py
@@ -161,7 +161,7 @@ class DataViewer(QMainWindow, ViewerBase):
 
         :rtype: bool. True if user wishes to close. False otherwise
         """
-        if self._warn_close and (not os.environ.get('GLUE_TESTING')):
+        if self._warn_close and (not os.environ.get('GLUE_TESTING')) and self.isVisible():
             buttons = QMessageBox.Ok | QMessageBox.Cancel
             dialog = QMessageBox.warning(self, "Confirm Close",
                                          "Do you want to close this window?",

--- a/glue/qt/widgets/image_widget.py
+++ b/glue/qt/widgets/image_widget.py
@@ -390,11 +390,16 @@ class ImageWidget(ImageWidgetBase):
         axes = self.client.axes
 
         def apply_mode(mode):
+            for roi_mode in roi_modes:
+                if roi_mode != mode:
+                    roi_mode._roi_tool.reset()
             self.apply_roi(mode.roi())
 
         rect = RectangleMode(axes, roi_callback=apply_mode)
         circ = CircleMode(axes, roi_callback=apply_mode)
         poly = PolyMode(axes, roi_callback=apply_mode)
+        roi_modes = [rect, circ, poly]
+
         contrast = ContrastMode(axes, move_callback=self._set_norm)
 
         self._contrast = contrast


### PR DESCRIPTION
This allows the dragging of the Circular and Polygon (lasso) selections, as with Rectangle, resolving #651

Note also this has the fix in PR #641 by accident. I can remove if desired.