### PR TITLE
Added missing LoadLog to __all__ to fix loading of session files

### DIFF
--- a/glue/core/data_factories/helpers.py
+++ b/glue/core/data_factories/helpers.py
@@ -43,7 +43,7 @@ from ..contracts import contract
 
 __all__ = ['load_data', 'auto_data', '__factories__', 'data_label',
            'load_data', '_extension', 'find_factory', 'get_default_factory',
-           'FileWatcher','set_default_factory']
+           'FileWatcher','set_default_factory', 'LoadLog']
 
 
 __factories__ = []

--- a/glue/core/state.py
+++ b/glue/core/state.py
@@ -371,7 +371,12 @@ class GlueUnSerializer(object):
         return decorator
 
     def _dispatch(self, rec):
+
         typ = _lookup(rec['_type'])
+
+        if typ is None:
+            raise GlueSerializeError("Unkonwn type %s" % rec['_type'])
+
         version = rec.get('_protocol', 1)
 
         if hasattr(typ, '__setgluestate__'):


### PR DESCRIPTION
 Loading old sessions expects LoadLog at glue.core.data_factories.LoadLog