### PR TITLE
Added patch for QMessageBox to allow copying of errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ v0.5 (Unreleased)
 * The error console log is now availble through the View menu
 * Fixed compatibility with Python 2.6
 * Python 3.x support is now stable
+* Fixed the ability to copy detailed error messages
 
 v0.4 (Released December 22, 2015)
 ---------------------------------

--- a/glue/main.py
+++ b/glue/main.py
@@ -97,7 +97,7 @@ def die_on_error(msg):
             except Exception as e:
                 import traceback
                 from . import qt
-                from .external.qt.QtGui import QMessageBox
+                from .utils.qt import QMessageBoxPatched as QMessageBox
                 m = "%s\n%s" % (msg, e)
                 detail = str(traceback.format_exc())
                 if len(m) > 500:

--- a/glue/qt/decorators.py
+++ b/glue/qt/decorators.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 from functools import wraps
 import traceback
-from ..external.qt.QtGui import QMessageBox
+from ..utils.qt import QMessageBoxPatched as QMessageBox
 
 
 def set_cursor(shape):

--- a/glue/qt/glue_application.py
+++ b/glue/qt/glue_application.py
@@ -7,13 +7,14 @@ import sys
 import webbrowser
 
 from ..external.qt.QtGui import (QKeySequence, QMainWindow, QGridLayout,
-                                 QMenu, QAction, QMessageBox,
+                                 QMenu, QAction,
                                  QFileDialog, QInputDialog,
                                  QToolButton, QVBoxLayout, QWidget, QPixmap,
                                  QBrush, QPainter, QLabel, QHBoxLayout,
                                  QTextEdit, QTextCursor, QPushButton,
                                  QListWidgetItem)
 from ..external.qt.QtCore import Qt, QSize, QSettings, Signal
+from ..utils.qt import QMessageBoxPatched as QMessageBox
 
 from ..core import command, Data
 from .. import env

--- a/glue/qt/qtutil.py
+++ b/glue/qt/qtutil.py
@@ -17,11 +17,11 @@ from ..external.qt import QtGui
 from ..external.qt.QtCore import (Qt, QThread, QAbstractListModel, QModelIndex)
 from ..external.qt.QtGui import (QColor, QInputDialog, QColorDialog,
                                  QListWidget, QTreeWidget, QPushButton,
-                                 QMessageBox,
                                  QTabBar, QBitmap, QIcon, QPixmap, QImage,
                                  QWidget,
                                  QLabel, QGridLayout,
                                  QRadioButton, QButtonGroup, QCheckBox)
+from ..utils.qt import QMessageBoxPatched as QMessageBox
 
 from .decorators import set_cursor
 from .mime import PyMimeData, LAYERS_MIME_TYPE

--- a/glue/tests/test_main.py
+++ b/glue/tests/test_main.py
@@ -12,7 +12,7 @@ from ..core import Data, DataCollection, Hub
 def test_die_on_error_exception():
     """Decorator should spawn a QMessageBox and exit"""
     with pytest.raises(SystemExit):
-        with patch('glue.external.qt.QtGui.QMessageBox') as qmb:
+        with patch('glue.utils.qt.QMessageBoxPatched') as qmb:
             @die_on_error('test_msg')
             def test():
                 raise Exception()

--- a/glue/utils/qt/__init__.py
+++ b/glue/utils/qt/__init__.py
@@ -1,1 +1,2 @@
 from .autocomplete_widget import *
+from .qmessagebox_widget import *

--- a/glue/utils/qt/qmessagebox_widget.py
+++ b/glue/utils/qt/qmessagebox_widget.py
@@ -1,0 +1,39 @@
+# A patched version of QMessageBox that allows copying the error
+
+from ...external.qt import QtGui
+
+__all__ = ['QMessageBoxPatched']
+
+
+class QMessageBoxPatched(QtGui.QMessageBox):
+
+    def __init__(self, *args, **kwargs):
+
+        super(QMessageBoxPatched, self).__init__(*args, **kwargs)
+
+        copy_action = QtGui.QAction('&Copy', self)
+        copy_action.setShortcut(QtGui.QKeySequence.Copy)
+        copy_action.triggered.connect(self.copy_detailed)
+
+        select_all = QtGui.QAction('Select &All', self)
+        select_all.setShortcut(QtGui.QKeySequence.SelectAll)
+        select_all.triggered.connect(self.select_all)
+
+        menubar = QtGui.QMenuBar()
+        editMenu = menubar.addMenu('&Edit')
+        editMenu.addAction(copy_action)
+        editMenu.addAction(select_all)
+
+        self.layout().setMenuBar(menubar)
+
+    @property
+    def detailed_text_widget(self):
+        return self.findChild(QtGui.QTextEdit)
+
+    def select_all(self):
+        self.detailed_text_widget.selectAll()
+
+    def copy_detailed(self):
+        clipboard = QtGui.QApplication.clipboard()
+        selected_text = self.detailed_text_widget.textCursor().selectedText()
+        clipboard.setText(selected_text)

--- a/glue/utils/qt/tests/test_qmessagebox_widget.py
+++ b/glue/utils/qt/tests/test_qmessagebox_widget.py
@@ -1,0 +1,17 @@
+from .. import QMessageBoxPatched as QMessageBox
+from ....qt import get_qapp
+from ....external.qt import QtGui
+
+
+def test_main():
+
+    app = get_qapp()
+
+    w = QMessageBox(QMessageBox.Critical, "Error", "An error occurred")
+    w.setDetailedText("Spam")
+    w.select_all()
+    w.copy_detailed()
+
+    assert app.clipboard().text() == "Spam"
+
+    app.quit()


### PR DESCRIPTION
This is a Qt bug and requires a workaround: https://bugreports.qt.io/browse/QTBUG-6731

Fixes #673