### PR TITLE
Look for plugins via entry points

### DIFF
--- a/glue/__init__.py
+++ b/glue/__init__.py
@@ -118,9 +118,37 @@ def custom_viewer(name, **kwargs):
     from .qt.custom_viewer import CustomViewer
     return CustomViewer.create_new_subclass(name, **kwargs)
 
+from .logger import logger
+
 # Register default plugins (but don't load them)
 from .plugins import register_plugins
+logger.info("Registering built-in plugins")
 register_plugins()
+
+# Search for plugins installed via entry_points. Basically, any package can
+# define plugins for glue, and needs to define an entry point using the
+# following format:
+#
+# entry_points = """
+# [glue.plugins]
+# webcam_importer=glue_exp.importers.webcam:setup
+# vizier_importer=glue_exp.importers.vizier:setup
+# dataverse_importer=glue_exp.importers.dataverse:setup
+# """
+#
+# where ``setup`` is a function that does whatever is needed to set up the
+# plugin, such as add items to various registries.
+
+logger.info("Loading external plugins")
+from pkg_resources import iter_entry_points
+for item in iter_entry_points(group='glue.plugins', name=None):
+    try:
+        function = item.resolve()
+        function()
+    except Exception as exc:
+        logger.info("Loading plugin: {0} failed (Exception: {1})".format(item.name, exc))
+    else:
+        logger.info("Loading plugin: {0} succeeded".format(item.name))
 
 # Load user's configuration file
 from .config import load_configuration

--- a/glue/__init__.py
+++ b/glue/__init__.py
@@ -120,36 +120,6 @@ def custom_viewer(name, **kwargs):
 
 from .logger import logger
 
-# Register default plugins (but don't load them)
-from .plugins import register_plugins
-logger.info("Registering built-in plugins")
-register_plugins()
-
-# Search for plugins installed via entry_points. Basically, any package can
-# define plugins for glue, and needs to define an entry point using the
-# following format:
-#
-# entry_points = """
-# [glue.plugins]
-# webcam_importer=glue_exp.importers.webcam:setup
-# vizier_importer=glue_exp.importers.vizier:setup
-# dataverse_importer=glue_exp.importers.dataverse:setup
-# """
-#
-# where ``setup`` is a function that does whatever is needed to set up the
-# plugin, such as add items to various registries.
-
-logger.info("Loading external plugins")
-from pkg_resources import iter_entry_points
-for item in iter_entry_points(group='glue.plugins', name=None):
-    try:
-        function = item.resolve()
-        function()
-    except Exception as exc:
-        logger.info("Loading plugin: {0} failed (Exception: {1})".format(item.name, exc))
-    else:
-        logger.info("Loading plugin: {0} succeeded".format(item.name))
-
 # Load user's configuration file
 from .config import load_configuration
 env = load_configuration()
@@ -157,6 +127,8 @@ env = load_configuration()
 from .qglue import qglue
 
 from .version import __version__
+
+from .main import load_plugins
 
 def test(no_optional_skip=False):
     import os

--- a/glue/__init__.py
+++ b/glue/__init__.py
@@ -118,8 +118,6 @@ def custom_viewer(name, **kwargs):
     from .qt.custom_viewer import CustomViewer
     return CustomViewer.create_new_subclass(name, **kwargs)
 
-from .logger import logger
-
 # Load user's configuration file
 from .config import load_configuration
 env = load_configuration()

--- a/glue/_plugin_helpers.py
+++ b/glue/_plugin_helpers.py
@@ -1,4 +1,4 @@
-# The following funtion is a thin wrapper around iter_entry_tools. The reason it
+# The following funtion is a thin wrapper around iter_entry_points. The reason it
 # is in this separate file is that when making the Mac app, py2app doesn't
 # support entry points, so we replace this function with a version that has the
 # entry points we want hardcoded. If this function was in glue/main.py, the

--- a/glue/_plugin_helpers.py
+++ b/glue/_plugin_helpers.py
@@ -1,0 +1,12 @@
+# The following funtion is a thin wrapper around iter_entry_tools. The reason it
+# is in this separate file is that when making the Mac app, py2app doesn't
+# support entry points, so we replace this function with a version that has the
+# entry points we want hardcoded. If this function was in glue/main.py, the
+# reference to the iter_plugin_entry_points function in load_plugin would be
+# evaluated at compile time rather than at runtime, so the patched version
+# wouldn't be used.
+
+
+def iter_plugin_entry_points():
+    from pkg_resources import iter_entry_points
+    return iter_entry_points(group='glue.plugins', name=None)

--- a/glue/main.py
+++ b/glue/main.py
@@ -236,5 +236,38 @@ def main(argv=sys.argv):
             start_glue(config=opt.config)
 
 
+def load_plugins():
+
+    # Register default plugins (but don't load them)
+    from .plugins import register_plugins
+    logger.info("Registering built-in plugins")
+    register_plugins()
+
+    # Search for plugins installed via entry_points. Basically, any package can
+    # define plugins for glue, and needs to define an entry point using the
+    # following format:
+    #
+    # entry_points = """
+    # [glue.plugins]
+    # webcam_importer=glue_exp.importers.webcam:setup
+    # vizier_importer=glue_exp.importers.vizier:setup
+    # dataverse_importer=glue_exp.importers.dataverse:setup
+    # """
+    #
+    # where ``setup`` is a function that does whatever is needed to set up the
+    # plugin, such as add items to various registries.
+
+    logger.info("Loading external plugins")
+    from pkg_resources import iter_entry_points
+    for item in iter_entry_points(group='glue.plugins', name=None):
+        try:
+            function = item.resolve()
+            function()
+        except Exception as exc:
+            logger.info("Loading plugin: {0} failed (Exception: {1})".format(item.name, exc))
+        else:
+            logger.info("Loading plugin: {0} succeeded".format(item.name))
+
+
 if __name__ == "__main__":
     sys.exit(main(sys.argv))  # prama: no cover

--- a/glue/main.py
+++ b/glue/main.py
@@ -256,8 +256,8 @@ def load_plugins():
     # plugin, such as add items to various registries.
 
     logger.info("Loading external plugins")
-    from pkg_resources import iter_entry_points
-    for item in iter_entry_points(group='glue.plugins', name=None):
+    from ._plugin_helpers import iter_plugin_entry_points
+    for item in iter_plugin_entry_points():
         if item.module_name in _loaded_plugins:
             logger.info("Plugin {0} already loaded".format(item.name))
             continue

--- a/glue/plugins/__init__.py
+++ b/glue/plugins/__init__.py
@@ -1,16 +1,6 @@
 import sys
 
 
-def register_plugins():
-    from ..config import qt_client, exporters, tool_registry, link_function
-    qt_client.lazy_add('glue.plugins.ginga_viewer')
-    exporters.lazy_add('glue.plugins.export_d3po')
-    exporters.lazy_add('glue.plugins.export_plotly')
-    tool_registry.lazy_add('glue.plugins.tools.pv_slicer')
-    tool_registry.lazy_add('glue.plugins.tools.spectrum_tool')
-    link_function.lazy_add('glue.plugins.coordinate_helpers')
-
-
 def load_plugin(plugin):
     """
     Load plugin referred to by name 'plugin'

--- a/glue/plugins/coordinate_helpers/__init__.py
+++ b/glue/plugins/coordinate_helpers/__init__.py
@@ -1,5 +1,4 @@
 def setup():
-    from ...logger import logger
     try:
         from . import link_helpers
     except ImportError:

--- a/glue/plugins/coordinate_helpers/__init__.py
+++ b/glue/plugins/coordinate_helpers/__init__.py
@@ -3,7 +3,4 @@ def setup():
     try:
         from . import link_helpers
     except ImportError:
-        import warnings
-        logger.info("Could not import coordinate_helpers plugin, since Astropy>=0.4 is required")
-    else:
-        logger.info("Loaded coordinate helpers plugin")
+        raise ImportError("Astropy >= 0.4 is required")

--- a/glue/plugins/export_d3po.py
+++ b/glue/plugins/export_d3po.py
@@ -247,7 +247,6 @@ def launch(path):
 
 
 def setup():
-    from ..logger import logger
     from ..config import exporters
     exporters.add('D3PO', save_d3po, can_save_d3po, outmode='directory')
 

--- a/glue/plugins/export_d3po.py
+++ b/glue/plugins/export_d3po.py
@@ -250,7 +250,6 @@ def setup():
     from ..logger import logger
     from ..config import exporters
     exporters.add('D3PO', save_d3po, can_save_d3po, outmode='directory')
-    logger.info("Loaded d3po exporter plugin")
 
 
 HTML = """

--- a/glue/plugins/export_plotly.py
+++ b/glue/plugins/export_plotly.py
@@ -305,7 +305,6 @@ def save_plotly(application, label):
     plotly.plot(*args, **kwargs)
 
 def setup():
-    from ..logger import logger
     from ..config import exporters, settings
     exporters.add('Plotly', save_plotly, can_save_plotly, outmode='label')
     settings.add('PLOTLY_USER', 'Glue')

--- a/glue/plugins/export_plotly.py
+++ b/glue/plugins/export_plotly.py
@@ -310,4 +310,3 @@ def setup():
     exporters.add('Plotly', save_plotly, can_save_plotly, outmode='label')
     settings.add('PLOTLY_USER', 'Glue')
     settings.add('PLOTLY_APIKEY', 't24aweai14')
-    logger.info("Loaded plotly exporter plugin")

--- a/glue/plugins/ginga_viewer/__init__.py
+++ b/glue/plugins/ginga_viewer/__init__.py
@@ -3,8 +3,7 @@ def setup():
     try:
         from .qt_widget import GingaWidget
     except ImportError:
-        logger.info("Could not load ginga viewer plugin, since ginga is required")
+        raise Exception("ginga is required")
     else:
         from ...config import qt_client
         qt_client.add(GingaWidget)
-        logger.info("Loaded ginga viewer plugin")

--- a/glue/plugins/ginga_viewer/__init__.py
+++ b/glue/plugins/ginga_viewer/__init__.py
@@ -1,9 +1,8 @@
 def setup():
-    from ...logger import logger
     try:
         from .qt_widget import GingaWidget
     except ImportError:
-        raise Exception("ginga is required")
+        raise ImportError("ginga is required")
     else:
         from ...config import qt_client
         qt_client.add(GingaWidget)

--- a/glue/plugins/tools/pv_slicer.py
+++ b/glue/plugins/tools/pv_slicer.py
@@ -5,7 +5,6 @@ from ...qt.widgets.mpl_widget import defer_draw
 
 
 def setup():
-    from ...logger import logger
     from ...config import tool_registry
     from ...qt.widgets import ImageWidget
     tool_registry.add(PVSlicerTool, widget_cls=ImageWidget)

--- a/glue/plugins/tools/pv_slicer.py
+++ b/glue/plugins/tools/pv_slicer.py
@@ -9,7 +9,6 @@ def setup():
     from ...config import tool_registry
     from ...qt.widgets import ImageWidget
     tool_registry.add(PVSlicerTool, widget_cls=ImageWidget)
-    logger.info("Loaded pv slicer plugin")
 
 
 class PVSlicerTool(object):

--- a/glue/plugins/tools/spectrum_tool.py
+++ b/glue/plugins/tools/spectrum_tool.py
@@ -38,7 +38,6 @@ def setup():
     from ...config import tool_registry
     from ...qt.widgets import ImageWidget
     tool_registry.add(SpectrumTool, widget_cls=ImageWidget)
-    logger.info("Loaded spectrum tool plugin")
 
 
 class Extractor(object):

--- a/glue/plugins/tools/spectrum_tool.py
+++ b/glue/plugins/tools/spectrum_tool.py
@@ -34,7 +34,6 @@ from ...utils import drop_axis
 
 
 def setup():
-    from ...logger import logger
     from ...config import tool_registry
     from ...qt.widgets import ImageWidget
     tool_registry.add(SpectrumTool, widget_cls=ImageWidget)

--- a/glue/qt/glue_application.py
+++ b/glue/qt/glue_application.py
@@ -18,6 +18,7 @@ from ..utils.qt import QMessageBoxPatched as QMessageBox
 
 from ..core import command, Data
 from .. import env
+from ..main import load_plugins
 from ..qt import get_qapp
 from .decorators import set_cursor, messagebox_on_error
 from ..core.application_base import Application
@@ -191,6 +192,8 @@ class GlueApplication(Application, QMainWindow):
         pth = os.path.abspath(os.path.dirname(__file__))
         pth = os.path.join(pth, 'icons', 'app_icon.png')
         self.app.setWindowIcon(QIcon(pth))
+
+        load_plugins()
 
         self.setWindowIcon(self.app.windowIcon())
         self.setAttribute(Qt.WA_DeleteOnClose)

--- a/setup.py
+++ b/setup.py
@@ -67,10 +67,24 @@ class PyTest(TestCommand):
 cmdclass['test'] = PyTest
 
 
-console_scripts = ['glue = glue.main:main',
-                   'glue-config = glue.config_gen:main',
-                   'glue-deps = glue._deps:main',
+console_scripts = [
                    ]
+
+# Define built-in plugins
+entry_points = """
+[glue.plugins]
+ginga_viewer = glue.plugins.ginga_viewer:setup
+export_d3po = glue.plugins.export_d3po:setup
+export_plotly = glue.plugins.export_plotly:setup
+pv_slicer = glue.plugins.tools.pv_slicer:setup
+spectrum_tool = glue.plugins.tools.spectrum_tool:setup
+coordinate_helpers = glue.plugins.coordinate_helpers:setup
+
+[console_scripts]
+glue = glue.main:main
+glue-config = glue.config_gen:main
+glue-deps = glue._deps:main
+"""
 
 setup(name='glueviz',
       version=__version__,
@@ -88,7 +102,7 @@ setup(name='glueviz',
           'License :: OSI Approved :: BSD License'
           ],
       packages = find_packages(),
-      entry_points={'console_scripts' : console_scripts},
+      entry_points=entry_points,
       cmdclass=cmdclass,
       package_data={'': ['*.png', '*.ui']}
     )


### PR DESCRIPTION
This is a WIP, but it shows how glue can load plugins via entry points. The logger doesn't currently work because the level is only set once ``main()`` is executed.

This brings up a more fundamental philosophical question which is whether we should be doing all this in ``__init__.py`` (short answer: I don't think so). This means that if anyone writes a package that imports something from glue, all plugins will be loaded, and some may take a while. We could instead do all this (loading internal plugins, loading external plugins, and loading user configuration) when the application is started instead.

However, if someone wants to use glue from a Python script but needs to use one of the plugins (which somehow enhances command-line usage) then this won't necessarily work for them.

As a compromise, we could put the loading of plugins and of the configuration in a function that gets executed when ``GlueApplication`` is instantiated, and which users can also call from Python scripts if needed:

```python
import glue
glue.load_config()
glue.load_plugins()
```

Yes, this is a bit more manual for the case where someone wants to use glue from Python without launching the application and needs access to plugins, but that seems like a corner case?

@ChrisBeaumont - what do you think about this idea?