### PR TITLE
Failure when trying to save session

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@ v0.6 (unreleased)
 
 * Fixed treatment of newlines when copying detailed error. [#687]
 
+* Fix a bug that prevented sessions from being saved with embedded files if
+  component units were Astropy units. [#686]
+
 v0.5 (2015-07-03)
 -----------------
 

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -187,6 +187,14 @@ class Component(object):
         self._data = data
 
     @property
+    def units(self):
+        return self._units
+
+    @units.setter
+    def units(self, value):
+        self._units = str(value)
+
+    @property
     def hidden(self):
         """Whether the Component is hidden by default"""
         return False

--- a/glue/core/tests/test_component.py
+++ b/glue/core/tests/test_component.py
@@ -12,6 +12,8 @@ from ..data import (Component, ComponentID, Data,
                     DerivedComponent, CoordinateComponent,
                     CategoricalComponent)
 from ... import core
+from ...tests.helpers import requires_astropy
+from ...external import six
 
 
 VIEWS = (np.s_[:], np.s_[1], np.s_[::-1], np.s_[0, :])
@@ -302,3 +304,22 @@ def test_view_derived(view):
     dc = DerivedComponent(d, link)
 
     np.testing.assert_array_equal(dc[view], comp.data[view] * 3)
+
+
+@requires_astropy
+def test_units():
+
+    # Make sure that units get converted to strings. At the moment if these
+    # are set to Astropy units for example, things can go wrong for example
+    # when writing out the datasets. Once we settle on a units framework, we
+    # can then use that instead of converting units to strings.
+
+    from astropy import units as u
+
+    comp = Component([1,2,3], units='m')
+    assert comp.units == 'm'
+    assert isinstance(comp.units, six.string_types)
+
+    comp = Component([1,2,3], units=u.m)
+    assert comp.units == 'm'
+    assert isinstance(comp.units, six.string_types)


### PR DESCRIPTION
I tried to save a session set up with the W5 example:

```
Traceback (most recent call last): 

File "/Users/tom/miniconda3/envs/gluedev/lib/python3.4/site-packages/glueviz-0.5.0-py3.4.egg/glue/core/application_base.py", line 25, in wrapper 
    return func(*args, **kwargs) 

File "/Users/tom/miniconda3/envs/gluedev/lib/python3.4/site-packages/glueviz-0.5.0-py3.4.egg/glue/core/application_base.py", line 94, in save_session
     state = gs.dumps(indent=2) 

File "/Users/tom/miniconda3/envs/gluedev/lib/python3.4/site-packages/glueviz-0.5.0-py3.4.egg/glue/core/state.py", line 339, in dumps 
    return json.dumps(result, indent=indent, default=self.json_default)

 File "/Users/tom/miniconda3/envs/gluedev/lib/python3.4/json/__init__.py", line 237, in dumps     **kw).encode(obj) 

File "/Users/tom/miniconda3/envs/gluedev/lib/python3.4/json/encoder.py", line 194, in encode
     chunks = list(chunks) 

File "/Users/tom/miniconda3/envs/gluedev/lib/python3.4/json/encoder.py", line 422, in _iterencode 
    yield from _iterencode_dict(o, _current_indent_level) 

File "/Users/tom/miniconda3/envs/gluedev/lib/python3.4/json/encoder.py", line 396, in _iterencode_dict 
    yield from chunks 

File "/Users/tom/miniconda3/envs/gluedev/lib/python3.4/json/encoder.py", line 396, in _iterencode_dict     yield from chunks 

File "/Users/tom/miniconda3/envs/gluedev/lib/python3.4/json/encoder.py", line 430, in _iterencode 
    yield from _iterencode(o, _current_indent_level) 

File "/Users/tom/miniconda3/envs/gluedev/lib/python3.4/json/encoder.py", line 427, in _iterencode
     raise ValueError("Circular reference detected") 
ValueError: Circular reference detected 
```