### PR TITLE
Copying error does not include newlines

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Full changelog
 v0.6 (unreleased)
 -----------------
 
-* No changes yet
+* Fixed treatment of newlines when copying detailed error. [#687]
 
 v0.5 (2015-07-03)
 -----------------

--- a/glue/utils/qt/qmessagebox_widget.py
+++ b/glue/utils/qt/qmessagebox_widget.py
@@ -1,5 +1,6 @@
 # A patched version of QMessageBox that allows copying the error
 
+import os
 from ...external.qt import QtGui
 
 __all__ = ['QMessageBoxPatched']
@@ -36,4 +37,6 @@ class QMessageBoxPatched(QtGui.QMessageBox):
     def copy_detailed(self):
         clipboard = QtGui.QApplication.clipboard()
         selected_text = self.detailed_text_widget.textCursor().selectedText()
+        # Newlines are unicode, so need to normalize them to ASCII
+        selected_text = os.linesep.join(selected_text.splitlines())
         clipboard.setText(selected_text)


### PR DESCRIPTION
When copying an error from the error console, the output is something like:

```
Traceback (most recent call last):   File "/Users/tom/miniconda3/envs/gluedev/lib/python3.4/site-packages/glueviz-0.5.0-py3.4.egg/glue/core/application_base.py", line 25, in wrapper     return func(*args, **kwargs)   File "/Users/tom/miniconda3/envs/gluedev/lib/python3.4/site-packages/glueviz-0.5.0-py3.4.egg/glue/core/application_base.py", line 94, in save_session     state = gs.dumps(indent=2)   File "/Users/tom/miniconda3/envs/gluedev/lib/python3.4/site-packages/glueviz-0.5.0-py3.4.egg/glue/core/state.py", line 339, in dumps     return json.dumps(result, indent=indent, default=self.json_default)   File "/Users/tom/miniconda3/envs/gluedev/lib/python3.4/json/__init__.py", line 237, in dumps     **kw).encode(obj)   File "/Users/tom/miniconda3/envs/gluedev/lib/python3.4/json/encoder.py", line 194, in encode     chunks = list(chunks)   File "/Users/tom/miniconda3/envs/gluedev/lib/python3.4/json/encoder.py", line 422, in _iterencode     yield from _iterencode_dict(o, _current_indent_level)   File "/Users/tom/miniconda3/envs/gluedev/lib/python3.4/json/encoder.py", line 396, in _iterencode_dict     yield from chunks   File "/Users/tom/miniconda3/envs/gluedev/lib/python3.4/json/encoder.py", line 396, in _iterencode_dict     yield from chunks   File "/Users/tom/miniconda3/envs/gluedev/lib/python3.4/json/encoder.py", line 430, in _iterencode     yield from _iterencode(o, _current_indent_level)   File "/Users/tom/miniconda3/envs/gluedev/lib/python3.4/json/encoder.py", line 427, in _iterencode     raise ValueError("Circular reference detected") ValueError: Circular reference detected 
```

Newlines are missing...