### PR TITLE
Added new selection ‘Move’ mode

### DIFF
--- a/doc/getting_started/index.rst
+++ b/doc/getting_started/index.rst
@@ -55,11 +55,13 @@ We can highlight the west arm of W5 using the rectangle selector:
 
 Notice that this highlights the relevant pixels in the image, adds a new subset (which we've named ``west arm``) to the data manager, and adds a new visualization layer (also labeled ``west arm (w5)``) in the visualization dashboard.
 
-We can redefine this subset by dragging a new rectangle in the image. Alternately, we could define a second subset by clicking the ``New Subset`` button (next to the folder button).
+We can redefine this subset by dragging a new rectangle in the image, or we can
+also move around the current subset by pressing the 'control' key and clicking
+on the subset then dragging it. Alternately, we could define a second subset by
+clicking the ``New Subset`` button (next to the folder button).
 
 .. _multi_selection_note:
 .. note:: When multiple subsets are defined, only the highlighted entries in the data manager are affected when drawing new subsets. If no subsets are highlighted, then a new subset is created.
-
 
 You can edit the properties of a visualization layer (color, name, etc.) By double-clicking on the entry in the visualization dashboard.
 

--- a/glue/core/roi.py
+++ b/glue/core/roi.py
@@ -18,7 +18,7 @@ __all__ = ['Roi', 'RectangularROI', 'CircularROI', 'PolygonalROI',
            'XRangeROI', 'RangeROI', 'YRangeROI','VertexROIBase']
 
 PATCH_COLOR = '#FFFF00'
-
+SCRUBBING_KEY = 'control'
 
 try:
     from matplotlib.nxutils import points_inside_poly
@@ -653,15 +653,21 @@ class MplRectangularROI(AbstractMplRoi):
         return RectangularROI()
 
     def start_selection(self, event):
+
         if event.inaxes != self._axes:
-            return
+            return False
+
+        if event.key == SCRUBBING_KEY:
+            if not self._roi.defined():
+                return False
+            elif not self._roi.contains(event.xdata, event.ydata):
+                return False
 
         self._roi_store()
         self._xi = event.xdata
         self._yi = event.ydata
 
-        if self._roi.defined() and \
-           self._roi.contains(event.xdata, event.ydata):
+        if event.key == SCRUBBING_KEY:
             self._scrubbing = True
             self._cx, self._cy = self._roi.center()
         else:
@@ -673,8 +679,15 @@ class MplRectangularROI(AbstractMplRoi):
         self._sync_patch()
 
     def update_selection(self, event):
+
         if not self._mid_selection or event.inaxes != self._axes:
-            return
+            return False
+
+        if event.key == SCRUBBING_KEY:
+            if not self._roi.defined():
+                return False
+            elif not self._roi.contains(event.xdata, event.ydata):
+                return False
 
         if self._scrubbing:
             self._roi.move_to(self._cx + event.xdata - self._xi,
@@ -738,13 +751,19 @@ class MplXRangeROI(AbstractMplRoi):
         return XRangeROI()
 
     def start_selection(self, event):
+
         if event.inaxes != self._axes:
-            return
+            return False
+
+        if event.key == SCRUBBING_KEY:
+            if not self._roi.defined():
+                return False
+            elif not self._roi.contains(event.xdata, event.ydata):
+                return False
 
         self._roi_store()
 
-        if self._roi.defined() and \
-           self._roi.contains(event.xdata, event.xdata):
+        if event.key == SCRUBBING_KEY:
             self._scrubbing = True
             self._dx = event.xdata - self._roi.center()
         else:
@@ -755,8 +774,15 @@ class MplXRangeROI(AbstractMplRoi):
         self._sync_patch()
 
     def update_selection(self, event):
+
         if not self._mid_selection or event.inaxes != self._axes:
-            return
+            return False
+
+        if event.key == SCRUBBING_KEY:
+            if not self._roi.defined():
+                return False
+            elif not self._roi.contains(event.xdata, event.ydata):
+                return False
 
         if self._scrubbing:
             self._roi.move_to(event.xdata + self._dx)
@@ -812,13 +838,19 @@ class MplYRangeROI(AbstractMplRoi):
         return YRangeROI()
 
     def start_selection(self, event):
+
         if event.inaxes != self._axes:
-            return
+            return False
+
+        if event.key == SCRUBBING_KEY:
+            if not self._roi.defined():
+                return False
+            elif not self._roi.contains(event.xdata, event.ydata):
+                return False
 
         self._roi_store()
 
-        if self._roi.defined() and \
-           self._roi.contains(event.ydata, event.ydata):
+        if event.key == SCRUBBING_KEY:
             self._scrubbing = True
             self._dy = event.ydata - self._roi.center()
         else:
@@ -829,8 +861,15 @@ class MplYRangeROI(AbstractMplRoi):
         self._sync_patch()
 
     def update_selection(self, event):
+
         if not self._mid_selection or event.inaxes != self._axes:
-            return
+            return False
+
+        if event.key == SCRUBBING_KEY:
+            if not self._roi.defined():
+                return False
+            elif not self._roi.contains(event.xdata, event.ydata):
+                return False
 
         if self._scrubbing:
             self._roi.move_to(event.ydata + self._dy)
@@ -918,16 +957,23 @@ class MplCircularROI(AbstractMplRoi):
         self._axes.figure.canvas.draw()
 
     def start_selection(self, event):
-        if event.inaxes != self._axes:
-            return
 
-        self._roi_store()
+        if event.inaxes != self._axes:
+            return False
+
         xy = data_to_pixel(self._axes, [event.xdata], [event.ydata])
         xi = xy[0, 0]
         yi = xy[0, 1]
 
-        if self._roi.defined() and \
-           self._roi.contains(xi, yi):
+        if event.key == SCRUBBING_KEY:
+            if not self._roi.defined():
+                return False
+            elif not self._roi.contains(xi, yi):
+                return False
+
+        self._roi_store()
+
+        if event.key == SCRUBBING_KEY:
             self._scrubbing = True
             (xc, yc) = self._roi.get_center()
             self._dx = xc - xi
@@ -943,12 +989,19 @@ class MplCircularROI(AbstractMplRoi):
         self._sync_patch()
 
     def update_selection(self, event):
+
         if not self._mid_selection or event.inaxes != self._axes:
-            return
+            return False
 
         xy = data_to_pixel(self._axes, [event.xdata], [event.ydata])
         xi = xy[0, 0]
         yi = xy[0, 1]
+
+        if event.key == SCRUBBING_KEY:
+            if not self._roi.defined():
+                return False
+            elif not self._roi.contains(xi, yi):
+                return False
 
         if self._scrubbing:
             self._roi.set_center(xi + self._dx, yi + self._dy)
@@ -1032,12 +1085,19 @@ class MplPolygonalROI(AbstractMplRoi):
         self._axes.figure.canvas.draw()
 
     def start_selection(self, event):
+
         if event.inaxes != self._axes:
-            return
+            return False
+
+        if event.key == SCRUBBING_KEY:
+            if not self._roi.defined():
+                return False
+            elif not self._roi.contains(event.xdata, event.ydata):
+                return False
 
         self._roi_store()
-        if self._roi.defined() and \
-           self._roi.contains(event.xdata, event.ydata):
+
+        if event.key == SCRUBBING_KEY:
             self._scrubbing = True
             self._cx = event.xdata
             self._cy = event.ydata
@@ -1049,8 +1109,15 @@ class MplPolygonalROI(AbstractMplRoi):
         self._sync_patch()
 
     def update_selection(self, event):
+
         if not self._mid_selection or event.inaxes != self._axes:
-            return
+            return False
+
+        if event.key == SCRUBBING_KEY:
+            if not self._roi.defined():
+                return False
+            elif not self._roi.contains(event.xdata, event.ydata):
+                return False
 
         if self._scrubbing:
             self._roi.move_to(event.xdata - self._cx,

--- a/glue/core/roi.py
+++ b/glue/core/roi.py
@@ -686,8 +686,6 @@ class MplRectangularROI(AbstractMplRoi):
         if event.key == SCRUBBING_KEY:
             if not self._roi.defined():
                 return False
-            elif not self._roi.contains(event.xdata, event.ydata):
-                return False
 
         if self._scrubbing:
             self._roi.move_to(self._cx + event.xdata - self._xi,
@@ -781,8 +779,6 @@ class MplXRangeROI(AbstractMplRoi):
         if event.key == SCRUBBING_KEY:
             if not self._roi.defined():
                 return False
-            elif not self._roi.contains(event.xdata, event.ydata):
-                return False
 
         if self._scrubbing:
             self._roi.move_to(event.xdata + self._dx)
@@ -867,8 +863,6 @@ class MplYRangeROI(AbstractMplRoi):
 
         if event.key == SCRUBBING_KEY:
             if not self._roi.defined():
-                return False
-            elif not self._roi.contains(event.xdata, event.ydata):
                 return False
 
         if self._scrubbing:
@@ -1000,8 +994,6 @@ class MplCircularROI(AbstractMplRoi):
         if event.key == SCRUBBING_KEY:
             if not self._roi.defined():
                 return False
-            elif not self._roi.contains(xi, yi):
-                return False
 
         if self._scrubbing:
             self._roi.set_center(xi + self._dx, yi + self._dy)
@@ -1115,8 +1107,6 @@ class MplPolygonalROI(AbstractMplRoi):
 
         if event.key == SCRUBBING_KEY:
             if not self._roi.defined():
-                return False
-            elif not self._roi.contains(event.xdata, event.ydata):
                 return False
 
         if self._scrubbing:

--- a/glue/core/tests/test_roi.py
+++ b/glue/core/tests/test_roi.py
@@ -478,6 +478,7 @@ class TestMpl(object):
             roi.start_selection(event)
             event = DummyEvent(10, 10, inaxes=self.axes)
             roi.update_selection(event)
+            roi.finalize_selection(DummyEvent(10, 10))
 
         if outside:
             roi.start_selection(DummyEvent(16, 16, inaxes=self.axes, key='control'))

--- a/glue/qt/mouse_mode.py
+++ b/glue/qt/mouse_mode.py
@@ -201,8 +201,11 @@ class RoiMode(RoiModeBase):
         dx = abs(event.x - self._start_event.x)
         dy = abs(event.y - self._start_event.y)
         if (dx + dy) > self._drag_dist:
-            self._roi_tool.start_selection(self._start_event)
-            self._drag = True
+            status = self._roi_tool.start_selection(self._start_event)
+            # If start_selection returns False, the selection has not been
+            # started and we should abort, so we set self._drag to False in this
+            # case.
+            self._drag = True if status is None else status
 
     def press(self, event):
         self._start_event = event


### PR DESCRIPTION
Fixes https://github.com/glue-viz/glue/issues/688 by adding a dedicated 'Move' mode for selections which is not enabled by default.