### PR TITLE
ROI refactoring

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,9 @@ v0.6 (unreleased)
 * Fix a bug that prevented sessions from being saved with embedded files if
   component units were Astropy units. [#686]
 
+* Improved under-the-hood creation of ROIs for Scatter and Histogram Clients. [#676]
+
+
 v0.5 (2015-07-03)
 -----------------
 

--- a/glue/clients/histogram_client.py
+++ b/glue/clients/histogram_client.py
@@ -5,6 +5,7 @@ import numpy as np
 from ..core.client import Client
 from ..core import message as msg
 from ..core.data import Data, CategoricalComponent
+from ..core.roi import RangeROI
 from ..core.subset import RangeSubsetState, CategoricalRoiSubsetState
 from ..core.exceptions import IncompatibleDataException, IncompatibleAttribute
 from ..core.edit_subset_mode import EditSubsetMode
@@ -378,16 +379,9 @@ class HistogramClient(Client):
         if self.xlog:
             lo = 10 ** lo
             hi = 10 ** hi
-
-        comp = list(self._get_data_components('x'))
-        if comp:
-            comp = comp[0]
-            if comp.categorical:
-                state = CategoricalRoiSubsetState.from_range(comp, self.component,
-                                                             lo, hi)
-            else:
-                state = RangeSubsetState(lo, hi)
-                state.att = self.component
+        nroi = RangeROI(min=lo, max=hi, orientation='x')
+        for comp in self._get_data_components('x'):
+            state = comp.subset_from_roi(self.component, nroi, coord='x')
             mode = EditSubsetMode()
             visible = [d for d in self.data if self.is_layer_visible(d)]
             focus = visible[0] if len(visible) > 0 else None

--- a/glue/clients/scatter_client.py
+++ b/glue/clients/scatter_client.py
@@ -7,7 +7,7 @@ import numpy as np
 from ..core.client import Client
 from ..core.data import Data, IncompatibleAttribute, ComponentID, CategoricalComponent
 from ..core.subset import RoiSubsetState, RangeSubsetState, CategoricalRoiSubsetState, AndState
-from ..core.roi import PolygonalROI, RangeROI, CategoricalRoi, RectangularROI
+from ..core.roi import PolygonalROI, RangeROI, CategoricalROI, RectangularROI
 from ..core.util import relim
 from ..core.edit_subset_mode import EditSubsetMode
 from ..core.message import ComponentReplacedMessage

--- a/glue/clients/scatter_client.py
+++ b/glue/clients/scatter_client.py
@@ -277,31 +277,16 @@ class ScatterClient(Client):
         # every editable subset is updated
         # using specified ROI
 
-        if isinstance(roi, RangeROI):
-            lo, hi = roi.range()
-            att = self.xatt if roi.ori == 'x' else self.yatt
-            if self._check_categorical(att):
-                comp = list(self._get_data_components(roi.ori))
-                if comp:
-                    subset_state = CategoricalRoiSubsetState.from_range(comp[0], att, lo, hi)
-                else:
-                    subset_state = None
-            else:
-                subset_state = RangeSubsetState(lo, hi, att)
-        else:
-            if self._check_categorical(self.xatt) or self._check_categorical(self.yatt):
-                subset_state = self._process_categorical_roi(roi)
-            else:
-                subset_state = RoiSubsetState()
-                subset_state.xatt = self.xatt
-                subset_state.yatt = self.yatt
-                x, y = roi.to_polygon()
-                subset_state.roi = PolygonalROI(x, y)
-
-        mode = EditSubsetMode()
-        visible = [d for d in self._data if self.is_visible(d)]
-        focus = visible[0] if len(visible) > 0 else None
-        mode.update(self._data, subset_state, focus_data=focus)
+        for x_comp, y_comp in zip(self._get_data_components('x'),
+                                  self._get_data_components('y')):
+            subset_state = x_comp.subset_from_roi(self.xatt, roi,
+                                                  other_comp=y_comp,
+                                                  other_att=self.yatt,
+                                                  coord='x')
+            mode = EditSubsetMode()
+            visible = [d for d in self._data if self.is_visible(d)]
+            focus = visible[0] if len(visible) > 0 else None
+            mode.update(self._data, subset_state, focus_data=focus)
 
     def _set_xlog(self, state):
         """ Set the x axis scaling

--- a/glue/clients/tests/test_histogram_client.py
+++ b/glue/clients/tests/test_histogram_client.py
@@ -14,6 +14,7 @@ from ...core.data_collection import DataCollection
 from ...core.exceptions import IncompatibleDataException
 from ...core.data import Data, CategoricalComponent, ComponentID
 from ...core.subset import RangeSubsetState, CategoricalRoiSubsetState
+from ...core.roi import RangeROI, PolygonalROI
 
 from .util import renderless_figure
 
@@ -222,9 +223,7 @@ class TestHistogramClient(object):
         # bins are -7...-1
 
         self.data.edit_subset = [self.data.subsets[0]]
-
-        roi = MagicMock()
-        roi.to_polygon.return_value = [-5.1, -4.5, -3.2], [2, 3, 4]
+        roi = PolygonalROI(vx=[-5.1, -4.5, -3.2], vy=[2, 3, 4])
 
         self.client.apply_roi(roi)
         state = self.data.subsets[0].subset_state
@@ -239,8 +238,7 @@ class TestHistogramClient(object):
         self.client.set_component(self.data.id['x'])
         self.data.edit_subset = [self.data.subsets[0]]
         self.client.xlog = True
-        roi = MagicMock()
-        roi.to_polygon.return_value = [1, 2, 3], [2, 3, 4]
+        roi = PolygonalROI(vx=[1, 2, 3], vy=[2, 3, 4])
 
         self.client.apply_roi(roi)
         state = self.data.subsets[0].subset_state

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -16,7 +16,7 @@ from .component_link import (ComponentLink, CoordinateComponentLink,
 from .subset import (Subset, InequalitySubsetState, SubsetState,
                      RoiSubsetState, RangeSubsetState,
                      CategoricalRoiSubsetState, AndState)
-from .roi import (PolygonalROI, CategoricalRoi, RangeROI, RectangularROI,
+from .roi import (PolygonalROI, CategoricalROI, RangeROI, RectangularROI,
                     XRangeROI, YRangeROI)
 from .hub import Hub
 from .util import split_component_view, row_lookup
@@ -243,11 +243,18 @@ class Component(object):
         raise NotImplementedError
 
     def subset_from_roi(self, att, roi, other_comp=None, other_att=None, coord='x'):
-        """ Create an SubsetState object
+        """ Create a SubsetState object from an ROI.
+
+        This encapsulates the logic for creating subset states with
+        Components. See the documentation for CategoricalComponents for caveats
+        involved with mixed-type plots.
+
         :param att: attribute name of this Component
         :param roi: an ROI object
         :param other_comp: The other Component for 2D ROIs
         :param other_att: The attribute name of the other Component
+        :param coord: The orientation of this Component
+        :param is_nested: True if this was passed from another Component.
         :return: A SubsetState (or subclass) object
         """
 
@@ -255,6 +262,7 @@ class Component(object):
 
         if hasattr(roi, 'min') and hasattr(roi, 'ori'):
             # RangeROI and its subclasses
+            assert roi.ori in set('xy')
             lo, hi = roi.range()
             if roi.ori == coord:
                 subset_state = RangeSubsetState(lo, hi, att)
@@ -267,7 +275,7 @@ class Component(object):
             elif roi.ori != coord:
                 subset_state = RangeSubsetState(lo, hi, other_att)
             else:
-                raise AssertionError('RangeROI.ori must be "x" or "y"')
+                raise AssertionError
         else:
             if isinstance(other_comp, CategoricalComponent):
                 return other_comp.subset_from_roi(other_att, roi,
@@ -483,12 +491,21 @@ class CategoricalComponent(Component):
         self.jitter(method=self._jitter_method)
         self._data.setflags(write=False)
 
-    def subset_from_roi(self, att, roi, other_comp=None, other_att=None, coord='x', is_nested=False):
-        """ Create an SubsetState object
+    def subset_from_roi(self, att, roi, other_comp=None,
+                        other_att=None, coord='x',
+                        is_nested=False):
+        """ Create a SubsetState object from an ROI.
+
+        This encapsulates the logic for creating subset states with
+        CategoricalComponents. There is an important caveat, only RangeROIs
+        and RectangularROIs make sense in mixed type plots. As such, polygons
+        are converted to their outer-most edges in this case.
+
         :param att: attribute name of this Component
         :param roi: an ROI object
         :param other_comp: The other Component for 2D ROIs
         :param other_att: The attribute name of the other Component
+        :param coord: The orientation of this Component
         :param is_nested: True if this was passed from another Component.
         :return: A SubsetState (or subclass) object
         """
@@ -497,6 +514,7 @@ class CategoricalComponent(Component):
 
         if hasattr(roi, 'min') and hasattr(roi, 'ori'):
             # RangeRoi and its subclasses
+            assert roi.ori in set('xy')
             if roi.ori == coord:
                 return CategoricalRoiSubsetState.from_range(self, att, roi.min, roi.max)
             elif roi.ori != coord:
@@ -506,8 +524,8 @@ class CategoricalComponent(Component):
                                                   other_att=att,
                                                   coord=other_coord)
             else:
-                raise AssertionError('RangeROI.ori must be "x" or "y"')
-        elif isinstance(roi, CategoricalRoi):
+                raise AssertionError
+        elif isinstance(roi, CategoricalROI):
             return CategoricalRoiSubsetState(roi=roi, att=att)
         else:
             x, y = roi.to_polygon()

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -13,7 +13,10 @@ from .visual import COLORS
 from .exceptions import IncompatibleAttribute
 from .component_link import (ComponentLink, CoordinateComponentLink,
                              BinaryComponentLink)
-from .subset import Subset, InequalitySubsetState, SubsetState
+from .subset import (Subset, InequalitySubsetState, SubsetState,
+                     RoiSubsetState, RangeSubsetState,
+                     CategoricalRoiSubsetState, AndState)
+from .roi import PolygonalROI, CategoricalRoi, RangeROI, RectangularROI
 from .hub import Hub
 from .util import split_component_view, row_lookup
 from ..utils import unique, shape_to_string, view_shape, coerce_numeric, check_sorted
@@ -238,6 +241,33 @@ class Component(object):
     def jitter(self, method=None):
         raise NotImplementedError
 
+    def subset_from_roi(self, att, roi, other_comp=None, other_att=None):
+        """ Create an SubsetState object
+        :param att: attribute name of this Component
+        :param roi: an ROI object
+        :param other_comp: The other Component for 2D ROIs
+        :param other_att: The attribute name of the other Component
+        :return: A SubsetState (or subclass) object
+        """
+
+        if isinstance(other_comp, CategoricalComponent):
+            return other_comp.subset_from_roi(other_att, roi,
+                                              other_comp=self,
+                                              other_att=att,
+                                              is_nested=True)
+
+        if isinstance(roi, RangeROI):
+            lo, hi = roi.range()
+            subset_state = RangeSubsetState(lo, hi, att)
+        else:
+            subset_state = RoiSubsetState()
+            subset_state.xatt = att
+            subset_state.yatt = other_att
+            x, y = roi.to_polygon()
+            subset_state.roi = PolygonalROI(x, y)
+
+        return subset_state
+
     def to_series(self, **kwargs):
         """ Convert into a pandas.Series object.
 
@@ -437,6 +467,30 @@ class CategoricalComponent(Component):
         self._data = row_lookup(self._categorical_data, self._categories)
         self.jitter(method=self._jitter_method)
         self._data.setflags(write=False)
+
+    def subset_from_roi(self, att, roi, other_comp=None, other_att=None, is_nested=False):
+        """ Create an SubsetState object
+        :param att: attribute name of this Component
+        :param roi: an ROI object
+        :param other_comp: The other Component for 2D ROIs
+        :param other_att: The attribute name of the other Component
+        :param is_nested: True if this was passed from another Component.
+        :return: A SubsetState (or subclass) object
+        """
+
+        if isinstance(roi, RangeROI):
+            return CategoricalRoiSubsetState.from_range(self, att, roi.min, roi.max)
+        elif isinstance(roi, CategoricalRoi):
+            return CategoricalRoiSubsetState(roi=roi, att=att)
+        elif isinstance(roi, RectangularROI):
+            if is_nested:
+                roi = roi.transpose()
+            cat_subset = CategoricalRoiSubsetState.from_range(self, att,
+                                                              roi.xmin, roi.xmax)
+            cont_subset = RangeSubsetState(roi.ymin, roi.ymax, other_att)
+            return AndState(cat_subset, cont_subset)
+        else:
+            raise NotImplementedError
 
     def jitter(self, method=None):
         """

--- a/glue/core/roi.py
+++ b/glue/core/roi.py
@@ -165,6 +165,16 @@ class RectangularROI(Roi):
         self.ymin += dy
         self.ymax += dy
 
+    def transpose(self, copy=True):
+        if copy:
+            new = self.copy()
+            new.xmin, new.xmax = self.ymin, self.ymax
+            new.ymin, new.ymax = self.xmin, self.xmax
+            return new
+
+        self.xmin, self.ymin = self.ymin, self.xmin
+        self.xmax, self.ymax = self.ymax, self.xmax
+
     def corner(self):
         return (self.xmin, self.ymin)
 
@@ -1115,6 +1125,11 @@ class CategoricalRoi(Roi):
             self.categories = None
         else:
             self.update_categories(categories)
+
+    def to_polygon(self):
+        """ Just not possible.
+        """
+        raise NotImplementedError
 
     def _categorical_helper(self, indata):
         """

--- a/glue/core/roi.py
+++ b/glue/core/roi.py
@@ -1114,7 +1114,7 @@ class MplPathROI(MplPolygonalROI):
         self._axes.figure.canvas.draw()
 
 
-class CategoricalRoi(Roi):
+class CategoricalROI(Roi):
 
     """
     A ROI abstraction to represent selections of categorical data.
@@ -1190,7 +1190,7 @@ class CategoricalRoi(Roi):
         :return: CategoricalRoi object
         """
 
-        roi = CategoricalRoi()
+        roi = CategoricalROI()
         cat_data = cat_comp._categories
         roi.update_categories(cat_data[np.floor(lo):np.ceil(hi)])
         return roi

--- a/glue/core/subset.py
+++ b/glue/core/subset.py
@@ -14,7 +14,7 @@ from .util import split_component_view
 from ..utils import view_shape
 from ..external.six import PY3
 from .contracts import contract
-from .roi import CategoricalRoi
+from .roi import CategoricalROI
 
 __all__ = ['Subset', 'SubsetState', 'RoiSubsetState', 'CompositeSubsetState',
            'OrState', 'AndState', 'XorState', 'InvertState',
@@ -475,7 +475,7 @@ class CategoricalRoiSubsetState(SubsetState):
     @staticmethod
     def from_range(component, att, lo, hi):
 
-        roi = CategoricalRoi.from_range(component, lo, hi)
+        roi = CategoricalROI.from_range(component, lo, hi)
         subset = CategoricalRoiSubsetState(roi=roi,
                                            att=att)
         return subset

--- a/glue/core/tests/test_data.py
+++ b/glue/core/tests/test_data.py
@@ -356,13 +356,21 @@ class TestROICreation(object):
 
     def test_range_roi(self):
 
-        d = Data(x=[1, 2, 3], y=[1, 2, 3])
-        comp = d.get_component(d.id['x'])
+        d = Data(xdata=[1, 2, 3], ydata=[1, 2, 3])
+        comp = d.get_component(d.id['xdata'])
         roi = RangeROI('x', min=2,max=3)
-        s = comp.subset_from_roi('x', roi)
+        s = comp.subset_from_roi('xdata', roi)
         assert isinstance(s, RangeSubsetState)
         np.testing.assert_array_equal((s.lo, s.hi),
                                       [2, 3])
+
+        roi = RangeROI('y', min=2,max=3)
+        s = comp.subset_from_roi('xdata', roi, other_att='ydata',
+                                 other_comp=d.get_component(d.id['ydata']))
+        assert isinstance(s, RangeSubsetState)
+        assert s.att == 'ydata'
+
+
 
     def test_range_roi_categorical(self):
 

--- a/glue/core/tests/test_data.py
+++ b/glue/core/tests/test_data.py
@@ -16,7 +16,9 @@ from ..component_link import ComponentLink
 from ..registry import Registry
 from ... import core
 from ...external import six
-
+from ..subset import (Subset, CategoricalRoiSubsetState, SubsetState,
+                      RoiSubsetState, RangeSubsetState, AndState)
+from ..roi import PolygonalROI, CategoricalRoi, RangeROI, RectangularROI
 
 class TestCoordinates(Coordinates):
 
@@ -349,6 +351,72 @@ class TestData(object):
         np.testing.assert_array_equal(s.to_mask(), [False, True, False])
         d.update_components({d.id['x']: [10, 20, 30]})
         np.testing.assert_array_equal(s.to_mask(), [False, False, False])
+
+class TestROICreation(object):
+
+    def test_range_roi(self):
+
+        d = Data(x=[1, 2, 3], y=[1, 2, 3])
+        comp = d.get_component(d.id['x'])
+        roi = RangeROI('x', min=2,max=3)
+        s = comp.subset_from_roi('x', roi)
+        assert isinstance(s, RangeSubsetState)
+        np.testing.assert_array_equal((s.lo, s.hi),
+                                      [2, 3])
+
+    def test_range_roi_categorical(self):
+
+        d = Data(x=['a', 'b', 'c'], y=[1, 2, 3])
+        comp = d.get_component(d.id['x'])
+        roi = CategoricalRoi(['b', 'c'])
+        s = comp.subset_from_roi('x', roi)
+        assert isinstance(s, CategoricalRoiSubsetState)
+        np.testing.assert_array_equal((s.roi.contains(['a', 'b', 'c'], None)),
+                                      [False, True, True])
+
+        roi = RangeROI('x', min=1, max=3)
+        s = comp.subset_from_roi('x', roi)
+        assert isinstance(s, CategoricalRoiSubsetState)
+        np.testing.assert_array_equal((s.roi.contains(['a', 'b', 'c'], None)),
+                                      [False, True, True])
+
+    def test_polygon_roi(self):
+
+        d = Data(x=[1, 1.3, 3, 10], y=[1, 1.5, 3, 10])
+        x_comp = d.get_component(d.id['x'])
+        y_comp = d.get_component(d.id['y'])
+        roi = PolygonalROI([0, 0, 2, 2], [0, 2, 2, 0])
+        s = x_comp.subset_from_roi('x', roi, other_comp=y_comp, other_att='y')
+        assert isinstance(s, RoiSubsetState)
+        np.testing.assert_array_equal(s.to_mask(d), [True, True, False, False])
+
+    def test_polygon_raises_categorical(self):
+
+        d = Data(x=[1, 1.3, 3, 10], y=['a', 'b', 'c', 'd'])
+        x_comp = d.get_component(d.id['x'])
+        y_comp = d.get_component(d.id['y'])
+        roi = PolygonalROI([0, 0, 2, 2], [0, 2, 2, 0])
+        with pytest.raises(NotImplementedError):
+            s = x_comp.subset_from_roi('x', roi, other_comp=y_comp, other_att='y')
+
+        with pytest.raises(NotImplementedError):
+            s = y_comp.subset_from_roi('y', roi, other_comp=x_comp, other_att='x')
+
+    def test_rectangular_categorical(self):
+
+        d = Data(x=[1, 1.3, 3, 10], y=['a', 'b', 'c', 'd'])
+        x_comp = d.get_component(d.id['x'])
+        y_comp = d.get_component(d.id['y'])
+        roi = RectangularROI(xmin=0, xmax=2, ymin=0, ymax=2)
+        s = x_comp.subset_from_roi('x', roi, other_comp=y_comp, other_att='y')
+        assert isinstance(s, AndState)
+
+        np.testing.assert_array_equal(s.to_mask(d), [True, True, False, False])
+
+        s = y_comp.subset_from_roi('y', roi, other_comp=x_comp, other_att='x')
+        assert isinstance(s, AndState)
+
+        np.testing.assert_array_equal(s.to_mask(d), [True, True, False, False])
 
 
 def test_component_id_item_access():

--- a/glue/core/tests/test_data.py
+++ b/glue/core/tests/test_data.py
@@ -18,7 +18,7 @@ from ... import core
 from ...external import six
 from ..subset import (Subset, CategoricalRoiSubsetState, SubsetState,
                       RoiSubsetState, RangeSubsetState, AndState)
-from ..roi import PolygonalROI, CategoricalRoi, RangeROI, RectangularROI
+from ..roi import PolygonalROI, CategoricalROI, RangeROI, RectangularROI
 
 class TestCoordinates(Coordinates):
 
@@ -376,7 +376,7 @@ class TestROICreation(object):
 
         d = Data(x=['a', 'b', 'c'], y=[1, 2, 3])
         comp = d.get_component(d.id['x'])
-        roi = CategoricalRoi(['b', 'c'])
+        roi = CategoricalROI(['b', 'c'])
         s = comp.subset_from_roi('x', roi)
         assert isinstance(s, CategoricalRoiSubsetState)
         np.testing.assert_array_equal((s.roi.contains(['a', 'b', 'c'], None)),
@@ -398,17 +398,14 @@ class TestROICreation(object):
         assert isinstance(s, RoiSubsetState)
         np.testing.assert_array_equal(s.to_mask(d), [True, True, False, False])
 
-    def test_polygon_raises_categorical(self):
+    def test_polygon_categorical(self):
 
         d = Data(x=[1, 1.3, 3, 10], y=['a', 'b', 'c', 'd'])
         x_comp = d.get_component(d.id['x'])
         y_comp = d.get_component(d.id['y'])
         roi = PolygonalROI([0, 0, 2, 2], [0, 2, 2, 0])
-        with pytest.raises(NotImplementedError):
-            s = x_comp.subset_from_roi('x', roi, other_comp=y_comp, other_att='y')
-
-        with pytest.raises(NotImplementedError):
-            s = y_comp.subset_from_roi('y', roi, other_comp=x_comp, other_att='x')
+        s = x_comp.subset_from_roi('x', roi, other_comp=y_comp, other_att='y')
+        assert isinstance(s, AndState)
 
     def test_rectangular_categorical(self):
 

--- a/glue/core/tests/test_roi.py
+++ b/glue/core/tests/test_roi.py
@@ -10,7 +10,7 @@ from matplotlib.figure import Figure
 from glue.core.data import CategoricalComponent
 from mock import MagicMock
 
-from ..roi import (RectangularROI, UndefinedROI, CircularROI, PolygonalROI, CategoricalRoi,
+from ..roi import (RectangularROI, UndefinedROI, CircularROI, PolygonalROI, CategoricalROI,
                    MplCircularROI, MplRectangularROI, MplPolygonalROI, MplPickROI, PointROI,
                    XRangeROI, MplXRangeROI, YRangeROI, MplYRangeROI)
 
@@ -345,33 +345,33 @@ class TestCategorical(object):
 
     def test_empty(self):
 
-        roi = CategoricalRoi()
+        roi = CategoricalROI()
         assert not roi.defined()
 
     def test_defined(self):
 
-        nroi = CategoricalRoi(categories=['a', 'b', 'c'])
+        nroi = CategoricalROI(categories=['a', 'b', 'c'])
         assert nroi.defined()
         nroi.reset()
         assert not nroi.defined()
 
     def test_loads_from_components(self):
 
-        roi = CategoricalRoi()
+        roi = CategoricalROI()
         comp = CategoricalComponent(np.array(['a', 'a', 'b']))
         roi.update_categories(comp)
 
         np.testing.assert_array_equal(roi.categories,
                                       np.array(['a', 'b']))
 
-        roi = CategoricalRoi(categories=comp)
+        roi = CategoricalROI(categories=comp)
         np.testing.assert_array_equal(roi.categories,
                                       np.array(['a', 'b']))
 
 
     def test_applies_components(self):
 
-        roi = CategoricalRoi()
+        roi = CategoricalROI()
         comp = CategoricalComponent(np.array(['a', 'b', 'c']))
         roi.update_categories(CategoricalComponent(np.array(['a', 'b'])))
         contained = roi.contains(comp, None)
@@ -382,7 +382,7 @@ class TestCategorical(object):
 
         comp = CategoricalComponent(np.array(list('abcdefghijklmnopqrstuvwxyz')*2))
 
-        roi = CategoricalRoi.from_range(comp, 6, 10)
+        roi = CategoricalROI.from_range(comp, 6, 10)
         np.testing.assert_array_equal(roi.categories,
                                       np.array(list('ghij')))
 


### PR DESCRIPTION
I've done some refactoring of the ROI logic into the Component classes as suggested in #676 . I've removed all of the logic from the ScatterClient and HistogramClients and it transparently deals with the issues involved with categorical axes.

@ChrisBeaumont, we discussed this before, but dealing with PolygonalROIs with Categorical axes is not intuitive. Currently if a PolyROI is passed to a mixed axis I expand it to its bounding rectangle and then generate everything. This covers all of my use-cases but may be confusing to others. The other option is to only accept RectangularROIs and raise an error otherwise; but without some GUI hinting this may also be confusing. Thoughts?