### PR TITLE
Make sure plugins are loaded at the start of start_glue

### DIFF
--- a/glue/main.py
+++ b/glue/main.py
@@ -153,6 +153,11 @@ def start_glue(gluefile=None, config=None, datafiles=None):
     import glue
     from glue.qt.glue_application import GlueApplication
 
+    # Start off by loading plugins. We need to do this before restoring
+    # the session or loading the configuration since these may use existing
+    # plugins.
+    load_plugins()
+
     datafiles = datafiles or []
 
     data, hub = None, None

--- a/glue/qt/glue_application.py
+++ b/glue/qt/glue_application.py
@@ -193,6 +193,8 @@ class GlueApplication(Application, QMainWindow):
         pth = os.path.join(pth, 'icons', 'app_icon.png')
         self.app.setWindowIcon(QIcon(pth))
 
+        # Even though we loaded the plugins in start_glue, we re-load them here
+        # in case glue was started directly by initializing this class.
         load_plugins()
 
         self.setWindowIcon(self.app.windowIcon())


### PR DESCRIPTION
At the moment, ``load_plugins`` gets called when ``GlueApplication`` gets initialized. However, if the user starts Glue from the command-line with a session file for example, this means the session file will get loaded before the plugins, but may require the plugins to work correctly. Therefore, this PR ensures that ``load_plugins`` gets called at the start of ``start_glue``.

However, we call it again in ``GlueApplication`` in case another use stats up glue by instantiating ``GlueApplication``. While we have logic in ``load_plugins`` to avoid loading the same plugin twice, this isn't very elegant.

A nicer solution would be to only load the plugins in ``GlueApplication`` and instead of loading the session and config in ``start_glue``, we give ``GlueApplication`` class methods such as ``GlueApplication.from_session_file`` and ``GlueApplication.from_data_files`` - then these classes would call ``GlueApplication.__init__`` before doing anything else, which would ensure the plugins are loaded.

@ChrisBeaumont - any thoughts on this?