### PR TITLE
Add two functions to __all__ to preserve backward-compatibility

### DIFF
--- a/glue/core/data_factories/dendro_loader.py
+++ b/glue/core/data_factories/dendro_loader.py
@@ -7,7 +7,7 @@ import numpy as np
 from astrodendro import Dendrogram
 from ..data import Data
 
-__all__ = []
+__all__ = ['load_dendro']
 
 
 def load_dendro(file):

--- a/glue/core/data_factories/tables.py
+++ b/glue/core/data_factories/tables.py
@@ -7,7 +7,8 @@ from ...external import six
 
 from .helpers import set_default_factory, __factories__, has_extension
 
-__all__ = ['tabular_data', 'sextractor_factory']
+__all__ = ['tabular_data', 'sextractor_factory', 'astropy_tabular_data',
+           'formatted_table_factory']
 
 
 def _ascii_identifier_v02(origin, args, kwargs):


### PR DESCRIPTION
@keflavich - I noticed in your script you had to hack around this but this was an oversight, not a deliberate API change.