### PR TITLE
Allow to specify which extension is used to get the wcs info

### DIFF
--- a/glue/core/data_factories/gridded.py
+++ b/glue/core/data_factories/gridded.py
@@ -25,12 +25,19 @@ def is_fits(filename):
         return False
 
 
-def gridded_data(filename, format='auto', **kwargs):
+def gridded_data(filename, format='auto', wcs_ext=0, **kwargs):
     """
     Construct an n - dimensional data object from ``filename``. If the
     format cannot be determined from the extension, it can be
     specified using the ``format`` option. Valid formats are 'fits' and
     'hdf5'.
+
+    :param wcs_ext:
+        Specify the number of the extension used to read the wcs info.
+    :param kwargs:
+        Extra arguments passed to the function used to extract data
+        (``extract_data_fits`` or ``extract_data_hdf5``).
+
     """
     result = Data()
 
@@ -42,7 +49,7 @@ def gridded_data(filename, format='auto', **kwargs):
     if is_fits(filename):
         from ...external.astro import fits
         arrays = extract_data_fits(filename, **kwargs)
-        header = fits.getheader(filename)
+        header = fits.getheader(filename, ext=wcs_ext)
         result.coords = coordinates_from_header(header)
     elif is_hdf5(filename):
         arrays = extract_data_hdf5(filename, **kwargs)

--- a/glue/core/data_factories/io.py
+++ b/glue/core/data_factories/io.py
@@ -19,15 +19,14 @@ def filter_hdulist_by_shape(hdulist, use_hdu='all'):
 
     # If only a subset are requested, extract those
     if use_hdu != 'all':
+        if isinstance(use_hdu, int):
+            use_hdu = [use_hdu]
         hdulist = [hdulist[hdu] for hdu in use_hdu]
 
     # Now only keep HDUs that are not tables or empty.
-    valid_hdus = []
-    for hdu in hdulist:
-        if (isinstance(hdu, fits.PrimaryHDU) or \
-            isinstance(hdu, fits.ImageHDU)) and \
-            hdu.data is not None:
-            valid_hdus.append(hdu)
+    valid_hdus = [hdu for hdu in hdulist
+                  if (isinstance(hdu, (fits.PrimaryHDU, fits.ImageHDU)) and
+                      hdu.data is not None)]
 
     # Check that dimensions of all HDU are the same
     # Allow for HDU's that have no data.
@@ -51,7 +50,7 @@ def extract_data_fits(filename, use_hdu='all'):
 
     # Read in all HDUs
     hdulist = fits.open(filename, ignore_blank=True)
-    hdulist = filter_hdulist_by_shape(hdulist)
+    hdulist = filter_hdulist_by_shape(hdulist, use_hdu=use_hdu)
 
     # Extract data
     arrays = {}


### PR DESCRIPTION
Hi,
I have a FITS cube which has the WCS info only in the first extension (with the data), whereas glue expect it to be in the primary header. This PR make it possible to load the cube in glue from a python script, specifying the extension in `load_data`. I don't know how it would be possible to have this option in the UI, I didn't look at the UI code yet, but with some guidance I could try to add an option for this.
I also fixed the use of the `use_hdu` keyword which wasn't passed to the function where it is used.