### PR TITLE
Expose true categorical data in ``CategoricalComponent``

### DIFF
--- a/glue/clients/histogram_client.py
+++ b/glue/clients/histogram_client.py
@@ -229,10 +229,10 @@ class HistogramClient(Client):
         c = list(self._get_data_components('x'))
         if c:
             c = c[0]
-            if isinstance(c, CategoricalComponent):
-                val = min(c._categories.size, 100)
+            if c.categorical:
+                val = min(c.categories.size, 100)
                 if not calculate_only:
-                    self.xlimits = (-0.5, c._categories.size - 0.5)
+                    self.xlimits = (-0.5, c.categories.size - 0.5)
 
         if not calculate_only:
             self.nbins = val

--- a/glue/clients/scatter_client.py
+++ b/glue/clients/scatter_client.py
@@ -117,7 +117,8 @@ class ScatterClient(Client):
         data = layer.data
         comp = data.components if show_hidden else data.visible_components
         return [c for c in comp if
-                data.get_component(c).numeric]
+                data.get_component(c).numeric
+                or data.get_component(c).categorical]
 
     def add_layer(self, layer):
         """ Adds a new visual layer to a client, to display either a dataset
@@ -438,7 +439,7 @@ class ScatterClient(Client):
         for data in self._data:
             try:
                 comp = data.get_component(attribute)
-                if isinstance(comp, CategoricalComponent):
+                if comp.categorical:
                     return True
             except IncompatibleAttribute:
                 pass

--- a/glue/clients/util.py
+++ b/glue/clients/util.py
@@ -94,14 +94,14 @@ def update_ticks(axes, coord, components, is_log):
     else:
         raise TypeError("coord must be one of x,y")
 
-    is_cat = all(isinstance(comp, CategoricalComponent) for comp in components)
+    is_cat = all(comp.categorical for comp in components)
     if is_log:
         axis.set_major_locator(LogLocator())
         axis.set_major_formatter(LogFormatterMathtext())
     elif is_cat:
         all_categories = np.empty((0,), dtype=np.object)
         for comp in components:
-            all_categories = np.union1d(comp._categories, all_categories)
+            all_categories = np.union1d(comp.categories, all_categories)
         locator = MaxNLocator(10, integer=True)
         locator.view_limits(0, all_categories.shape[0])
         format_func = partial(tick_linker, all_categories)

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import operator
 import logging
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -403,6 +404,35 @@ class CategoricalComponent(Component):
             self._update_categories()
         else:
             self._update_data()
+
+    @property
+    def codes(self):
+        """
+        The index of the category for each value in the array.
+        """
+        return self._data
+
+    @property
+    def labels(self):
+        """
+        The original categorical data.
+        """
+        return self._categorical_data
+
+    @property
+    def categories(self):
+        """
+        The categories.
+        """
+        return self._categories
+
+    @property
+    def data(self):
+        # TODO: deprecate this in future
+        # warnings.warn("The 'data' attribute is deprecated. Use 'codes' "
+        #               "instead to access the underlying index of the "
+        #               "categories")
+        return self.codes
 
     @property
     def categorical(self):

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -428,11 +428,14 @@ class CategoricalComponent(Component):
 
     @property
     def data(self):
-        # TODO: deprecate this in future
-        # warnings.warn("The 'data' attribute is deprecated. Use 'codes' "
-        #               "instead to access the underlying index of the "
-        #               "categories")
+        warnings.warn("The 'data' attribute is deprecated. Use 'codes' "
+                      "instead to access the underlying index of the "
+                      "categories")
         return self.codes
+
+    @property
+    def numeric(self):
+        return False
 
     @property
     def categorical(self):
@@ -1100,7 +1103,10 @@ class Data(object):
         if view is not None:
             result = comp[view]
         else:
-            result = comp.data
+            if comp.categorical:
+                result = comp.codes
+            else:
+                result = comp.data
 
         assert result.shape == shp, \
             "Component view returned bad shape: %s %s" % (result.shape, shp)

--- a/glue/core/data_factories/tests/test_data_factories.py
+++ b/glue/core/data_factories/tests/test_data_factories.py
@@ -202,7 +202,7 @@ def test_csv_pandas_factory():
     correct_cats = np.unique(np.asarray(['some', 'categorical',
                                          'data', 'here',
                                          '', '', '']))
-    np.testing.assert_equal(d.get_component(cat_comp)._categories,
+    np.testing.assert_equal(d.get_component(cat_comp).categories,
                             correct_cats)
     cat_comp = d.find_component_id('d')
     assert isinstance(d.get_component(cat_comp), CategoricalComponent)

--- a/glue/core/roi.py
+++ b/glue/core/roi.py
@@ -1243,7 +1243,7 @@ class CategoricalRoi(Roi):
         hi = np.ceil(hi) if hi > 0 else 0
 
         roi = CategoricalRoi()
-        cat_data = cat_comp._categories
+        cat_data = cat_comp.categories
         roi.update_categories(cat_data[lo:hi])
 
         return roi

--- a/glue/core/tests/test_component.py
+++ b/glue/core/tests/test_component.py
@@ -102,13 +102,12 @@ class TestCategoricalComponent(object):
         np.testing.assert_equal(cat_comp.labels, data)
         np.testing.assert_equal(cat_comp.codes, [0, 1, 2, 1, 1, 2, 0, 2, 3])
         np.testing.assert_equal(cat_comp.categories, ['a', 'b', 'c', 'd'])
-        # TODO: uncomment once data is deprecated
-        # with warnings.catch_warnings(record=True) as w:
-        #     cat_comp.data
-        # assert len(w) == 1
-        # assert str(w[0].message) == ("The 'data' attribute is deprecated. Use 'codes' "
-        #                              "instead to access the underlying index of the "
-        #                              "categories")
+        with warnings.catch_warnings(record=True) as w:
+            cat_comp.data
+        assert len(w) == 1
+        assert str(w[0].message) == ("The 'data' attribute is deprecated. Use 'codes' "
+                                     "instead to access the underlying index of the "
+                                     "categories")
 
     def test_accepts_numpy(self):
         cat_comp = CategoricalComponent(self.array_data)
@@ -121,36 +120,36 @@ class TestCategoricalComponent(object):
 
     def test_multi_nans(self):
         cat_comp = CategoricalComponent(['', '', 'a', 'b', 'c', 'zanthia'])
-        np.testing.assert_equal(cat_comp._data,
+        np.testing.assert_equal(cat_comp.codes,
                                 np.array([0, 0, 1, 2, 3, 4]))
-        np.testing.assert_equal(cat_comp._categories,
+        np.testing.assert_equal(cat_comp.categories,
                                 np.asarray(['', 'a', 'b', 'c', 'zanthia']))
 
     def test_calculate_grouping(self):
         cat_comp = CategoricalComponent(self.array_data)
-        np.testing.assert_equal(cat_comp._categories, np.asarray(['a', 'b']))
-        np.testing.assert_equal(cat_comp._data, np.array([0, 0, 1, 1]))
-        assert cat_comp._data.dtype == np.float
+        np.testing.assert_equal(cat_comp.categories, np.asarray(['a', 'b']))
+        np.testing.assert_equal(cat_comp.codes, np.array([0, 0, 1, 1]))
+        assert cat_comp.codes.dtype == np.float
 
     def test_accepts_provided_grouping(self):
         ncategories = ['b', 'c']
         cat_data = list('aaabbbcccddd')
         cat_comp = CategoricalComponent(cat_data, categories=ncategories)
 
-        assert cat_comp._categories == ncategories
-        assert np.all(np.isnan(cat_comp._data[:3]))
-        assert np.all(cat_comp._data[3:6] == 0)
-        assert np.all(cat_comp._data[6:9] == 1)
-        assert np.all(np.isnan(cat_comp._data[9:]))
+        assert cat_comp.categories == ncategories
+        assert np.all(np.isnan(cat_comp.codes[:3]))
+        assert np.all(cat_comp.codes[3:6] == 0)
+        assert np.all(cat_comp.codes[6:9] == 1)
+        assert np.all(np.isnan(cat_comp.codes[9:]))
 
     def test_uniform_jitter(self):
         cat_comp = CategoricalComponent(self.array_data)
         second_comp = CategoricalComponent(self.array_data)
         cat_comp.jitter(method='uniform')
-        assert np.all(cat_comp._data != second_comp._data), "Didn't jitter data!"
+        assert np.all(cat_comp.codes != second_comp.codes), "Didn't jitter data!"
         second_comp.jitter(method='uniform')
-        np.testing.assert_equal(cat_comp._data,
-                                second_comp._data,
+        np.testing.assert_equal(cat_comp.codes,
+                                second_comp.codes,
                                 "Didn't jitter data consistently!")
         assert cat_comp._jitter_method == 'uniform'
 
@@ -158,12 +157,12 @@ class TestCategoricalComponent(object):
         cat_comp = CategoricalComponent(self.array_data)
         second_comp = CategoricalComponent(self.array_data)
         cat_comp.jitter(method='uniform')
-        delta = np.abs(cat_comp._data - second_comp._data).sum()
+        delta = np.abs(cat_comp.codes - second_comp.codes).sum()
         assert delta > 0
         second_comp.jitter(method='uniform')
         second_comp.jitter(method='uniform')
-        np.testing.assert_equal(cat_comp._data,
-                                second_comp._data,
+        np.testing.assert_equal(cat_comp.codes,
+                                second_comp.codes,
                                 "Data double jittered!")
 
     def test_unjitter_data(self):
@@ -171,28 +170,28 @@ class TestCategoricalComponent(object):
         second_comp = CategoricalComponent(self.array_data)
 
         cat_comp.jitter(method='uniform')
-        delta = np.abs(cat_comp._data - second_comp._data).sum()
+        delta = np.abs(cat_comp.codes - second_comp.codes).sum()
         assert delta > 0
 
         cat_comp.jitter(method=None)
-        np.testing.assert_equal(cat_comp._data,
-                                second_comp._data,
+        np.testing.assert_equal(cat_comp.codes,
+                                second_comp.codes,
                                 "Didn't un-jitter data!")
 
     def test_jitter_on_init(self):
         cat_comp = CategoricalComponent(self.array_data, jitter='uniform')
         second_comp = CategoricalComponent(self.array_data)
         second_comp.jitter(method='uniform')
-        delta = np.abs(cat_comp._data - second_comp._data).sum()
+        delta = np.abs(cat_comp.codes - second_comp.codes).sum()
         assert delta == 0
 
     def test_object_dtype(self):
         d = np.array([1, 3, 3, 1, 'a', 'b', 'a'], dtype=object)
         c = CategoricalComponent(d)
 
-        np.testing.assert_array_equal(c._categories,
+        np.testing.assert_array_equal(c.categories,
                                       np.array([1, 3, 'a', 'b'], dtype=object))
-        np.testing.assert_array_equal(c._data, [0, 1, 1, 0, 2, 3, 2])
+        np.testing.assert_array_equal(c.codes, [0, 1, 1, 0, 2, 3, 2])
 
     def test_valueerror_on_bad_jitter(self):
 

--- a/glue/core/tests/test_component.py
+++ b/glue/core/tests/test_component.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, division, print_function
 
 import operator
 
+import warnings
 from mock import MagicMock
 import pytest
 import numpy as np
@@ -94,6 +95,20 @@ class TestCategoricalComponent(object):
 
         d = Data(x=['a', 'b', 'c'])
         assert isinstance(d.get_component('x'), CategoricalComponent)
+
+    def test_basic_properties(self):
+        data = ['a', 'b', 'c', 'b', 'b', 'c', 'a', 'c', 'd']
+        cat_comp = CategoricalComponent(data)
+        np.testing.assert_equal(cat_comp.labels, data)
+        np.testing.assert_equal(cat_comp.codes, [0, 1, 2, 1, 1, 2, 0, 2, 3])
+        np.testing.assert_equal(cat_comp.categories, ['a', 'b', 'c', 'd'])
+        # TODO: uncomment once data is deprecated
+        # with warnings.catch_warnings(record=True) as w:
+        #     cat_comp.data
+        # assert len(w) == 1
+        # assert str(w[0].message) == ("The 'data' attribute is deprecated. Use 'codes' "
+        #                              "instead to access the underlying index of the "
+        #                              "categories")
 
     def test_accepts_numpy(self):
         cat_comp = CategoricalComponent(self.array_data)

--- a/glue/plugins/export_plotly.py
+++ b/glue/plugins/export_plotly.py
@@ -25,7 +25,7 @@ def _data(layer, component):
     result = layer[component]
     comp = layer.data.get_component(component)
     if isinstance(comp, CategoricalComponent):
-        result = comp._categories[result.astype(np.int)]
+        result = comp.categories[result.astype(np.int)]
     return result
 
 

--- a/glue/qt/custom_viewer.py
+++ b/glue/qt/custom_viewer.py
@@ -141,8 +141,8 @@ class AttributeInfo(np.ndarray):
         values = layer[cid, view]
         comp = layer.data.get_component(cid)
         categories = None
-        if isinstance(comp, core.data.CategoricalComponent):
-            categories = comp._categories
+        if comp.categorical:
+            categories = comp.categories
         return cls.make(cid, values, comp, categories)
 
     def __gluestate__(self, context):

--- a/glue/qt/widgets/histogram_widget.py
+++ b/glue/qt/widgets/histogram_widget.py
@@ -148,7 +148,8 @@ class HistogramWidget(DataViewer):
             item.setFlags(item.flags() & ~Qt.ItemIsEnabled)
             model.appendRow(item)
             for c in d.visible_components:
-                if not d.get_component(c).numeric:
+                if (not d.get_component(c).categorical and
+                    not d.get_component(c).numeric):
                     continue
                 if c is new:
                     found = True


### PR DESCRIPTION
For a categorical component, ``data['name']`` and ``component.data`` both return numerical values that are mapped to the components, but there is no easy (public) way to get the original data as a Numpy array as far as I can tell. One can either use the private attribute ``component._categorical_data`` but this is not ideal because not part of the public API, and there is also ``to_series`` which can be used to get a dataframe. Can we add a way to get the original data as a Numpy array? (either by making ``_categorical_data`` public or adding ``to_array``?