### PR TITLE
Fix categorical selection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,11 @@ v0.6 (unreleased)
   ``@data_factory`` decorator, and not by adding functions to
   ``__factories__``, as was possible in early versions of Glue. [#724]
 
+v0.5.3 (unreleased)
+-------------------
+
+* Fix selection in scatter plots when categorical data are present. [#727]
+
 v0.5.2 (2015-08-13)
 -------------------
 

--- a/glue/clients/scatter_client.py
+++ b/glue/clients/scatter_client.py
@@ -259,13 +259,14 @@ class ScatterClient(Client):
             subsets = []
             axes = [('x', roi.xmin, roi.xmax),
                     ('y', roi.ymin, roi.ymax)]
+
             for coord, lo, hi in axes:
                 comp = list(self._get_data_components(coord))
                 if comp:
                     if comp[0].categorical:
-                        subset = CategoricalRoiSubsetState.from_range(comp[0], self.xatt, lo, hi)
+                        subset = CategoricalRoiSubsetState.from_range(comp[0], self._get_attribute(coord), lo, hi)
                     else:
-                        subset = RangeSubsetState(lo, hi, self.xatt)
+                        subset = RangeSubsetState(lo, hi, self._get_attribute(coord))
                 else:
                     subset = None
                 subsets.append(subset)
@@ -408,15 +409,19 @@ class ScatterClient(Client):
         """The data objects in the scatter plot"""
         return list(self._data)
 
+    def _get_attribute(self, coord):
+        if coord == 'x':
+            return self.xatt
+        elif coord == 'y':
+            return self.yatt
+        else:
+            raise TypeError('coord must be x or y')
+
     def _get_data_components(self, coord):
         """ Returns the components for each dataset for x and y axes.
         """
-        if coord == 'x':
-            attribute = self.xatt
-        elif coord == 'y':
-            attribute = self.yatt
-        else:
-            raise TypeError('coord must be x or y')
+
+        attribute = self._get_attribute(coord)
 
         for data in self._data:
             try:

--- a/glue/clients/tests/test_histogram_client.py
+++ b/glue/clients/tests/test_histogram_client.py
@@ -384,7 +384,7 @@ class TestCategoricalHistogram(TestHistogramClient):
         state = self.data.subsets[0].subset_state
         assert isinstance(state, CategoricalRoiSubsetState)
         np.testing.assert_equal(self.data.subsets[0].subset_state.roi.categories,
-                                np.array(['a', 'b', 'c', 'd', 'e']))
+                                np.array(['b', 'c', 'd', 'e']))
 
 
     # REMOVED TESTS

--- a/glue/clients/tests/test_scatter_client.py
+++ b/glue/clients/tests/test_scatter_client.py
@@ -707,6 +707,23 @@ class TestCategoricalScatterClient(TestScatterClient):
         assert isinstance(data.edit_subset.subset_state,
                           core.subset.AndState)
 
+    @pytest.mark.parametrize(('roi_limits', 'mask'), [((0, -0.1, 10, 0.1), [0, 0, 0]),
+                                                      ((0, 0.9, 10, 1.1), [1, 0, 0]),
+                                                      ((0, 1.9, 10, 2.1), [0, 1, 0]),
+                                                      ((0, 2.9, 10, 3.1), [0, 0, 1]),
+                                                      ((0, 0.9, 10, 3.1), [1, 1, 1]),
+                                                      ((-0.1, -1, 0.1, 5), [1, 1, 0]),
+                                                      ((0.9, -1, 1.1, 5), [0, 0, 1]),
+                                                      ((-0.1, 0.9, 1.1, 3.1), [1, 1, 1])])
+    def test_apply_roi_results(self, roi_limits, mask):
+        # Regression test for glue-viz/glue#718
+        data = self.add_data_and_attributes()
+        roi = core.roi.RectangularROI()
+        roi.update_limits(*roi_limits)
+        x, y = self.roi_points
+        self.client.apply_roi(roi)
+        np.testing.assert_equal(data.edit_subset.to_mask(), mask)
+
     # REMOVED TESTS
     def test_invalid_plot(self):
         """ This fails because the axis ticks shouldn't reset after

--- a/glue/core/roi.py
+++ b/glue/core/roi.py
@@ -236,7 +236,7 @@ class RangeROI(Roi):
         """:param orientation: 'x' or 'y'. Sets which axis to range"""
         super(RangeROI, self).__init__()
         if orientation not in ['x', 'y']:
-            raise TypeError("Orientation must be one of 'x', 'y'")
+            raise ValueError("Orientation must be one of 'x', 'y'")
 
         self.min = min
         self.max = max

--- a/glue/core/roi.py
+++ b/glue/core/roi.py
@@ -1232,7 +1232,18 @@ class CategoricalRoi(Roi):
         :return: CategoricalRoi object
         """
 
+        # Convert lo and hi to integers. Note that if lo or hi are negative,
+        # which can happen if the user zoomed out, we need to reset the to zero
+        # otherwise they will have strange effects when slicing the categories.
+
+        # Note that we used ceil for lo, because if lo is 0.9 then we should
+        # only select 1 and above.
+
+        lo = np.ceil(lo) if lo > 0 else 0
+        hi = np.ceil(hi) if hi > 0 else 0
+
         roi = CategoricalRoi()
         cat_data = cat_comp._categories
-        roi.update_categories(cat_data[np.floor(lo):np.ceil(hi)])
+        roi.update_categories(cat_data[lo:hi])
+
         return roi

--- a/glue/core/tests/test_roi.py
+++ b/glue/core/tests/test_roi.py
@@ -12,12 +12,37 @@ from mock import MagicMock
 
 from ..roi import (RectangularROI, UndefinedROI, CircularROI, PolygonalROI, CategoricalRoi,
                    MplCircularROI, MplRectangularROI, MplPolygonalROI, MplPickROI, PointROI,
-                   XRangeROI, MplXRangeROI, YRangeROI, MplYRangeROI)
+                   XRangeROI, MplXRangeROI, YRangeROI, MplYRangeROI, RangeROI)
 
 from .. import roi as r
 
 FIG = Figure()
 AXES = FIG.add_subplot(111)
+
+
+class TestPoint(object):
+
+    def setup_method(self, method):
+        self.roi = PointROI(1, 2)
+
+    def test_contains(self):
+        assert not self.roi.contains(3, 3)
+        assert not self.roi.contains(1, 2)
+
+    def test_move_to(self):
+        self.roi.move_to(4, 5)
+        assert self.roi.x == 4
+        assert self.roi.y == 5
+
+    def test_defined(self):
+        assert self.roi.defined()
+
+    def test_not_defined(self):
+        self.roi.reset()
+        assert not self.roi.defined()
+
+    def test_center(self):
+        assert self.roi.center() == (1, 2)
 
 
 class TestRectangle(object):
@@ -95,7 +120,15 @@ class TestRectangle(object):
         assert type(str(self.roi)) == str
 
 
+class TestRange(object):
+
+    def test_wrong_orientation(self):
+        with pytest.raises(ValueError):
+            RangeROI(orientation='a')
+
+
 class TestXRange(object):
+
     def test_undefined_on_init(self):
         assert not XRangeROI().defined()
 


### PR DESCRIPTION
@JudoWill @ChrisBeaumont - this is an immediate fix for the selection in scatter plots with rectangular selections when categorical ROI are present.

I would like to merge this pretty soon and release 0.5.3, since this is a reasonably big bug, and #692 could then go in 0.6.