### PR TITLE
Add automatic file name extension when saving sessions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@ Full changelog
 v0.6 (unreleased)
 -----------------
 
+* When saving a session, if no extension is specified, the .glu extension is
+  added. [#729]
+
 * Added a GUI plugin manager in the 'Plugins' menu. [#682]
 
 * Data factories can now be given priorities to determine which ones should

--- a/glue/qt/glue_application.py
+++ b/glue/qt/glue_application.py
@@ -694,8 +694,15 @@ class GlueApplication(Application, QMainWindow):
         # include file filter twice, so it shows up in Dialog
         outfile, file_filter = QFileDialog.getSaveFileName(self,
                                                            filter="Glue Session (*.glu);; Glue Session including data (*.glu)")
+
+        # This indicates that the user cancelled
         if not outfile:
             return
+
+        # Add extension if not specified
+        if not '.' in outfile:
+            outfile += '.glu'
+
         self.save_session(outfile, include_data="including data" in file_filter)
 
     @messagebox_on_error("Failed to export session")

--- a/glue/qt/tests/test_application.py
+++ b/glue/qt/tests/test_application.py
@@ -51,7 +51,7 @@ class TestGlueApplication(object):
         with patch('glue.qt.glue_application.QFileDialog') as fd:
             fd.getSaveFileName.return_value = '/tmp/junk', 'jnk'
             self.app._choose_save_session()
-            self.app.save_session.assert_called_once_with('/tmp/junk', include_data=False)
+            self.app.save_session.assert_called_once_with('/tmp/junk.glu', include_data=False)
 
     def test_save_session_cancel(self):
         """shouldnt try to save file if no file name provided"""


### PR DESCRIPTION
When I save a session file, it saves it exactly with the name I enter in the dialogue (e.g. "mysession"), when when I try to load it again, that session file is not shown in the "Open" dialogue, because it does not have the correct file name extension. Either I should be able to select all files (even those with extensions that are not "glu") or glu should add the extension automatically when saving.