### PR TITLE
Improve cube slider

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@ v0.6 (unreleased)
   ``get_default_factory`` functions are now deprecated since it is possible to
   achieve this solely with priorities. [#719]
 
+* Improved cube slider to include editable slice value as well as
+  first/previous/next/last buttons. [#690]
+
 * Registering data factories should now always be done with the
   ``@data_factory`` decorator, and not by adding functions to
   ``__factories__``, as was possible in early versions of Glue. [#724]

--- a/glue/qt/ui/cube_slider.ui
+++ b/glue/qt/ui/cube_slider.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>354</width>
-    <height>85</height>
+    <height>73</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -16,6 +16,9 @@
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">
     <layout class="QVBoxLayout" name="verticalLayout">
+     <property name="spacing">
+      <number>0</number>
+     </property>
      <item>
       <widget class="QSlider" name="slider">
        <property name="orientation">

--- a/glue/qt/ui/cube_slider.ui
+++ b/glue/qt/ui/cube_slider.ui
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>354</width>
+    <height>85</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <widget class="QSlider" name="slider">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <widget class="QToolButton" name="first">
+         <property name="text">
+          <string>&lt;&lt;</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QToolButton" name="prev">
+         <property name="text">
+          <string>&lt;</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="label">
+         <property name="maximumSize">
+          <size>
+           <width>70</width>
+           <height>16777215</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QToolButton" name="next">
+         <property name="text">
+          <string>&gt;</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QToolButton" name="last">
+         <property name="text">
+          <string>&gt;&gt;</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/glue/qt/widgets/data_slice_widget.py
+++ b/glue/qt/widgets/data_slice_widget.py
@@ -87,6 +87,8 @@ class SliceWidget(QWidget):
             value = max(value - 1, imin)
         elif action == 'next':
             value = min(value + 1, imax)
+        else:
+            raise ValueError("Action should be one of first/prev/next/last")
         self._ui_slider.slider.setValue(value)
 
     def _update_mode(self, *args):

--- a/glue/qt/widgets/data_slice_widget.py
+++ b/glue/qt/widgets/data_slice_widget.py
@@ -8,12 +8,12 @@ from ...external.qt.QtCore import Qt, Signal
 from ..widget_properties import (TextProperty,
                                  ValueProperty,
                                  CurrentComboProperty)
-from ..qtutil import nonpartial
+from ..qtutil import nonpartial, load_ui
 
 
 class SliceWidget(QWidget):
     label = TextProperty('_ui_label')
-    slice_center = ValueProperty('_ui_slider')
+    slice_center = ValueProperty('_ui_slider.slider')
     mode = CurrentComboProperty('_ui_mode')
 
     slice_changed = Signal(int)
@@ -46,50 +46,39 @@ class SliceWidget(QWidget):
 
         layout.addLayout(top)
 
-        slider = QSlider(Qt.Horizontal)
-        slider.setMinimum(lo)
-        slider.setMaximum(hi)
-        slider.setValue((lo + hi) / 2)
-        slider.valueChanged.connect(lambda x:
-                                    self.slice_changed.emit(self.mode))
+        slider = load_ui('cube_slider')
+        slider.slider
 
-        slider_lbl = QLineEdit()
-        slider_lbl.setMinimumWidth(50)
-        slider_lbl.setText(str(slider.value()))
-        slider.valueChanged.connect(lambda x: slider_lbl.setText(str(x)))
-        slider_lbl.textChanged.connect(lambda x: slider.setValue(int(x)))
+        slider.slider.setMinimum(lo)
+        slider.slider.setMaximum(hi)
+        slider.slider.setValue((lo + hi) / 2)
+        slider.slider.valueChanged.connect(lambda x:
+                                                  self.slice_changed.emit(self.mode))
+        slider.slider.valueChanged.connect(lambda x: slider.label.setText(str(x)))
 
-        browser = {}
-        browser['first'] = QPushButton("<<")
-        browser['prev'] = QPushButton("<")
-        browser['label'] = slider_lbl
-        browser['next'] = QPushButton(">")
-        browser['last'] = QPushButton(">>")
+        slider.label.setMinimumWidth(50)
+        slider.label.setText(str(slider.slider.value()))
+        slider.label.textChanged.connect(lambda x: slider.slider.setValue(int(x)))
 
-        slider_browser = QHBoxLayout()
-        for key in ['first', 'prev', 'label', 'next', 'last']:
-            slider_browser.addWidget(browser[key])
-            if key == 'label':
-                pass
-            else:
-                browser[key].clicked.connect(nonpartial(self._browse_slice, key))
+        slider.first.clicked.connect(nonpartial(self._browse_slice, 'first'))
+        slider.prev.clicked.connect(nonpartial(self._browse_slice, 'prev'))
+        slider.next.clicked.connect(nonpartial(self._browse_slice, 'next'))
+        slider.last.clicked.connect(nonpartial(self._browse_slice, 'last'))
 
-        layout.addLayout(slider_browser)
         layout.addWidget(slider)
 
         self.setLayout(layout)
 
         self._ui_label = label
         self._ui_slider = slider
-        self._ui_slider_browser = browser
         self._ui_mode = mode
         self._update_mode()
         self._frozen = False
 
     def _browse_slice(self, action):
-        imin = self._ui_slider.minimum()
-        imax = self._ui_slider.maximum()
-        value = self._ui_slider.value()
+        imin = self._ui_slider.slider.minimum()
+        imax = self._ui_slider.slider.maximum()
+        value = self._ui_slider.slider.value()
         if action == 'first':
             value = imin
         elif action == 'last':
@@ -98,17 +87,13 @@ class SliceWidget(QWidget):
             value = max(value - 1, imin)
         elif action == 'next':
             value = min(value + 1, imax)
-        self._ui_slider.setValue(value)
+        self._ui_slider.slider.setValue(value)
 
     def _update_mode(self, *args):
         if self.mode != 'slice':
             self._ui_slider.hide()
-            for key in self._ui_slider_browser:
-                self._ui_slider_browser[key].hide()
         else:
             self._ui_slider.show()
-            for key in self._ui_slider_browser:
-                self._ui_slider_browser[key].show()
 
     def freeze(self):
         self.mode = 'slice'

--- a/glue/qt/widgets/tests/test_data_slice.py
+++ b/glue/qt/widgets/tests/test_data_slice.py
@@ -2,7 +2,33 @@ import numpy as np
 from mock import MagicMock
 
 from .... import core
-from ..data_slice_widget import DataSlice
+from ..data_slice_widget import SliceWidget, DataSlice
+
+
+class TestSliceWidget(object):
+
+    def test_slice_center(self):
+        s = SliceWidget(lo=0, hi=10)
+        assert s.slice_center == 5
+
+    def test_browse_slice(self):
+        s = SliceWidget(lo=0, hi=10)
+        assert s.slice_center == 5
+        s._ui_slider.prev.click()
+        assert s.slice_center == 4
+        s._ui_slider.next.click()
+        s._ui_slider.next.click()
+        assert s.slice_center == 6
+        s._ui_slider.first.click()
+        assert s.slice_center == 0
+        s._ui_slider.prev.click()
+        assert s.slice_center == 0
+        s._ui_slider.last.click()
+        assert s.slice_center == 10
+        s._ui_slider.next.click()
+        assert s.slice_center == 10
+        s._ui_slider.prev.click()
+        assert s.slice_center == 9
 
 
 class TestArraySlice(object):


### PR DESCRIPTION
At the moment, for a cube with 2000 slices, it's impossible to view some of the slices because the slider can't be moved to a high enough resolution. We could add step forward/back buttons on the side of the slider for more fine-tuned control