### PR TITLE
Multi cube slicer esthetic improvements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,8 @@ v0.6 (unreleased)
   achieve this solely with priorities. [#719]
 
 * Improved cube slider to include editable slice value as well as
-  first/previous/next/last buttons. [#690]
+  first/previous/next/last buttons, and improved spacing of sliders for 4+
+  dimensional cubes. [#690, #734]
 
 * Registering data factories should now always be done with the
   ``@data_factory`` decorator, and not by adding functions to

--- a/glue/qt/ui/cube_slider.ui
+++ b/glue/qt/ui/cube_slider.ui
@@ -7,13 +7,19 @@
     <x>0</x>
     <y>0</y>
     <width>354</width>
-    <height>73</height>
+    <height>57</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>8</number>
+   </property>
    <item row="0" column="0">
     <layout class="QVBoxLayout" name="verticalLayout">
      <property name="spacing">

--- a/glue/qt/widgets/data_slice_widget.py
+++ b/glue/qt/widgets/data_slice_widget.py
@@ -197,7 +197,6 @@ class DataSlice(QWidget):
                 line = QFrame()
                 line.setFrameShape(QFrame.HLine)
                 line.setFrameShadow(QFrame.Sunken)
-                line.setStyleSheet("border: 1px solid #919191")
                 self.layout.addWidget(line)
             s.show()  # this somehow fixes #342
 

--- a/glue/qt/widgets/data_slice_widget.py
+++ b/glue/qt/widgets/data_slice_widget.py
@@ -1,7 +1,7 @@
 from functools import partial
 from ...compat.collections import Counter
 
-from ...external.qt.QtGui import (QWidget, QSlider, QLabel, QComboBox,
+from ...external.qt.QtGui import (QWidget, QSlider, QLabel, QComboBox, QFrame,
                                   QHBoxLayout, QVBoxLayout, QPushButton, QLineEdit)
 from ...external.qt.QtCore import Qt, Signal
 
@@ -29,6 +29,7 @@ class SliceWidget(QWidget):
 
         layout = QVBoxLayout()
         layout.setContentsMargins(3, 1, 3, 1)
+        layout.setSpacing(0)
 
         top = QHBoxLayout()
         top.setContentsMargins(3, 3, 3, 3)
@@ -192,6 +193,12 @@ class DataSlice(QWidget):
         # ... and add to the layout
         for s in self._slices[::-1]:
             self.layout.addWidget(s)
+            if s is not self._slices[0]:
+                line = QFrame()
+                line.setFrameShape(QFrame.HLine)
+                line.setFrameShadow(QFrame.Sunken)
+                line.setStyleSheet("border: 1px solid #919191")
+                self.layout.addWidget(line)
             s.show()  # this somehow fixes #342
 
         self.layout.addStretch(5)


### PR DESCRIPTION
**Before**

<img width="314" alt="screen shot 2015-08-28 at 4 19 38 pm" src="https://cloud.githubusercontent.com/assets/314716/9550185/c77e5714-4da1-11e5-8eef-2500e49571a0.png">

**After**

<img width="309" alt="screen shot 2015-08-28 at 4 29 02 pm" src="https://cloud.githubusercontent.com/assets/314716/9550213/eca87204-4da1-11e5-84c5-d5d5c92e4c4c.png">

I think this makes it clearer which slider goes with which dimension
