### PR TITLE
Don’t use tight layout as it causes bouncing around of axes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@ Full changelog
 v0.6 (unreleased)
 -----------------
 
+* Prevent axes from moving around when data viewers are being resized, and
+  instead make the absolute margins between axes and figure edge fixed. [#745]
+
 * When a box has been drawn to extract a spectrum from a cube, the box can
   then be moved by pressing the control key and dragging it. [#707]
 

--- a/doc/customizing_guide/custom_viewer.rst
+++ b/doc/customizing_guide/custom_viewer.rst
@@ -230,3 +230,12 @@ Other Guidelines
  - By default, ``plot_data`` and ``plot_subset`` are called whenever
    UI settings change. To disable this behavior, set
    ``viewer.redraw_on_settings_change=False``.
+
+ - By default, Glue sets the margins of figures so that the space between axes
+   and the edge of figures is constant in absolute terms. If the default values
+   are not adequate for your viewer, you can set the margins in the ``setup``
+   method of the custom viewer by doing e.g.::
+
+       axes.resizer.margins = [0.75, 0.25, 0.5, 0.25]
+
+   where the list gives the ``[left, right, bottom, top]`` margins in inches.

--- a/glue/clients/histogram_client.py
+++ b/glue/clients/histogram_client.py
@@ -13,7 +13,7 @@ from .util import update_ticks, visible_limits
 from ..core.callback_property import CallbackProperty, add_callback
 from ..utils import lookup_class
 from ..utils.matplotlib import freeze_margins
-
+from .viz_client import init_mpl
 
 class UpdateProperty(CallbackProperty):
 
@@ -58,8 +58,7 @@ class HistogramClient(Client):
         super(HistogramClient, self).__init__(data)
 
         self._artists = artist_container or LayerArtistContainer()
-        self._axes = figure.add_subplot(111)
-        freeze_margins(self._axes, [1, 0.25, 0.50, 0.25])
+        self._figure, self._axes = init_mpl(figure=figure, axes=None)
         self._component = None
         self._saved_nbins = None
         self._xlim = {}

--- a/glue/clients/histogram_client.py
+++ b/glue/clients/histogram_client.py
@@ -12,7 +12,7 @@ from .layer_artist import HistogramLayerArtist, LayerArtistContainer
 from .util import update_ticks, visible_limits
 from ..core.callback_property import CallbackProperty, add_callback
 from ..utils import lookup_class
-from ..utils.matplotlib import fix_margins
+from ..utils.matplotlib import freeze_margins
 
 
 class UpdateProperty(CallbackProperty):
@@ -59,7 +59,7 @@ class HistogramClient(Client):
 
         self._artists = artist_container or LayerArtistContainer()
         self._axes = figure.add_subplot(111)
-        fix_margins(self._axes, [1, 0.25, 0.50, 0.25])
+        freeze_margins(self._axes, [1, 0.25, 0.50, 0.25])
         self._component = None
         self._saved_nbins = None
         self._xlim = {}

--- a/glue/clients/histogram_client.py
+++ b/glue/clients/histogram_client.py
@@ -57,15 +57,10 @@ class HistogramClient(Client):
         super(HistogramClient, self).__init__(data)
 
         self._artists = artist_container or LayerArtistContainer()
-        self._axes = figure.add_subplot(111)
+        self._axes = figure.add_axes([0.125, 0.125, 0.8, 0.8])
         self._component = None
         self._saved_nbins = None
         self._xlim = {}
-
-        try:
-            self._axes.figure.set_tight_layout(True)
-        except AttributeError:  # pragma: nocover (matplotlib < 1.1)
-            pass
 
     @property
     def bins(self):

--- a/glue/clients/histogram_client.py
+++ b/glue/clients/histogram_client.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
 import numpy as np
-import matplotlib.pyplot as plt
 
 from ..core.client import Client
 from ..core import message as msg
@@ -13,7 +12,7 @@ from .layer_artist import HistogramLayerArtist, LayerArtistContainer
 from .util import update_ticks, visible_limits
 from ..core.callback_property import CallbackProperty, add_callback
 from ..utils import lookup_class
-from ..utils.matplotlib import fixed_margin_axes
+from ..utils.matplotlib import fix_margins
 
 
 class UpdateProperty(CallbackProperty):
@@ -59,9 +58,8 @@ class HistogramClient(Client):
         super(HistogramClient, self).__init__(data)
 
         self._artists = artist_container or LayerArtistContainer()
-        FixedMarginAxes = fixed_margin_axes(plt.Axes, [1, 0.5, 0.75, 0.5])
-        self._axes = FixedMarginAxes(figure)
-        figure.add_axes(self._axes)
+        self._axes = figure.add_subplot(111)
+        fix_margins(self._axes, [1, 0.25, 0.50, 0.25])
         self._component = None
         self._saved_nbins = None
         self._xlim = {}

--- a/glue/clients/histogram_client.py
+++ b/glue/clients/histogram_client.py
@@ -13,7 +13,7 @@ from .layer_artist import HistogramLayerArtist, LayerArtistContainer
 from .util import update_ticks, visible_limits
 from ..core.callback_property import CallbackProperty, add_callback
 from ..utils import lookup_class
-from ..utils.matplotlib import FixedMarginAxes
+from ..utils.matplotlib import fixed_margin_axes
 
 
 class UpdateProperty(CallbackProperty):
@@ -59,8 +59,8 @@ class HistogramClient(Client):
         super(HistogramClient, self).__init__(data)
 
         self._artists = artist_container or LayerArtistContainer()
-        FixedMarginMplAxes = FixedMarginAxes(plt.Axes, [1, 0.5, 0.75, 0.5])
-        self._axes = FixedMarginMplAxes(figure)
+        FixedMarginAxes = fixed_margin_axes(plt.Axes, [1, 0.5, 0.75, 0.5])
+        self._axes = FixedMarginAxes(figure)
         figure.add_axes(self._axes)
         self._component = None
         self._saved_nbins = None

--- a/glue/clients/histogram_client.py
+++ b/glue/clients/histogram_client.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import numpy as np
+import matplotlib.pyplot as plt
 
 from ..core.client import Client
 from ..core import message as msg
@@ -12,6 +13,7 @@ from .layer_artist import HistogramLayerArtist, LayerArtistContainer
 from .util import update_ticks, visible_limits
 from ..core.callback_property import CallbackProperty, add_callback
 from ..utils import lookup_class
+from ..utils.matplotlib import FixedMarginAxes
 
 
 class UpdateProperty(CallbackProperty):
@@ -57,7 +59,9 @@ class HistogramClient(Client):
         super(HistogramClient, self).__init__(data)
 
         self._artists = artist_container or LayerArtistContainer()
-        self._axes = figure.add_axes([0.125, 0.125, 0.8, 0.8])
+        FixedMarginMplAxes = FixedMarginAxes(plt.Axes, [1, 0.5, 0.75, 0.5])
+        self._axes = FixedMarginMplAxes(figure)
+        figure.add_axes(self._axes)
         self._component = None
         self._saved_nbins = None
         self._xlim = {}

--- a/glue/clients/profile_viewer.py
+++ b/glue/clients/profile_viewer.py
@@ -236,12 +236,6 @@ class RangeArtist(object):
 
 def _build_axes(figure):
 
-    # tight-layout clobbers manual positioning
-    try:
-        figure.set_tight_layout(False)
-    except AttributeError:  # old MPL
-        pass
-
     ax2 = figure.add_subplot(122)
     ax1 = figure.add_subplot(121, sharex=ax2)
 

--- a/glue/clients/viz_client.py
+++ b/glue/clients/viz_client.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 import matplotlib.pyplot as plt
 from ..core.client import Client
 from ..core import Data
-from ..utils.matplotlib import FixedMarginAxes
+from ..utils.matplotlib import fixed_margin_axes
 from .layer_artist import LayerArtistContainer
 
 __all__ = ['VizClient', 'GenericMplClient']
@@ -153,15 +153,15 @@ def init_mpl(figure, axes, wcs=False, axes_factory=None):
     else:
         _figure = figure or plt.figure()
         if wcs and WCSAxes is not None:
-            FixedMarginWCSAxes = FixedMarginAxes(WCSAxes, [1, 0.5, 0.75, 0.5])
+            FixedMarginWCSAxes = fixed_margin_axes(WCSAxes, [1, 0.5, 0.75, 0.5])
             _axes = FixedMarginWCSAxes(_figure)
             _figure.add_axes(_axes)
         else:
             if axes_factory is not None:
                 _axes = axes_factory(_figure)
             else:
-                FixedMarginMplAxes = FixedMarginAxes(plt.Axes, [1, 0.5, 0.75, 0.5])
-                _axes = FixedMarginMplAxes(_figure)
+                FixedMarginAxes = fixed_margin_axes(plt.Axes, [1, 0.5, 0.75, 0.5])
+                _axes = FixedMarginAxes(_figure)
                 _figure.add_axes(_axes)
 
     return _figure, _axes

--- a/glue/clients/viz_client.py
+++ b/glue/clients/viz_client.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 import matplotlib.pyplot as plt
 from ..core.client import Client
 from ..core import Data
+from ..utils.matplotlib import FixedMarginAxes
 from .layer_artist import LayerArtistContainer
 
 __all__ = ['VizClient', 'GenericMplClient']
@@ -136,8 +137,9 @@ class VizClient(Client):
 
 
 def init_mpl(figure, axes, wcs=False, axes_factory=None):
-    if axes is not None and figure is not None and \
-            axes.figure is not figure:
+
+    if (axes is not None and figure is not None and
+            axes.figure is not figure):
         raise ValueError("Axes and figure are incompatible")
 
     try:
@@ -151,13 +153,16 @@ def init_mpl(figure, axes, wcs=False, axes_factory=None):
     else:
         _figure = figure or plt.figure()
         if wcs and WCSAxes is not None:
-            _axes = WCSAxes(_figure, [0.125, 0.125, 0.8, 0.8])
+            FixedMarginWCSAxes = FixedMarginAxes(WCSAxes, [1, 0.5, 0.75, 0.5])
+            _axes = FixedMarginWCSAxes(_figure)
             _figure.add_axes(_axes)
         else:
             if axes_factory is not None:
                 _axes = axes_factory(_figure)
             else:
-                _axes = _figure.add_axes([0.125, 0.125, 0.8, 0.8])
+                FixedMarginMplAxes = FixedMarginAxes(plt.Axes, [1, 0.5, 0.75, 0.5])
+                _axes = FixedMarginMplAxes(_figure)
+                _figure.add_axes(_axes)
 
     return _figure, _axes
 

--- a/glue/clients/viz_client.py
+++ b/glue/clients/viz_client.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 import matplotlib.pyplot as plt
 from ..core.client import Client
 from ..core import Data
-from ..utils.matplotlib import fixed_margin_axes
+from ..utils.matplotlib import fix_margins
 from .layer_artist import LayerArtistContainer
 
 __all__ = ['VizClient', 'GenericMplClient']
@@ -143,26 +143,25 @@ def init_mpl(figure, axes, wcs=False, axes_factory=None):
         raise ValueError("Axes and figure are incompatible")
 
     try:
-        from ..external.wcsaxes import WCSAxes
+        from ..external.wcsaxes import WCSAxesSubplot
     except ImportError:
-        WCSAxes = None
+        WCSAxesSubplot = None
 
     if axes is not None:
         _axes = axes
         _figure = axes.figure
     else:
         _figure = figure or plt.figure()
-        if wcs and WCSAxes is not None:
-            FixedMarginWCSAxes = fixed_margin_axes(WCSAxes, [1, 0.5, 0.75, 0.5])
-            _axes = FixedMarginWCSAxes(_figure)
+        if wcs and WCSAxesSubplot is not None:
+            _axes = WCSAxesSubplot(_figure, 111)
             _figure.add_axes(_axes)
+            fix_margins(_axes, [1, 0.25, 0.50, 0.25])
         else:
             if axes_factory is not None:
                 _axes = axes_factory(_figure)
             else:
-                FixedMarginAxes = fixed_margin_axes(plt.Axes, [1, 0.5, 0.75, 0.5])
-                _axes = FixedMarginAxes(_figure)
-                _figure.add_axes(_axes)
+                _axes = _figure.add_subplot(1, 1, 1)
+                fix_margins(_axes, [1, 0.25, 0.50, 0.25])
 
     return _figure, _axes
 

--- a/glue/clients/viz_client.py
+++ b/glue/clients/viz_client.py
@@ -136,7 +136,7 @@ class VizClient(Client):
         raise NotImplementedError()
 
 
-def init_mpl(figure, axes, wcs=False, axes_factory=None):
+def init_mpl(figure=None, axes=None, wcs=False, axes_factory=None):
 
     if (axes is not None and figure is not None and
             axes.figure is not figure):
@@ -155,13 +155,13 @@ def init_mpl(figure, axes, wcs=False, axes_factory=None):
         if wcs and WCSAxesSubplot is not None:
             _axes = WCSAxesSubplot(_figure, 111)
             _figure.add_axes(_axes)
-            freeze_margins(_axes, [1, 0.25, 0.50, 0.25])
         else:
             if axes_factory is not None:
                 _axes = axes_factory(_figure)
             else:
                 _axes = _figure.add_subplot(1, 1, 1)
-                freeze_margins(_axes, [1, 0.25, 0.50, 0.25])
+
+    freeze_margins(_axes, margins=[1, 0.25, 0.50, 0.25])
 
     return _figure, _axes
 

--- a/glue/clients/viz_client.py
+++ b/glue/clients/viz_client.py
@@ -141,27 +141,23 @@ def init_mpl(figure, axes, wcs=False, axes_factory=None):
         raise ValueError("Axes and figure are incompatible")
 
     try:
-        from ..external.wcsaxes import WCSAxesSubplot
+        from ..external.wcsaxes import WCSAxes
     except ImportError:
-        WCSAxesSubplot = None
+        WCSAxes = None
 
     if axes is not None:
         _axes = axes
         _figure = axes.figure
     else:
         _figure = figure or plt.figure()
-        if wcs and WCSAxesSubplot is not None:
-            _axes = WCSAxesSubplot(_figure, 111)
+        if wcs and WCSAxes is not None:
+            _axes = WCSAxes(_figure, [0.125, 0.125, 0.8, 0.8])
             _figure.add_axes(_axes)
         else:
             if axes_factory is not None:
                 _axes = axes_factory(_figure)
             else:
-                _axes = _figure.add_subplot(1, 1, 1)
-    try:
-        _figure.set_tight_layout(True)
-    except AttributeError:  # matplotlib < 1.1
-        pass
+                _axes = _figure.add_axes([0.125, 0.125, 0.8, 0.8])
 
     return _figure, _axes
 

--- a/glue/clients/viz_client.py
+++ b/glue/clients/viz_client.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 import matplotlib.pyplot as plt
 from ..core.client import Client
 from ..core import Data
-from ..utils.matplotlib import fix_margins
+from ..utils.matplotlib import freeze_margins
 from .layer_artist import LayerArtistContainer
 
 __all__ = ['VizClient', 'GenericMplClient']
@@ -155,13 +155,13 @@ def init_mpl(figure, axes, wcs=False, axes_factory=None):
         if wcs and WCSAxesSubplot is not None:
             _axes = WCSAxesSubplot(_figure, 111)
             _figure.add_axes(_axes)
-            fix_margins(_axes, [1, 0.25, 0.50, 0.25])
+            freeze_margins(_axes, [1, 0.25, 0.50, 0.25])
         else:
             if axes_factory is not None:
                 _axes = axes_factory(_figure)
             else:
                 _axes = _figure.add_subplot(1, 1, 1)
-                fix_margins(_axes, [1, 0.25, 0.50, 0.25])
+                freeze_margins(_axes, [1, 0.25, 0.50, 0.25])
 
     return _figure, _axes
 

--- a/glue/external/axescache.py
+++ b/glue/external/axescache.py
@@ -127,6 +127,7 @@ class AxesCache(object):
 
     def __init__(self, axes):
         self.axes = axes
+        self.ax_class = axes.__class__
 
         self._capture = None
         self.axes.draw = self.draw
@@ -134,7 +135,7 @@ class AxesCache(object):
 
     def draw(self, renderer, *args, **kwargs):
         if self._capture is None or not self._enabled:
-            Axes.draw(self.axes, renderer, *args, **kwargs)
+            self.ax_class.draw(self.axes, renderer, *args, **kwargs)
             self._capture = RenderCapture(self.axes, renderer)
         else:
             self.axes.axesPatch.draw(renderer, *args, **kwargs)

--- a/glue/external/axescache.py
+++ b/glue/external/axescache.py
@@ -127,7 +127,6 @@ class AxesCache(object):
 
     def __init__(self, axes):
         self.axes = axes
-        self.ax_class = axes.__class__
 
         self._capture = None
         self.axes.draw = self.draw
@@ -135,7 +134,7 @@ class AxesCache(object):
 
     def draw(self, renderer, *args, **kwargs):
         if self._capture is None or not self._enabled:
-            self.ax_class.draw(self.axes, renderer, *args, **kwargs)
+            Axes.draw(self.axes, renderer, *args, **kwargs)
             self._capture = RenderCapture(self.axes, renderer)
         else:
             self.axes.axesPatch.draw(renderer, *args, **kwargs)

--- a/glue/qt/widgets/mpl_widget.py
+++ b/glue/qt/widgets/mpl_widget.py
@@ -61,10 +61,6 @@ class MplCanvas(FigureCanvas):
         self.roi_callback = None
 
         self.fig = Figure(facecolor='#ffffff')
-        try:
-            self.fig.set_tight_layout(True)
-        except AttributeError:  # matplotlib < 1.1
-            pass
 
         FigureCanvas.__init__(self, self.fig)
         FigureCanvas.setSizePolicy(self,

--- a/glue/utils/matplotlib.py
+++ b/glue/utils/matplotlib.py
@@ -176,3 +176,49 @@ def point_contour(x, y, data):
         return None
     xy = xy[0]
     return xy
+
+
+def FixedMarginAxes(ax_class, margins=[1, 1, 1, 1]):
+    """
+    Class factory to make an axes class that will preserve fixed margins when
+    figure is resized.
+
+    Parameters
+    ----------
+    ax_class : matplotlib.axes.Axes
+        The axes class to wrap
+    margins : iterable
+        The margins, in inches. The order of the margins is
+        ``[left, right, bottom, top]``
+    """
+
+    # Note that margins gets used directly in get_fixed_margin_rect and we
+    # don't pass it through the axes class.
+
+    def get_fixed_margin_rect(fig):
+
+        fig_width = fig.get_figwidth()
+        fig_height = fig.get_figheight()
+
+        x0 = margins[0] / fig_width
+        x1 = 1 - margins[1] / fig_width
+        y0 = margins[2] / fig_height
+        y1 = 1 - margins[3] / fig_height
+
+        dx = max(0.01, x1 - x0)
+        dy = max(0.01, y1 - y0)
+
+        return [x0, y0, dx, dy]
+
+    class ax_subclass(ax_class):
+
+        def __init__(self, fig, **kwargs):
+            rect = get_fixed_margin_rect(fig)
+            super(ax_subclass, self).__init__(fig, rect, **kwargs)
+
+        def draw(self, *args, **kwargs):
+            rect = get_fixed_margin_rect(self.figure)
+            self.set_position(rect)
+            super(ax_subclass, self).draw(*args, **kwargs)
+
+    return ax_subclass

--- a/glue/utils/matplotlib.py
+++ b/glue/utils/matplotlib.py
@@ -178,7 +178,7 @@ def point_contour(x, y, data):
     return xy
 
 
-def FixedMarginAxes(ax_class, margins=[1, 1, 1, 1]):
+def fixed_margin_axes(ax_class, margins=[1, 1, 1, 1]):
     """
     Class factory to make an axes class that will preserve fixed margins when
     figure is resized.

--- a/glue/utils/matplotlib.py
+++ b/glue/utils/matplotlib.py
@@ -178,47 +178,42 @@ def point_contour(x, y, data):
     return xy
 
 
-def fixed_margin_axes(ax_class, margins=[1, 1, 1, 1]):
+class AxesResizer(object):
+
+    def __init__(self, ax, margins):
+
+        self.ax = ax
+        self.margins = margins
+
+    def on_resize(self, event):
+
+        fig_width = self.ax.figure.get_figwidth()
+        fig_height = self.ax.figure.get_figheight()
+
+        x0 = self.margins[0] / fig_width
+        x1 = 1 - self.margins[1] / fig_width
+        y0 = self.margins[2] / fig_height
+        y1 = 1 - self.margins[3] / fig_height
+
+        dx = max(0.01, x1 - x0)
+        dy = max(0.01, y1 - y0)
+
+        self.ax.set_position([x0, y0, dx, dy]) 
+        self.ax.figure.canvas.draw()
+
+
+def fix_margins(axes, margins=[1, 1, 1, 1]):
     """
-    Class factory to make an axes class that will preserve fixed margins when
-    figure is resized.
+    Make sure margins of axes stay fixed.
 
     Parameters
     ----------
     ax_class : matplotlib.axes.Axes
-        The axes class to wrap
+        The axes class for which to fix the margins
     margins : iterable
         The margins, in inches. The order of the margins is
         ``[left, right, bottom, top]``
     """
 
-    # Note that margins gets used directly in get_fixed_margin_rect and we
-    # don't pass it through the axes class.
-
-    def get_fixed_margin_rect(fig):
-
-        fig_width = fig.get_figwidth()
-        fig_height = fig.get_figheight()
-
-        x0 = margins[0] / fig_width
-        x1 = 1 - margins[1] / fig_width
-        y0 = margins[2] / fig_height
-        y1 = 1 - margins[3] / fig_height
-
-        dx = max(0.01, x1 - x0)
-        dy = max(0.01, y1 - y0)
-
-        return [x0, y0, dx, dy]
-
-    class ax_subclass(ax_class):
-
-        def __init__(self, fig, **kwargs):
-            rect = get_fixed_margin_rect(fig)
-            super(ax_subclass, self).__init__(fig, rect, **kwargs)
-
-        def draw(self, *args, **kwargs):
-            rect = get_fixed_margin_rect(self.figure)
-            self.set_position(rect)
-            super(ax_subclass, self).draw(*args, **kwargs)
-
-    return ax_subclass
+    resizer = AxesResizer(axes, margins)
+    axes.figure.canvas.mpl_connect('resize_event', resizer.on_resize)

--- a/glue/utils/matplotlib.py
+++ b/glue/utils/matplotlib.py
@@ -202,7 +202,7 @@ class AxesResizer(object):
         self.ax.figure.canvas.draw()
 
 
-def fix_margins(axes, margins=[1, 1, 1, 1]):
+def freeze_margins(axes, margins=[1, 1, 1, 1]):
     """
     Make sure margins of axes stay fixed.
 

--- a/glue/utils/matplotlib.py
+++ b/glue/utils/matplotlib.py
@@ -185,6 +185,14 @@ class AxesResizer(object):
         self.ax = ax
         self.margins = margins
 
+    @property
+    def margins(self):
+        return self._margins
+
+    @margins.setter
+    def margins(self, margins):
+        self._margins = margins
+
     def on_resize(self, event):
 
         fig_width = self.ax.figure.get_figwidth()
@@ -198,7 +206,7 @@ class AxesResizer(object):
         dx = max(0.01, x1 - x0)
         dy = max(0.01, y1 - y0)
 
-        self.ax.set_position([x0, y0, dx, dy]) 
+        self.ax.set_position([x0, y0, dx, dy])
         self.ax.figure.canvas.draw()
 
 
@@ -213,7 +221,15 @@ def freeze_margins(axes, margins=[1, 1, 1, 1]):
     margins : iterable
         The margins, in inches. The order of the margins is
         ``[left, right, bottom, top]``
+
+    Notes
+    -----
+    The object that controls the resizing is stored as the resizer attribute of
+    the Axes. This can be used to then change the margins:
+
+        >> ax.resizer.margins = [0.5, 0.5, 0.5, 0.5]
+
     """
 
-    resizer = AxesResizer(axes, margins)
-    axes.figure.canvas.mpl_connect('resize_event', resizer.on_resize)
+    axes.resizer = AxesResizer(axes, margins)
+    axes.figure.canvas.mpl_connect('resize_event', axes.resizer.on_resize)

--- a/glue/utils/tests/test_matplotlib.py
+++ b/glue/utils/tests/test_matplotlib.py
@@ -9,7 +9,7 @@ from ...tests.helpers import requires_scipy
 
 from ..matplotlib import (point_contour, fast_limits, all_artists, new_artists,
                           remove_artists, view_cascade, get_extent, color2rgb,
-                          defer_draw)
+                          defer_draw, freeze_margins)
 
 
 @requires_scipy
@@ -94,3 +94,43 @@ def test_defer_draw():
                          (('red', (1, 0, 0)), ('green', (0, 0.5020, 0)), ('orange', (1., 0.6470, 0.))))
 def test_color2rgb(color, rgb):
     assert_allclose(color2rgb(color), rgb, atol=0.001)
+
+
+def test_freeze_margins():
+
+    fig = plt.figure(figsize=(4,4))
+
+    ax = fig.add_subplot(1,1,1)
+    freeze_margins(ax, margins=[1, 1, 1, 1])
+
+    bbox = ax.get_position()
+    np.testing.assert_allclose(bbox.x0, 0.125)
+    np.testing.assert_allclose(bbox.y0, 0.1)
+    np.testing.assert_allclose(bbox.x1, 0.9)
+    np.testing.assert_allclose(bbox.y1, 0.9)
+
+    fig.canvas.resize_event()
+
+    bbox = ax.get_position()
+    np.testing.assert_allclose(bbox.x0, 0.25)
+    np.testing.assert_allclose(bbox.y0, 0.25)
+    np.testing.assert_allclose(bbox.x1, 0.75)
+    np.testing.assert_allclose(bbox.y1, 0.75)
+
+    fig.set_size_inches(8,8)
+    fig.canvas.resize_event()
+
+    bbox = ax.get_position()
+    np.testing.assert_allclose(bbox.x0, 0.125)
+    np.testing.assert_allclose(bbox.y0, 0.125)
+    np.testing.assert_allclose(bbox.x1, 0.875)
+    np.testing.assert_allclose(bbox.y1, 0.875)
+
+    ax.resizer.margins = [0, 1, 2, 4]
+    fig.canvas.resize_event()
+
+    bbox = ax.get_position()
+    np.testing.assert_allclose(bbox.x0, 0.)
+    np.testing.assert_allclose(bbox.y0, 0.25)
+    np.testing.assert_allclose(bbox.x1, 0.875)
+    np.testing.assert_allclose(bbox.y1, 0.5)


### PR DESCRIPTION
I looked into the issue described in https://github.com/glue-viz/glue/issues/730, namely that the axes appear to bounce around when being resized. This is due to the tight layout option, which causes the axes to be re-drawn after every draw with a different bounding box.

This PR disables this, and tries to instead optimize space used by setting the rect for the axes created. Of course, this isn't perfect either because the axes size is relative to the window so for larger axes there is a lot of wasted space. I am going to look into whether there is a better way to do that, but in the mean time, this does produce smoother axes resizing without any bouncing.