### PR TITLE
Use [gui_scripts] entry point for main glue script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,9 +77,11 @@ spectrum_tool = glue.plugins.tools.spectrum_tool:setup
 coordinate_helpers = glue.plugins.coordinate_helpers:setup
 
 [console_scripts]
-glue = glue.main:main
 glue-config = glue.config_gen:main
 glue-deps = glue._deps:main
+
+[gui_scripts]
+glue = glue.main:main
 """
 
 setup(name='glueviz',


### PR DESCRIPTION
Doesn't fix https://github.com/glue-viz/glue/issues/597 but I think this is the correct way of specifying it and matters for WIndows apparently.