### PR TITLE
Improvements to widget properties

### DIFF
--- a/glue/qt/tests/test_widget_properties.py
+++ b/glue/qt/tests/test_widget_properties.py
@@ -20,7 +20,10 @@ from ...external.qt.QtGui import (QCheckBox,
                                   QLabel,
                                   QSlider,
                                   QTabWidget,
-                                  QWidget)
+                                  QWidget,
+                                  QKeyEvent)
+
+from ...external.qt import QtCore, get_qapp
 
 from ...external.echo import CallbackProperty
 
@@ -248,15 +251,23 @@ def test_connect_float_edit():
     t = Test()
 
     line = QLineEdit()
+    dum = QWidget()
 
     connect_float_edit(t, 'a', line)
 
-    # TODO: simulate editingFinished event
-    # line.setText('1.0')
-    # assert t.a == 1.0
-    #
-    # line.setText('4.0')
-    # assert t.a == 4.0
+    event = QKeyEvent(QtCore.QEvent.KeyPress,
+                      QtCore.Qt.Key_Return,
+                      QtCore.Qt.NoModifier)
+
+    app = get_qapp()
+
+    line.setText('1.0')
+    app.sendEvent(line, event)
+    assert t.a == 1.0
+
+    line.setText('4.0')
+    app.sendEvent(line, event)
+    assert t.a == 4.0
 
     t.a = 3.0
     assert line.text() == '3'

--- a/glue/qt/tests/test_widget_properties.py
+++ b/glue/qt/tests/test_widget_properties.py
@@ -1,42 +1,180 @@
 from __future__ import absolute_import, division, print_function
 
-from ..widget_properties import (ButtonProperty,
-                                 FloatLineProperty)
+import pytest
 
-from ...external.qt.QtGui import QCheckBox, QLineEdit
+from ..widget_properties import (CurrentComboDataProperty,
+                                 CurrentComboTextProperty,
+                                 CurrentTabProperty,
+                                 TextProperty,
+                                 ButtonProperty,
+                                 FloatLineProperty,
+                                 ValueProperty)
+
+from ...external.qt.QtGui import (QCheckBox,
+                                  QLineEdit,
+                                  QComboBox,
+                                  QLabel,
+                                  QSlider,
+                                  QTabWidget,
+                                  QWidget)
 
 
-class TestClass(object):
-    b = ButtonProperty('_button')
-    fl = FloatLineProperty('_float')
 
-    def __init__(self):
-        self._button = QCheckBox()
-        self._float = QLineEdit()
+
+
+def test_combo_data():
+
+    class TestClass(object):
+
+        co = CurrentComboDataProperty('_combo')
+
+        def __init__(self):
+            self._combo = QComboBox()
+            self._combo.addItem('a', 'a')
+            self._combo.addItem('b', 'b')
+
+    tc = TestClass()
+
+    tc.co = 'a'
+    assert tc.co == 'a'
+    assert tc._combo.currentIndex() == 0
+
+    tc.co = 'b'
+    assert tc.co == 'b'
+    assert tc._combo.currentIndex() == 1
+
+    with pytest.raises(ValueError) as exc:
+        tc.co = 'c'
+    assert exc.value.args[0] == "Cannot find data 'c' in combo box"
+
+
+def test_combo_text():
+
+    class TestClass(object):
+
+        co = CurrentComboTextProperty('_combo')
+
+        def __init__(self):
+            self._combo = QComboBox()
+            self._combo.addItem('a')
+            self._combo.addItem('b')
+
+    tc = TestClass()
+
+    tc.co = 'a'
+    assert tc.co == 'a'
+    assert tc._combo.currentIndex() == 0
+
+    tc.co = 'b'
+    assert tc.co == 'b'
+    assert tc._combo.currentIndex() == 1
+
+    with pytest.raises(ValueError) as exc:
+        tc.co = 'c'
+    assert exc.value.args[0] == "Cannot find text 'c' in combo box"
+
+
+def test_text():
+
+    class TestClass(object):
+        lab = TextProperty('_label')
+        def __init__(self):
+            self._label = QLabel()
+
+    tc = TestClass()
+    tc.lab = 'hello'
+    assert tc.lab == 'hello'
+    assert tc._label.text() == 'hello'
 
 
 def test_button():
-    tc = TestClass()
-    assert tc.b == tc._button.checkState()
 
-    tc.b = True
+    class TestClass(object):
+        but = ButtonProperty('_button')
+        def __init__(self):
+            self._button = QCheckBox()
+
+    tc = TestClass()
+
+    assert tc.but == tc._button.checkState()
+
+    tc.but = True
     assert tc._button.isChecked()
 
-    tc.b = False
+    tc.but = False
     assert not tc._button.isChecked()
 
     tc._button.setChecked(True)
-    assert tc.b
+    assert tc.but
 
     tc._button.setChecked(False)
-    assert not tc.b
+    assert not tc.but
 
 
 def test_float():
+
+    class TestClass(object):
+        flt = FloatLineProperty('_float')
+        def __init__(self):
+            self._float = QLineEdit()
+
     tc = TestClass()
 
-    tc.fl = 1.0
+    tc.flt = 1.0
     assert float(tc._float.text()) == 1.0
 
     tc._float.setText('10')
-    assert tc.fl == 10.0
+    assert tc.flt == 10.0
+
+
+def test_value():
+
+    class TestClass(object):
+        val = ValueProperty('_slider')
+        def __init__(self):
+            self._slider = QSlider()
+
+    tc = TestClass()
+
+    tc.val = 2.0
+    assert tc.val == 2.0
+    assert tc._slider.value() == 2.0
+
+
+def test_value_mapping():
+
+    class TestClass(object):
+        val = ValueProperty('_slider', mapping=(lambda x: 2 * x,
+                                                lambda x: 0.5 * x))
+        def __init__(self):
+            self._slider = QSlider()
+
+    tc = TestClass()
+
+    tc.val = 2.0
+    assert tc.val == 2.0
+    assert tc._slider.value() == 1.0
+
+
+def test_tab():
+
+    class TestClass(object):
+        tab = CurrentTabProperty('_tab')
+        def __init__(self):
+            self._tab = QTabWidget()
+            self._tab.addTab(QWidget(), 'tab1')
+            self._tab.addTab(QWidget(), 'tab2')
+
+    tc = TestClass()
+
+    tc.tab = 'tab1'
+    assert tc.tab == 'tab1'
+    assert tc._tab.currentIndex() == 0
+
+    tc.tab = 'tab2'
+    assert tc.tab == 'tab2'
+    assert tc._tab.currentIndex() == 1
+
+    with pytest.raises(ValueError) as exc:
+        tc.tab = 'tab3'
+    assert exc.value.args[0] == "Cannot find value 'tab3' in tabs"

--- a/glue/qt/tests/test_widget_properties.py
+++ b/glue/qt/tests/test_widget_properties.py
@@ -8,7 +8,11 @@ from ..widget_properties import (CurrentComboDataProperty,
                                  TextProperty,
                                  ButtonProperty,
                                  FloatLineProperty,
-                                 ValueProperty)
+                                 ValueProperty,
+                                 connect_bool_button,
+                                 connect_current_combo,
+                                 connect_float_edit,
+                                 connect_int_spin)
 
 from ...external.qt.QtGui import (QCheckBox,
                                   QLineEdit,
@@ -18,7 +22,7 @@ from ...external.qt.QtGui import (QCheckBox,
                                   QTabWidget,
                                   QWidget)
 
-
+from ...external.echo import CallbackProperty
 
 
 
@@ -126,6 +130,9 @@ def test_float():
     tc._float.setText('10')
     assert tc.flt == 10.0
 
+    tc._float.setText('')
+    assert tc.flt == 0.0
+
 
 def test_value():
 
@@ -178,3 +185,96 @@ def test_tab():
     with pytest.raises(ValueError) as exc:
         tc.tab = 'tab3'
     assert exc.value.args[0] == "Cannot find value 'tab3' in tabs"
+
+
+def test_connect_bool_button():
+
+    class Test(object):
+        a = CallbackProperty()
+
+    t = Test()
+
+    box = QCheckBox()
+    connect_bool_button(t, 'a', box)
+
+    box.setChecked(True)
+    assert t.a
+
+    box.setChecked(False)
+    assert not t.a
+
+    t.a = True
+    assert box.isChecked()
+
+    t.a = False
+    assert not box.isChecked()
+
+
+def test_connect_current_combo():
+
+    class Test(object):
+        a = CallbackProperty()
+
+    t = Test()
+
+    combo = QComboBox()
+    combo.addItem('a', 'a')
+    combo.addItem('b', 'b')
+
+    connect_current_combo(t, 'a', combo)
+
+    combo.setCurrentIndex(1)
+    assert t.a == 'b'
+
+    combo.setCurrentIndex(0)
+    assert t.a == 'a'
+
+    t.a = 'b'
+    assert combo.currentIndex() == 1
+
+    t.a = 'a'
+    assert combo.currentIndex() == 0
+
+    # TODO: should the following not return an error?
+    t.a = 'c'
+    assert combo.currentIndex() == 0
+
+
+def test_connect_float_edit():
+
+    class Test(object):
+        a = CallbackProperty()
+
+    t = Test()
+
+    line = QLineEdit()
+
+    connect_float_edit(t, 'a', line)
+
+    # TODO: simulate editingFinished event
+    # line.setText('1.0')
+    # assert t.a == 1.0
+    #
+    # line.setText('4.0')
+    # assert t.a == 4.0
+
+    t.a = 3.0
+    assert line.text() == '3'
+
+
+def test_connect_int_spin():
+
+    class Test(object):
+        a = CallbackProperty()
+
+    t = Test()
+
+    slider = QSlider()
+
+    connect_int_spin(t, 'a', slider)
+
+    slider.setValue(4)
+    assert t.a == 4
+
+    t.a = 3.0
+    assert slider.value() == 3.0

--- a/glue/qt/tests/test_widget_properties.py
+++ b/glue/qt/tests/test_widget_properties.py
@@ -28,7 +28,6 @@ from ...external.qt import QtCore, get_qapp
 from ...external.echo import CallbackProperty
 
 
-
 def test_combo_data():
 
     class TestClass(object):

--- a/glue/qt/widget_properties.py
+++ b/glue/qt/widget_properties.py
@@ -83,8 +83,11 @@ class CurrentComboDataProperty(WidgetProperty):
         Update the currently selected item to the one which stores value in
         its itemData
         """
-        idx = widget.findData(value)
-        if idx == -1:
+        # Note, we don't use findData here because it doesn't work
+        # well with non-str data
+        try:
+            idx = _find_combo_data(widget, value)
+        except ValueError:
             raise ValueError("Cannot find data '{0}' in combo box".format(value))
         widget.setCurrentIndex(idx)
 
@@ -278,3 +281,15 @@ def connect_int_spin(client, prop, widget):
     """
     add_callback(client, prop, widget.setValue)
     widget.valueChanged.connect(partial(setattr, client, prop))
+
+
+def _find_combo_data(widget, value):
+    """
+    Returns the index in a combo box where itemData == value
+
+    Raises a ValueError if data is not found
+    """
+    for i in range(widget.count()):
+        if widget.itemData(i) == value:
+            return i
+    raise ValueError("%s not found in combo box" % value)

--- a/glue/qt/widget_properties.py
+++ b/glue/qt/widget_properties.py
@@ -28,24 +28,24 @@ from ..core.callback_property import add_callback
 
 
 class WidgetProperty(object):
-
-    """ Base class for widget properties
+    """
+    Base class for widget properties
 
     Subclasses implement, at a minimum, the "get" and "set" methods,
     which translate between widget states and python variables
+
+    Parameters
+    ----------
+    att : str
+        The location, within a class instance, of the widget to wrap around.
+        If the widget is nested inside another variable, normal '.' syntax
+        can be used (e.g. 'sub_window.button')
+    docstring : str, optional
+        Optional short summary for the property. Used by sphinx. Should be 1
+        sentence or less.
     """
 
     def __init__(self, att, docstring=''):
-        """
-        :param att: The location, within a class instance, of the widget
-        to wrap around. If the widget is nested inside another variable,
-        normal '.' syntax can be used (e.g. 'sub_window.button')
-
-        :type att: str
-        :param docstring: Optional short summary for the property.
-                          Used by sphinx. Should be 1 sentence or less.
-        :type docstring: str
-        """
         self.__doc__ = docstring
         self._att = att.split('.')
 
@@ -57,6 +57,7 @@ class WidgetProperty(object):
         widget = reduce(getattr, [instance] + self._att)
         self.setter(widget, value)
 
+
     def getter(self, widget):
         """ Return the state of a widget. Depends on type of widget,
         and must be overridden"""
@@ -67,25 +68,78 @@ class WidgetProperty(object):
         raise NotImplementedError()
 
 
-class CurrentComboProperty(WidgetProperty):
-
-    """Wrapper around ComboBoxes"""
+class CurrentComboDataProperty(WidgetProperty):
+    """
+    Wrapper around ComboBoxes
+    """
 
     def getter(self, widget):
-        """ Return the itemData stored in the currently-selected item """
+        """
+        Return the itemData stored in the currently-selected item
+        """
         return widget.itemData(widget.currentIndex())
 
     def setter(self, widget, value):
-        """ Update the currently selected item to the one which stores value in
+        """
+        Update the currently selected item to the one which stores value in
         its itemData
         """
-        idx = _find_combo_data(widget, value)
+        idx = widget.findData(value)
+        if idx == -1:
+            raise ValueError("Cannot find data '{0}' in combo box".format(value))
+        widget.setCurrentIndex(idx)
+
+CurrentComboProperty = CurrentComboDataProperty
+
+
+class CurrentComboTextProperty(WidgetProperty):
+    """
+    Wrapper around ComboBoxes
+    """
+
+    def getter(self, widget):
+        """
+        Return the itemData stored in the currently-selected item
+        """
+        return widget.itemText(widget.currentIndex())
+
+    def setter(self, widget, value):
+        """
+        Update the currently selected item to the one which stores value in
+        its itemData
+        """
+        idx = widget.findText(value)
+        if idx == -1:
+            raise ValueError("Cannot find text '{0}' in combo box".format(value))
+        widget.setCurrentIndex(idx)
+
+
+class CurrentTabProperty(WidgetProperty):
+
+    def getter(self, widget):
+        """
+        Return the itemData stored in the currently-selected item
+        """
+        return widget.tabText(widget.currentIndex())
+
+    def setter(self, widget, value):
+        """
+        Update the currently selected item to the one which stores value in
+        its itemData
+        """
+        for idx in range(widget.count()):
+            if widget.tabText(idx) == value:
+                break
+        else:
+            raise ValueError("Cannot find value '{0}' in tabs".format(value))
+
         widget.setCurrentIndex(idx)
 
 
 class TextProperty(WidgetProperty):
-
-    """ Wrapper around the text() and setText() methods for QLabel etc"""
+    """
+    Wrapper around the text() and setText() methods for QLabel etc
+    """
 
     def getter(self, widget):
         return widget.text()
@@ -95,8 +149,9 @@ class TextProperty(WidgetProperty):
 
 
 class ButtonProperty(WidgetProperty):
-
-    """Wrapper around the check state for QAbstractButton widgets"""
+    """
+    Wrapper around the check state for QAbstractButton widgets
+    """
 
     def getter(self, widget):
         return widget.isChecked()
@@ -106,10 +161,10 @@ class ButtonProperty(WidgetProperty):
 
 
 class FloatLineProperty(WidgetProperty):
+    """
+    Wrapper around the text state for QLineEdit widgets.
 
-    """Wrapper around the text state for QLineEdit widgets.
-
-    Assumes that the text is a floating point number
+    Assumes that the text is a floating-point number
     """
 
     def getter(self, widget):
@@ -124,14 +179,40 @@ class FloatLineProperty(WidgetProperty):
 
 
 class ValueProperty(WidgetProperty):
+    """
+    Wrapper around widgets with value() and setValue()
 
-    """Wrapper around value() and setValue() intspin boxes"""
+    Parameters
+    ----------
+    att : str
+        The location, within a class instance, of the widget to wrap around.
+        If the widget is nested inside another variable, normal '.' syntax
+        can be used (e.g. 'sub_window.button')
+    docstring : str, optional
+        Optional short summary for the property. Used by sphinx. Should be 1
+        sentence or less.
+    mapping : tuple, optional
+        If specified, should be a tuple of two functions - the first to map
+        from Qt widget values to Python values, and the second to map from
+        Python values to Qt widget values. This can be used for to specify a
+        non-linear mapping for sliders.
+    """
+    
+    def __init__(self, att, docstring='', mapping=None):
+        super(ValueProperty, self).__init__(att, docstring=docstring)
+        self.mapping = mapping
 
     def getter(self, widget):
-        return widget.value()
+        if self.mapping is None:
+            return widget.value()
+        else:
+            return self.mapping[0](widget.value())
 
     def setter(self, widget, value):
-        widget.setValue(value)
+        if self.mapping is None:
+            widget.setValue(value)
+        else:
+            widget.setValue(self.mapping[1](value))
 
 
 def connect_bool_button(client, prop, widget):
@@ -199,13 +280,13 @@ def connect_int_spin(client, prop, widget):
     widget.valueChanged.connect(partial(setattr, client, prop))
 
 
-def _find_combo_data(widget, value):
+def _find_index(widget, value, func='itemData'):
     """
-    Returns the index in a combo box where itemData == value
+    Returns the index where func(index) == value
 
     Raises a ValueError if data is not found
     """
     for i in range(widget.count()):
-        if widget.itemData(i) == value:
+        if getattr(widget, func)(i) == value:
             return i
-    raise ValueError("%s not found in combo box" % value)
+    raise ValueError("%s not found" % value)

--- a/glue/qt/widget_properties.py
+++ b/glue/qt/widget_properties.py
@@ -69,7 +69,7 @@ class WidgetProperty(object):
 
 class CurrentComboDataProperty(WidgetProperty):
     """
-    Wrapper around ComboBoxes
+    Wrapper around the data in QComboBox.
     """
 
     def getter(self, widget):
@@ -96,7 +96,7 @@ CurrentComboProperty = CurrentComboDataProperty
 
 class CurrentComboTextProperty(WidgetProperty):
     """
-    Wrapper around ComboBoxes
+    Wrapper around the text in QComboBox.
     """
 
     def getter(self, widget):
@@ -117,6 +117,9 @@ class CurrentComboTextProperty(WidgetProperty):
 
 
 class CurrentTabProperty(WidgetProperty):
+    """
+    Wrapper around QTabWidget.
+    """
 
     def getter(self, widget):
         """

--- a/glue/qt/widget_properties.py
+++ b/glue/qt/widget_properties.py
@@ -61,11 +61,11 @@ class WidgetProperty(object):
     def getter(self, widget):
         """ Return the state of a widget. Depends on type of widget,
         and must be overridden"""
-        raise NotImplementedError()
+        raise NotImplementedError()  # pragma: no cover
 
     def setter(self, widget, value):
         """ Set the state of a widget to a certain value"""
-        raise NotImplementedError()
+        raise NotImplementedError()  # pragma: no cover
 
 
 class CurrentComboDataProperty(WidgetProperty):
@@ -197,7 +197,7 @@ class ValueProperty(WidgetProperty):
         Python values to Qt widget values. This can be used for to specify a
         non-linear mapping for sliders.
     """
-    
+
     def __init__(self, att, docstring='', mapping=None):
         super(ValueProperty, self).__init__(att, docstring=docstring)
         self.mapping = mapping
@@ -232,9 +232,8 @@ def connect_current_combo(client, prop, widget):
     """
 
     def _push_combo(value):
-        try:
-            idx = _find_combo_data(widget, value)
-        except ValueError:  # not found. Punt instead of failing
+        idx = widget.findData(value)
+        if idx == -1:
             return
         widget.setCurrentIndex(idx)
 
@@ -263,6 +262,8 @@ def connect_float_edit(client, prop, widget):
             setattr(client, prop, 0)
 
     def update_widget(val):
+        if val is None:
+            val = 0.
         widget.setText(pretty_number(val))
 
     add_callback(client, prop, update_widget)
@@ -278,15 +279,3 @@ def connect_int_spin(client, prop, widget):
     """
     add_callback(client, prop, widget.setValue)
     widget.valueChanged.connect(partial(setattr, client, prop))
-
-
-def _find_index(widget, value, func='itemData'):
-    """
-    Returns the index where func(index) == value
-
-    Raises a ValueError if data is not found
-    """
-    for i in range(widget.count()):
-        if getattr(widget, func)(i) == value:
-            return i
-    raise ValueError("%s not found" % value)

--- a/glue/qt/widget_properties.py
+++ b/glue/qt/widget_properties.py
@@ -57,7 +57,6 @@ class WidgetProperty(object):
         widget = reduce(getattr, [instance] + self._att)
         self.setter(widget, value)
 
-
     def getter(self, widget):
         """ Return the state of a widget. Depends on type of widget,
         and must be overridden"""


### PR DESCRIPTION
Several changes in this pull request, following work on the 3-d viewer:

* ``CurrentComboProperty`` has been renamed to ``CurrentComboDataProperty`` and ``CurrentComboTextProperty`` has been added, to differentiate between cases where the item should be selected based on the text vs data in the combo box (note that for backward-compatibility, ``CurrentComboProperty`` is set to ``CurrentComboDataProperty``)
* Adds the ability to define a mapping function for value-based properties, which can be useful for e.g. log-space sliders
* Adds ``CurrentTabProperty``. The tests have been expanded to cover all widget properties.
* Significantly expands tests in ``test_widget_properties.py`` to test all functions/classes

@ChrisBeaumont - am I right in thinking that when one doesn't need an actual callback, but instead just needs the property to be set when called, then the widget properties should be used, whereas if an immediate callback is needed, the callback properties and connect functions should be used?