### PR TITLE
Save loaded plugins

### DIFF
--- a/glue/core/application_base.py
+++ b/glue/core/application_base.py
@@ -95,6 +95,28 @@ class Application(HubListener):
         with open(path, 'w') as out:
             out.write(state)
 
+    @staticmethod
+    def restore_session(path):
+        """
+        Reload a previously-saved session
+
+        Parameters
+        ----------
+        path : str
+            Path to the file to load
+
+        Returns
+        -------
+        app : :class:`Application`
+            The loaded application
+        """
+        from ..core.state import GlueUnSerializer
+
+        with open(path) as infile:
+            state = GlueUnSerializer.load(infile)
+
+        return state.object('__main__')
+
     def new_tab(self):
         raise NotImplementedError()
 
@@ -214,9 +236,9 @@ class Application(HubListener):
     def __gluestate__(self, context):
         viewers = [list(map(context.id, tab)) for tab in self.viewers]
         data = self.session.data_collection
-
+        from ..main import _loaded_plugins
         return dict(session=context.id(self.session), viewers=viewers,
-                    data=context.id(data))
+                    data=context.id(data), plugins=_loaded_plugins)
 
     @classmethod
     def __setgluestate__(cls, rec, context):

--- a/glue/core/application_base.py
+++ b/glue/core/application_base.py
@@ -231,7 +231,7 @@ class Application(HubListener):
         """Return a tuple of tuples of viewers currently open
         The i'th tuple stores the viewers in the i'th close_tab
         """
-        raise NotImplementedError()
+        return []
 
     def __gluestate__(self, context):
         viewers = [list(map(context.id, tab)) for tab in self.viewers]

--- a/glue/core/state.py
+++ b/glue/core/state.py
@@ -330,7 +330,7 @@ class GlueSerializer(object):
         """
         if np.isscalar(o) and isinstance(o, np.generic):
             return np.asscalar(o)  # coerce numpy number to pure-python type
-        if isinstance(o, tuple):
+        if isinstance(o, (tuple, set)):
             return list(o)
         return o
 

--- a/glue/core/tests/test_application_base.py
+++ b/glue/core/tests/test_application_base.py
@@ -9,8 +9,8 @@ from ...external.six.moves import cPickle as pickle
 
 class MockApplication(Application):
 
-    def __init__(self, data=None, hub=None):
-        super(MockApplication, self).__init__(data, hub)
+    def __init__(self, data_collection=None, session=None):
+        super(MockApplication, self).__init__(data_collection=data_collection, session=session)
         self.tab = MagicMock()
         self.errors = MagicMock()
 
@@ -54,3 +54,10 @@ class TestApplicationBase(object):
         assert args[1] == [x]
 
         assert self.app.data_collection.merge.call_count == 1
+
+
+def test_session(tmpdir):
+    session_file = tmpdir.join('test.glu').strpath
+    app = MockApplication()
+    app.save_session(session_file)
+    app2 = MockApplication.restore_session(session_file)

--- a/glue/qt/glue_application.py
+++ b/glue/qt/glue_application.py
@@ -731,7 +731,7 @@ class GlueApplication(Application, QMainWindow):
         if not file_name:
             return
 
-        ga = self.restore(file_name)
+        ga = self.restore_session(file_name)
         self.close()
         return ga
 
@@ -757,22 +757,23 @@ class GlueApplication(Application, QMainWindow):
         return ga
 
     @staticmethod
-    def restore(path, show=True):
-        """Reload a previously-saved session
-
-        :param path: Path to the file to load
-        :type path: str
-        :param show: If True (the default), immediately show the widget
-        :type show: bool
-
-        :returns: A new :class:`GlueApplication`
+    def restore_session(path, show=True):
         """
-        from ..core.state import GlueUnSerializer
+        Reload a previously-saved session
 
-        with open(path) as infile:
-            state = GlueUnSerializer.load(infile)
+        Parameters
+        ----------
+        path : str
+            Path to the file to load
+        show : bool, optional
+            If True (the default), immediately show the widget
 
-        ga = state.object('__main__')
+        Returns
+        -------
+        app : :class:`GlueApplication`
+            The loaded application
+        """
+        ga = super(GlueApplication, self).restore_session(path)
         if show:
             ga.show()
         return ga


### PR DESCRIPTION
Also moves some of the generic restore_session code to Application.

I had another commit which raised a warning if plugins were missing on loading, but it will generate unnecessary noise in most cases. What we need to know really is whether the plugins are *really* needed to load the session (someone could have had an irrelevant plugin loaded). However, doing this is going to be a fair bit more work.

For now, I'd like to merge this, just for information purposes, so that if we need to diagnose issues with users having issues loading files, we can check manually which plugins were loaded.

@ChrisBeaumont - does this sound reasonable? The plan would be to then figure out (after 0.6) how to determine exactly which plugins are needed when loading the session.