### PR TITLE
Bug when selecting pixels in image viewer with non-square pixels

### DIFF
--- a/glue/clients/image_client.py
+++ b/glue/clients/image_client.py
@@ -369,7 +369,10 @@ class ImageClient(VizClient):
         transpose = self.slice.index('x') < self.slice.index('y')
         for a in self.artists[s]:
             meth = a.update if not force else a.force_update
-            meth(view, transpose)
+            if isinstance(a, SubsetImageLayerArtist):
+                meth(view, transpose=transpose, aspect=self.display_aspect)
+            else:
+                meth(view, transpose=transpose)
 
         if redraw:
             self._redraw()

--- a/glue/clients/layer_artist.py
+++ b/glue/clients/layer_artist.py
@@ -607,9 +607,14 @@ class RGBImageLayerArtist(ImageLayerArtist, RGBImageLayerBase):
 
 class SubsetImageLayerArtist(LayerArtist, SubsetImageLayerBase):
 
-    def update(self, view, transpose=False):
-        subset = self.layer
+    def update(self, view, transpose=False, aspect=None):
+
         self.clear()
+
+        if aspect is None:
+            aspect = 'equal'
+
+        subset = self.layer
         logging.debug("View into subset %s is %s", self.layer, view)
 
         try:
@@ -634,6 +639,7 @@ class SubsetImageLayerArtist(LayerArtist, SubsetImageLayerBase):
                                           interpolation='nearest',
                                           origin='lower',
                                           zorder=5, visible=self.visible)]
+        self._axes.set_aspect(aspect, adjustable='datalim')
 
 
 class DendroLayerArtist(LayerArtist):


### PR DESCRIPTION
To reproduce:

* Open image in image viewer
* Set pixel ratio to automatic
* Select region, and the plot snaps back to square pixels