### PR TITLE
Default to linear stretch and min/max limits

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -55,6 +55,8 @@ v0.6 (unreleased)
 * Added two new settings ``settings.SUBSET_COLORS`` and ``settings.DATA_COLOR``
   that can be used to customize the default subset and data colors. [#742]
 
+* Improve defaults for image data limits.
+
 v0.5.3 (unreleased)
 -------------------
 

--- a/glue/clients/ds9norm.py
+++ b/glue/clients/ds9norm.py
@@ -123,8 +123,8 @@ class DS9Normalize(Normalize, object):
         self.stretch = 'linear'
         self.bias = 0.5
         self.contrast = 1.0
-        self.clip_lo = 5.
-        self.clip_hi = 95.
+        self.clip_lo = 0.
+        self.clip_hi = 100.
 
     @property
     def stretch(self):

--- a/glue/clients/layer_artist.py
+++ b/glue/clients/layer_artist.py
@@ -409,14 +409,9 @@ class ImageLayerArtist(LayerArtist, ImageLayerBase):
             a.set_cmap(value)
 
     def _default_norm(self, layer):
-        vals = np.sort(layer.ravel())
-        vals = vals[np.isfinite(vals)]
         result = DS9Normalize()
-        result.stretch = 'arcsinh'
         result.clip = True
-        if vals.size > 0:
-            result.vmin = vals[.01 * vals.size]
-            result.vmax = vals[.99 * vals.size]
+        result.update_clip(layer)
         return result
 
     def override_image(self, image):
@@ -462,7 +457,6 @@ class ImageLayerArtist(LayerArtist, ImageLayerBase):
         artists = []
 
         lr0 = self._extract_view(views[0], transpose)
-        self.norm = self.norm or self._default_norm(lr0)
         self.norm = self.norm or self._default_norm(lr0)
         self._update_clip(views[0][0])
 


### PR DESCRIPTION
I think it makes sense to default to min/max and a linear stretch. The current defaults often over-clip:

**Current**:

<img width="1200" alt="screen shot 2015-10-18 at 2 02 58 pm" src="https://cloud.githubusercontent.com/assets/314716/10563977/11fb9e60-75a1-11e5-9f8b-ec319fcdf0b3.png">

**This PR**

<img width="1205" alt="screen shot 2015-10-18 at 2 01 35 pm" src="https://cloud.githubusercontent.com/assets/314716/10563979/198fbff8-75a1-11e5-8da9-63380917fc28.png">

I was also wondering whether we should move the selection of the percentile, colormap, and scaling function to the options widget? We could then additionally add two fields to manually set the data limits.

@ChrisBeaumont - what do you think?
