### PR TITLE
Improve histogram limit setting

### DIFF
--- a/glue/clients/histogram_client.py
+++ b/glue/clients/histogram_client.py
@@ -231,9 +231,11 @@ class HistogramClient(Client):
                 continue
 
             if self.xlog:
-                if np.any(data > 0):
-                    lo = min(lo, np.nanmin(data[data > 0]))
-                    hi = max(hi, np.nanmax(data[data > 0]))
+                positive = data > 0
+                if np.any(positive):
+                    positive_data = data[positive]
+                    lo = min(lo, np.nanmin(positive_data))
+                    hi = max(hi, np.nanmax(positive_data))
                 else:
                     lo = 1
                     hi = 10

--- a/glue/clients/histogram_client.py
+++ b/glue/clients/histogram_client.py
@@ -304,6 +304,8 @@ class HistogramClient(Client):
         if self._component is component:
             return
 
+        self._sync_enabled = False
+
         iscat = lambda x: isinstance(x, CategoricalComponent)
 
         def comp_obj():
@@ -319,8 +321,6 @@ class HistogramClient(Client):
         first_add = self._component is None
         self._component = component
         cur = comp_obj()
-
-        self._sync_enabled = False
 
         if (self.xlog, self.component) in self._xlim:
             self.xmin, self.xmax = self._xlim[(self.xlog, self.component)]

--- a/glue/clients/layer_artist.py
+++ b/glue/clients/layer_artist.py
@@ -905,7 +905,7 @@ class HistogramLayerArtist(LayerArtist, HistogramLayerBase):
         else:
             rng = self.lo, self.hi
         nbinpatch = self._axes.hist(data,
-                                    bins=self.nbins,
+                                    bins=int(self.nbins),
                                     range=rng)
         self._y, self.x, self.artists = nbinpatch
         return True

--- a/glue/clients/tests/test_histogram_client.py
+++ b/glue/clients/tests/test_histogram_client.py
@@ -245,8 +245,8 @@ class TestHistogramClient(object):
         self.client.apply_roi(roi)
         state = self.data.subsets[0].subset_state
         assert isinstance(state, RangeSubsetState)
-        assert state.lo == 10
-        assert state.hi == 1000
+        np.testing.assert_allclose(state.lo, 7.3680629972807736)
+        np.testing.assert_allclose(state.hi, 1000)
 
     def test_xlimits_sticky_with_component(self):
         self.client.add_layer(self.data)

--- a/glue/qt/widgets/histogram_widget.py
+++ b/glue/qt/widgets/histogram_widget.py
@@ -77,15 +77,16 @@ class HistogramWidget(DataViewer):
         self.resize(self.central_widget.size())
 
     def _connect(self):
+
         ui = self.ui
         cl = self.client
-        ui.attributeCombo.currentIndexChanged.connect(
-            self._set_attribute_from_combo)
+
+        ui.attributeCombo.currentIndexChanged.connect(self._set_attribute_from_combo)
+
         ui.normalized_box.toggled.connect(partial(setattr, cl, 'normed'))
         ui.autoscale_box.toggled.connect(partial(setattr, cl, 'autoscale'))
         ui.cumulative_box.toggled.connect(partial(setattr, cl, 'cumulative'))
-        ui.xlog_box.toggled.connect(partial(setattr, cl, 'xlog'))
-        ui.ylog_box.toggled.connect(partial(setattr, cl, 'ylog'))
+
         connect_int_spin(cl, 'nbins', ui.binSpinBox)
         connect_float_edit(cl, 'xmin', ui.xmin)
         connect_float_edit(cl, 'xmax', ui.xmax)
@@ -182,20 +183,21 @@ class HistogramWidget(DataViewer):
 
     @defer_draw
     def _set_attribute_from_combo(self, *args):
-        for d in self._data:
-            try:
-                component = d.get_component(self.component)
-            except:
-                continue
+        if self.component is not None:
+            for d in self._data:
+                try:
+                    component = d.get_component(self.component)
+                except:
+                    continue
+                else:
+                    break
+            if component.categorical:
+                if self.ui.xlog_box.isEnabled():
+                    self.ui.xlog_box.setEnabled(False)
+                    self.xlog = False
             else:
-                break
-        if component.categorical:
-            if self.ui.xlog_box.isEnabled():
-                self.ui.xlog_box.setEnabled(False)
-                self.xlog = False
-        else:
-            if not self.ui.xlog_box.isEnabled():
-                self.ui.xlog_box.setEnabled(True)
+                if not self.ui.xlog_box.isEnabled():
+                    self.ui.xlog_box.setEnabled(True)
         self.client.set_component(self.component)
         self.update_window_title()
 

--- a/glue/qt/widgets/histogram_widget.py
+++ b/glue/qt/widgets/histogram_widget.py
@@ -180,6 +180,20 @@ class HistogramWidget(DataViewer):
 
     @defer_draw
     def _set_attribute_from_combo(self, *args):
+        for d in self._data:
+            try:
+                component = d.get_component(self.component)
+            except:
+                continue
+            else:
+                break
+        if component.categorical:
+            if self.ui.xlog_box.isEnabled():
+                self.ui.xlog_box.setEnabled(False)
+                self.xlog = False
+        else:
+            if not self.ui.xlog_box.isEnabled():
+                self.ui.xlog_box.setEnabled(True)
         self.client.set_component(self.component)
         self.update_window_title()
 

--- a/glue/qt/widgets/histogram_widget.py
+++ b/glue/qt/widgets/histogram_widget.py
@@ -8,7 +8,7 @@ from ...external.qt.QtCore import Qt
 from ...core import message as msg
 from ...clients.histogram_client import HistogramClient
 from ..widget_properties import (connect_int_spin, ButtonProperty,
-                                 FloatLineProperty,
+                                 FloatLineProperty, connect_float_edit,
                                  ValueProperty)
 from ..glue_toolbar import GlueToolbar
 from ..mouse_mode import HRangeMode
@@ -81,27 +81,14 @@ class HistogramWidget(DataViewer):
         cl = self.client
         ui.attributeCombo.currentIndexChanged.connect(
             self._set_attribute_from_combo)
-        ui.attributeCombo.currentIndexChanged.connect(
-            self._update_minmax_labels)
-        connect_int_spin(cl, 'nbins', ui.binSpinBox)
         ui.normalized_box.toggled.connect(partial(setattr, cl, 'normed'))
         ui.autoscale_box.toggled.connect(partial(setattr, cl, 'autoscale'))
         ui.cumulative_box.toggled.connect(partial(setattr, cl, 'cumulative'))
         ui.xlog_box.toggled.connect(partial(setattr, cl, 'xlog'))
         ui.ylog_box.toggled.connect(partial(setattr, cl, 'ylog'))
-        ui.xmin.editingFinished.connect(self._set_limits)
-        ui.xmax.editingFinished.connect(self._set_limits)
-
-    @defer_draw
-    def _set_limits(self):
-        lo = float(self.ui.xmin.text())
-        hi = float(self.ui.xmax.text())
-        self.client.xlimits = lo, hi
-
-    def _update_minmax_labels(self):
-        lo, hi = pretty_number(self.client.xlimits)
-        self.ui.xmin.setText(lo)
-        self.ui.xmax.setText(hi)
+        connect_int_spin(cl, 'nbins', ui.binSpinBox)
+        connect_float_edit(cl, 'xmin', ui.xmin)
+        connect_float_edit(cl, 'xmax', ui.xmax)
 
     def make_toolbar(self):
         result = GlueToolbar(self.central_widget.canvas, self,
@@ -209,7 +196,6 @@ class HistogramWidget(DataViewer):
 
         self.client.add_layer(data)
         self._update_attributes()
-        self._update_minmax_labels()
 
         return True
 

--- a/glue/qt/widgets/histogram_widget.py
+++ b/glue/qt/widgets/histogram_widget.py
@@ -9,7 +9,7 @@ from ...core import message as msg
 from ...clients.histogram_client import HistogramClient
 from ..widget_properties import (connect_int_spin, ButtonProperty,
                                  FloatLineProperty, connect_float_edit,
-                                 ValueProperty)
+                                 ValueProperty, connect_bool_button)
 from ..glue_toolbar import GlueToolbar
 from ..mouse_mode import HRangeMode
 from .data_viewer import DataViewer
@@ -89,6 +89,8 @@ class HistogramWidget(DataViewer):
         connect_int_spin(cl, 'nbins', ui.binSpinBox)
         connect_float_edit(cl, 'xmin', ui.xmin)
         connect_float_edit(cl, 'xmax', ui.xmax)
+        connect_bool_button(cl, 'xlog', ui.xlog_box)
+        connect_bool_button(cl, 'ylog', ui.ylog_box)
 
     def make_toolbar(self):
         result = GlueToolbar(self.central_widget.canvas, self,

--- a/glue/qt/widgets/tests/test_histogram_widget.py
+++ b/glue/qt/widgets/tests/test_histogram_widget.py
@@ -8,6 +8,9 @@ from . import simple_session
 from ..histogram_widget import HistogramWidget, _hash
 from .... import core
 
+from ....external.qt.QtGui import QKeyEvent
+from ....external.qt import QtCore, get_qapp
+
 
 def mock_data():
     return core.Data(label='d1', x=[1, 2, 3], y=[2, 3, 4])
@@ -103,14 +106,20 @@ class TestHistogramWidget(object):
         self.widget.ui.binSpinBox.setValue(7.0)
         assert self.widget.client.nbins == 7
 
-    def test_update_xmin(self):
+    def test_update_xmin_xmax(self):
+
+        event = QKeyEvent(QtCore.QEvent.KeyPress,
+                          QtCore.Qt.Key_Return,
+                          QtCore.Qt.NoModifier)
+
+        app = get_qapp()
+
         self.widget.ui.xmin.setText('-5')
-        self.widget._set_limits()
+        app.sendEvent(self.widget.ui.xmin, event)
         assert self.widget.client.xlimits[0] == -5
 
-    def test_update_xmax(self):
-        self.widget.ui.xmin.setText('15')
-        self.widget._set_limits()
+        self.widget.ui.xmax.setText('15')
+        app.sendEvent(self.widget.ui.xmax, event)
         assert self.widget.client.xlimits[1] == 15
 
     def test_update_component_updates_title(self):

--- a/glue/qt/widgets/tests/test_histogram_widget.py
+++ b/glue/qt/widgets/tests/test_histogram_widget.py
@@ -8,9 +8,6 @@ from . import simple_session
 from ..histogram_widget import HistogramWidget, _hash
 from .... import core
 
-from ....external.qt.QtGui import QKeyEvent
-from ....external.qt import QtCore, get_qapp
-
 
 def mock_data():
     return core.Data(label='d1', x=[1, 2, 3], y=[2, 3, 4])
@@ -108,18 +105,12 @@ class TestHistogramWidget(object):
 
     def test_update_xmin_xmax(self):
 
-        event = QKeyEvent(QtCore.QEvent.KeyPress,
-                          QtCore.Qt.Key_Return,
-                          QtCore.Qt.NoModifier)
-
-        app = get_qapp()
-
         self.widget.ui.xmin.setText('-5')
-        app.sendEvent(self.widget.ui.xmin, event)
+        self.widget.ui.xmin.editingFinished.emit()
         assert self.widget.client.xlimits[0] == -5
 
         self.widget.ui.xmax.setText('15')
-        app.sendEvent(self.widget.ui.xmax, event)
+        self.widget.ui.xmax.editingFinished.emit()
         assert self.widget.client.xlimits[1] == 15
 
     def test_update_component_updates_title(self):


### PR DESCRIPTION
This implements the following improvements:

* fixes the failures with Numpy 1.10 (in principle)
* changes the automated limit calculation for histograms to ignore values <= 0 when xlog is True
* remembers the separate min/max settings for xlog=True/False
* remembers which components should be shown in log
* disable xlog checkbox for categorical components

This needs unit tests to test what has been implemented above.