### PR TITLE
New convenience method to get component from ID

### DIFF
--- a/glue/core/data_collection.py
+++ b/glue/core/data_collection.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 from .hub import Hub, HubListener
-from .data import Data
+from .data import Data, IncompatibleAttribute
 from .link_manager import LinkManager
 from .registry import Registry
 from .message import (DataCollectionAddMessage,
@@ -296,3 +296,11 @@ class DataCollection(HubListener):
 
     def __nonzero__(self):
         return True
+
+    def get_component_by_id(self, component_id):
+        for data in self:
+            try:
+                return data.get_component(component_id)
+            except IncompatibleAttribute:
+                continue
+        raise ValueError("Component ID {0} not found in any datasets in data collection".format(component_id))

--- a/glue/core/tests/test_data_collection.py
+++ b/glue/core/tests/test_data_collection.py
@@ -310,3 +310,14 @@ class TestDataCollection(object):
         assert_array_equal(c['a'], [3, 4, 5])
         dc.merge(a, b)
         assert_array_equal(c['a'], [3, 4, 5])
+
+    def test_get_component_by_id(self):
+        d1 = Data(x=[1, 2, 3])
+        d2 = Data(y=[2, 3, 4])
+        c1 = d1.find_component_id('x')
+        dc = DataCollection([d1, d2])
+        comp = dc.get_component_by_id(c1)
+        c2 = ComponentID('z')
+        with pytest.raises(ValueError) as exc:
+            comp = dc.get_component_by_id(c2)
+        assert exc.value.args[0] == "Component ID z not found in any datasets in data collection"

--- a/glue/qt/widgets/histogram_widget.py
+++ b/glue/qt/widgets/histogram_widget.py
@@ -184,13 +184,7 @@ class HistogramWidget(DataViewer):
     @defer_draw
     def _set_attribute_from_combo(self, *args):
         if self.component is not None:
-            for d in self._data:
-                try:
-                    component = d.get_component(self.component)
-                except:
-                    continue
-                else:
-                    break
+            component = self._data.get_component_by_id(self.component)
             if component.categorical:
                 if self.ui.xlog_box.isEnabled():
                     self.ui.xlog_box.setEnabled(False)


### PR DESCRIPTION
This is a continuation of the discussion from #759. However, it's still not clear to me whether component IDs should be uniquely tied to a specific data component. The following example illustrates that a component ID can point to two separate sets of data values:

```python
In [2]: d1 = Data(x=[1,2,3])

In [3]: d2 = Data(y=[4,5,6])

In [4]: c1 = d1.find_component_id('x')

In [5]: c2 = d2.find_component_id('y')

In [6]: 

In [6]: d1.update_id(c1, c2)

In [7]: 

In [7]: print(d1[c2])
[1 2 3]

In [8]: print(d2[c2])
[4 5 6]
```

In HistogramClient, ``_get_data_components`` actually will return all matches but then ``set_component`` will just choose the first arbitrarily.

@ChrisBeaumont - could you clarify what the intent was in terms of the component IDs, and to what extent they are unique?