### PR TITLE
Fix PySide segfault

### DIFF
--- a/glue/qt/tests/test_widget_properties.py
+++ b/glue/qt/tests/test_widget_properties.py
@@ -235,8 +235,9 @@ def test_connect_current_combo():
     assert combo.currentIndex() == 0
 
     # TODO: should the following not return an error?
-    t.a = 'c'
-    assert combo.currentIndex() == 0
+    with pytest.raises(ValueError) as exc:
+        t.a = 'c'
+    assert exc.value.args[0] == 'c not found in combo box'
 
 
 def test_connect_float_edit():

--- a/glue/qt/widget_properties.py
+++ b/glue/qt/widget_properties.py
@@ -237,7 +237,9 @@ def connect_current_combo(client, prop, widget):
     """
 
     def _push_combo(value):
-        idx = widget.findData(value)
+        # NOTE: we can't use findData here because if the data is not a 
+        # string, PySide will crash
+        idx = _find_combo_data(widget, value)
         if idx == -1:
             return
         widget.setCurrentIndex(idx)


### PR DESCRIPTION
Use _find_combo_data instead of findData, because PySide crashes if the data is not a string

Closes #770