### PR TITLE
Updating travis to reflect recent miniconda changes

### DIFF
--- a/.setup_conda.sh
+++ b/.setup_conda.sh
@@ -4,12 +4,16 @@ python_version=$1
 
 if [ ${python_version:0:1} == "2" ]
 then
-    wget http://repo.continuum.io/miniconda/Miniconda-3.6.0-Linux-x86_64.sh -O miniconda.sh
+    wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
 else
-    wget http://repo.continuum.io/miniconda/Miniconda3-3.6.0-Linux-x86_64.sh -O miniconda.sh
+    wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
 fi
 
-chmod +x miniconda.sh
-./miniconda.sh -b
-export PATH=/home/travis/anaconda/bin:/home/travis/miniconda/bin:/home/travis/miniconda3/bin:$PATH
-which conda
+# http://conda.pydata.org/docs/travis.html#the-travis-yml-file
+
+bash miniconda.sh -b -p $HOME/miniconda
+export PATH="$HOME/miniconda/bin:$PATH"
+hash -r
+conda config --set always_yes yes --set changeps1 no
+conda update -q conda
+conda info -a

--- a/continuous-integration/travis/install_conda_linux.sh
+++ b/continuous-integration/travis/install_conda_linux.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
+# http://conda.pydata.org/docs/travis.html#the-travis-yml-file
 wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
-chmod +x miniconda.sh
-./miniconda.sh -b
-export PATH=/home/travis/miniconda/bin:$PATH
-conda update --yes conda
+bash miniconda.sh -b -p $HOME/miniconda
+export PATH="$HOME/miniconda/bin:$PATH"

--- a/continuous-integration/travis/install_conda_osx.sh
+++ b/continuous-integration/travis/install_conda_osx.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-wget http://repo.continuum.io/miniconda/Miniconda-3.7.3-MacOSX-x86_64.sh -O miniconda.sh
-chmod +x miniconda.sh
-./miniconda.sh -b
-export PATH=/Users/travis/miniconda/bin:$PATH
-conda update --yes conda
+# http://conda.pydata.org/docs/travis.html#the-travis-yml-file
+wget http://repo.continuum.io/miniconda/Miniconda-latest-MacOSX-x86_64.sh -O miniconda.sh
+
+bash miniconda.sh -b -p $HOME/miniconda
+export PATH="$HOME/miniconda/bin:$PATH"


### PR DESCRIPTION
And to use the latest miniconda script.

(See failures in astropy and affiliated packages, astropy/astropy#4291)

Some of the changes may be irrelevant or cause a fail (glue doesn't use the travis scripts inherited from astropy so I'm not that familiar with it).