### PR TITLE
Test error and fails

### DIFF
--- a/glue/qt/widgets/tests/test_image_widget.py
+++ b/glue/qt/widgets/tests/test_image_widget.py
@@ -231,6 +231,10 @@ class TestImageWidget(_TestImageWidgetBase):
         time.sleep(0.5)
         app.processEvents()
 
+        if self.widget.client._view_window is None:
+            if not CI or not TRAVIS_LINUX:
+                pytest.xfail('Only works reliably on Travis with Linux')
+
         extx0, exty0 = self.widget.client._view_window[4:]
 
         # While resizing, the view window should not change until we've


### PR DESCRIPTION
I believe that all required packages (listed on the webpage, and also in the test header) are installed, still the imports qt/qtconsole etc import don't work causing an error. 

Other than that there are 3 more failing tests and 2 pytest warnings.

```
====================================================== test session starts =======================================================
platform darwin -- Python 2.7.10, pytest-2.8.2, py-1.4.30, pluggy-0.3.1

                glue:	0.6.0.dev2173

             REQUIRED
     PyQt4 or PySide:	INSTALLED (unknown version)
               numpy:	INSTALLED (1.10.1)
          matplotlib:	INSTALLED (1.5.0)
              pandas:	INSTALLED (0.17.0)
             astropy:	INSTALLED (1.1.dev13982)

              GENERAL
                dill:	MISSING (Used when saving Glue sessions)
                h5py:	MISSING (Used to support HDF5 files)
               scipy:	INSTALLED (0.16.0)
             skimage:	INSTALLED (0.12dev)

     IPYTHON TERMINAL
             IPython:	INSTALLED (4.0.0)
           ipykernel:	INSTALLED (unknown version)
           qtconsole:	MISSING (Needed for interactive IPython terminal)
           traitlets:	INSTALLED (4.0.0)
            pygments:	INSTALLED (2.0.2)
                 zmq:	INSTALLED (15.0.0)

            ASTRONOMY
               pyavm:	MISSING (Used to parse AVM metadata in image files)

              TESTING
                mock:	INSTALLED (1.3.0)
              pytest:	INSTALLED (2.8.2)

               EXPORT
              plotly:	MISSING (Used to explort plots to Plot.ly)


rootdir: /Users/bsipocz/munka/devel/glue, inifile: 
plugins: capturelog-0.7, cov-2.1.0, html-1.6, mpl-0.3, selenium-1.0b1, variables-1.2
collected 1739 items / 1 errors / 1 skipped 

glue/clients/tests/test_dendro_client.py ...............
glue/clients/tests/test_ds9norm.py ...........
glue/clients/tests/test_histogram_client.py .......................................................................................
glue/clients/tests/test_image_client.py ............................................
glue/clients/tests/test_layer_artist.py .
glue/clients/tests/test_profile_viewer.py ................
glue/clients/tests/test_scatter_client.py ....................................................................................................
glue/core/data_factories/tests/test_data_factories.py ...............................
glue/core/data_factories/tests/test_dendro_loader.py ssssssss
glue/core/data_factories/tests/test_excel.py sss
glue/core/data_factories/tests/test_fits.py ........
glue/core/data_factories/tests/test_hdf5.py sssss
glue/core/tests/test_aggregate.py ................................
glue/core/tests/test_application_base.py ..
glue/core/tests/test_client.py ...................
glue/core/tests/test_command.py ..........
glue/core/tests/test_communication.py ....s.....
glue/core/tests/test_component.py ........................................................
glue/core/tests/test_component_link.py .........................
glue/core/tests/test_coordinate_links.py .....
glue/core/tests/test_coordinates.py ..................
glue/core/tests/test_data.py ............................................................
glue/core/tests/test_data_collection.py .............................
glue/core/tests/test_data_retrieval.py .
glue/core/tests/test_decorators.py ......
glue/core/tests/test_edit_subset_mode.py ........................
glue/core/tests/test_fitters.py ................
glue/core/tests/test_hub.py ..................
glue/core/tests/test_joins.py ..........
glue/core/tests/test_layout.py ....
glue/core/tests/test_link_helpers.py .............
glue/core/tests/test_link_manager.py ................
glue/core/tests/test_links.py ...
glue/core/tests/test_message.py ...
glue/core/tests/test_pandas.py ......
glue/core/tests/test_parse.py ................
glue/core/tests/test_registry.py ..........
glue/core/tests/test_roi.py ..............................................................................................................................................................
glue/core/tests/test_session_back_compat.py .s
glue/core/tests/test_simpleforms.py ......
glue/core/tests/test_state.py .................................
glue/core/tests/test_subset.py ...............................................................................................................................
glue/core/tests/test_subset_group.py .............................................
glue/core/tests/test_tree.py ...
glue/core/tests/test_tree_layout.py ...........
glue/core/tests/test_tree_traversal.py ......
glue/core/tests/test_util.py ........
glue/external/tests/test_echo.py .......................
glue/plugins/coordinate_helpers/tests/test_deprecated.py ..
glue/plugins/coordinate_helpers/tests/test_link_helpers.py ......
glue/plugins/ginga_viewer/tests/test_client.py ......................ssssss...
glue/plugins/ginga_viewer/tests/test_qt_widget.py ............
glue/plugins/tests/test_d3po.py .
glue/plugins/tests/test_plotly.py ....
glue/plugins/tools/tests/test_pv.py ........
glue/plugins/tools/tests/test_spectrum_tool.py ................
glue/qt/tests/test_application.py ....F..F........
glue/qt/tests/test_component_selector.py ..
glue/qt/tests/test_custom_viewer.py ................................................
glue/qt/tests/test_data_collection_model.py ..............
glue/qt/tests/test_layer_artist_model.py ..................
glue/qt/tests/test_link_equation.py ..................
glue/qt/tests/test_mouse_mode.py ...........................................................
glue/qt/tests/test_plugin_manager.py ...
glue/qt/tests/test_qtutil.py ......................................................
glue/qt/tests/test_simpleforms.py ...
glue/qt/tests/test_toolbar.py .
glue/qt/tests/test_widget_properties.py ............
glue/qt/widgets/tests/test_data_slice.py .......
glue/qt/widgets/tests/test_data_viewer.py ............
glue/qt/widgets/tests/test_dendro_widget.py ...
glue/qt/widgets/tests/test_histogram_widget.py .................
glue/qt/widgets/tests/test_image_widget.py ...............F.............
glue/qt/widgets/tests/test_layer_tree_widget.py ........................
glue/qt/widgets/tests/test_scatter_widget.py ..............................................
glue/qt/widgets/tests/test_settings.py ..
glue/qt/widgets/tests/test_style_dialog.py .
glue/qt/widgets/tests/test_subset_facet.py ...
glue/qt/widgets/tests/test_table_widget.py ......
glue/tests/test_config.py .....
glue/tests/test_deps.py .........
glue/tests/test_main.py .......................
glue/tests/test_qglue.py ..................
glue/utils/qt/tests/test_qmessagebox_widget.py .
glue/utils/tests/test_array.py ................
glue/utils/tests/test_matplotlib.py ...........
glue/utils/tests/test_misc.py ...............

============================================================= ERRORS =============================================================
____________________________________ ERROR collecting glue/qt/widgets/tests/test_terminal.py _____________________________________
glue/qt/widgets/tests/test_terminal.py:8: in <module>
    from ..terminal import glue_terminal
glue/qt/widgets/terminal.py:79: in <module>
    from IPython.zmq.ipkernel import Kernel
E   ImportError: No module named zmq.ipkernel
-------------------------------------------------------- Captured stderr ---------------------------------------------------------
/sw/lib/python2.7/site-packages/IPython/utils/traitlets.py:5: UserWarning: IPython.utils.traitlets has moved to a top-level traitlets package.
  warn("IPython.utils.traitlets has moved to a top-level traitlets package.")
/sw/lib/python2.7/site-packages/IPython/kernel/__init__.py:13: ShimWarning: The `IPython.kernel` package has been deprecated. You should import from ipykernel or jupyter_client instead.
  "You should import from ipykernel or jupyter_client instead.", ShimWarning)
/sw/lib/python2.7/site-packages/IPython/qt.py:13: ShimWarning: The `IPython.qt` package has been deprecated. You should import from qtconsole instead.
  "You should import from qtconsole instead.", ShimWarning)
============================================================ FAILURES ============================================================
___________________________________________ TestGlueApplication.test_terminal_present ____________________________________________

self = <glue.qt.tests.test_application.TestGlueApplication object at 0x130ad5450>

    @requires_ipython_ge_012
    def test_terminal_present(self):
        """For good setups, terminal is available"""
        if not self.app.has_terminal():
            sys.stderr.write(self.app._terminal_exception)
>           assert False
E           assert False

glue/qt/tests/test_application.py:84: AssertionError
---------------------------------------------------------- Captured log ----------------------------------------------------------
hub.py                     104 INFO     Subscribing DataCollection (0 data sets)
	 to DataAddComponentMessage
main.py                    265 INFO     Loading external plugins using setuptools==18.4
main.py                    276 INFO     Plugin ginga_viewer already loaded
main.py                    276 INFO     Plugin export_plotly already loaded
main.py                    276 INFO     Plugin export_d3po already loaded
main.py                    276 INFO     Plugin pv_slicer already loaded
main.py                    276 INFO     Plugin spectrum_tool already loaded
main.py                    276 INFO     Plugin coordinate_helpers already loaded
uiparser.py                986 DEBUG    UI version is 4.0
uiparser.py                854 DEBUG    uiname is GlueApplication
uiparser.py                815 DEBUG    toplevel widget is QWidget
properties.py              406 DEBUG    setting property geometry
properties.py              406 DEBUG    setting property windowTitle
uiparser.py                126 DEBUG    push QWidget GlueApplication
properties.py              406 DEBUG    setting property leftMargin
properties.py              406 DEBUG    setting property topMargin
properties.py              406 DEBUG    setting property rightMargin
properties.py              406 DEBUG    setting property bottomMargin
properties.py              406 DEBUG    setting property pyuicContentsMargins
uiparser.py                126 DEBUG    push QHBoxLayout horizontalLayout
properties.py              406 DEBUG    setting property orientation
uiparser.py                126 DEBUG    push QSplitter main_splitter
properties.py              406 DEBUG    setting property orientation
uiparser.py                126 DEBUG    push QSplitter data_plot_splitter
properties.py              406 DEBUG    setting property font
properties.py              406 DEBUG    setting property layoutDirection
properties.py              406 DEBUG    setting property title
properties.py              406 DEBUG    setting property flat
uiparser.py                126 DEBUG    push QGroupBox data_layers
uiparser.py                140 DEBUG    pop widget QGroupBox data_layers
uiparser.py                147 DEBUG    new topwidget <PyQt4.QtGui.QSplitter object at 0x130e9f6d8>
properties.py              406 DEBUG    setting property orientation
uiparser.py                126 DEBUG    push QSplitter plot_splitter
properties.py              406 DEBUG    setting property font
properties.py              406 DEBUG    setting property title
properties.py              406 DEBUG    setting property flat
uiparser.py                126 DEBUG    push QGroupBox plot_layers
uiparser.py                140 DEBUG    pop widget QGroupBox plot_layers
uiparser.py                147 DEBUG    new topwidget <PyQt4.QtGui.QSplitter object at 0x130e9f808>
properties.py              406 DEBUG    setting property font
properties.py              406 DEBUG    setting property title
properties.py              406 DEBUG    setting property flat
properties.py              406 DEBUG    setting property checkable
uiparser.py                126 DEBUG    push QGroupBox plot_options
uiparser.py                140 DEBUG    pop widget QGroupBox plot_options
uiparser.py                147 DEBUG    new topwidget <PyQt4.QtGui.QSplitter object at 0x130e9f808>
uiparser.py                140 DEBUG    pop widget QSplitter plot_splitter
uiparser.py                147 DEBUG    new topwidget <PyQt4.QtGui.QSplitter object at 0x130e9f6d8>
uiparser.py                140 DEBUG    pop widget QSplitter data_plot_splitter
uiparser.py                147 DEBUG    new topwidget <PyQt4.QtGui.QSplitter object at 0x130e9f640>
properties.py              406 DEBUG    setting property enabled
properties.py              406 DEBUG    setting property sizePolicy
properties.py              406 DEBUG    setting property minimumSize
properties.py              406 DEBUG    setting property tabShape
properties.py              406 DEBUG    setting property currentIndex
properties.py              406 DEBUG    setting property elideMode
properties.py              406 DEBUG    setting property usesScrollButtons
properties.py              406 DEBUG    setting property documentMode
properties.py              406 DEBUG    setting property tabsClosable
properties.py              406 DEBUG    setting property movable
uiparser.py                126 DEBUG    push QTabWidget tabWidget
uiparser.py                140 DEBUG    pop widget QTabWidget tabWidget
uiparser.py                147 DEBUG    new topwidget <PyQt4.QtGui.QSplitter object at 0x130e9f640>
uiparser.py                140 DEBUG    pop widget QSplitter main_splitter
uiparser.py                147 DEBUG    new topwidget <PyQt4.QtGui.QWidget object at 0x130e9f510>
uiparser.py                134 DEBUG    pop layout QHBoxLayout horizontalLayout
uiparser.py                140 DEBUG    pop widget QWidget GlueApplication
uiparser.py                147 DEBUG    new topwidget None
hub.py                     104 INFO     Subscribing <glue.qt.data_collection_model.DataCollectionModel object at 0x130f26f28> to DataCollectionDeleteMessage
hub.py                     104 INFO     Subscribing <glue.qt.data_collection_model.DataCollectionModel object at 0x130f26f28> to SubsetDeleteMessage
hub.py                     104 INFO     Subscribing <glue.qt.data_collection_model.DataCollectionModel object at 0x130f26f28> to DataCollectionAddMessage
hub.py                     104 INFO     Subscribing <glue.qt.data_collection_model.DataCollectionModel object at 0x130f26f28> to SubsetCreateMessage
----------------------------------------------------- Captured stderr setup ------------------------------------------------------
INFO:glue.core.hub:Subscribing DataCollection (0 data sets)
	 to DataAddComponentMessage
INFO:glue:Loading external plugins using setuptools==18.4
INFO:glue:Plugin ginga_viewer already loaded
INFO:glue:Plugin export_plotly already loaded
INFO:glue:Plugin export_d3po already loaded
INFO:glue:Plugin pv_slicer already loaded
INFO:glue:Plugin spectrum_tool already loaded
INFO:glue:Plugin coordinate_helpers already loaded
DEBUG:PyQt4.uic.uiparser:UI version is 4.0
DEBUG:PyQt4.uic.uiparser:uiname is GlueApplication
DEBUG:PyQt4.uic.uiparser:toplevel widget is QWidget
DEBUG:PyQt4.uic.properties:setting property geometry
DEBUG:PyQt4.uic.properties:setting property windowTitle
DEBUG:PyQt4.uic.uiparser:push QWidget GlueApplication
DEBUG:PyQt4.uic.properties:setting property leftMargin
DEBUG:PyQt4.uic.properties:setting property topMargin
DEBUG:PyQt4.uic.properties:setting property rightMargin
DEBUG:PyQt4.uic.properties:setting property bottomMargin
DEBUG:PyQt4.uic.properties:setting property pyuicContentsMargins
DEBUG:PyQt4.uic.uiparser:push QHBoxLayout horizontalLayout
DEBUG:PyQt4.uic.properties:setting property orientation
DEBUG:PyQt4.uic.uiparser:push QSplitter main_splitter
DEBUG:PyQt4.uic.properties:setting property orientation
DEBUG:PyQt4.uic.uiparser:push QSplitter data_plot_splitter
DEBUG:PyQt4.uic.properties:setting property font
DEBUG:PyQt4.uic.properties:setting property layoutDirection
DEBUG:PyQt4.uic.properties:setting property title
DEBUG:PyQt4.uic.properties:setting property flat
DEBUG:PyQt4.uic.uiparser:push QGroupBox data_layers
DEBUG:PyQt4.uic.uiparser:pop widget QGroupBox data_layers
DEBUG:PyQt4.uic.uiparser:new topwidget <PyQt4.QtGui.QSplitter object at 0x130e9f6d8>
DEBUG:PyQt4.uic.properties:setting property orientation
DEBUG:PyQt4.uic.uiparser:push QSplitter plot_splitter
DEBUG:PyQt4.uic.properties:setting property font
DEBUG:PyQt4.uic.properties:setting property title
DEBUG:PyQt4.uic.properties:setting property flat
DEBUG:PyQt4.uic.uiparser:push QGroupBox plot_layers
DEBUG:PyQt4.uic.uiparser:pop widget QGroupBox plot_layers
DEBUG:PyQt4.uic.uiparser:new topwidget <PyQt4.QtGui.QSplitter object at 0x130e9f808>
DEBUG:PyQt4.uic.properties:setting property font
DEBUG:PyQt4.uic.properties:setting property title
DEBUG:PyQt4.uic.properties:setting property flat
DEBUG:PyQt4.uic.properties:setting property checkable
DEBUG:PyQt4.uic.uiparser:push QGroupBox plot_options
DEBUG:PyQt4.uic.uiparser:pop widget QGroupBox plot_options
DEBUG:PyQt4.uic.uiparser:new topwidget <PyQt4.QtGui.QSplitter object at 0x130e9f808>
DEBUG:PyQt4.uic.uiparser:pop widget QSplitter plot_splitter
DEBUG:PyQt4.uic.uiparser:new topwidget <PyQt4.QtGui.QSplitter object at 0x130e9f6d8>
DEBUG:PyQt4.uic.uiparser:pop widget QSplitter data_plot_splitter
DEBUG:PyQt4.uic.uiparser:new topwidget <PyQt4.QtGui.QSplitter object at 0x130e9f640>
DEBUG:PyQt4.uic.properties:setting property enabled
DEBUG:PyQt4.uic.properties:setting property sizePolicy
DEBUG:PyQt4.uic.properties:setting property minimumSize
DEBUG:PyQt4.uic.properties:setting property tabShape
DEBUG:PyQt4.uic.properties:setting property currentIndex
DEBUG:PyQt4.uic.properties:setting property elideMode
DEBUG:PyQt4.uic.properties:setting property usesScrollButtons
DEBUG:PyQt4.uic.properties:setting property documentMode
DEBUG:PyQt4.uic.properties:setting property tabsClosable
DEBUG:PyQt4.uic.properties:setting property movable
DEBUG:PyQt4.uic.uiparser:push QTabWidget tabWidget
DEBUG:PyQt4.uic.uiparser:pop widget QTabWidget tabWidget
DEBUG:PyQt4.uic.uiparser:new topwidget <PyQt4.QtGui.QSplitter object at 0x130e9f640>
DEBUG:PyQt4.uic.uiparser:pop widget QSplitter main_splitter
DEBUG:PyQt4.uic.uiparser:new topwidget <PyQt4.QtGui.QWidget object at 0x130e9f510>
DEBUG:PyQt4.uic.uiparser:pop layout QHBoxLayout horizontalLayout
DEBUG:PyQt4.uic.uiparser:pop widget QWidget GlueApplication
DEBUG:PyQt4.uic.uiparser:new topwidget None
INFO:glue.core.hub:Subscribing <glue.qt.data_collection_model.DataCollectionModel object at 0x130f26f28> to DataCollectionDeleteMessage
INFO:glue.core.hub:Subscribing <glue.qt.data_collection_model.DataCollectionModel object at 0x130f26f28> to SubsetDeleteMessage
INFO:glue.core.hub:Subscribing <glue.qt.data_collection_model.DataCollectionModel object at 0x130f26f28> to DataCollectionAddMessage
INFO:glue.core.hub:Subscribing <glue.qt.data_collection_model.DataCollectionModel object at 0x130f26f28> to SubsetCreateMessage
------------------------------------------------------ Captured stderr call ------------------------------------------------------
Traceback (most recent call last):
  File "/Users/bsipocz/munka/devel/glue/glue/qt/glue_application.py", line 804, in _create_terminal
    from .widgets.terminal import glue_terminal
  File "/Users/bsipocz/munka/devel/glue/glue/qt/widgets/terminal.py", line 79, in <module>
    from IPython.zmq.ipkernel import Kernel
ImportError: No module named zmq.ipkernel
-------------------------------------------------------- pytest-selenium ---------------------------------------------------------

____________________________________________ TestGlueApplication.test_toggle_terminal ____________________________________________

self = <glue.qt.tests.test_application.TestGlueApplication object at 0x130c9abd0>

    @requires_ipython_ge_012
    def test_toggle_terminal(self):
        term = MagicMock()
        self.app._terminal = term
    
        term.isVisible.return_value = False
        self.app._terminal_button.click()
>       assert term.show.call_count == 1
E       assert 0 == 1
E        +  where 0 = <MagicMock name='mock.show' id='5116296592'>.call_count
E        +    where <MagicMock name='mock.show' id='5116296592'> = <MagicMock id='5116135888'>.show

glue/qt/tests/test_application.py:121: AssertionError
---------------------------------------------------------- Captured log ----------------------------------------------------------
hub.py                     104 INFO     Subscribing DataCollection (0 data sets)
	 to DataAddComponentMessage
main.py                    265 INFO     Loading external plugins using setuptools==18.4
main.py                    276 INFO     Plugin ginga_viewer already loaded
main.py                    276 INFO     Plugin export_plotly already loaded
main.py                    276 INFO     Plugin export_d3po already loaded
main.py                    276 INFO     Plugin pv_slicer already loaded
main.py                    276 INFO     Plugin spectrum_tool already loaded
main.py                    276 INFO     Plugin coordinate_helpers already loaded
uiparser.py                986 DEBUG    UI version is 4.0
uiparser.py                854 DEBUG    uiname is GlueApplication
uiparser.py                815 DEBUG    toplevel widget is QWidget
properties.py              406 DEBUG    setting property geometry
properties.py              406 DEBUG    setting property windowTitle
uiparser.py                126 DEBUG    push QWidget GlueApplication
properties.py              406 DEBUG    setting property leftMargin
properties.py              406 DEBUG    setting property topMargin
properties.py              406 DEBUG    setting property rightMargin
properties.py              406 DEBUG    setting property bottomMargin
properties.py              406 DEBUG    setting property pyuicContentsMargins
uiparser.py                126 DEBUG    push QHBoxLayout horizontalLayout
properties.py              406 DEBUG    setting property orientation
uiparser.py                126 DEBUG    push QSplitter main_splitter
properties.py              406 DEBUG    setting property orientation
uiparser.py                126 DEBUG    push QSplitter data_plot_splitter
properties.py              406 DEBUG    setting property font
properties.py              406 DEBUG    setting property layoutDirection
properties.py              406 DEBUG    setting property title
properties.py              406 DEBUG    setting property flat
uiparser.py                126 DEBUG    push QGroupBox data_layers
uiparser.py                140 DEBUG    pop widget QGroupBox data_layers
uiparser.py                147 DEBUG    new topwidget <PyQt4.QtGui.QSplitter object at 0x130ecb510>
properties.py              406 DEBUG    setting property orientation
uiparser.py                126 DEBUG    push QSplitter plot_splitter
properties.py              406 DEBUG    setting property font
properties.py              406 DEBUG    setting property title
properties.py              406 DEBUG    setting property flat
uiparser.py                126 DEBUG    push QGroupBox plot_layers
uiparser.py                140 DEBUG    pop widget QGroupBox plot_layers
uiparser.py                147 DEBUG    new topwidget <PyQt4.QtGui.QSplitter object at 0x130ecb640>
properties.py              406 DEBUG    setting property font
properties.py              406 DEBUG    setting property title
properties.py              406 DEBUG    setting property flat
properties.py              406 DEBUG    setting property checkable
uiparser.py                126 DEBUG    push QGroupBox plot_options
uiparser.py                140 DEBUG    pop widget QGroupBox plot_options
uiparser.py                147 DEBUG    new topwidget <PyQt4.QtGui.QSplitter object at 0x130ecb640>
uiparser.py                140 DEBUG    pop widget QSplitter plot_splitter
uiparser.py                147 DEBUG    new topwidget <PyQt4.QtGui.QSplitter object at 0x130ecb510>
uiparser.py                140 DEBUG    pop widget QSplitter data_plot_splitter
uiparser.py                147 DEBUG    new topwidget <PyQt4.QtGui.QSplitter object at 0x130ecb478>
properties.py              406 DEBUG    setting property enabled
properties.py              406 DEBUG    setting property sizePolicy
properties.py              406 DEBUG    setting property minimumSize
properties.py              406 DEBUG    setting property tabShape
properties.py              406 DEBUG    setting property currentIndex
properties.py              406 DEBUG    setting property elideMode
properties.py              406 DEBUG    setting property usesScrollButtons
properties.py              406 DEBUG    setting property documentMode
properties.py              406 DEBUG    setting property tabsClosable
properties.py              406 DEBUG    setting property movable
uiparser.py                126 DEBUG    push QTabWidget tabWidget
uiparser.py                140 DEBUG    pop widget QTabWidget tabWidget
uiparser.py                147 DEBUG    new topwidget <PyQt4.QtGui.QSplitter object at 0x130ecb478>
uiparser.py                140 DEBUG    pop widget QSplitter main_splitter
uiparser.py                147 DEBUG    new topwidget <PyQt4.QtGui.QWidget object at 0x130ecb348>
uiparser.py                134 DEBUG    pop layout QHBoxLayout horizontalLayout
uiparser.py                140 DEBUG    pop widget QWidget GlueApplication
uiparser.py                147 DEBUG    new topwidget None
hub.py                     104 INFO     Subscribing <glue.qt.data_collection_model.DataCollectionModel object at 0x130f32d60> to DataCollectionDeleteMessage
hub.py                     104 INFO     Subscribing <glue.qt.data_collection_model.DataCollectionModel object at 0x130f32d60> to SubsetDeleteMessage
hub.py                     104 INFO     Subscribing <glue.qt.data_collection_model.DataCollectionModel object at 0x130f32d60> to DataCollectionAddMessage
hub.py                     104 INFO     Subscribing <glue.qt.data_collection_model.DataCollectionModel object at 0x130f32d60> to SubsetCreateMessage
----------------------------------------------------- Captured stderr setup ------------------------------------------------------
INFO:glue.core.hub:Subscribing DataCollection (0 data sets)
	 to DataAddComponentMessage
INFO:glue:Loading external plugins using setuptools==18.4
INFO:glue:Plugin ginga_viewer already loaded
INFO:glue:Plugin export_plotly already loaded
INFO:glue:Plugin export_d3po already loaded
INFO:glue:Plugin pv_slicer already loaded
INFO:glue:Plugin spectrum_tool already loaded
INFO:glue:Plugin coordinate_helpers already loaded
DEBUG:PyQt4.uic.uiparser:UI version is 4.0
DEBUG:PyQt4.uic.uiparser:uiname is GlueApplication
DEBUG:PyQt4.uic.uiparser:toplevel widget is QWidget
DEBUG:PyQt4.uic.properties:setting property geometry
DEBUG:PyQt4.uic.properties:setting property windowTitle
DEBUG:PyQt4.uic.uiparser:push QWidget GlueApplication
DEBUG:PyQt4.uic.properties:setting property leftMargin
DEBUG:PyQt4.uic.properties:setting property topMargin
DEBUG:PyQt4.uic.properties:setting property rightMargin
DEBUG:PyQt4.uic.properties:setting property bottomMargin
DEBUG:PyQt4.uic.properties:setting property pyuicContentsMargins
DEBUG:PyQt4.uic.uiparser:push QHBoxLayout horizontalLayout
DEBUG:PyQt4.uic.properties:setting property orientation
DEBUG:PyQt4.uic.uiparser:push QSplitter main_splitter
DEBUG:PyQt4.uic.properties:setting property orientation
DEBUG:PyQt4.uic.uiparser:push QSplitter data_plot_splitter
DEBUG:PyQt4.uic.properties:setting property font
DEBUG:PyQt4.uic.properties:setting property layoutDirection
DEBUG:PyQt4.uic.properties:setting property title
DEBUG:PyQt4.uic.properties:setting property flat
DEBUG:PyQt4.uic.uiparser:push QGroupBox data_layers
DEBUG:PyQt4.uic.uiparser:pop widget QGroupBox data_layers
DEBUG:PyQt4.uic.uiparser:new topwidget <PyQt4.QtGui.QSplitter object at 0x130ecb510>
DEBUG:PyQt4.uic.properties:setting property orientation
DEBUG:PyQt4.uic.uiparser:push QSplitter plot_splitter
DEBUG:PyQt4.uic.properties:setting property font
DEBUG:PyQt4.uic.properties:setting property title
DEBUG:PyQt4.uic.properties:setting property flat
DEBUG:PyQt4.uic.uiparser:push QGroupBox plot_layers
DEBUG:PyQt4.uic.uiparser:pop widget QGroupBox plot_layers
DEBUG:PyQt4.uic.uiparser:new topwidget <PyQt4.QtGui.QSplitter object at 0x130ecb640>
DEBUG:PyQt4.uic.properties:setting property font
DEBUG:PyQt4.uic.properties:setting property title
DEBUG:PyQt4.uic.properties:setting property flat
DEBUG:PyQt4.uic.properties:setting property checkable
DEBUG:PyQt4.uic.uiparser:push QGroupBox plot_options
DEBUG:PyQt4.uic.uiparser:pop widget QGroupBox plot_options
DEBUG:PyQt4.uic.uiparser:new topwidget <PyQt4.QtGui.QSplitter object at 0x130ecb640>
DEBUG:PyQt4.uic.uiparser:pop widget QSplitter plot_splitter
DEBUG:PyQt4.uic.uiparser:new topwidget <PyQt4.QtGui.QSplitter object at 0x130ecb510>
DEBUG:PyQt4.uic.uiparser:pop widget QSplitter data_plot_splitter
DEBUG:PyQt4.uic.uiparser:new topwidget <PyQt4.QtGui.QSplitter object at 0x130ecb478>
DEBUG:PyQt4.uic.properties:setting property enabled
DEBUG:PyQt4.uic.properties:setting property sizePolicy
DEBUG:PyQt4.uic.properties:setting property minimumSize
DEBUG:PyQt4.uic.properties:setting property tabShape
DEBUG:PyQt4.uic.properties:setting property currentIndex
DEBUG:PyQt4.uic.properties:setting property elideMode
DEBUG:PyQt4.uic.properties:setting property usesScrollButtons
DEBUG:PyQt4.uic.properties:setting property documentMode
DEBUG:PyQt4.uic.properties:setting property tabsClosable
DEBUG:PyQt4.uic.properties:setting property movable
DEBUG:PyQt4.uic.uiparser:push QTabWidget tabWidget
DEBUG:PyQt4.uic.uiparser:pop widget QTabWidget tabWidget
DEBUG:PyQt4.uic.uiparser:new topwidget <PyQt4.QtGui.QSplitter object at 0x130ecb478>
DEBUG:PyQt4.uic.uiparser:pop widget QSplitter main_splitter
DEBUG:PyQt4.uic.uiparser:new topwidget <PyQt4.QtGui.QWidget object at 0x130ecb348>
DEBUG:PyQt4.uic.uiparser:pop layout QHBoxLayout horizontalLayout
DEBUG:PyQt4.uic.uiparser:pop widget QWidget GlueApplication
DEBUG:PyQt4.uic.uiparser:new topwidget None
INFO:glue.core.hub:Subscribing <glue.qt.data_collection_model.DataCollectionModel object at 0x130f32d60> to DataCollectionDeleteMessage
INFO:glue.core.hub:Subscribing <glue.qt.data_collection_model.DataCollectionModel object at 0x130f32d60> to SubsetDeleteMessage
INFO:glue.core.hub:Subscribing <glue.qt.data_collection_model.DataCollectionModel object at 0x130f32d60> to DataCollectionAddMessage
INFO:glue.core.hub:Subscribing <glue.qt.data_collection_model.DataCollectionModel object at 0x130f32d60> to SubsetCreateMessage
------------------------------------------------------ Captured stderr call ------------------------------------------------------
2015-11-04 23:47:40,184 | E | ImageView.py:616 (redraw_now) | Error redrawing image: Dimensions of actual window are not yet determined
2015-11-04 23:47:40,185 | E | ImageView.py:621 (redraw_now) | Traceback:
  File "/Users/bsipocz/.virtualenvs/astropy-dev/lib/python2.7/site-packages/ginga-2.0.20141120010840-py2.7.egg/ginga/ImageView.py", line 604, in redraw_now
    self.redraw_data(whence=whence)
  File "/Users/bsipocz/.virtualenvs/astropy-dev/lib/python2.7/site-packages/ginga-2.0.20141120010840-py2.7.egg/ginga/qtw/ImageViewCanvasQt.py", line 49, in redraw_data
    super(ImageViewCanvas, self).redraw_data(whence=whence)
  File "/Users/bsipocz/.virtualenvs/astropy-dev/lib/python2.7/site-packages/ginga-2.0.20141120010840-py2.7.egg/ginga/ImageView.py", line 630, in redraw_data
    rgbobj = self.get_rgb_object(whence=whence)
  File "/Users/bsipocz/.virtualenvs/astropy-dev/lib/python2.7/site-packages/ginga-2.0.20141120010840-py2.7.egg/ginga/ImageView.py", line 692, in get_rgb_object
    win_wd, win_ht = self.get_window_size()
  File "/Users/bsipocz/.virtualenvs/astropy-dev/lib/python2.7/site-packages/ginga-2.0.20141120010840-py2.7.egg/ginga/ImageView.py", line 301, in get_window_size
    raise ImageViewError("Dimensions of actual window are not yet determined")

2015-11-04 23:48:09.162 python[18563:459537] modalSession has been exited prematurely - check for a reentrant call to endModalSession:
-------------------------------------------------------- pytest-selenium ---------------------------------------------------------

__________________________________________________ TestImageWidget.test_resize ___________________________________________________

self = <glue.qt.widgets.tests.test_image_widget.TestImageWidget object at 0x142375bd0>

    @pytest.mark.skipif("CI and not TRAVIS_LINUX")
    def test_resize(self):
    
        # Regression test for a bug that caused images to not be shown at
        # full resolution after resizing a widget.
    
        # This test only runs correctly on Linux on Travis at the moment,
        # although it works fine locally on MacOS X. I have not yet tracked
        # down the cause of the failure, but essentially the first time that
        # self.widget.client._view_window is accessed below, it is still None.
        # The issue is made more complicated by the fact that whether the test
        # succeeds or not (after removing code in ImageWidget) depends on
        # whether another test is run first - in particular I tried with
        # test_resize from test_application.py. I was able to then get the
        # test here to pass if the other test_resize was *not* run first.
        # This should be investigated more in future, but for now, it's most
        # important that we get the fix in.
    
        # What appears to happen when the test fails is that the QTimer gets
        # started but basically never ends up triggering the timeout.
    
        large = core.Data(label='largeim', x=np.random.random((1024, 1024)))
        self.collect.append(large)
    
        app = get_qapp()
        self.widget.add_data(large)
        self.widget.show()
    
        self.widget.resize(300, 300)
        time.sleep(0.5)
        app.processEvents()
    
>       extx0, exty0 = self.widget.client._view_window[4:]
E       TypeError: 'NoneType' object has no attribute '__getitem__'

glue/qt/widgets/tests/test_image_widget.py:202: TypeError
---------------------------------------------------------- Captured log ----------------------------------------------------------
hub.py                     104 INFO     Subscribing DataCollection (0 data sets)
	 to DataAddComponentMessage
uiparser.py                986 DEBUG    UI version is 4.0
uiparser.py                854 DEBUG    uiname is ImageWidget
uiparser.py                815 DEBUG    toplevel widget is QWidget
properties.py              406 DEBUG    setting property geometry
properties.py              406 DEBUG    setting property baseSize
properties.py              406 DEBUG    setting property focusPolicy
properties.py              406 DEBUG    setting property windowTitle
uiparser.py                126 DEBUG    push QWidget ImageWidget
properties.py              406 DEBUG    setting property leftMargin
properties.py              406 DEBUG    setting property topMargin
properties.py              406 DEBUG    setting property rightMargin
properties.py              406 DEBUG    setting property bottomMargin
properties.py              406 DEBUG    setting property pyuicContentsMargins
uiparser.py                126 DEBUG    push QVBoxLayout verticalLayout_2
uiparser.py                126 DEBUG    push QWidget option_dashboard
properties.py              406 DEBUG    setting property leftMargin
properties.py              406 DEBUG    setting property topMargin
properties.py              406 DEBUG    setting property rightMargin
properties.py              406 DEBUG    setting property bottomMargin
properties.py              406 DEBUG    setting property pyuicContentsMargins
uiparser.py                126 DEBUG    push QVBoxLayout verticalLayout
properties.py              406 DEBUG    setting property margin
uiparser.py                126 DEBUG    push QGridLayout gridLayout
properties.py              406 DEBUG    setting property text
uiparser.py                126 DEBUG    push QLabel mono_att_label
uiparser.py                140 DEBUG    pop widget QLabel mono_att_label
uiparser.py                147 DEBUG    new topwidget <PyQt4.QtGui.QWidget object at 0x142ef0938>
properties.py              406 DEBUG    setting property sizePolicy
properties.py              406 DEBUG    setting property toolTip
properties.py              406 DEBUG    setting property sizeAdjustPolicy
uiparser.py                126 DEBUG    push GlueComboBox displayDataCombo
uiparser.py                140 DEBUG    pop widget GlueComboBox displayDataCombo
uiparser.py                147 DEBUG    new topwidget <PyQt4.QtGui.QWidget object at 0x142ef0938>
properties.py              406 DEBUG    setting property sizePolicy
properties.py              406 DEBUG    setting property toolTip
properties.py              406 DEBUG    setting property sizeAdjustPolicy
uiparser.py                126 DEBUG    push GlueComboBox attributeComboBox
uiparser.py                140 DEBUG    pop widget GlueComboBox attributeComboBox
uiparser.py                147 DEBUG    new topwidget <PyQt4.QtGui.QWidget object at 0x142ef0938>
properties.py              406 DEBUG    setting property text
uiparser.py                126 DEBUG    push QLabel label
uiparser.py                140 DEBUG    pop widget QLabel label
uiparser.py                147 DEBUG    new topwidget <PyQt4.QtGui.QWidget object at 0x142ef0938>
properties.py              406 DEBUG    setting property text
uiparser.py                126 DEBUG    push QLabel label_2
uiparser.py                140 DEBUG    pop widget QLabel label_2
uiparser.py                147 DEBUG    new topwidget <PyQt4.QtGui.QWidget object at 0x142ef0938>
uiparser.py                126 DEBUG    push QComboBox aspectCombo
uiparser.py                140 DEBUG    pop widget QComboBox aspectCombo
uiparser.py                147 DEBUG    new topwidget <PyQt4.QtGui.QWidget object at 0x142ef0938>
uiparser.py                134 DEBUG    pop layout QGridLayout gridLayout
uiparser.py                126 DEBUG    push QHBoxLayout monochrome_options
properties.py              406 DEBUG    setting property text
properties.py              406 DEBUG    setting property checked
uiparser.py                126 DEBUG    push QRadioButton monochrome
uiparser.py                140 DEBUG    pop widget QRadioButton monochrome
uiparser.py                147 DEBUG    new topwidget <PyQt4.QtGui.QWidget object at 0x142ef0938>
properties.py              406 DEBUG    setting property text
uiparser.py                126 DEBUG    push QRadioButton rgb
uiparser.py                140 DEBUG    pop widget QRadioButton rgb
uiparser.py                147 DEBUG    new topwidget <PyQt4.QtGui.QWidget object at 0x142ef0938>
uiparser.py                134 DEBUG    pop layout QHBoxLayout monochrome_options
uiparser.py                126 DEBUG    push QVBoxLayout slice_layout
uiparser.py                134 DEBUG    pop layout QVBoxLayout slice_layout
properties.py              406 DEBUG    setting property enabled
uiparser.py                126 DEBUG    push RGBEdit rgb_options
uiparser.py                140 DEBUG    pop widget RGBEdit rgb_options
uiparser.py                147 DEBUG    new topwidget <PyQt4.QtGui.QWidget object at 0x142ef0938>
uiparser.py                134 DEBUG    pop layout QVBoxLayout verticalLayout
uiparser.py                140 DEBUG    pop widget QWidget option_dashboard
uiparser.py                147 DEBUG    new topwidget <PyQt4.QtGui.QWidget object at 0x142ef0808>
uiparser.py                134 DEBUG    pop layout QVBoxLayout verticalLayout_2
uiparser.py                140 DEBUG    pop widget QWidget ImageWidget
uiparser.py                147 DEBUG    new topwidget None
uiparser.py                986 DEBUG    UI version is 4.0
uiparser.py                854 DEBUG    uiname is widget
uiparser.py                815 DEBUG    toplevel widget is QWidget
properties.py              406 DEBUG    setting property geometry
properties.py              406 DEBUG    setting property sizePolicy
properties.py              406 DEBUG    setting property windowTitle
uiparser.py                126 DEBUG    push QWidget widget
properties.py              406 DEBUG    setting property margin
uiparser.py                126 DEBUG    push QHBoxLayout horizontalLayout_5
properties.py              406 DEBUG    setting property margin
uiparser.py                126 DEBUG    push QVBoxLayout verticalLayout
properties.py              406 DEBUG    setting property margin
uiparser.py                126 DEBUG    push QHBoxLayout horizontalLayout
properties.py              406 DEBUG    setting property minimumSize
properties.py              406 DEBUG    setting property layoutDirection
properties.py              406 DEBUG    setting property text
properties.py              406 DEBUG    setting property alignment
uiparser.py                126 DEBUG    push QLabel uncertainty_label
uiparser.py                140 DEBUG    pop widget QLabel uncertainty_label
uiparser.py                147 DEBUG    new topwidget <PyQt4.QtGui.QWidget object at 0x143250180>
properties.py              406 DEBUG    setting property sizePolicy
uiparser.py                126 DEBUG    push QComboBox uncertainty_combo
uiparser.py                140 DEBUG    pop widget QComboBox uncertainty_combo
uiparser.py                147 DEBUG    new topwidget <PyQt4.QtGui.QWidget object at 0x143250180>
uiparser.py                134 DEBUG    pop layout QHBoxLayout horizontalLayout
properties.py              406 DEBUG    setting property margin
uiparser.py                126 DEBUG    push QHBoxLayout horizontalLayout_2
properties.py              406 DEBUG    setting property minimumSize
properties.py              406 DEBUG    setting property layoutDirection
properties.py              406 DEBUG    setting property text
properties.py              406 DEBUG    setting property alignment
uiparser.py                126 DEBUG    push QLabel profile_label
uiparser.py                140 DEBUG    pop widget QLabel profile_label
uiparser.py                147 DEBUG    new topwidget <PyQt4.QtGui.QWidget object at 0x143250180>
properties.py              406 DEBUG    setting property sizePolicy
uiparser.py                126 DEBUG    push QComboBox profile_combo
uiparser.py                140 DEBUG    pop widget QComboBox profile_combo
uiparser.py                147 DEBUG    new topwidget <PyQt4.QtGui.QWidget object at 0x143250180>
uiparser.py                134 DEBUG    pop layout QHBoxLayout horizontalLayout_2
properties.py              406 DEBUG    setting property spacing
properties.py              406 DEBUG    setting property margin
uiparser.py                126 DEBUG    push QHBoxLayout horizontalLayout_3
properties.py              406 DEBUG    setting property text
uiparser.py                126 DEBUG    push QToolButton settings_button
uiparser.py                140 DEBUG    pop widget QToolButton settings_button
uiparser.py                147 DEBUG    new topwidget <PyQt4.QtGui.QWidget object at 0x143250180>
properties.py              406 DEBUG    setting property text
uiparser.py                126 DEBUG    push QPushButton fit_button
uiparser.py                140 DEBUG    pop widget QPushButton fit_button
uiparser.py                147 DEBUG    new topwidget <PyQt4.QtGui.QWidget object at 0x143250180>
properties.py              406 DEBUG    setting property text
uiparser.py                126 DEBUG    push QPushButton clear_button
uiparser.py                140 DEBUG    pop widget QPushButton clear_button
uiparser.py                147 DEBUG    new topwidget <PyQt4.QtGui.QWidget object at 0x143250180>
uiparser.py                134 DEBUG    pop layout QHBoxLayout horizontalLayout_3
uiparser.py                126 DEBUG    push QTextBrowser results_box
uiparser.py                140 DEBUG    pop widget QTextBrowser results_box
uiparser.py                147 DEBUG    new topwidget <PyQt4.QtGui.QWidget object at 0x143250180>
uiparser.py                134 DEBUG    pop layout QVBoxLayout verticalLayout
uiparser.py                134 DEBUG    pop layout QHBoxLayout horizontalLayout_5
uiparser.py                140 DEBUG    pop widget QWidget widget
uiparser.py                147 DEBUG    new topwidget None
hub.py                     104 INFO     Subscribing <glue.clients.image_client.MplImageClient object at 0x142f3aad0> to SubsetCreateMessage
hub.py                     104 INFO     Subscribing <glue.clients.image_client.MplImageClient object at 0x142f3aad0> to SubsetUpdateMessage
hub.py                     104 INFO     Subscribing <glue.clients.image_client.MplImageClient object at 0x142f3aad0> to SubsetDeleteMessage
hub.py                     104 INFO     Subscribing <glue.clients.image_client.MplImageClient object at 0x142f3aad0> to DataUpdateMessage
hub.py                     104 INFO     Subscribing <glue.clients.image_client.MplImageClient object at 0x142f3aad0> to NumericalDataChangedMessage
hub.py                     104 INFO     Subscribing <glue.clients.image_client.MplImageClient object at 0x142f3aad0> to DataCollectionDeleteMessage
hub.py                     104 INFO     Subscribing <glue.clients.image_client.MplImageClient object at 0x142f3aad0> to ComponentReplacedMessage
hub.py                     104 INFO     Subscribing Image Widget to DataCollectionAddMessage
hub.py                     104 INFO     Subscribing Image Widget to DataCollectionDeleteMessage
hub.py                     104 INFO     Subscribing Image Widget to DataUpdateMessage
hub.py                     104 INFO     Subscribing Image Widget to ComponentsChangedMessage
hub.py                     178 INFO     Broadcasting DataCollectionAddMessage: 
	 Sent from: DataCollection (1 data set)
	  0: im
data.py                    219 DEBUG    Using (slice(0, 2, 1), slice(0, 2, 1)) to index data of shape (2, 2)
data.py                    219 DEBUG    Using (slice(0, 2, 1), slice(0, 2, 1)) to index data of shape (2, 2)
matplotlib.py               70 DEBUG    image shape: (2, 2), view: (x, slice(0, 2, 1), slice(0, 2, 1))
data.py                    219 DEBUG    Using (slice(0, 2, 1), slice(0, 2, 1)) to index data of shape (2, 2)
data.py                    219 DEBUG    Using (slice(None, None, 1), slice(None, None, 1)) to index data of shape (2, 2)
data.py                    219 DEBUG    Using (slice(0, 2, 1), slice(0, 2, 1)) to index data of shape (2, 2)
data.py                    219 DEBUG    Using (slice(0, 2, 1), slice(0, 2, 1)) to index data of shape (2, 2)
matplotlib.py               70 DEBUG    image shape: (2, 2), view: (x, slice(0, 2, 1), slice(0, 2, 1))
data.py                    219 DEBUG    Using (slice(0, 2, 1), slice(0, 2, 1)) to index data of shape (2, 2)
data.py                    219 DEBUG    Using (slice(0, 2, 1), slice(0, 2, 1)) to index data of shape (2, 2)
data.py                    219 DEBUG    Using (slice(0, 2, 1), slice(0, 2, 1)) to index data of shape (2, 2)
data.py                    219 DEBUG    Using (slice(0, 2, 1), slice(0, 2, 1)) to index data of shape (2, 2)
matplotlib.py               70 DEBUG    image shape: (2, 2), view: (x, slice(0, 2, 1), slice(0, 2, 1))
data.py                    219 DEBUG    Using (slice(0, 2, 1), slice(0, 2, 1)) to index data of shape (2, 2)
data.py                    219 DEBUG    Using (slice(0, 2, 1), slice(0, 2, 1)) to index data of shape (2, 2)
data.py                    219 DEBUG    Using (slice(0, 2, 1), slice(0, 2, 1)) to index data of shape (2, 2)
matplotlib.py               70 DEBUG    image shape: (2, 2), view: (x, slice(0, 2, 1), slice(0, 2, 1))
data.py                    219 DEBUG    Using (slice(0, 2, 1), slice(0, 2, 1)) to index data of shape (2, 2)
data.py                    219 DEBUG    Using (slice(0, 2, 1), slice(0, 2, 1)) to index data of shape (2, 2)
data.py                    219 DEBUG    Using (slice(0, 2, 1), slice(0, 2, 1)) to index data of shape (2, 2)
hub.py                     178 INFO     Broadcasting DataCollectionAddMessage: 
	 Sent from: DataCollection (2 data sets)
	  0: im
	  1: cube
hub.py                     178 INFO     Broadcasting DataCollectionAddMessage: 
	 Sent from: DataCollection (3 data sets)
	  0: im
	  1: cube
	  2: largeim
data.py                    219 DEBUG    Using (slice(0, 1024, 3), slice(0, 1024, 3)) to index data of shape (1024, 1024)
matplotlib.py               70 DEBUG    image shape: (1024, 1024), view: (x, slice(0, 1024, 3), slice(0, 1024, 3))
data.py                    219 DEBUG    Using (slice(0, 1024, 3), slice(0, 1024, 3)) to index data of shape (1024, 1024)
data.py                    219 DEBUG    Using (slice(None, None, 20.48), slice(None, None, 20.48)) to index data of shape (1024, 1024)
data.py                    219 DEBUG    Using (slice(0, 1024, 3), slice(0, 1024, 3)) to index data of shape (1024, 1024)
data.py                    219 DEBUG    Using (slice(0, 1024, 3), slice(0, 1024, 3)) to index data of shape (1024, 1024)
matplotlib.py               70 DEBUG    image shape: (1024, 1024), view: (x, slice(0, 1024, 3), slice(0, 1024, 3))
data.py                    219 DEBUG    Using (slice(0, 1024, 3), slice(0, 1024, 3)) to index data of shape (1024, 1024)
data.py                    219 DEBUG    Using (slice(0, 1024, 3), slice(0, 1024, 3)) to index data of shape (1024, 1024)
data.py                    219 DEBUG    Using (slice(0, 1024, 3), slice(0, 1024, 3)) to index data of shape (1024, 1024)
data.py                    219 DEBUG    Using (slice(0, 1024, 3), slice(0, 1024, 3)) to index data of shape (1024, 1024)
matplotlib.py               70 DEBUG    image shape: (1024, 1024), view: (x, slice(0, 1024, 3), slice(0, 1024, 3))
data.py                    219 DEBUG    Using (slice(0, 1024, 3), slice(0, 1024, 3)) to index data of shape (1024, 1024)
data.py                    219 DEBUG    Using (slice(0, 1024, 3), slice(0, 1024, 3)) to index data of shape (1024, 1024)
data.py                    219 DEBUG    Using (slice(0, 1024, 3), slice(0, 1024, 3)) to index data of shape (1024, 1024)
matplotlib.py               70 DEBUG    image shape: (1024, 1024), view: (x, slice(0, 1024, 3), slice(0, 1024, 3))
data.py                    219 DEBUG    Using (slice(0, 1024, 3), slice(0, 1024, 3)) to index data of shape (1024, 1024)
data.py                    219 DEBUG    Using (slice(0, 1024, 3), slice(0, 1024, 3)) to index data of shape (1024, 1024)
data.py                    219 DEBUG    Using (slice(0, 1024, 3), slice(0, 1024, 3)) to index data of shape (1024, 1024)
data.py                    219 DEBUG    Using (slice(0, 1024, 3), slice(0, 1024, 3)) to index data of shape (1024, 1024)
matplotlib.py               70 DEBUG    image shape: (1024, 1024), view: (x, slice(0, 1024, 3), slice(0, 1024, 3))
data.py                    219 DEBUG    Using (slice(0, 1024, 3), slice(0, 1024, 3)) to index data of shape (1024, 1024)
data.py                    219 DEBUG    Using (slice(0, 1024, 3), slice(0, 1024, 3)) to index data of shape (1024, 1024)
data.py                    219 DEBUG    Using (slice(0, 1024, 3), slice(0, 1024, 3)) to index data of shape (1024, 1024)
matplotlib.py               70 DEBUG    image shape: (1024, 1024), view: (x, slice(0, 1024, 3), slice(0, 1024, 3))
data.py                    219 DEBUG    Using (slice(0, 1024, 3), slice(0, 1024, 3)) to index data of shape (1024, 1024)
data.py                    219 DEBUG    Using (slice(0, 1024, 3), slice(0, 1024, 3)) to index data of shape (1024, 1024)
data.py                    219 DEBUG    Using (slice(0, 1024, 3), slice(0, 1024, 3)) to index data of shape (1024, 1024)
----------------------------------------------------- Captured stderr setup ------------------------------------------------------
INFO:glue.core.hub:Subscribing DataCollection (0 data sets)
	 to DataAddComponentMessage
DEBUG:PyQt4.uic.uiparser:UI version is 4.0
DEBUG:PyQt4.uic.uiparser:uiname is ImageWidget
DEBUG:PyQt4.uic.uiparser:toplevel widget is QWidget
DEBUG:PyQt4.uic.properties:setting property geometry
DEBUG:PyQt4.uic.properties:setting property baseSize
DEBUG:PyQt4.uic.properties:setting property focusPolicy
DEBUG:PyQt4.uic.properties:setting property windowTitle
DEBUG:PyQt4.uic.uiparser:push QWidget ImageWidget
DEBUG:PyQt4.uic.properties:setting property leftMargin
DEBUG:PyQt4.uic.properties:setting property topMargin
DEBUG:PyQt4.uic.properties:setting property rightMargin
DEBUG:PyQt4.uic.properties:setting property bottomMargin
DEBUG:PyQt4.uic.properties:setting property pyuicContentsMargins
DEBUG:PyQt4.uic.uiparser:push QVBoxLayout verticalLayout_2
DEBUG:PyQt4.uic.uiparser:push QWidget option_dashboard
DEBUG:PyQt4.uic.properties:setting property leftMargin
DEBUG:PyQt4.uic.properties:setting property topMargin
DEBUG:PyQt4.uic.properties:setting property rightMargin
DEBUG:PyQt4.uic.properties:setting property bottomMargin
DEBUG:PyQt4.uic.properties:setting property pyuicContentsMargins
DEBUG:PyQt4.uic.uiparser:push QVBoxLayout verticalLayout
DEBUG:PyQt4.uic.properties:setting property margin
DEBUG:PyQt4.uic.uiparser:push QGridLayout gridLayout
DEBUG:PyQt4.uic.properties:setting property text
DEBUG:PyQt4.uic.uiparser:push QLabel mono_att_label
DEBUG:PyQt4.uic.uiparser:pop widget QLabel mono_att_label
DEBUG:PyQt4.uic.uiparser:new topwidget <PyQt4.QtGui.QWidget object at 0x142ef0938>
DEBUG:PyQt4.uic.properties:setting property sizePolicy
DEBUG:PyQt4.uic.properties:setting property toolTip
DEBUG:PyQt4.uic.properties:setting property sizeAdjustPolicy
DEBUG:PyQt4.uic.uiparser:push GlueComboBox displayDataCombo
DEBUG:PyQt4.uic.uiparser:pop widget GlueComboBox displayDataCombo
DEBUG:PyQt4.uic.uiparser:new topwidget <PyQt4.QtGui.QWidget object at 0x142ef0938>
DEBUG:PyQt4.uic.properties:setting property sizePolicy
DEBUG:PyQt4.uic.properties:setting property toolTip
DEBUG:PyQt4.uic.properties:setting property sizeAdjustPolicy
DEBUG:PyQt4.uic.uiparser:push GlueComboBox attributeComboBox
DEBUG:PyQt4.uic.uiparser:pop widget GlueComboBox attributeComboBox
DEBUG:PyQt4.uic.uiparser:new topwidget <PyQt4.QtGui.QWidget object at 0x142ef0938>
DEBUG:PyQt4.uic.properties:setting property text
DEBUG:PyQt4.uic.uiparser:push QLabel label
DEBUG:PyQt4.uic.uiparser:pop widget QLabel label
DEBUG:PyQt4.uic.uiparser:new topwidget <PyQt4.QtGui.QWidget object at 0x142ef0938>
DEBUG:PyQt4.uic.properties:setting property text
DEBUG:PyQt4.uic.uiparser:push QLabel label_2
DEBUG:PyQt4.uic.uiparser:pop widget QLabel label_2
DEBUG:PyQt4.uic.uiparser:new topwidget <PyQt4.QtGui.QWidget object at 0x142ef0938>
DEBUG:PyQt4.uic.uiparser:push QComboBox aspectCombo
DEBUG:PyQt4.uic.uiparser:pop widget QComboBox aspectCombo
DEBUG:PyQt4.uic.uiparser:new topwidget <PyQt4.QtGui.QWidget object at 0x142ef0938>
DEBUG:PyQt4.uic.uiparser:pop layout QGridLayout gridLayout
DEBUG:PyQt4.uic.uiparser:push QHBoxLayout monochrome_options
DEBUG:PyQt4.uic.properties:setting property text
DEBUG:PyQt4.uic.properties:setting property checked
DEBUG:PyQt4.uic.uiparser:push QRadioButton monochrome
DEBUG:PyQt4.uic.uiparser:pop widget QRadioButton monochrome
DEBUG:PyQt4.uic.uiparser:new topwidget <PyQt4.QtGui.QWidget object at 0x142ef0938>
DEBUG:PyQt4.uic.properties:setting property text
DEBUG:PyQt4.uic.uiparser:push QRadioButton rgb
DEBUG:PyQt4.uic.uiparser:pop widget QRadioButton rgb
DEBUG:PyQt4.uic.uiparser:new topwidget <PyQt4.QtGui.QWidget object at 0x142ef0938>
DEBUG:PyQt4.uic.uiparser:pop layout QHBoxLayout monochrome_options
DEBUG:PyQt4.uic.uiparser:push QVBoxLayout slice_layout
DEBUG:PyQt4.uic.uiparser:pop layout QVBoxLayout slice_layout
DEBUG:PyQt4.uic.properties:setting property enabled
DEBUG:PyQt4.uic.uiparser:push RGBEdit rgb_options
DEBUG:PyQt4.uic.uiparser:pop widget RGBEdit rgb_options
DEBUG:PyQt4.uic.uiparser:new topwidget <PyQt4.QtGui.QWidget object at 0x142ef0938>
DEBUG:PyQt4.uic.uiparser:pop layout QVBoxLayout verticalLayout
DEBUG:PyQt4.uic.uiparser:pop widget QWidget option_dashboard
DEBUG:PyQt4.uic.uiparser:new topwidget <PyQt4.QtGui.QWidget object at 0x142ef0808>
DEBUG:PyQt4.uic.uiparser:pop layout QVBoxLayout verticalLayout_2
DEBUG:PyQt4.uic.uiparser:pop widget QWidget ImageWidget
DEBUG:PyQt4.uic.uiparser:new topwidget None
DEBUG:PyQt4.uic.uiparser:UI version is 4.0
DEBUG:PyQt4.uic.uiparser:uiname is widget
DEBUG:PyQt4.uic.uiparser:toplevel widget is QWidget
DEBUG:PyQt4.uic.properties:setting property geometry
DEBUG:PyQt4.uic.properties:setting property sizePolicy
DEBUG:PyQt4.uic.properties:setting property windowTitle
DEBUG:PyQt4.uic.uiparser:push QWidget widget
DEBUG:PyQt4.uic.properties:setting property margin
DEBUG:PyQt4.uic.uiparser:push QHBoxLayout horizontalLayout_5
DEBUG:PyQt4.uic.properties:setting property margin
DEBUG:PyQt4.uic.uiparser:push QVBoxLayout verticalLayout
DEBUG:PyQt4.uic.properties:setting property margin
DEBUG:PyQt4.uic.uiparser:push QHBoxLayout horizontalLayout
DEBUG:PyQt4.uic.properties:setting property minimumSize
DEBUG:PyQt4.uic.properties:setting property layoutDirection
DEBUG:PyQt4.uic.properties:setting property text
DEBUG:PyQt4.uic.properties:setting property alignment
DEBUG:PyQt4.uic.uiparser:push QLabel uncertainty_label
DEBUG:PyQt4.uic.uiparser:pop widget QLabel uncertainty_label
DEBUG:PyQt4.uic.uiparser:new topwidget <PyQt4.QtGui.QWidget object at 0x143250180>
DEBUG:PyQt4.uic.properties:setting property sizePolicy
DEBUG:PyQt4.uic.uiparser:push QComboBox uncertainty_combo
DEBUG:PyQt4.uic.uiparser:pop widget QComboBox uncertainty_combo
DEBUG:PyQt4.uic.uiparser:new topwidget <PyQt4.QtGui.QWidget object at 0x143250180>
DEBUG:PyQt4.uic.uiparser:pop layout QHBoxLayout horizontalLayout
DEBUG:PyQt4.uic.properties:setting property margin
DEBUG:PyQt4.uic.uiparser:push QHBoxLayout horizontalLayout_2
DEBUG:PyQt4.uic.properties:setting property minimumSize
DEBUG:PyQt4.uic.properties:setting property layoutDirection
DEBUG:PyQt4.uic.properties:setting property text
DEBUG:PyQt4.uic.properties:setting property alignment
DEBUG:PyQt4.uic.uiparser:push QLabel profile_label
DEBUG:PyQt4.uic.uiparser:pop widget QLabel profile_label
DEBUG:PyQt4.uic.uiparser:new topwidget <PyQt4.QtGui.QWidget object at 0x143250180>
DEBUG:PyQt4.uic.properties:setting property sizePolicy
DEBUG:PyQt4.uic.uiparser:push QComboBox profile_combo
DEBUG:PyQt4.uic.uiparser:pop widget QComboBox profile_combo
DEBUG:PyQt4.uic.uiparser:new topwidget <PyQt4.QtGui.QWidget object at 0x143250180>
DEBUG:PyQt4.uic.uiparser:pop layout QHBoxLayout horizontalLayout_2
DEBUG:PyQt4.uic.properties:setting property spacing
DEBUG:PyQt4.uic.properties:setting property margin
DEBUG:PyQt4.uic.uiparser:push QHBoxLayout horizontalLayout_3
DEBUG:PyQt4.uic.properties:setting property text
DEBUG:PyQt4.uic.uiparser:push QToolButton settings_button
DEBUG:PyQt4.uic.uiparser:pop widget QToolButton settings_button
DEBUG:PyQt4.uic.uiparser:new topwidget <PyQt4.QtGui.QWidget object at 0x143250180>
DEBUG:PyQt4.uic.properties:setting property text
DEBUG:PyQt4.uic.uiparser:push QPushButton fit_button
DEBUG:PyQt4.uic.uiparser:pop widget QPushButton fit_button
DEBUG:PyQt4.uic.uiparser:new topwidget <PyQt4.QtGui.QWidget object at 0x143250180>
DEBUG:PyQt4.uic.properties:setting property text
DEBUG:PyQt4.uic.uiparser:push QPushButton clear_button
DEBUG:PyQt4.uic.uiparser:pop widget QPushButton clear_button
DEBUG:PyQt4.uic.uiparser:new topwidget <PyQt4.QtGui.QWidget object at 0x143250180>
DEBUG:PyQt4.uic.uiparser:pop layout QHBoxLayout horizontalLayout_3
DEBUG:PyQt4.uic.uiparser:push QTextBrowser results_box
DEBUG:PyQt4.uic.uiparser:pop widget QTextBrowser results_box
DEBUG:PyQt4.uic.uiparser:new topwidget <PyQt4.QtGui.QWidget object at 0x143250180>
DEBUG:PyQt4.uic.uiparser:pop layout QVBoxLayout verticalLayout
DEBUG:PyQt4.uic.uiparser:pop layout QHBoxLayout horizontalLayout_5
DEBUG:PyQt4.uic.uiparser:pop widget QWidget widget
DEBUG:PyQt4.uic.uiparser:new topwidget None
INFO:glue.core.hub:Subscribing <glue.clients.image_client.MplImageClient object at 0x142f3aad0> to SubsetCreateMessage
INFO:glue.core.hub:Subscribing <glue.clients.image_client.MplImageClient object at 0x142f3aad0> to SubsetUpdateMessage
INFO:glue.core.hub:Subscribing <glue.clients.image_client.MplImageClient object at 0x142f3aad0> to SubsetDeleteMessage
INFO:glue.core.hub:Subscribing <glue.clients.image_client.MplImageClient object at 0x142f3aad0> to DataUpdateMessage
INFO:glue.core.hub:Subscribing <glue.clients.image_client.MplImageClient object at 0x142f3aad0> to NumericalDataChangedMessage
INFO:glue.core.hub:Subscribing <glue.clients.image_client.MplImageClient object at 0x142f3aad0> to DataCollectionDeleteMessage
INFO:glue.core.hub:Subscribing <glue.clients.image_client.MplImageClient object at 0x142f3aad0> to ComponentReplacedMessage
INFO:glue.core.hub:Subscribing Image Widget to DataCollectionAddMessage
INFO:glue.core.hub:Subscribing Image Widget to DataCollectionDeleteMessage
INFO:glue.core.hub:Subscribing Image Widget to DataUpdateMessage
INFO:glue.core.hub:Subscribing Image Widget to ComponentsChangedMessage
INFO:glue.core.hub:Broadcasting DataCollectionAddMessage: 
	 Sent from: DataCollection (1 data set)
	  0: im
DEBUG:root:Using (slice(0, 2, 1), slice(0, 2, 1)) to index data of shape (2, 2)
DEBUG:root:Using (slice(0, 2, 1), slice(0, 2, 1)) to index data of shape (2, 2)
DEBUG:root:image shape: (2, 2), view: (x, slice(0, 2, 1), slice(0, 2, 1))
DEBUG:root:Using (slice(0, 2, 1), slice(0, 2, 1)) to index data of shape (2, 2)
DEBUG:root:Using (slice(None, None, 1), slice(None, None, 1)) to index data of shape (2, 2)
DEBUG:root:Using (slice(0, 2, 1), slice(0, 2, 1)) to index data of shape (2, 2)
DEBUG:root:Using (slice(0, 2, 1), slice(0, 2, 1)) to index data of shape (2, 2)
DEBUG:root:image shape: (2, 2), view: (x, slice(0, 2, 1), slice(0, 2, 1))
DEBUG:root:Using (slice(0, 2, 1), slice(0, 2, 1)) to index data of shape (2, 2)
DEBUG:root:Using (slice(0, 2, 1), slice(0, 2, 1)) to index data of shape (2, 2)
DEBUG:root:Using (slice(0, 2, 1), slice(0, 2, 1)) to index data of shape (2, 2)
DEBUG:root:Using (slice(0, 2, 1), slice(0, 2, 1)) to index data of shape (2, 2)
DEBUG:root:image shape: (2, 2), view: (x, slice(0, 2, 1), slice(0, 2, 1))
DEBUG:root:Using (slice(0, 2, 1), slice(0, 2, 1)) to index data of shape (2, 2)
DEBUG:root:Using (slice(0, 2, 1), slice(0, 2, 1)) to index data of shape (2, 2)
DEBUG:root:Using (slice(0, 2, 1), slice(0, 2, 1)) to index data of shape (2, 2)
DEBUG:root:image shape: (2, 2), view: (x, slice(0, 2, 1), slice(0, 2, 1))
DEBUG:root:Using (slice(0, 2, 1), slice(0, 2, 1)) to index data of shape (2, 2)
DEBUG:root:Using (slice(0, 2, 1), slice(0, 2, 1)) to index data of shape (2, 2)
DEBUG:root:Using (slice(0, 2, 1), slice(0, 2, 1)) to index data of shape (2, 2)
INFO:glue.core.hub:Broadcasting DataCollectionAddMessage: 
	 Sent from: DataCollection (2 data sets)
	  0: im
	  1: cube
------------------------------------------------------ Captured stderr call ------------------------------------------------------
INFO:glue.core.hub:Broadcasting DataCollectionAddMessage: 
	 Sent from: DataCollection (3 data sets)
	  0: im
	  1: cube
	  2: largeim
DEBUG:root:Using (slice(0, 1024, 3), slice(0, 1024, 3)) to index data of shape (1024, 1024)
DEBUG:root:image shape: (1024, 1024), view: (x, slice(0, 1024, 3), slice(0, 1024, 3))
DEBUG:root:Using (slice(0, 1024, 3), slice(0, 1024, 3)) to index data of shape (1024, 1024)
DEBUG:root:Using (slice(None, None, 20.48), slice(None, None, 20.48)) to index data of shape (1024, 1024)
DEBUG:root:Using (slice(0, 1024, 3), slice(0, 1024, 3)) to index data of shape (1024, 1024)
DEBUG:root:Using (slice(0, 1024, 3), slice(0, 1024, 3)) to index data of shape (1024, 1024)
DEBUG:root:image shape: (1024, 1024), view: (x, slice(0, 1024, 3), slice(0, 1024, 3))
DEBUG:root:Using (slice(0, 1024, 3), slice(0, 1024, 3)) to index data of shape (1024, 1024)
DEBUG:root:Using (slice(0, 1024, 3), slice(0, 1024, 3)) to index data of shape (1024, 1024)
DEBUG:root:Using (slice(0, 1024, 3), slice(0, 1024, 3)) to index data of shape (1024, 1024)
DEBUG:root:Using (slice(0, 1024, 3), slice(0, 1024, 3)) to index data of shape (1024, 1024)
DEBUG:root:image shape: (1024, 1024), view: (x, slice(0, 1024, 3), slice(0, 1024, 3))
DEBUG:root:Using (slice(0, 1024, 3), slice(0, 1024, 3)) to index data of shape (1024, 1024)
DEBUG:root:Using (slice(0, 1024, 3), slice(0, 1024, 3)) to index data of shape (1024, 1024)
DEBUG:root:Using (slice(0, 1024, 3), slice(0, 1024, 3)) to index data of shape (1024, 1024)
DEBUG:root:image shape: (1024, 1024), view: (x, slice(0, 1024, 3), slice(0, 1024, 3))
DEBUG:root:Using (slice(0, 1024, 3), slice(0, 1024, 3)) to index data of shape (1024, 1024)
DEBUG:root:Using (slice(0, 1024, 3), slice(0, 1024, 3)) to index data of shape (1024, 1024)
DEBUG:root:Using (slice(0, 1024, 3), slice(0, 1024, 3)) to index data of shape (1024, 1024)
DEBUG:root:Using (slice(0, 1024, 3), slice(0, 1024, 3)) to index data of shape (1024, 1024)
DEBUG:root:image shape: (1024, 1024), view: (x, slice(0, 1024, 3), slice(0, 1024, 3))
DEBUG:root:Using (slice(0, 1024, 3), slice(0, 1024, 3)) to index data of shape (1024, 1024)
DEBUG:root:Using (slice(0, 1024, 3), slice(0, 1024, 3)) to index data of shape (1024, 1024)
DEBUG:root:Using (slice(0, 1024, 3), slice(0, 1024, 3)) to index data of shape (1024, 1024)
DEBUG:root:image shape: (1024, 1024), view: (x, slice(0, 1024, 3), slice(0, 1024, 3))
DEBUG:root:Using (slice(0, 1024, 3), slice(0, 1024, 3)) to index data of shape (1024, 1024)
DEBUG:root:Using (slice(0, 1024, 3), slice(0, 1024, 3)) to index data of shape (1024, 1024)
DEBUG:root:Using (slice(0, 1024, 3), slice(0, 1024, 3)) to index data of shape (1024, 1024)
-------------------------------------------------------- pytest-selenium ---------------------------------------------------------

======================== 3 failed, 1712 passed, 25 skipped, 2 pytest-warnings, 1 error in 193.26 seconds =========================
```