### PR TITLE
Show PyQt4/PyQt5/PySide versions correctly in glue-deps

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@ v0.6 (unreleased)
 
 * Fix ``glue -t`` option. [#791]
 
+* Updated ``glue-deps`` to show PyQt/PySide versions. [#796]
+
 * Fix bug that caused viewers to be restored with the wrong size. [#781, #783]
 
 * Prevent axes from moving around when data viewers are being resized, and

--- a/glue/tests/test_deps.py
+++ b/glue/tests/test_deps.py
@@ -59,7 +59,7 @@ def test_optional_dependency_not_imported():
     Ensure that a GlueApplication instance can be created without
     importing any non-required dependency
     """
-    optional_deps = categories[1:]
+    optional_deps = categories[2:]
     deps = [dep.module for cateogry, deps in optional_deps for dep in deps]
     deps.extend(['astropy'])
 


### PR DESCRIPTION
Will help debugging user issues. Examples:

```
        GUI FRAMEWORK
               PyQt4:	INSTALLED (PyQt: 4.11.4 - Qt: 4.8.7)
               PyQt5:	NOT INSTALLED
              PySide:	NOT INSTALLED
```

```
        GUI FRAMEWORK
               PyQt4:	NOT INSTALLED
               PyQt5:	INSTALLED (PyQt: 5.3.1 - Qt: 5.3.1)
              PySide:	NOT INSTALLED
```

```
        GUI FRAMEWORK
               PyQt4:	NOT INSTALLED
               PyQt5:	NOT INSTALLED
              PySide:	INSTALLED (PySide: 1.1.2 - Qt: 4.8.7)
```