### PR TITLE
a quickie hack to have glueviz use integer indicies such that some pl…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,11 @@ notifications:
 
 env:
   matrix:
-    - PYTHON_VERSION=2.7 MPL_VERSION=1.4 ASTROPY_VERSION=1.0
-    - PYTHON_VERSION=3.4 MPL_VERSION=1.4 ASTROPY_VERSION=1.0
+    - PYTHON_VERSION=2.7 ASTROPY_VERSION=1.0
+    - PYTHON_VERSION=3.4 ASTROPY_VERSION=1.0
   global:
     - PYTEST_ARGS="--cov glue"
+    - MPL_VERSION=1.5
     - NUMPY_VERSION=1.9
     - IPYTHON_VERSION=4
     - NO_CFG_FILES=false
@@ -34,17 +35,17 @@ matrix:
         # Astropy dev
         - os: linux
           env:
-            - PYTHON_VERSION=2.7 MPL_VERSION=1.4 ASTROPY_VERSION=dev
+            - PYTHON_VERSION=2.7 ASTROPY_VERSION=dev
 
         # Numpy dev
         - os: linux
           env:
-            - PYTHON_VERSION=2.7 MPL_VERSION=1.4 NUMPY_VERSION=dev
+            - PYTHON_VERSION=2.7 NUMPY_VERSION=dev
 
         # PyQt5
         - os: linux
           env:
-            - PYTHON_VERSION=2.7 MPL_VERSION=1.5 NUMPY_VERSION=1.10 ASTROPY_VERSION=1.0 QT_PKG=pyqt5
+            - PYTHON_VERSION=2.7 NUMPY_VERSION=1.10 ASTROPY_VERSION=1.0 QT_PKG=pyqt5
             # We don't test ginga with PyQt5 due to a bug in ginga with QT_API
             - PIP_DEPENDENCIES="pytest-cov coveralls pyavm astrodendro awscli"
 
@@ -58,13 +59,11 @@ matrix:
             - CONDA_DEPENDENCIES="pytz pyparsing cycler python-dateutil freetype libpng sip qt pip setuptools=7.0 pandas mock pbr six funcsigs --no-deps"
             - IPYTHON_VERSION=None
             - ASTROPY_VERSION=''
-            - MPL_VERSION=1.4
             - PIP_DEPENDENCIES="pytest-cov coveralls"
 
         - os: linux
           env:
             - PYTHON_VERSION=2.7
-            - MPL_VERSION=1.4
             - ASTROPY_VERSION=1.0
             - DOC_TRIGGER=1
             - APP_TRIGGER=1
@@ -85,10 +84,10 @@ matrix:
         # Test with PySide, but due to segmentation faults, mark as an
         # allowed failure.
         - os: linux
-          env: PYTHON_VERSION=2.7 MPL_VERSION=1.4 ASTROPY_VERSION=1.0 QT_PKG=pyside
+          env: PYTHON_VERSION=2.7 ASTROPY_VERSION=1.0 QT_PKG=pyside
 
     allow_failures:
-      - env: PYTHON_VERSION=2.7 MPL_VERSION=1.4 ASTROPY_VERSION=1.0 QT_PKG=pyside
+      - env: PYTHON_VERSION=2.7 ASTROPY_VERSION=1.0 QT_PKG=pyside
 
 before_install:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,11 @@ matrix:
           env:
             - PYTHON_VERSION=2.7 MPL_VERSION=1.4 ASTROPY_VERSION=dev
 
+        # Numpy dev
+        - os: linux
+          env:
+            - PYTHON_VERSION=2.7 MPL_VERSION=1.4 NUMPY_VERSION=dev
+
         # PyQt5
         - os: linux
           env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
   global:
     - PYTEST_ARGS="--cov glue"
     - MPL_VERSION=1.5
-    - NUMPY_VERSION=1.9
+    - NUMPY_VERSION=1.10
     - IPYTHON_VERSION=4
     - NO_CFG_FILES=false
     - QT_PKG=pyqt
@@ -76,10 +76,10 @@ matrix:
           env: PYTHON_VERSION=2.7 MPL_VERSION=1.3 ASTROPY_VERSION=0.3 NUMPY_VERSION=1.8
 
         - os: linux
-          env: PYTHON_VERSION=2.7 MPL_VERSION=1.4 ASTROPY_VERSION=0.4 IPYTHON_VERSION=1.1
+          env: PYTHON_VERSION=2.7 MPL_VERSION=1.4 ASTROPY_VERSION=0.4 NUMPY_VERSION=1.9 IPYTHON_VERSION=1.1
 
         - os: linux
-          env: PYTHON_VERSION=2.7 MPL_VERSION=1.4 ASTROPY_VERSION=0.4 IPYTHON_VERSION=0.13
+          env: PYTHON_VERSION=2.7 MPL_VERSION=1.4 ASTROPY_VERSION=0.4 NUMPY_VERSION=1.9 IPYTHON_VERSION=0.13
 
         # Test with PySide, but due to segmentation faults, mark as an
         # allowed failure.

--- a/glue/clients/layer_artist.py
+++ b/glue/clients/layer_artist.py
@@ -416,8 +416,8 @@ class ImageLayerArtist(LayerArtist, ImageLayerBase):
         result.stretch = 'arcsinh'
         result.clip = True
         if vals.size > 0:
-            result.vmin = vals[np.int64(.01 * vals.size)]
-            result.vmax = vals[np.int64(.99 * vals.size)]
+            result.vmin = vals[np.intp(.01 * vals.size)]
+            result.vmax = vals[np.intp(.99 * vals.size)]
         return result
 
     def override_image(self, image):

--- a/glue/clients/layer_artist.py
+++ b/glue/clients/layer_artist.py
@@ -416,8 +416,8 @@ class ImageLayerArtist(LayerArtist, ImageLayerBase):
         result.stretch = 'arcsinh'
         result.clip = True
         if vals.size > 0:
-            result.vmin = vals[.01 * vals.size]
-            result.vmax = vals[.99 * vals.size]
+            result.vmin = vals[np.int64(.01 * vals.size)]
+            result.vmax = vals[np.int64(.99 * vals.size)]
         return result
 
     def override_image(self, image):

--- a/glue/clients/util.py
+++ b/glue/clients/util.py
@@ -14,7 +14,7 @@ def small_view(data, attribute):
     statistical summaries
     """
     shp = data.shape
-    view = tuple([slice(None, None, max(s / 50, 1)) for s in shp])
+    view = tuple([slice(None, None, np.int64(max(s / 50, 1))) for s in shp])
     return data[attribute, view]
 
 
@@ -23,7 +23,7 @@ def small_view_array(data):
     Same as small_view, except using a numpy array as input
     """
     shp = data.shape
-    view = tuple([slice(None, None, max(s / 50, 1)) for s in shp])
+    view = tuple([slice(None, None, np.int64(max(s / 50, 1))) for s in shp])
     return np.asarray(data)[view]
 
 

--- a/glue/clients/util.py
+++ b/glue/clients/util.py
@@ -14,7 +14,7 @@ def small_view(data, attribute):
     statistical summaries
     """
     shp = data.shape
-    view = tuple([slice(None, None, np.int64(max(s / 50, 1))) for s in shp])
+    view = tuple([slice(None, None, np.intp(max(s / 50, 1))) for s in shp])
     return data[attribute, view]
 
 
@@ -23,7 +23,7 @@ def small_view_array(data):
     Same as small_view, except using a numpy array as input
     """
     shp = data.shape
-    view = tuple([slice(None, None, np.int64(max(s / 50, 1))) for s in shp])
+    view = tuple([slice(None, None, np.intp(max(s / 50, 1))) for s in shp])
     return np.asarray(data)[view]
 
 

--- a/glue/plugins/ginga_viewer/qt_widget.py
+++ b/glue/plugins/ginga_viewer/qt_widget.py
@@ -58,7 +58,10 @@ class GingaWidget(ImageWidgetBase):
         self.canvas = ImageViewCanvas(self.logger, render='widget')
 
         # prevent widget from grabbing focus
-        self.canvas.set_follow_focus(False)
+        try:
+            self.canvas.set_enter_focus(False)
+        except AttributeError:
+            self.canvas.set_follow_focus(False)
 
         # enable interactive features
         bindings = self.canvas.get_bindings()

--- a/glue/utils/matplotlib.py
+++ b/glue/utils/matplotlib.py
@@ -103,7 +103,7 @@ def fast_limits(data, plo, phi):
     """
 
     shp = data.shape
-    view = tuple([slice(None, None, max(s / 50, 1)) for s in shp])
+    view = tuple([slice(None, None, np.int64(max(s / 50, 1))) for s in shp])
     values = np.asarray(data)[view]
     if ~np.isfinite(values).any():
         return (0.0, 1.0)

--- a/glue/utils/matplotlib.py
+++ b/glue/utils/matplotlib.py
@@ -103,7 +103,7 @@ def fast_limits(data, plo, phi):
     """
 
     shp = data.shape
-    view = tuple([slice(None, None, np.int64(max(s / 50, 1))) for s in shp])
+    view = tuple([slice(None, None, np.intp(max(s / 50, 1))) for s in shp])
     values = np.asarray(data)[view]
     if ~np.isfinite(values).any():
         return (0.0, 1.0)


### PR DESCRIPTION
…aces such that the functionality is compatible with numpy indexing where float indicies are not allowed

The current development version of numpy (1.11.0.dev)  does not allow float indexing of arrays
such as x[0.1]

This kind of indexing is done in several places in the codebase of glueviz.

I implemented some fixes.