### PR TITLE
Create documentation about layer artists

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,9 @@ v0.7 (unreleased)
 * The ``artist_container`` argument to client classes has been renamed to
   ``layer_artist_container``. [#814]
 
+* Added documentation about how to use layer artists in custom Qt data viewers.
+  [#814]
+
 v0.6 (2015-11-20)
 -----------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@ v0.7 (unreleased)
 
 * Python 2.6 is no longer supported. [#804]
 
+* The ``artist_container`` argument to client classes has been renamed to
+  ``layer_artist_container``. [#814]
+
 v0.6 (2015-11-20)
 -----------------
 

--- a/glue/clients/histogram_client.py
+++ b/glue/clients/histogram_client.py
@@ -57,10 +57,10 @@ class HistogramClient(Client):
     xmin = UpdateProperty(None, relim=True)
     xmax = UpdateProperty(None, relim=True)
 
-    def __init__(self, data, figure, artist_container=None):
+    def __init__(self, data, figure, layer_artist_container=None):
         super(HistogramClient, self).__init__(data)
 
-        self._artists = artist_container or LayerArtistContainer()
+        self._artists = layer_artist_container or LayerArtistContainer()
         self._figure, self._axes = init_mpl(figure=figure, axes=None)
         self._component = None
         self._saved_nbins = None

--- a/glue/clients/image_client.py
+++ b/glue/clients/image_client.py
@@ -41,11 +41,11 @@ class ImageClient(VizClient):
     display_attribute = CallbackProperty(None)
     display_aspect = CallbackProperty('equal')
 
-    def __init__(self, data, artist_container=None):
+    def __init__(self, data, layer_artist_container=None):
 
         VizClient.__init__(self, data)
 
-        self.artists = artist_container
+        self.artists = layer_artist_container
         if self.artists is None:
             self.artists = LayerArtistContainer()
 
@@ -705,8 +705,8 @@ class ImageClient(VizClient):
 
 class MplImageClient(ImageClient):
 
-    def __init__(self, data, figure=None, axes=None, artist_container=None):
-        super(MplImageClient, self).__init__(data, artist_container)
+    def __init__(self, data, figure=None, axes=None, layer_artist_container=None):
+        super(MplImageClient, self).__init__(data, layer_artist_container)
 
         if axes is not None:
             raise ValueError("ImageClient does not accept an axes")

--- a/glue/clients/scatter_client.py
+++ b/glue/clients/scatter_client.py
@@ -37,7 +37,7 @@ class ScatterClient(Client):
     jitter = CallbackProperty()
 
     def __init__(self, data=None, figure=None, axes=None,
-                 artist_container=None):
+                 layer_artist_container=None):
         """
         Create a new ScatterClient object
 
@@ -52,7 +52,7 @@ class ScatterClient(Client):
         """
         Client.__init__(self, data=data)
         figure, axes = init_mpl(figure, axes)
-        self.artists = artist_container
+        self.artists = layer_artist_container
         if self.artists is None:
             self.artists = LayerArtistContainer()
 

--- a/glue/clients/viz_client.py
+++ b/glue/clients/viz_client.py
@@ -177,13 +177,13 @@ class GenericMplClient(Client):
     """
 
     def __init__(self, data=None, figure=None, axes=None,
-                 artist_container=None, axes_factory=None):
+                 layer_artist_container=None, axes_factory=None):
 
         super(GenericMplClient, self).__init__(data=data)
         if axes_factory is None:
             axes_factory = self.create_axes
         figure, self.axes = init_mpl(figure, axes, axes_factory=axes_factory)
-        self.artists = artist_container
+        self.artists = layer_artist_container
         if self.artists is None:
             self.artists = LayerArtistContainer()
 

--- a/glue/core/application_base.py
+++ b/glue/core/application_base.py
@@ -261,7 +261,7 @@ class ViewerBase(HubListener, PropertySetMixin):
 
     # the glue.clients.layer_artist.LayerArtistContainer
     # class/subclass to use
-    _container_cls = None
+    _layer_artist_container_cls = None
 
     def __init__(self, session):
 
@@ -271,7 +271,7 @@ class ViewerBase(HubListener, PropertySetMixin):
         self._session = session
         self._data = session.data_collection
         self._hub = None
-        self._container = self._container_cls()
+        self._layer_artist_container = self._layer_artist_container_cls()
 
     def register_to_hub(self, hub):
         self._hub = hub
@@ -393,7 +393,7 @@ class ViewerBase(HubListener, PropertySetMixin):
 
         A layer is a visual representation of a dataset or subset within
         the viewer"""
-        return tuple(self._container)
+        return tuple(self._layer_artist_container)
 
     def __gluestate__(self, context):
         return dict(session=context.id(self._session),

--- a/glue/plugins/ginga_viewer/client.py
+++ b/glue/plugins/ginga_viewer/client.py
@@ -22,8 +22,8 @@ from ginga import AstroImage, BaseImage
 
 class GingaClient(ImageClient):
 
-    def __init__(self, data, canvas=None, artist_container=None):
-        super(GingaClient, self).__init__(data, artist_container)
+    def __init__(self, data, canvas=None, layer_artist_container=None):
+        super(GingaClient, self).__init__(data, layer_artist_container)
         self._setup_ginga(canvas)
 
     def _setup_ginga(self, canvas):

--- a/glue/plugins/ginga_viewer/qt_widget.py
+++ b/glue/plugins/ginga_viewer/qt_widget.py
@@ -103,7 +103,7 @@ class GingaWidget(ImageWidgetBase):
         return []
 
     def make_client(self):
-        return GingaClient(self._data, self.canvas, self._container)
+        return GingaClient(self._data, self.canvas, self._layer_artist_container)
 
     def make_central_widget(self):
 

--- a/glue/qt/custom_viewer.py
+++ b/glue/qt/custom_viewer.py
@@ -616,7 +616,7 @@ class CustomViewer(object):
         for k in sorted(self.ui):
             v = self.ui[k]
             w = FormElement.auto(v)
-            w.container = self.widget._container
+            w.container = self.widget._layer_artist_container
             w.add_callback(callback)
             self._settings[k] = w
             if w.ui is not None:
@@ -876,7 +876,7 @@ class CustomWidgetBase(DataViewer):
         self.option_widget = self._build_ui()
         self.client = CustomClient(self._data,
                                    self.central_widget.canvas.fig,
-                                   artist_container=self._container,
+                                   layer_artist_container=self._layer_artist_container,
                                    coordinator=self._coordinator)
 
         self.make_toolbar()

--- a/glue/qt/widgets/data_viewer.py
+++ b/glue/qt/widgets/data_viewer.py
@@ -27,7 +27,7 @@ class DataViewer(ViewerBase, QMainWindow):
        * An automatic call to unregister on window close
        * Drag and drop support for adding data
     """
-    _container_cls = QtLayerArtistContainer
+    _layer_artist_container_cls = QtLayerArtistContainer
     LABEL = 'Override this'
 
     def __init__(self, session, parent=None):
@@ -38,7 +38,7 @@ class DataViewer(ViewerBase, QMainWindow):
         ViewerBase.__init__(self, session)
         self.setWindowIcon(get_qapp().windowIcon())
         self._view = LayerArtistView()
-        self._view.setModel(self._container.model)
+        self._view.setModel(self._layer_artist_container.model)
         self._tb_vis = {}  # store whether toolbars are enabled
         self.setAttribute(Qt.WA_DeleteOnClose)
         self.setAcceptDrops(True)
@@ -50,11 +50,11 @@ class DataViewer(ViewerBase, QMainWindow):
         self.statusBar().setStyleSheet("QStatusBar{font-size:10px}")
 
         # close window when last plot layer deleted
-        self._container.on_empty(lambda: self.close(warn=False))
-        self._container.on_changed(self.update_window_title)
+        self._layer_artist_container.on_empty(lambda: self.close(warn=False))
+        self._layer_artist_container.on_changed(self.update_window_title)
 
     def remove_layer(self, layer):
-        self._container.pop(layer)
+        self._layer_artist_container.pop(layer)
 
     def dragEnterEvent(self, event):
         """ Accept the event if it has data layers"""

--- a/glue/qt/widgets/dendro_widget.py
+++ b/glue/qt/widgets/dendro_widget.py
@@ -38,7 +38,7 @@ class DendroWidget(DataViewer):
         self.ui = load_ui('dendrowidget', self.option_widget)
         self.client = DendroClient(self._data,
                                    self.central_widget.canvas.fig,
-                                   artist_container=self._container)
+                                   layer_artist_container=self._layer_artist_container)
 
         self._connect()
 

--- a/glue/qt/widgets/histogram_widget.py
+++ b/glue/qt/widgets/histogram_widget.py
@@ -52,7 +52,7 @@ class HistogramWidget(DataViewer):
         self._tweak_geometry()
         self.client = HistogramClient(self._data,
                                       self.central_widget.canvas.fig,
-                                      artist_container=self._container)
+                                      layer_artist_container=self._layer_artist_container)
         self._init_limits()
         self.make_toolbar()
         self._connect()
@@ -130,7 +130,7 @@ class HistogramWidget(DataViewer):
 
         found = False
         for d in self._data:
-            if d not in self._container:
+            if d not in self._layer_artist_container:
                 continue
             item = QtGui.QStandardItem(d.label)
             item.setData(_hash(d), role=Qt.UserRole)
@@ -225,7 +225,7 @@ class HistogramWidget(DataViewer):
         pass
 
     def data_present(self, data):
-        return data in self._container
+        return data in self._layer_artist_container
 
     def register_to_hub(self, hub):
         super(HistogramWidget, self).register_to_hub(hub)

--- a/glue/qt/widgets/image_widget.py
+++ b/glue/qt/widgets/image_widget.py
@@ -391,7 +391,7 @@ class ImageWidget(ImageWidgetBase):
     def make_client(self):
         return MplImageClient(self._data,
                               self.central_widget.canvas.fig,
-                              artist_container=self._container)
+                              layer_artist_container=self._layer_artist_container)
 
     def make_central_widget(self):
         return MplWidget()

--- a/glue/qt/widgets/scatter_widget.py
+++ b/glue/qt/widgets/scatter_widget.py
@@ -58,7 +58,7 @@ class ScatterWidget(DataViewer):
 
         self.client = ScatterClient(self._data,
                                     self.central_widget.canvas.fig,
-                                    artist_container=self._container)
+                                    layer_artist_container=self._layer_artist_container)
 
         self._connect()
         self.unique_fields = set()

--- a/glue/qt/widgets/tests/test_histogram_widget.py
+++ b/glue/qt/widgets/tests/test_histogram_widget.py
@@ -40,7 +40,7 @@ class TestHistogramWidget(object):
         combo = widget.ui.attributeCombo
         row = 0
         for data in dc:
-            if data not in widget._container:
+            if data not in widget._layer_artist_container:
                 continue
             assert combo.itemText(row) == data.label
             assert combo.itemData(row) == _hash(data)

--- a/glue/qt/widgets/tests/test_image_widget.py
+++ b/glue/qt/widgets/tests/test_image_widget.py
@@ -163,7 +163,7 @@ class TestImageWidget(_TestImageWidgetBase):
             assert False
 
         self.widget.add_data(self.im)
-        self.widget._container.on_empty(fail)
+        self.widget._layer_artist_container.on_empty(fail)
         self.widget.rgb_mode = True
         self.widget.rgb_mode = False
 


### PR DESCRIPTION
@ChrisBeaumont - while working on this, I ran across a couple of things in the API that would be nice to update:

* ``DataViewer._container``: this name is pretty obscure, and it should maybe instead be ``DataViewer._layer_artists`` or ``DataViewer._layer_artist_container``.

* Maybe the layer artist container should have a consistent name between clients and widgets (at the moment it's ``.artists`` vs ``_container`` for the same object, and ``artist_container`` in some kwargs). What about ``.layer_artists``, and make it public for both clients and widgets?

* I have a mental block when I run across instances of the ``layer`` variable which really is the layer *data*. Would you have any objections to me renaming ``layer`` to ``layer_data``? So then we'd never have just 'layer' - either layer artist or layer data.

What do you think?

Side note: at the moment, we don't really talk about the possibility of using clients in these docs - and that's because in principle one doesn't *have* to use a separate client class. Before writing docs on how to better separate client functionality and GUI, I think it would be good to converge on a solution in https://github.com/glue-viz/glue/issues/775 first, so adding details of clients to the page here is low priority for now in my view.

@PennyQ - just for info, I've started working on this, but it's by no means complete. I'll work on it more over the next couple of days (in my spare time).