### PR TITLE
Issue opening a FITS cube

### DIFF
--- a/glue/core/data_factories/fits.py
+++ b/glue/core/data_factories/fits.py
@@ -16,7 +16,7 @@ def is_fits(filename):
     try:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            with fits.open(filename):
+            with fits.open(filename, ignore_missing_end=True):
                 return True
     except IOError:
         return False
@@ -52,7 +52,7 @@ def fits_reader(source, auto_merge=False, exclude_exts=None, label=None):
 
     exclude_exts = exclude_exts or []
     if not isinstance(source, fits.hdu.hdulist.HDUList):
-        hdulist = fits.open(source)
+        hdulist = fits.open(source, ignore_missing_end=True)
         hdulist.verify('fix')
     else:
         hdulist = source
@@ -147,7 +147,7 @@ def is_casalike(filename, **kwargs):
 
     if not is_fits(filename):
         return False
-    with fits.open(filename) as hdulist:
+    with fits.open(filename, ignore_missing_end=True) as hdulist:
         if len(hdulist) != 1:
             return False
         if hdulist[0].header['NAXIS'] != 4:
@@ -172,7 +172,7 @@ def casalike_cube(filename, **kwargs):
     from ...external.astro import fits
 
     result = Data()
-    with fits.open(filename, **kwargs) as hdulist:
+    with fits.open(filename, ignore_missing_end=True, **kwargs) as hdulist:
         array = hdulist[0].data
         header = hdulist[0].header
     result.coords = coordinates_from_header(header)

--- a/glue/plugins/dendro_viewer/data_factory.py
+++ b/glue/plugins/dendro_viewer/data_factory.py
@@ -30,7 +30,7 @@ def is_dendro(file, **kwargs):
 
         from ...external.astro import fits
 
-        hdulist = fits.open(file)
+        hdulist = fits.open(file, ignore_missing_end=True)
 
         # In recent versions of Astropy, we could do 'DATA' in hdulist etc. but
         # this doesn't work with Astropy 0.3, so we use the following method


### PR DESCRIPTION
The FITS cubes that can't be opened in Glue are from the COMPLETE FCRAO survey (one example [here] (https://dataverse.harvard.edu/dataset.xhtml?persistentId=hdl:10904/10072)). As I remember, older versions of Glue had no problem opening the same FITS cube(s). Below's the error message returned by Glue:

```

Error message: Could not parse file: /Users/hopechen/Documents/projects/PDF/observation/Oph/OphA_12coFCRAO_F_xyv.fits

Traceback (most recent call last):
  File "//anaconda/lib/python2.7/site-packages/glue/qt/qtutil.py", line 103, in data_wizard
    result = gdd.load_data()
  File "//anaconda/lib/python2.7/site-packages/glue/qt/decorators.py", line 20, in result
    return func(*args, **kwargs)
  File "//anaconda/lib/python2.7/site-packages/glue/qt/qtutil.py", line 172, in load_data
    d = load_data(path, factory=fac.function)
  File "//anaconda/lib/python2.7/site-packages/glue/core/data_factories/helpers.py", line 248, in load_data
    d = as_list(factory(path, **kwargs))
  File "//anaconda/lib/python2.7/site-packages/glue/core/data_factories/helpers.py", line 324, in auto_data
    return fac(filename, *args, **kwargs)
  File "//anaconda/lib/python2.7/site-packages/glue/core/data_factories/tables.py", line 111, in tabular_data
    raise IOError("Could not parse file: %s" % path)
IOError: Could not parse file: /Users/hopechen/Documents/projects/PDF/observation/Oph/OphA_12coFCRAO_F_xyv.fits

```

When opening the same file using the astropy fits io (`fits.open()`), I have to turn on `ignore_missing_end` to circumvent the problem of missing end card. I don’t know whether this could be related to Glue not being able to open the file, though.