### PR TITLE
WIP: Implementation of a combo box with recent items

### DIFF
--- a/glue/qt/qtutil.py
+++ b/glue/qt/qtutil.py
@@ -396,6 +396,9 @@ def _custom_widgets():
     from glue.qt.link_equation import LinkEquation
     yield LinkEquation
 
+    from glue.utils.qt.qcombobox_recent import QComboBoxRecent
+    yield QComboBoxRecent
+
 
 def load_ui(path, parent=None):
     """

--- a/glue/qt/ui/imagewidget.ui
+++ b/glue/qt/ui/imagewidget.ui
@@ -60,7 +60,7 @@
          </widget>
         </item>
         <item row="0" column="1">
-         <widget class="QComboBox" name="displayDataCombo">
+         <widget class="QComboBoxRecent" name="displayDataCombo">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -76,7 +76,7 @@
          </widget>
         </item>
         <item row="1" column="1">
-         <widget class="QComboBox" name="attributeComboBox">
+         <widget class="QComboBoxRecent" name="attributeComboBox">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -179,6 +179,11 @@
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>QComboBoxRecent</class>
+   <extends>QComboBox</extends>
+   <header>glue.utils.qt</header>
+  </customwidget>
   <customwidget>
    <class>RGBEdit</class>
    <extends>QWidget</extends>

--- a/glue/qt/ui/scatterwidget.ui
+++ b/glue/qt/ui/scatterwidget.ui
@@ -75,7 +75,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QComboBox" name="xAxisComboBox">
+         <widget class="QComboBoxRecent" name="xAxisComboBox">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -125,7 +125,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QComboBox" name="yAxisComboBox">
+         <widget class="QComboBoxRecent" name="yAxisComboBox">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -339,6 +339,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QComboBoxRecent</class>
+   <extends>QComboBox</extends>
+   <header>glue.utils.qt</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/glue/utils/qt/__init__.py
+++ b/glue/utils/qt/__init__.py
@@ -10,3 +10,4 @@ from .mixins import *
 from .mime import *
 from .python_list_model import *
 from .threading import *
+from .qcombobox_recent import *

--- a/glue/utils/qt/qcombobox_recent.py
+++ b/glue/utils/qt/qcombobox_recent.py
@@ -1,0 +1,149 @@
+from __future__ import absolute_import, division, print_function
+
+from functools import wraps
+
+from glue.external.qt import QtGui
+from glue.external.qt.QtCore import Qt
+
+__all__ = ['QComboBoxRecent']
+
+# For the QComboBoxRecent class below, we need to overload methods from the
+# original class so that we always apply an offset to indices that are passed as
+# input and ones that are returned. To do that, we create wrapper functions.
+
+
+def subtract_offset(method):
+    @wraps(method)
+    def wrapper(self, *args, **kwargs):
+        index = method(self, *args, **kwargs)
+        if index == -1:
+            return index
+        else:
+            return index - self.offset
+    return wrapper
+
+
+def add_offset(method):
+    @wraps(method)
+    def wrapper(self, index, *args, **kwargs):
+        return method(self, index + self.offset, *args, **kwargs)
+    return wrapper
+
+
+def identity(method):
+    @wraps(method)
+    def wrapper(self, *args, **kwargs):
+        return method(self, *args, **kwargs)
+    return wrapper
+
+
+class QComboBoxRecent(QtGui.QComboBox):
+    """
+    Subclass of QComboBox that includes the 5 most recent selections at the
+    top.
+
+    In order to make this as compatible as a drop-in replacement, all the usual
+    methods are overriden so that the index returned e.g. by currentIndex and
+    used to set setCurrentIndex is the one from the original list, not the one
+    in the resulting combo box with the most recent items.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(QComboBoxRecent, self).__init__(*args, **kwargs)
+        self.init_recent()
+        self.currentIndexChanged.connect(self._index_changed)
+        self.recent = []
+
+    def clear(self):
+        super(QComboBoxRecent, self).clear()
+        self.init_recent()
+
+    def init_recent(self):
+        self._insertItem(0, "Recent items")
+        self._setItemData(0, "data", role=Qt.UserRole - 1)
+        self._insertItem(1, "All items")
+        self._setItemData(1, "data", role=Qt.UserRole - 1)
+        self._setCurrentIndex(-1)
+
+    @property
+    def offset(self):
+        """
+        By how many items items are offset in the new combo box compared to the
+        original list. This is used to compute offsets for the index.
+        """
+        return 2 + len(self.recent)
+
+    def _index_changed(self):
+
+        index = self._currentIndex()
+
+        if index == -1:
+            return
+
+        self._original_index = index - self.offset
+
+        try:
+            self.blockSignals(True)
+            text = self._itemText(index)
+            data = self._itemData(index)
+            for idx in range(len(self.recent)):
+                if text == self.recent[idx][0] and data is self.recent[idx][1]:
+                    self.recent.pop(idx)
+                    self._removeItem(idx + 1)
+                    break
+            if len(self.recent) == 5:
+                self.recent.pop(4)
+                self._removeItem(5)
+            self.recent.insert(0, (text, data))
+            self._insertItem(1, text, data)
+            self._setCurrentIndex(1)
+        finally:
+            self.blockSignals(False)
+
+    # We now overload methods that take the index as one of the arguments, or
+    # return an index, and we need to adjust the index accordingly.
+
+    # The following methods return an index and therefore we need to subtract
+    # the offset.
+
+    def currentIndex(self):
+        index = QtGui.QComboBox.currentIndex(self)
+        if index == -1:
+            return -1
+        elif index < self.offset:
+            return self._original_index
+        else:
+            return index - self.offset
+
+    # currentIndex = subtract_offset(QtGui.QComboBox.currentIndex)
+    findData = subtract_offset(QtGui.QComboBox.findData)
+    findText = subtract_offset(QtGui.QComboBox.findText)
+    count = subtract_offset(QtGui.QComboBox.count)
+
+    # The following methods take an index as the first argument and therefore
+    # we need to add an offset.
+    insertItem = add_offset(QtGui.QComboBox.insertItem)
+    insertItems = add_offset(QtGui.QComboBox.insertItems)
+    insertSeparator = add_offset(QtGui.QComboBox.insertSeparator)
+    itemData = add_offset(QtGui.QComboBox.itemData)
+    itemIcon = add_offset(QtGui.QComboBox.itemIcon)
+    itemText = add_offset(QtGui.QComboBox.itemText)
+    setItemData = add_offset(QtGui.QComboBox.setItemData)
+    removeItem = add_offset(QtGui.QComboBox.removeItem)
+    setCurrentIndex = add_offset(QtGui.QComboBox.setCurrentIndex)
+
+    # We now want to keep the original methods accessible with a leading
+    # underscore.
+    _currentIndex = identity(QtGui.QComboBox.currentIndex)
+    _findData = identity(QtGui.QComboBox.findData)
+    _findText = identity(QtGui.QComboBox.findText)
+    _count = identity(QtGui.QComboBox.count)
+    _insertItem = identity(QtGui.QComboBox.insertItem)
+    _insertItems = identity(QtGui.QComboBox.insertItems)
+    _insertSeparator = identity(QtGui.QComboBox.insertSeparator)
+    _itemData = identity(QtGui.QComboBox.itemData)
+    _itemIcon = identity(QtGui.QComboBox.itemIcon)
+    _itemText = identity(QtGui.QComboBox.itemText)
+    _setItemData = identity(QtGui.QComboBox.setItemData)
+    _removeItem = identity(QtGui.QComboBox.removeItem)
+    _setCurrentIndex = identity(QtGui.QComboBox.setCurrentIndex)

--- a/glue/utils/qt/tests/test_qcombobox_recent.py
+++ b/glue/utils/qt/tests/test_qcombobox_recent.py
@@ -1,0 +1,134 @@
+from ..qcombobox_recent import QComboBoxRecent
+
+
+def _items_as_string(box):
+    items = [box._itemText(i) for i in range(box._count())]
+    print(items)
+    items[items.index('Recent items')] = "/"
+    items[items.index('All items')] = "/"
+    return "".join(items)
+
+
+def test_qcombobox_recent_event():
+    """
+    We need to check that the index changed event is intercepted and also offset
+    """
+
+    class EventHandler(object):
+
+        def __init__(self, box):
+            self.box = box
+
+        def on_change(self, idx):
+            self.index = self.box.currentIndex()
+
+    box = QComboBoxRecent()
+
+    handler = EventHandler(box)
+
+    box.show()
+    for letter in 'abcdefghij':
+        box.addItem(letter)
+    box.currentIndexChanged.connect(handler.on_change)
+
+    box.setCurrentIndex(7)
+
+    assert handler.index == 7
+    assert box.itemText(handler.index) == 'h'
+
+    box.setCurrentIndex(7)
+
+    assert handler.index == 7
+    assert box.itemText(handler.index) == 'h'
+
+
+def test_qcombobox_recent():
+
+    box = QComboBoxRecent()
+    box.show()
+
+    # Should only include 'Recent items' and 'All items'
+    # assert _items_as_string(box) == "//"
+
+    for letter in 'abcdefghij':
+        box.addItem(letter)
+
+    # Initial recent list is empty
+    # assert _items_as_string(box) == "//abcdefghij"
+
+    # Selecting 'c' puts it in the recent list
+    box._setCurrentIndex(4)
+    assert _items_as_string(box) == "/c/abcdefghij"
+    assert box._currentIndex() == 1
+
+    # Selecting 'c' again doesn't change anything
+    box._setCurrentIndex(5)
+    assert _items_as_string(box) == "/c/abcdefghij"
+    assert box._currentIndex() == 1
+
+    # Selecting 'c' from recents list doesn't change anything
+    box._setCurrentIndex(1)
+    assert _items_as_string(box) == "/c/abcdefghij"
+    assert box._currentIndex() == 1
+
+    # Selecting 'a' puts it in the recent list
+    box._setCurrentIndex(3)
+    assert _items_as_string(box) == "/ac/abcdefghij"
+    assert box._currentIndex() == 1
+
+    # Selecting 'c' from recents list puts it back at front
+    box._setCurrentIndex(2)
+    assert _items_as_string(box) == "/ca/abcdefghij"
+    assert box._currentIndex() == 1
+
+    # Selecting 'a' from main list swaps recents list
+    box._setCurrentIndex(4)
+    assert _items_as_string(box) == "/ac/abcdefghij"
+    assert box._currentIndex() == 1
+
+    # Selecting 'f' from main list adds to recent list
+    box._setCurrentIndex(9)
+    assert _items_as_string(box) == "/fac/abcdefghij"
+    assert box._currentIndex() == 1
+
+    # Selecting 'g' from main list adds to recent list
+    box._setCurrentIndex(11)
+    assert _items_as_string(box) == "/gfac/abcdefghij"
+    assert box._currentIndex() == 1
+
+    # Selecting 'f' from main list moves around recent list
+    box._setCurrentIndex(11)
+    assert _items_as_string(box) == "/fgac/abcdefghij"
+    assert box._currentIndex() == 1
+
+    # Selecting 'a' from recents list moves around recent list
+    box._setCurrentIndex(3)
+    assert _items_as_string(box) == "/afgc/abcdefghij"
+    assert box._currentIndex() == 1
+
+    # Selecting 'h' from main list adds to recent list
+    box._setCurrentIndex(13)
+    assert _items_as_string(box) == "/hafgc/abcdefghij"
+    assert box._currentIndex() == 1
+
+    # Selecting 'b' from main list adds to recent list and drops one from recent list
+    box._setCurrentIndex(8)
+    assert _items_as_string(box) == "/bhafg/abcdefghij"
+    assert box._currentIndex() == 1
+
+    # Check that setting to -1 works
+    box._setCurrentIndex(-1)
+    assert box._currentIndex() == -1
+    assert box.currentIndex() == -1
+
+    # Selecting 'd' from main list adds to recent list and drops one from
+    # recent list
+    box._setCurrentIndex(10)
+    assert _items_as_string(box) == "/dbhaf/abcdefghij"
+    assert box._currentIndex() == 1
+
+    # Inserting an item adds it at the start of the full data not the recent
+    # list
+    box.insertItem(0, 'z')
+    assert _items_as_string(box) == "/dbhaf/zabcdefghij"
+    assert box._currentIndex() == 1

--- a/glue/utils/qt/widget_properties.py
+++ b/glue/utils/qt/widget_properties.py
@@ -264,7 +264,8 @@ def connect_current_combo(client, prop, widget):
                 raise
         widget.setCurrentIndex(idx)
 
-    def _pull_combo(idx):
+    def _pull_combo():
+        idx = widget.currentIndex()
         if idx == -1:
             setattr(client, prop, None)
         else:


### PR DESCRIPTION
### Preview

This looks like:

![recent](https://cloud.githubusercontent.com/assets/314716/12293042/d0504ac4-b9e8-11e5-81bd-38c4c3632a53.jpg)
### Issues

From a UI point of view, there are still some issues, because at the moment if the QComboBox is long it moves up when I click on it, so I have to keep scrolling up to the recent items which defies the point. I have a StackOverflow question open here:

http://stackoverflow.com/questions/34765193/preventing-long-qcombobox-from-moving-up

so we'll see if there are any good solutions.
### Technical details:

The way this works in order to be usable by glue as-is is that it overloads all the methods of QComboBox so that the index (as seen by public methods) is still the index of the original list. There may be better ways of doing this with a custom view or delegate (or model proxy) but I'm not 100% sure. @ChrisBeaumont - do you have any thoughts on this?

Fixes https://github.com/glue-viz/glue/issues/812
