### PR TITLE
Update to the latest version of qt-helpers

### DIFF
--- a/glue/external/qt.py
+++ b/glue/external/qt.py
@@ -256,6 +256,10 @@ def reload_qt():
                           " Encountered the following errors: %s" %
                           '\n'.join(msgs))
 
+    # We patch this only now, once QtCore and QtGui are defined
+    if is_pyside() or is_pyqt4():
+        patch_qcombobox()
+
 
 def load_ui(path, parent=None, custom_widgets=None):
     if is_pyside():
@@ -303,9 +307,72 @@ def get_qapp(icon_path=None):
     # Make sure we use high resolution icons with PyQt5 for HDPI
     # displays. TODO: check impact on non-HDPI displays.
     if is_pyqt5():
-        qapp.setAttribute(QtCore.Qt.AA_UseHighDpiPixmaps);
+        qapp.setAttribute(QtCore.Qt.AA_UseHighDpiPixmaps)
 
     return qapp
+
+
+def patch_qcombobox():
+
+    # In PySide, using Python objects as userData in QComboBox causes
+    # Segmentation faults under certain conditions. Even in cases where it
+    # doesn't, findData does not work correctly. Likewise, findData also
+    # does not work correctly with Python objects when using PyQt4. On the
+    # other hand, PyQt5 deals with this case correctly. We therefore patch
+    # QComboBox when using PyQt4 and PySide to avoid issues.
+
+    class userDataWrapper(QtCore.QObject):
+        def __init__(self, data, parent=None):
+            super(userDataWrapper, self).__init__(parent)
+            self.data = data
+
+    _addItem = QtGui.QComboBox.addItem
+
+    def addItem(self, *args, **kwargs):
+        if len(args) == 3 or (not isinstance(args[0], QtGui.QIcon)
+                              and len(args) == 2):
+            args, kwargs['userData'] = args[:-1], args[-1]
+        if 'userData' in kwargs:
+            kwargs['userData'] = userDataWrapper(kwargs['userData'],
+                                                 parent=self)
+        _addItem(self, *args, **kwargs)
+
+    _insertItem = QtGui.QComboBox.insertItem
+
+    def insertItem(self, *args, **kwargs):
+        if len(args) == 4 or (not isinstance(args[1], QtGui.QIcon)
+                              and len(args) == 3):
+            args, kwargs['userData'] = args[:-1], args[-1]
+        if 'userData' in kwargs:
+            kwargs['userData'] = userDataWrapper(kwargs['userData'],
+                                                 parent=self)
+        _insertItem(self, *args, **kwargs)
+
+    _setItemData = QtGui.QComboBox.setItemData
+
+    def setItemData(self, index, value, role=QtCore.Qt.UserRole):
+        value = userDataWrapper(value, parent=self)
+        _setItemData(self, index, value, role=role)
+
+    _itemData = QtGui.QComboBox.itemData
+
+    def itemData(self, index, role=QtCore.Qt.UserRole):
+        userData = _itemData(self, index, role=role)
+        if isinstance(userData, userDataWrapper):
+            userData = userData.data
+        return userData
+
+    def findData(self, value):
+        for i in range(self.count()):
+            if self.itemData(i) == value:
+                return i
+        return -1
+
+    QtGui.QComboBox.addItem = addItem
+    QtGui.QComboBox.insertItem = insertItem
+    QtGui.QComboBox.setItemData = setItemData
+    QtGui.QComboBox.itemData = itemData
+    QtGui.QComboBox.findData = findData
 
 
 # Now load default Qt

--- a/glue/qt/qtutil.py
+++ b/glue/qt/qtutil.py
@@ -645,58 +645,9 @@ class RGBEdit(QWidget):
         self.artist.redraw()
 
 
-class GlueComboBox(QtGui.QComboBox):
-
-    """ Modification of QComboBox, that sidesteps PySide
-    sefgaults when storing some python objects as user data
-    """
-
-    def __init__(self, parent=None):
-        super(GlueComboBox, self).__init__(parent)
-        self._data = []
-
-    def addItem(self, text, userData=None):
-        # set before super, since super may trigger signals
-        self._data.append(userData)
-        super(GlueComboBox, self).addItem(text)
-
-    def addItems(self, items):
-        self._data.extend(None for _ in items)
-        super(GlueComboBox, self).addItems(items)
-
-    def itemData(self, index, role=Qt.UserRole):
-        assert len(self._data) == self.count()
-        if role != Qt.UserRole:
-            return super(GlueComboBox, self).itemData(index, role)
-        return self._data[index]
-
-    def setItemData(self, index, value, role=Qt.UserRole):
-        if role != Qt.UserRole:
-            return super(GlueComboBox, self).setItemData(index, value, role)
-        self._data[index] = value
-
-    def clear(self):
-        self._data = []
-        return super(GlueComboBox, self).clear()
-
-    def insertItem(self, *args):
-        raise NotImplementedError()
-
-    def insertItems(self, *args):
-        raise NotImplementedError()
-
-    def insertSeparator(self, index):
-        raise NotImplementedError()
-
-    def removeItem(self, index):
-        self._data.pop(index)
-        return super(GlueComboBox, self).removeItem(index)
-
-
 def _custom_widgets():
     # iterate over custom widgets referenced in .ui files
     yield GlueListWidget
-    yield GlueComboBox
     yield GlueActionButton
     yield RGBEdit
 

--- a/glue/qt/tests/test_qtutil.py
+++ b/glue/qt/tests/test_qtutil.py
@@ -16,7 +16,7 @@ from ...clients.layer_artist import RGBImageLayerArtist
 
 from .. import qtutil
 from ..qtutil import GlueDataDialog
-from ..qtutil import pretty_number, GlueComboBox, PythonListModel, update_combobox
+from ..qtutil import pretty_number, PythonListModel, update_combobox
 
 
 def test_glue_action_button():
@@ -141,96 +141,6 @@ class TestPrettyNumber(object):
     def test_list(self):
         assert pretty_number([1, 2, 3.3, 1e5]) == ['1', '2', '3.3',
                                                    '1.000e+05']
-
-
-class TestGlueComboBox(object):
-
-    def setup_method(self, method):
-        self.combo = GlueComboBox()
-
-    def test_add_data(self):
-        self.combo.addItem('hi', userData=3)
-        assert self.combo.itemData(0) == 3
-
-    def test_add_multi_data(self):
-        self.combo.addItem('hi', userData=3)
-        self.combo.addItem('ho', userData=4)
-        assert self.combo.itemData(0) == 3
-        assert self.combo.itemData(1) == 4
-
-    def test_replace(self):
-        self.combo.addItem('hi', userData=3)
-        self.combo.removeItem(0)
-        self.combo.addItem('ho', userData=4)
-        assert self.combo.itemData(0) == 4
-
-    def test_clear(self):
-        self.combo.addItem('a', 1)
-        self.combo.addItem('b', 2)
-        self.combo.addItem('c', 3)
-        self.combo.clear()
-        self.combo.addItem('d', 4)
-        assert self.combo.itemData(0) == 4
-
-    def test_mid_remove(self):
-        self.combo.addItem('a', 1)
-        self.combo.addItem('b', 2)
-        self.combo.addItem('c', 3)
-        self.combo.removeItem(1)
-        assert self.combo.itemData(1) == 3
-
-    def test_set_item_data(self):
-        self.combo.addItem('a', 1)
-        self.combo.setItemData(0, 2)
-        assert self.combo.itemData(0) == 2
-
-    def test_default_data(self):
-        self.combo.addItem('a')
-        assert self.combo.itemData(0) is None
-
-    def test_add_items(self):
-        self.combo.addItem('a', 1)
-        self.combo.addItems(['b', 'c', 'd'])
-        assert self.combo.itemData(0) == 1
-        assert self.combo.itemData(1) is None
-        assert self.combo.itemData(2) is None
-        assert self.combo.itemData(3) is None
-
-    def test_non_user_role(self):
-        """methods that edit data other than userRole dispatched to super"""
-        self.combo.addItem('a', 1)
-        assert self.combo.itemData(0, role=Qt.DisplayRole) == 'a'
-        self.combo.setItemData(0, 'b', role=Qt.DisplayRole)
-        assert self.combo.itemData(0, role=Qt.DisplayRole) == 'b'
-
-    def test_consistent_with_signals(self):
-        """Ensure that when signal/slot connections interrupt
-        methods mid-call, internal data state is consistent"""
-
-        # Qt swallows exceptions in signals, so we can't assert in this
-        # instead, store state and assert after signal
-        good = [False]
-
-        def assert_consistent(*args):
-            good[0] = len(self.combo._data) == self.combo.count()
-
-        # addItem
-        self.combo.currentIndexChanged.connect(assert_consistent)
-        self.combo.addItem('a', 1)
-        assert good[0]
-
-        # addItems
-        self.combo.clear()
-        good[0] = False
-        self.combo.addItems('b c d'.split())
-        assert good[0]
-
-        # removeItem
-        self.combo.clear()
-        self.combo.addItem('a', 1)
-        good[0] = False
-        self.combo.removeItem(0)
-        assert good[0]
 
 
 def test_qt4_to_mpl_color():
@@ -461,9 +371,8 @@ class TestListModel(object):
         assert list(m) == [1, 2, 3]
 
 
-
 def test_update_combobox():
-    combo = GlueComboBox()
+    combo = QtGui.QComboBox()
     update_combobox(combo, [('a', 1), ('b', 2)])
     update_combobox(combo, [('c', 3)])
 
@@ -473,7 +382,7 @@ def test_update_combobox_indexchanged():
     # emitted if the new index happened to be the same as the old one but the
     # label data was different.
 
-    class MyComboBox(GlueComboBox):
+    class MyComboBox(QtGui.QComboBox):
 
         def __init__(self, *args, **kwargs):
             self.change_count = 0

--- a/glue/qt/ui/imagewidget.ui
+++ b/glue/qt/ui/imagewidget.ui
@@ -60,7 +60,7 @@
          </widget>
         </item>
         <item row="0" column="1">
-         <widget class="GlueComboBox" name="displayDataCombo">
+         <widget class="QComboBox" name="displayDataCombo">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -76,7 +76,7 @@
          </widget>
         </item>
         <item row="1" column="1">
-         <widget class="GlueComboBox" name="attributeComboBox">
+         <widget class="QComboBox" name="attributeComboBox">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -179,11 +179,6 @@
   </layout>
  </widget>
  <customwidgets>
-  <customwidget>
-   <class>GlueComboBox</class>
-   <extends>QComboBox</extends>
-   <header>glue.qt.qtutil</header>
-  </customwidget>
   <customwidget>
    <class>RGBEdit</class>
    <extends>QWidget</extends>

--- a/glue/qt/widget_properties.py
+++ b/glue/qt/widget_properties.py
@@ -311,7 +311,8 @@ def _find_combo_data(widget, value):
 
     Raises a ValueError if data is not found
     """
-    for i in range(widget.count()):
-        if widget.itemData(i) == value:
-            return i
-    raise ValueError("%s not found in combo box" % value)
+    i = widget.findData(value)
+    if i == -1:
+        raise ValueError("%s not found in combo box" % value)
+    else:
+        return i


### PR DESCRIPTION
This includes a patched version of QComboBox, and removes GlueComboBox, since it should no longer be needed (the patch should now allow arbitrary data to be used as ``userData`` in ``QComboBox`` instances with PySide, PyQt4, and PyQt5.