### PR TITLE
Switch to absolute imports in most cases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,12 @@ env:
     - PYTHON_VERSION=3.4 ASTROPY_VERSION=1.0
   global:
     - PYTEST_ARGS="--cov glue"
-    - MPL_VERSION=1.5.0
+    - MATPLOTLIB_VERSION=1.5.0
     - NUMPY_VERSION=1.10
     - IPYTHON_VERSION=4
     - NO_CFG_FILES=false
     - QT_PKG=pyqt
-    - CONDA_DEPENDENCIES="pip scipy cython h5py pygments pyzmq scikit-image pandas sphinx=1.2.3 xlrd pillow pytest mock coverage pyyaml requests sphinx_rtd_theme"
+    - CONDA_DEPENDENCIES="pip ipython matplotlib scipy cython h5py pygments pyzmq scikit-image pandas sphinx=1.2.3 xlrd pillow pytest mock coverage pyyaml requests sphinx_rtd_theme"
     - PIP_DEPENDENCIES="pytest-cov coveralls pyavm astrodendro awscli ginga"
     - secure: NvQVc3XmmjXNVKrmaD31IgltsOImlnt3frAl4wU0pM223iejr7V57hz/V5Isx6sTANWEiRBMG27v2T8e5IiB7DQTxFUleZk3DWXQV1grw/GarEGUawXAgwDWpF0AE/7BRVJYqo2Elgaqf28+Jkun8ewvfPCiEROD2jWEpnZj+IQ=
     - secure: "SU9BYH8d9eNigypG3lC83s0NY6Mq9AHGKXyEGeXDtz1npJIC1KHdzPMP1v1K3dzCgl1p6ReMXPjZMCENyfNkad/xvzTzGk0Nu/4BjihrUPV6+ratVeLpv0JLm8ikh8q+sZURkdtzUOlds+Hfn5ku4LdpT87tcKHY9TINAGA34ZM="
@@ -58,9 +58,8 @@ matrix:
           env:
             - PYTHON_VERSION=2.7
             - PYTEST_ARGS="--cov glue"
-            - CONDA_DEPENDENCIES="pytz pyparsing cycler python-dateutil freetype libpng sip qt pip setuptools=7.0 pandas mock pbr six funcsigs --no-deps"
-            - IPYTHON_VERSION=None
-            - ASTROPY_VERSION=''
+            - CONDA_DEPENDENCIES="pytz pyparsing cycler python-dateutil freetype libpng sip qt pip setuptools=7.0 pandas mock pbr six funcsigs matplotlib"
+            - CONDA_DEPENDENCIES_FLAGS='--no-deps'
             - PIP_DEPENDENCIES="pytest-cov coveralls"
 
         - os: linux
@@ -75,13 +74,13 @@ matrix:
         # Test with older package versions:
 
         - os: linux
-          env: PYTHON_VERSION=2.7 MPL_VERSION=1.3 ASTROPY_VERSION=0.3 NUMPY_VERSION=1.8
+          env: PYTHON_VERSION=2.7 MATPLOTLIB_VERSION=1.3 ASTROPY_VERSION=0.3 NUMPY_VERSION=1.8
 
         - os: linux
-          env: PYTHON_VERSION=2.7 MPL_VERSION=1.4 ASTROPY_VERSION=0.4 NUMPY_VERSION=1.9 IPYTHON_VERSION=1.1
+          env: PYTHON_VERSION=2.7 MATPLOTLIB_VERSION=1.4 ASTROPY_VERSION=0.4 NUMPY_VERSION=1.9 IPYTHON_VERSION=1.1
 
         - os: linux
-          env: PYTHON_VERSION=2.7 MPL_VERSION=1.4 ASTROPY_VERSION=0.4 NUMPY_VERSION=1.9 IPYTHON_VERSION=0.13
+          env: PYTHON_VERSION=2.7 MATPLOTLIB_VERSION=1.4 ASTROPY_VERSION=0.4 NUMPY_VERSION=1.9 IPYTHON_VERSION=0.13
 
         # Test with PySide, but due to segmentation faults, mark as an
         # allowed failure.
@@ -97,10 +96,9 @@ before_install:
   - if [[ $QT_PKG == pyqt5 ]]; then export CONDA_CHANNELS="astropy-ci-extras astrofrog"; fi
 
   # Prepare dependency list
-  - export CONDA_DEPENDENCIES="matplotlib=$MPL_VERSION $QT_PKG "$CONDA_DEPENDENCIES
+  - export CONDA_DEPENDENCIES="$QT_PKG "$CONDA_DEPENDENCIES
 
   # Special cases depending on IPython version
-  - if [[ $IPYTHON_VERSION != None ]]; then export CONDA_DEPENDENCIES="IPython=$IPYTHON_VERSION "$CONDA_DEPENDENCIES; fi
   - if [[ $IPYTHON_VERSION == 4 ]]; then export CONDA_DEPENDENCIES="qtconsole ipykernel "$CONDA_DEPENDENCIES; fi
 
   # Documentation dependencies

--- a/glue/_plugin_helpers.py
+++ b/glue/_plugin_helpers.py
@@ -31,12 +31,12 @@ class PluginConfig(object):
 
         # Import at runtime because some tests change this value. We also don't
         # just import the variable directly otherwise it is cached.
-        from . import config
+        from glue import config
         cfg_dir = config.CFG_DIR
 
         plugin_cfg =  os.path.join(cfg_dir, 'plugins.cfg')
 
-        from .external.six.moves import configparser
+        from glue.external.six.moves import configparser
 
         config = configparser.ConfigParser()
         read = config.read(plugin_cfg)
@@ -56,12 +56,12 @@ class PluginConfig(object):
 
         # Import at runtime because some tests change this value. We also don't
         # just import the variable directly otherwise it is cached.
-        from . import config
+        from glue import config
         cfg_dir = config.CFG_DIR
 
         plugin_cfg =  os.path.join(cfg_dir, 'plugins.cfg')
 
-        from .external.six.moves import configparser
+        from glue.external.six.moves import configparser
 
         config = configparser.ConfigParser()
         config.add_section('plugins')

--- a/glue/backends.py
+++ b/glue/backends.py
@@ -31,7 +31,7 @@ def get_backend(backend='qt'):
     if backend != 'qt':
         raise ValueError("Only QT Backend supported")
 
-    from .qt import qt_backend
+    from glue.qt import qt_backend
 
     _backend = qt_backend
     return _backend

--- a/glue/clients/__init__.py
+++ b/glue/clients/__init__.py
@@ -3,7 +3,7 @@ from matplotlib import rcParams, rcdefaults
 # standardize mpl setup
 rcdefaults()
 
-from ..external.qt import is_pyqt5
+from glue.external.qt import is_pyqt5
 if is_pyqt5():
     rcParams['backend'] = 'Qt5Agg'
 else:

--- a/glue/clients/ds9norm.py
+++ b/glue/clients/ds9norm.py
@@ -25,7 +25,7 @@ from __future__ import absolute_import, division, print_function
 import numpy as np
 from matplotlib.colors import Normalize
 
-from ..utils import fast_limits
+from glue.utils import fast_limits
 
 
 def norm(x, vmin, vmax):

--- a/glue/clients/histogram_client.py
+++ b/glue/clients/histogram_client.py
@@ -2,18 +2,18 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 
-from ..core.client import Client
-from ..core import message as msg
-from ..core.data import Data
-from ..core.subset import RangeSubsetState, CategoricalRoiSubsetState
-from ..core.exceptions import IncompatibleDataException, IncompatibleAttribute
-from ..core.edit_subset_mode import EditSubsetMode
-from .layer_artist import HistogramLayerArtist, LayerArtistContainer
-from .util import update_ticks, visible_limits
-from ..core.callback_property import CallbackProperty, add_callback
-from ..utils import lookup_class
-from ..utils.matplotlib import freeze_margins
-from .viz_client import init_mpl
+from glue.core.client import Client
+from glue.core import message as msg
+from glue.core.data import Data
+from glue.core.subset import RangeSubsetState, CategoricalRoiSubsetState
+from glue.core.exceptions import IncompatibleDataException, IncompatibleAttribute
+from glue.core.edit_subset_mode import EditSubsetMode
+from glue.clients.layer_artist import HistogramLayerArtist, LayerArtistContainer
+from glue.clients.util import update_ticks, visible_limits
+from glue.core.callback_property import CallbackProperty, add_callback
+from glue.utils import lookup_class
+from glue.utils.matplotlib import freeze_margins
+from glue.clients.viz_client import init_mpl
 
 class UpdateProperty(CallbackProperty):
 

--- a/glue/clients/image_client.py
+++ b/glue/clients/image_client.py
@@ -5,19 +5,19 @@ from functools import wraps
 
 import numpy as np
 
-from ..external.modest_image import extract_matched_slices
-from ..core.exceptions import IncompatibleAttribute
-from ..core.data import Data
-from ..core.subset import Subset, RoiSubsetState
-from ..core.roi import PolygonalROI
-from ..core.message import ComponentReplacedMessage
-from ..core.callback_property import (
+from glue.external.modest_image import extract_matched_slices
+from glue.core.exceptions import IncompatibleAttribute
+from glue.core.data import Data
+from glue.core.subset import Subset, RoiSubsetState
+from glue.core.roi import PolygonalROI
+from glue.core.message import ComponentReplacedMessage
+from glue.core.callback_property import (
     callback_property, CallbackProperty)
-from ..core.edit_subset_mode import EditSubsetMode
-from ..utils import lookup_class, defer_draw
+from glue.core.edit_subset_mode import EditSubsetMode
+from glue.utils import lookup_class, defer_draw
 
-from .viz_client import VizClient, init_mpl
-from .layer_artist import (ScatterLayerArtist, LayerArtistContainer,
+from glue.clients.viz_client import VizClient, init_mpl
+from glue.clients.layer_artist import (ScatterLayerArtist, LayerArtistContainer,
                            ImageLayerArtist, SubsetImageLayerArtist,
                            RGBImageLayerArtist,
                            ImageLayerBase, RGBImageLayerBase,

--- a/glue/clients/layer_artist.py
+++ b/glue/clients/layer_artist.py
@@ -18,13 +18,13 @@ from abc import ABCMeta, abstractproperty, abstractmethod
 
 import numpy as np
 from matplotlib.cm import gray
-from ..external import six
-from ..core.exceptions import IncompatibleAttribute
-from ..core.util import PropertySetMixin, Pointer
-from ..core.subset import Subset
-from .util import small_view, small_view_array
-from ..utils import view_cascade, get_extent, color2rgb
-from .ds9norm import DS9Normalize
+from glue.external import six
+from glue.core.exceptions import IncompatibleAttribute
+from glue.core.util import PropertySetMixin, Pointer
+from glue.core.subset import Subset
+from glue.clients.util import small_view, small_view_array
+from glue.utils import view_cascade, get_extent, color2rgb
+from glue.clients.ds9norm import DS9Normalize
 
 
 __all__ = ['LayerArtistBase', 'LayerArtist',

--- a/glue/clients/profile_viewer.py
+++ b/glue/clients/profile_viewer.py
@@ -1,7 +1,7 @@
 import numpy as np
 from matplotlib.transforms import blended_transform_factory
 
-from ..core.callback_property import CallbackProperty, add_callback
+from glue.core.callback_property import CallbackProperty, add_callback
 
 
 PICK_THRESH = 30  # pixel distance threshold for picking

--- a/glue/clients/scatter_client.py
+++ b/glue/clients/scatter_client.py
@@ -4,18 +4,18 @@ from functools import partial
 
 import numpy as np
 
-from ..core.client import Client
-from ..core.data import Data, IncompatibleAttribute, ComponentID
-from ..core.subset import RoiSubsetState, RangeSubsetState, CategoricalRoiSubsetState, AndState
-from ..core.roi import PolygonalROI, RangeROI, RectangularROI
-from ..core.util import relim
-from ..core.edit_subset_mode import EditSubsetMode
-from ..core.message import ComponentReplacedMessage
-from ..utils import lookup_class
-from .viz_client import init_mpl
-from .layer_artist import ScatterLayerArtist, LayerArtistContainer
-from .util import update_ticks, visible_limits
-from ..core.callback_property import (CallbackProperty, add_callback,
+from glue.core.client import Client
+from glue.core.data import Data, IncompatibleAttribute, ComponentID
+from glue.core.subset import RoiSubsetState, RangeSubsetState, CategoricalRoiSubsetState, AndState
+from glue.core.roi import PolygonalROI, RangeROI, RectangularROI
+from glue.core.util import relim
+from glue.core.edit_subset_mode import EditSubsetMode
+from glue.core.message import ComponentReplacedMessage
+from glue.utils import lookup_class
+from glue.clients.viz_client import init_mpl
+from glue.clients.layer_artist import ScatterLayerArtist, LayerArtistContainer
+from glue.clients.util import update_ticks, visible_limits
+from glue.core.callback_property import (CallbackProperty, add_callback,
                                       delay_callback)
 
 

--- a/glue/clients/tests/test_histogram_client.py
+++ b/glue/clients/tests/test_histogram_client.py
@@ -10,12 +10,12 @@ from mock import MagicMock
 from ..histogram_client import HistogramClient
 from ..layer_artist import HistogramLayerArtist
 
-from ...core.data_collection import DataCollection
-from ...core.exceptions import IncompatibleDataException
-from ...core.data import Data
-from ...core.component import CategoricalComponent
-from ...core.component_id import ComponentID
-from ...core.subset import RangeSubsetState, CategoricalRoiSubsetState
+from glue.core.data_collection import DataCollection
+from glue.core.exceptions import IncompatibleDataException
+from glue.core.data import Data
+from glue.core.component import CategoricalComponent
+from glue.core.component_id import ComponentID
+from glue.core.subset import RangeSubsetState, CategoricalRoiSubsetState
 
 from .util import renderless_figure
 

--- a/glue/clients/tests/test_image_client.py
+++ b/glue/clients/tests/test_image_client.py
@@ -7,10 +7,10 @@ import pytest
 from mock import MagicMock
 import numpy as np
 
-from ...tests import example_data
-from ... import core
-from ...core.exceptions import IncompatibleAttribute
-from ...core.link_helpers import LinkSame
+from glue.tests import example_data
+from glue import core
+from glue.core.exceptions import IncompatibleAttribute
+from glue.core.link_helpers import LinkSame
 
 from ..layer_artist import RGBImageLayerArtist, ImageLayerArtist
 from ..image_client import MplImageClient

--- a/glue/clients/tests/test_layer_artist.py
+++ b/glue/clients/tests/test_layer_artist.py
@@ -1,6 +1,6 @@
 from .util import renderless_figure
 from ..layer_artist import ScatterLayerArtist
-from ...core import Data
+from glue.core import Data
 
 FIGURE = renderless_figure()
 

--- a/glue/clients/tests/test_scatter_client.py
+++ b/glue/clients/tests/test_scatter_client.py
@@ -11,14 +11,14 @@ from mock import MagicMock
 from timeit import timeit
 from functools import partial
 
-from ...tests import example_data
-from ...core.subset import RangeSubsetState, CategoricalRoiSubsetState, AndState
-from ...core.roi import RectangularROI, XRangeROI, YRangeROI
-from ...core.data import Data
-from ...core.data_collection import DataCollection
-from ...core.component import Component, CategoricalComponent
-from ...core.component_id import ComponentID
-from ...core.edit_subset_mode import EditSubsetMode
+from glue.tests import example_data
+from glue.core.subset import RangeSubsetState, CategoricalRoiSubsetState, AndState
+from glue.core.roi import RectangularROI, XRangeROI, YRangeROI
+from glue.core.data import Data
+from glue.core.data_collection import DataCollection
+from glue.core.component import Component, CategoricalComponent
+from glue.core.component_id import ComponentID
+from glue.core.edit_subset_mode import EditSubsetMode
 from ..scatter_client import ScatterClient
 from .util import renderless_figure
 

--- a/glue/clients/viz_client.py
+++ b/glue/clients/viz_client.py
@@ -1,10 +1,10 @@
 from __future__ import absolute_import, division, print_function
 
 import matplotlib.pyplot as plt
-from ..core.client import Client
-from ..core import Data
-from ..utils.matplotlib import freeze_margins
-from .layer_artist import LayerArtistContainer
+from glue.core.client import Client
+from glue.core import Data
+from glue.utils.matplotlib import freeze_margins
+from glue.clients.layer_artist import LayerArtistContainer
 
 __all__ = ['VizClient', 'GenericMplClient']
 
@@ -143,7 +143,7 @@ def init_mpl(figure=None, axes=None, wcs=False, axes_factory=None):
         raise ValueError("Axes and figure are incompatible")
 
     try:
-        from ..external.wcsaxes import WCSAxesSubplot
+        from glue.external.wcsaxes import WCSAxesSubplot
     except ImportError:
         WCSAxesSubplot = None
 

--- a/glue/config.py
+++ b/glue/config.py
@@ -71,7 +71,7 @@ class Registry(object):
         self._lazy_members.append(value)
 
     def _load_lazy_members(self):
-        from .plugins import load_plugin
+        from glue.plugins import load_plugin
         while self._lazy_members:
             plugin = self._lazy_members.pop()
             load_plugin(plugin)
@@ -351,8 +351,8 @@ class QtClientRegistry(Registry):
 
     def default_members(self):
         try:
-            from .qt.widgets import default_widgets
-            from .qt.custom_viewer import CUSTOM_WIDGETS
+            from glue.qt.widgets import default_widgets
+            from glue.qt.custom_viewer import CUSTOM_WIDGETS
             return default_widgets + CUSTOM_WIDGETS
         except ImportError as e:
             logging.getLogger(__name__).warning(
@@ -406,7 +406,7 @@ class LinkFunctionRegistry(Registry):
     item = namedtuple('LinkFunction', 'function info output_labels')
 
     def default_members(self):
-        from .core import link_helpers
+        from glue.core import link_helpers
         return list(self.item(l, "", l.output_args)
                     for l in link_helpers.__LINK_FUNCTIONS__)
 
@@ -457,7 +457,7 @@ class LinkHelperRegistry(Registry):
     item = namedtuple('LinkHelper', 'helper info input_labels')
 
     def default_members(self):
-        from .core.link_helpers import __LINK_HELPERS__ as helpers
+        from glue.core.link_helpers import __LINK_HELPERS__ as helpers
         return list(self.item(l, l.info_text, l.input_args)
                     for l in helpers)
 
@@ -478,7 +478,7 @@ class ProfileFitterRegistry(Registry):
         self.members.append(cls)
 
     def default_members(self):
-        from .core.fitters import __FITTERS__
+        from glue.core.fitters import __FITTERS__
         return list(__FITTERS__)
 
 
@@ -553,7 +553,7 @@ def _default_search_order():
        * Glue's own default config
     """
 
-    from . import config
+    from glue import config
 
     search_order = [os.path.join(os.getcwd(), 'config.py')]
     if 'GLUERC' in os.environ:

--- a/glue/config_gen.py
+++ b/glue/config_gen.py
@@ -26,7 +26,7 @@ def main():
 
     # Import at runtime because some tests change this value. We also don't
     # just import the function directly otherwise it is cached.
-    from . import config
+    from glue import config
     dest = config.CFG_DIR
 
     if not os.path.exists(dest):

--- a/glue/conftest.py
+++ b/glue/conftest.py
@@ -9,7 +9,7 @@ def pytest_addoption(parser):
 def pytest_configure(config):
 
     if config.getoption('no_optional_skip'):
-        from .tests import helpers
+        from glue.tests import helpers
         for attr in helpers.__dict__:
             if attr.startswith('requires_'):
                 # The following line replaces the decorators with a function
@@ -18,23 +18,23 @@ def pytest_configure(config):
 
     # Make sure we don't affect the real glue config dir
     import tempfile
-    from . import config
+    from glue import config
     config.CFG_DIR = tempfile.mkdtemp()
 
     # Force loading of plugins
-    from .main import load_plugins
+    from glue.main import load_plugins
     load_plugins()
 
 
 def pytest_report_header(config):
-    from . import __version__
+    from glue import __version__
     glue_version = "%20s:\t%s" % ("glue", __version__)
-    from ._deps import get_status
+    from glue._deps import get_status
     return os.linesep + glue_version + os.linesep + os.linesep + get_status()
 
 
-from .config import CFG_DIR as CFG_DIR_ORIG
+from glue.config import CFG_DIR as CFG_DIR_ORIG
 
 def pytest_unconfigure(config):
-    from . import config
+    from glue import config
     config.CFG_DIR = CFG_DIR_ORIG

--- a/glue/core/aggregate.py
+++ b/glue/core/aggregate.py
@@ -9,7 +9,7 @@ except ImportError:  # python3
 from functools import wraps
 
 import numpy as np
-from ..external.six.moves import range as xrange
+from glue.external.six.moves import range as xrange
 
 
 def check_empty(func):

--- a/glue/core/application_base.py
+++ b/glue/core/application_base.py
@@ -3,16 +3,16 @@ from __future__ import absolute_import, division, print_function
 from functools import wraps, partial
 import traceback
 
-from .data_collection import DataCollection
-from .data_factories import load_data
-from . import command
-from . import Data, Subset
-from .hub import HubListener
-from .util import PropertySetMixin
-from ..utils import as_list
-from .edit_subset_mode import EditSubsetMode
-from .session import Session
-from ..config import settings
+from glue.core.data_collection import DataCollection
+from glue.core.data_factories import load_data
+from glue.core import command
+from glue.core import Data, Subset
+from glue.core.hub import HubListener
+from glue.core.util import PropertySetMixin
+from glue.utils import as_list
+from glue.core.edit_subset_mode import EditSubsetMode
+from glue.core.session import Session
+from glue.config import settings
 
 __all__ = ['Application', 'ViewerBase']
 
@@ -89,7 +89,7 @@ class Application(HubListener):
         Note: Saving of client is not currently supported. Thus,
         restoring this session will lose all current viz windows
         """
-        from .state import GlueSerializer
+        from glue.core.state import GlueSerializer
         gs = GlueSerializer(self, include_data=include_data)
         state = gs.dumps(indent=2)
         with open(path, 'w') as out:
@@ -110,7 +110,7 @@ class Application(HubListener):
         app : :class:`Application`
             The loaded application
         """
-        from ..core.state import GlueUnSerializer
+        from glue.core.state import GlueUnSerializer
 
         with open(path) as infile:
             state = GlueUnSerializer.load(infile)
@@ -236,7 +236,7 @@ class Application(HubListener):
     def __gluestate__(self, context):
         viewers = [list(map(context.id, tab)) for tab in self.viewers]
         data = self.session.data_collection
-        from ..main import _loaded_plugins
+        from glue.main import _loaded_plugins
         return dict(session=context.id(self.session), viewers=viewers,
                     data=context.id(data), plugins=_loaded_plugins)
 

--- a/glue/core/callback_property.py
+++ b/glue/core/callback_property.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-from ..external.echo import (CallbackProperty, add_callback,
+from glue.external.echo import (CallbackProperty, add_callback,
                              delay_callback, ignore_callback,
                              remove_callback, callback_property)

--- a/glue/core/client.py
+++ b/glue/core/client.py
@@ -1,10 +1,10 @@
 from __future__ import absolute_import, division, print_function
 
-from .hub import HubListener
-from .data import Data
-from .subset import Subset
-from .data_collection import DataCollection
-from .message import (DataUpdateMessage,
+from glue.core.hub import HubListener
+from glue.core.data import Data
+from glue.core.subset import Subset
+from glue.core.data_collection import DataCollection
+from glue.core.message import (DataUpdateMessage,
                       SubsetUpdateMessage,
                       SubsetCreateMessage,
                       SubsetDeleteMessage,

--- a/glue/core/command.py
+++ b/glue/core/command.py
@@ -3,8 +3,8 @@ from __future__ import absolute_import, division, print_function
 from abc import ABCMeta, abstractmethod
 import logging
 
-from .data_factories import load_data
-from .util import CallbackMixin
+from glue.core.data_factories import load_data
+from glue.core.util import CallbackMixin
 
 MAX_UNDO = 50
 """

--- a/glue/core/component.py
+++ b/glue/core/component.py
@@ -6,9 +6,9 @@ import warnings
 import numpy as np
 import pandas as pd
 
-from ..utils import unique, shape_to_string, coerce_numeric, check_sorted
+from glue.utils import unique, shape_to_string, coerce_numeric, check_sorted
 
-from .util import row_lookup
+from glue.core.util import row_lookup
 
 __all__ = ['Component', 'DerivedComponent',
            'CategoricalComponent', 'CoordinateComponent']

--- a/glue/core/component_id.py
+++ b/glue/core/component_id.py
@@ -4,10 +4,10 @@ import operator
 
 import numpy as np
 
-from ..external import six
+from glue.external import six
 
-from .subset import InequalitySubsetState
-from .component_link import BinaryComponentLink
+from glue.core.subset import InequalitySubsetState
+from glue.core.component_link import BinaryComponentLink
 
 __all__ = ['ComponentID', 'ComponentIDDict']
 

--- a/glue/core/component_link.py
+++ b/glue/core/component_link.py
@@ -6,10 +6,10 @@ import numbers
 
 import numpy as np
 
-from .util import join_component_view
-from .subset import InequalitySubsetState
-from .contracts import contract, ContractsMeta
-from ..external.six import add_metaclass
+from glue.core.util import join_component_view
+from glue.core.subset import InequalitySubsetState
+from glue.core.contracts import contract, ContractsMeta
+from glue.external.six import add_metaclass
 
 __all__ = ['ComponentLink', 'BinaryComponentLink']
 
@@ -73,7 +73,7 @@ class ComponentLink(object):
             numpy arrays
 
         """
-        from .data import ComponentID
+        from glue.core.data import ComponentID
 
         self._from = comp_from
         self._to = comp_to
@@ -307,7 +307,7 @@ class BinaryComponentLink(ComponentLink):
     """
 
     def __init__(self, left, right, op):
-        from .data import ComponentID
+        from glue.core.data import ComponentID
 
         self._left = left
         self._right = right

--- a/glue/core/contracts.py
+++ b/glue/core/contracts.py
@@ -20,8 +20,8 @@ and never directly from the contracts package.
 from numpy import ndarray, s_
 from pandas import Series
 
-from ..config import enable_contracts
-from ..external.six import string_types
+from glue.config import enable_contracts
+from glue.external.six import string_types
 
 
 def _build_custom_contracts():
@@ -35,12 +35,12 @@ def _build_custom_contracts():
         """
         Value is a ComponentID or a string
         """
-        from . import ComponentID
+        from glue.core import ComponentID
         return isinstance(value, (ComponentID, string_types))
 
     @new_contract
     def component_like(value):
-        from . import Component, ComponentLink
+        from glue.core import Component, ComponentLink
         return isinstance(value, (Component, ComponentLink,
                                   ndarray, list, Series))
 
@@ -65,7 +65,7 @@ def _build_custom_contracts():
 
     @new_contract
     def data_view(value):
-        from . import ComponentID
+        from glue.core import ComponentID
 
         if value is None:
             return

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -5,22 +5,22 @@ from collections import OrderedDict
 import numpy as np
 import pandas as pd
 
-from ..config import settings
-from ..external import six
-from ..utils import view_shape
+from glue.config import settings
+from glue.external import six
+from glue.utils import view_shape
 
-from .contracts import contract
-from .coordinates import Coordinates
-from .visual import VisualAttributes
-from .exceptions import IncompatibleAttribute
+from glue.core.contracts import contract
+from glue.core.coordinates import Coordinates
+from glue.core.visual import VisualAttributes
+from glue.core.exceptions import IncompatibleAttribute
 
-from .component_link import ComponentLink, CoordinateComponentLink
+from glue.core.component_link import ComponentLink, CoordinateComponentLink
 
-from .subset import Subset, SubsetState
-from .hub import Hub
-from .util import split_component_view
-from .decorators import clear_cache
-from .message import (DataUpdateMessage,
+from glue.core.subset import Subset, SubsetState
+from glue.core.hub import Hub
+from glue.core.util import split_component_view
+from glue.core.decorators import clear_cache
+from glue.core.message import (DataUpdateMessage,
                       DataAddComponentMessage, NumericalDataChangedMessage,
                       SubsetCreateMessage, ComponentsChangedMessage,
                       ComponentReplacedMessage)
@@ -28,8 +28,8 @@ from .message import (DataUpdateMessage,
 # Note: leave all the following imports for component and component_id since
 # they are here for backward-compatibility (the code used to live in this 
 # file)
-from .component import Component, DerivedComponent, CoordinateComponent, CategoricalComponent
-from .component_id import ComponentID, ComponentIDDict
+from glue.core.component import Component, DerivedComponent, CoordinateComponent, CategoricalComponent
+from glue.core.component_id import ComponentID, ComponentIDDict
 
 __all__ = ['Data']
 

--- a/glue/core/data_collection.py
+++ b/glue/core/data_collection.py
@@ -1,16 +1,16 @@
 from __future__ import absolute_import, division, print_function
 
-from .hub import Hub, HubListener
-from .data import Data
-from .link_manager import LinkManager
-from .registry import Registry
-from .message import (DataCollectionAddMessage,
+from glue.core.hub import Hub, HubListener
+from glue.core.data import Data
+from glue.core.link_manager import LinkManager
+from glue.core.registry import Registry
+from glue.core.message import (DataCollectionAddMessage,
                       DataCollectionDeleteMessage,
                       DataAddComponentMessage)
-from .util import disambiguate
+from glue.core.util import disambiguate
 
-from ..config import settings
-from ..utils import as_list
+from glue.config import settings
+from glue.utils import as_list
 
 __all__ = ['DataCollection']
 
@@ -187,7 +187,7 @@ class DataCollection(HubListener):
 
         :returns: A new :class:`~glue.core.subset_group.SubsetGroup`
         """
-        from .subset_group import SubsetGroup
+        from glue.core.subset_group import SubsetGroup
         color = settings.SUBSET_COLORS[self._sg_count % len(settings.SUBSET_COLORS)]
         self._sg_count += 1
         label = label or "%i" % (self._sg_count)

--- a/glue/core/data_factories/astropy_table.py
+++ b/glue/core/data_factories/astropy_table.py
@@ -2,10 +2,10 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 
-from ..data import Component, Data
-from ...config import data_factory
+from glue.core.data import Component, Data
+from glue.config import data_factory
 
-from .helpers import has_extension
+from glue.core.data_factories.helpers import has_extension
 
 __all__ = ['astropy_tabular_data', 'sextractor_factory', 'cds_factory',
            'daophot_factory', 'ipac_factory', 'aastex_factory',

--- a/glue/core/data_factories/dendrogram.py
+++ b/glue/core/data_factories/dendrogram.py
@@ -1,10 +1,10 @@
 from __future__ import absolute_import, division, print_function
 
-from .helpers import has_extension
+from glue.core.data_factories.helpers import has_extension
 
 __all__ = []
 
 try:
-    from .dendro_loader import load_dendro, is_dendro
+    from glue.core.data_factories.dendro_loader import load_dendro, is_dendro
 except ImportError:
     pass

--- a/glue/core/data_factories/deprecated.py
+++ b/glue/core/data_factories/deprecated.py
@@ -1,12 +1,12 @@
 from __future__ import absolute_import, division, print_function
 
-from ..data import Component, Data
-from ...utils import file_format
-from ..coordinates import coordinates_from_header
-from ...config import data_factory
+from glue.core.data import Component, Data
+from glue.utils import file_format
+from glue.core.coordinates import coordinates_from_header
+from glue.config import data_factory
 
-from .fits import is_fits, is_image_hdu
-from .hdf5 import is_hdf5, extract_hdf5_datasets
+from glue.core.data_factories.fits import is_fits, is_image_hdu
+from glue.core.data_factories.hdf5 import is_hdf5, extract_hdf5_datasets
 
 __all__ = ['is_gridded_data', 'gridded_data']
 

--- a/glue/core/data_factories/excel.py
+++ b/glue/core/data_factories/excel.py
@@ -2,10 +2,10 @@ from __future__ import absolute_import, division, print_function
 
 import os
 
-from ...config import data_factory
+from glue.config import data_factory
 
-from .pandas import panda_process
-from .helpers import has_extension
+from glue.core.data_factories.pandas import panda_process
+from glue.core.data_factories.helpers import has_extension
 
 __all__ = []
 

--- a/glue/core/data_factories/fits.py
+++ b/glue/core/data_factories/fits.py
@@ -4,9 +4,9 @@ import warnings
 from os.path import basename
 from collections import OrderedDict
 
-from ...config import data_factory
-from ..data import Component, Data
-from ..coordinates import coordinates_from_header
+from glue.config import data_factory
+from glue.core.data import Component, Data
+from glue.core.coordinates import coordinates_from_header
 
 __all__ = ['is_fits', 'fits_reader', 'is_casalike', 'casalike_cube']
 

--- a/glue/core/data_factories/hdf5.py
+++ b/glue/core/data_factories/hdf5.py
@@ -4,8 +4,8 @@ import os
 import warnings
 from collections import OrderedDict
 
-from ..data import Component, Data
-from ...config import data_factory
+from glue.core.data import Component, Data
+from glue.config import data_factory
 
 __all__ = ['is_hdf5', 'hdf5_reader']
 

--- a/glue/core/data_factories/helpers.py
+++ b/glue/core/data_factories/helpers.py
@@ -27,11 +27,11 @@ from __future__ import absolute_import, division, print_function
 import os
 import warnings
 
-from ..data import Component, Data
-from ...utils import as_list
-from ...backends import get_backend
-from ...config import auto_refresh, data_factory
-from ..contracts import contract
+from glue.core.data import Component, Data
+from glue.utils import as_list
+from glue.backends import get_backend
+from glue.config import auto_refresh, data_factory
+from glue.core.contracts import contract
 
 __all__ = ['FileWatcher', 'LoadLog',
            'auto_data', 'data_label', 'find_factory',
@@ -218,7 +218,7 @@ def load_data(path, factory=None, **kwargs):
 
     Extra keywords are passed through to factory functions
     """
-    from ...qglue import parse_data
+    from glue.qglue import parse_data
 
     def as_data_objects(ds, lbl):
         # pack other container types like astropy tables
@@ -272,7 +272,7 @@ def get_default_factory(extension):  # pragma: no cover
 @contract(filename='string')
 def find_factory(filename, **kwargs):
 
-    from ...config import data_factory
+    from glue.config import data_factory
 
     # We no longer try the 'default' factory first because we actually need to
     # try all identifiers and select the one to use based on the priority. This

--- a/glue/core/data_factories/image.py
+++ b/glue/core/data_factories/image.py
@@ -2,11 +2,11 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 
-from ..data import Data
+from glue.core.data import Data
 
-from .helpers import has_extension, set_default_factory
-from ..coordinates import coordinates_from_wcs
-from ...config import data_factory
+from glue.core.data_factories.helpers import has_extension, set_default_factory
+from glue.core.coordinates import coordinates_from_wcs
+from glue.config import data_factory
 
 IMG_FMT = ['jpg', 'jpeg', 'bmp', 'png', 'tiff', 'tif']
 

--- a/glue/core/data_factories/pandas.py
+++ b/glue/core/data_factories/pandas.py
@@ -2,13 +2,13 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 
-from ..data import Data
-from ..component import Component, CategoricalComponent
+from glue.core.data import Data
+from glue.core.component import Component, CategoricalComponent
 
-from .helpers import has_extension
+from glue.core.data_factories.helpers import has_extension
 
-from ...external import six
-from ...config import data_factory
+from glue.external import six
+from glue.config import data_factory
 
 __all__ = ['pandas_read_table']
 

--- a/glue/core/data_factories/tables.py
+++ b/glue/core/data_factories/tables.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import, division, print_function
 
-from ...config import data_factory
+from glue.config import data_factory
 
-from .helpers import has_extension
+from glue.core.data_factories.helpers import has_extension
 
 __all__ = ['tabular_data']
 
@@ -13,8 +13,8 @@ __all__ = ['tabular_data']
                                        'dat.gz'),
               priority=1)
 def tabular_data(path, **kwargs):
-    from .astropy_table import astropy_tabular_data
-    from .pandas import pandas_read_table
+    from glue.core.data_factories.astropy_table import astropy_tabular_data
+    from glue.core.data_factories.pandas import pandas_read_table
     for fac in [astropy_tabular_data, pandas_read_table]:
         try:
             return fac(path, **kwargs)

--- a/glue/core/data_factories/tests/test_data_factories.py
+++ b/glue/core/data_factories/tests/test_data_factories.py
@@ -7,15 +7,15 @@ from mock import MagicMock
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
 
-from ... import data_factories as df
-from ...data import Data
-from ...component import CategoricalComponent
-from ...tests.util import make_file
+from glue.core import data_factories as df
+from glue.core.data import Data
+from glue.core.component import CategoricalComponent
+from glue.core.tests.util import make_file
 
-from ....tests.helpers import (requires_astropy, requires_astropy_ge_03,
+from glue.tests.helpers import (requires_astropy, requires_astropy_ge_03,
                                requires_pil_or_skimage)
 
-from ....config import data_factory
+from glue.config import data_factory
 
 
 def test_load_data_auto_assigns_label():

--- a/glue/core/data_factories/tests/test_excel.py
+++ b/glue/core/data_factories/tests/test_excel.py
@@ -4,10 +4,10 @@ import os
 
 from numpy.testing import assert_array_equal
 
-from ....tests.helpers import requires_xlrd
+from glue.tests.helpers import requires_xlrd
 
-from ... import data_factories as df
-from ...tests.util import make_file
+from glue.core import data_factories as df
+from glue.core.tests.util import make_file
 
 DATA = os.path.join(os.path.dirname(__file__), 'data')
 

--- a/glue/core/data_factories/tests/test_fits.py
+++ b/glue/core/data_factories/tests/test_fits.py
@@ -7,10 +7,10 @@ from copy import deepcopy
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from ...tests.util import make_file
-from ....tests.helpers import requires_astropy, requires_astropy_ge_04
+from glue.core.tests.util import make_file
+from glue.tests.helpers import requires_astropy, requires_astropy_ge_04
 
-from ... import data_factories as df
+from glue.core import data_factories as df
 from ..fits import fits_reader
 
 DATA = os.path.join(os.path.dirname(__file__), 'data')

--- a/glue/core/data_factories/tests/test_hdf5.py
+++ b/glue/core/data_factories/tests/test_hdf5.py
@@ -2,10 +2,10 @@ import pytest
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from ... import data_factories as df
+from glue.core import data_factories as df
 from ..helpers import auto_data
-from ...tests.util import make_file
-from ....tests.helpers import requires_h5py, requires_astropy
+from glue.core.tests.util import make_file
+from glue.tests.helpers import requires_h5py, requires_astropy
 
 
 @requires_h5py

--- a/glue/core/edit_subset_mode.py
+++ b/glue/core/edit_subset_mode.py
@@ -11,11 +11,11 @@ from __future__ import absolute_import, division, print_function
 
 import logging
 
-from .decorators import singleton
-from .data import Data
-from .data_collection import DataCollection
-from ..utils import as_list
-from .contracts import contract
+from glue.core.decorators import singleton
+from glue.core.data import Data
+from glue.core.data_collection import DataCollection
+from glue.utils import as_list
+from glue.core.contracts import contract
 
 
 @singleton

--- a/glue/core/fitters.py
+++ b/glue/core/fitters.py
@@ -8,7 +8,7 @@ help with using custom fitting utilities in Glue.
 
 import numpy as np
 
-from .simpleforms import IntOption, Option
+from glue.core.simpleforms import IntOption, Option
 
 
 __all__ = ['BaseFitter1D',

--- a/glue/core/glue_pickle.py
+++ b/glue/core/glue_pickle.py
@@ -1,5 +1,5 @@
 import logging
-from ..external.six.moves.cPickle import dumps, loads
+from glue.external.six.moves.cPickle import dumps, loads
 
 try:
     from dill import dumps, loads

--- a/glue/core/hub.py
+++ b/glue/core/hub.py
@@ -4,8 +4,8 @@ import logging
 from inspect import getmro
 from collections import defaultdict
 
-from .message import Message
-from .exceptions import InvalidSubscriber, InvalidMessage
+from glue.core.message import Message
+from glue.core.exceptions import InvalidSubscriber, InvalidMessage
 
 __all__ = ['Hub', 'HubListener']
 
@@ -38,9 +38,9 @@ class Hub(object):
         # Dictionary of subscriptions
         self._subscriptions = defaultdict(dict)
 
-        from .data import Data
-        from .subset import Subset
-        from .data_collection import DataCollection
+        from glue.core.data import Data
+        from glue.core.subset import Subset
+        from glue.core.data_collection import DataCollection
 
         listeners = set(filter(lambda x: isinstance(x, HubListener), args))
         data = set(filter(lambda x: isinstance(x, Data), args))

--- a/glue/core/layout.py
+++ b/glue/core/layout.py
@@ -5,7 +5,7 @@ calculations to organize rectangular windows in a larger canvas
 
 from collections import Counter
 
-from ..external import six
+from glue.external import six
 
 
 class Rectangle(object):

--- a/glue/core/link_helpers.py
+++ b/glue/core/link_helpers.py
@@ -14,9 +14,9 @@ multiple ComponentLinks easily. They are meant to be passed to
 
 from __future__ import absolute_import, division, print_function
 
-from .component_link import ComponentLink
-from .data import ComponentID
-from ..external import six
+from glue.core.component_link import ComponentLink
+from glue.core.data import ComponentID
+from glue.external import six
 
 import numpy as np
 

--- a/glue/core/link_manager.py
+++ b/glue/core/link_manager.py
@@ -17,11 +17,11 @@ by chaining x2y and y2z.
 """
 import logging
 
-from .data import DerivedComponent, Data, ComponentID
-from .component_link import ComponentLink
-from .link_helpers import LinkCollection
-from ..external import six
-from .contracts import contract
+from glue.core.data import DerivedComponent, Data, ComponentID
+from glue.core.component_link import ComponentLink
+from glue.core.link_helpers import LinkCollection
+from glue.external import six
+from glue.core.contracts import contract
 
 
 def accessible_links(cids, links):

--- a/glue/core/message.py
+++ b/glue/core/message.py
@@ -58,7 +58,7 @@ class SubsetMessage(Message):
     """
 
     def __init__(self, sender, tag=None):
-        from .subset import Subset
+        from glue.core.subset import Subset
         if (not isinstance(sender, Subset)):
             raise TypeError("Sender must be a subset: %s"
                             % type(sender))
@@ -108,7 +108,7 @@ class DataMessage(Message):
     """
 
     def __init__(self, sender, tag=None):
-        from .data import Data
+        from glue.core.data import Data
         if (not isinstance(sender, Data)):
             raise TypeError("Sender must be a data instance: %s"
                             % type(sender))
@@ -149,7 +149,7 @@ class NumericalDataChangedMessage(DataMessage):
 class DataCollectionMessage(Message):
 
     def __init__(self, sender, tag=None):
-        from .data_collection import DataCollection
+        from glue.core.data_collection import DataCollection
         if (not isinstance(sender, DataCollection)):
             raise TypeError("Sender must be a DataCollection instance: %s"
                             % type(sender))

--- a/glue/core/parse.py
+++ b/glue/core/parse.py
@@ -2,9 +2,9 @@ from __future__ import absolute_import, division, print_function
 
 import re
 
-from .data import ComponentID
-from .subset import Subset, SubsetState
-from .component_link import ComponentLink
+from glue.core.data import ComponentID
+from glue.core.subset import Subset, SubsetState
+from glue.core.component_link import ComponentLink
 
 TAG_RE = re.compile('\{\s*(?P<tag>\S+)\s*\}')
 
@@ -136,7 +136,7 @@ class ParsedCommand(object):
         return _reference_list(self._cmd, self._references)
 
     def evaluate(self, data, view=None):
-        from .. import env
+        from glue import env
         # pylint: disable=W0613, W0612
         references = self._references
         cmd = _dereference(self._cmd, self._references)

--- a/glue/core/registry.py
+++ b/glue/core/registry.py
@@ -3,8 +3,8 @@ from __future__ import absolute_import, division, print_function
 from collections import defaultdict
 from functools import wraps
 
-from .decorators import singleton
-from .util import disambiguate
+from glue.core.decorators import singleton
+from glue.core.util import disambiguate
 
 
 @singleton

--- a/glue/core/roi.py
+++ b/glue/core/roi.py
@@ -10,7 +10,7 @@ import copy
 
 np.seterr(all='ignore')
 
-from .exceptions import UndefinedROI
+from glue.core.exceptions import UndefinedROI
 
 __all__ = ['Roi', 'RectangularROI', 'CircularROI', 'PolygonalROI',
            'AbstractMplRoi', 'MplRectangularROI', 'MplCircularROI',

--- a/glue/core/session.py
+++ b/glue/core/session.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from . import DataCollection, CommandStack
+from glue.core import DataCollection, CommandStack
 
 
 class Session(object):
@@ -17,5 +17,5 @@ class Session(object):
         self.command_stack.session = self
 
         # set the global data_collection for subset updates
-        from .edit_subset_mode import EditSubsetMode
+        from glue.core.edit_subset_mode import EditSubsetMode
         EditSubsetMode().data_collection = self.data_collection

--- a/glue/core/state.py
+++ b/glue/core/state.py
@@ -63,19 +63,19 @@ from inspect import isgeneratorfunction
 
 import numpy as np
 
-from .subset import (OPSYM, SYMOP, CompositeSubsetState,
+from glue.core.subset import (OPSYM, SYMOP, CompositeSubsetState,
                      SubsetState, Subset, RoiSubsetState,
                      InequalitySubsetState, RangeSubsetState)
-from .data import (Data, Component, ComponentID, DerivedComponent,
+from glue.core.data import (Data, Component, ComponentID, DerivedComponent,
                    CoordinateComponent)
-from . import (VisualAttributes, ComponentLink, DataCollection)
-from .component_link import CoordinateComponentLink
-from ..utils import lookup_class
-from .roi import Roi
-from . import glue_pickle as gp
-from .. import core
-from .subset_group import coerce_subset_groups
-from ..external import six
+from glue.core import (VisualAttributes, ComponentLink, DataCollection)
+from glue.core.component_link import CoordinateComponentLink
+from glue.utils import lookup_class
+from glue.core.roi import Roi
+from glue.core import glue_pickle as gp
+from glue import core
+from glue.core.subset_group import coerce_subset_groups
+from glue.external import six
 from io import BytesIO
 from base64 import b64encode, b64decode
 

--- a/glue/core/subset.py
+++ b/glue/core/subset.py
@@ -5,18 +5,18 @@ import numbers
 
 import numpy as np
 
-from .visual import VisualAttributes
-from .decorators import memoize
-from .message import SubsetDeleteMessage, SubsetUpdateMessage
-from .exceptions import IncompatibleAttribute
-from .registry import Registry
-from .util import split_component_view
-from ..utils import view_shape
-from ..external.six import PY3
-from .contracts import contract
-from .roi import CategoricalRoi
+from glue.core.visual import VisualAttributes
+from glue.core.decorators import memoize
+from glue.core.message import SubsetDeleteMessage, SubsetUpdateMessage
+from glue.core.exceptions import IncompatibleAttribute
+from glue.core.registry import Registry
+from glue.core.util import split_component_view
+from glue.utils import view_shape
+from glue.external.six import PY3
+from glue.core.contracts import contract
+from glue.core.roi import CategoricalRoi
 
-from ..config import settings
+from glue.config import settings
 
 __all__ = ['Subset', 'SubsetState', 'RoiSubsetState', 'CompositeSubsetState',
            'OrState', 'AndState', 'XorState', 'InvertState',
@@ -648,10 +648,10 @@ class ElementSubsetState(SubsetState):
 class InequalitySubsetState(SubsetState):
 
     def __init__(self, left, right, op):
-        from .component_link import ComponentLink
+        from glue.core.component_link import ComponentLink
 
         super(InequalitySubsetState, self).__init__()
-        from .data import ComponentID
+        from glue.core.data import ComponentID
         valid_ops = [operator.gt, operator.ge,
                      operator.lt, operator.le,
                      operator.eq, operator.ne]
@@ -685,7 +685,7 @@ class InequalitySubsetState(SubsetState):
 
     @memoize
     def to_mask(self, data, view=None):
-        from .data import ComponentID
+        from glue.core.data import ComponentID
         left = self._left
         if not isinstance(self._left, numbers.Number):
             left = data[self._left, view]

--- a/glue/core/subset_group.py
+++ b/glue/core/subset_group.py
@@ -15,18 +15,18 @@ or Data.new_subset directly
 """
 from warnings import warn
 
-from . import Subset
-from .subset import SubsetState
-from .util import Pointer
-from .hub import HubListener
-from .visual import VisualAttributes
-from .message import (DataCollectionAddMessage,
+from glue.core import Subset
+from glue.core.subset import SubsetState
+from glue.core.util import Pointer
+from glue.core.hub import HubListener
+from glue.core.visual import VisualAttributes
+from glue.core.message import (DataCollectionAddMessage,
                       DataCollectionDeleteMessage
                       )
-from .contracts import contract
+from glue.core.contracts import contract
 
-from ..config import settings
-from ..external import six
+from glue.config import settings
+from glue.external import six
 
 __all__ = ['GroupedSubset', 'SubsetGroup']
 

--- a/glue/core/tests/test_command.py
+++ b/glue/core/tests/test_command.py
@@ -4,12 +4,12 @@ from mock import MagicMock
 import pytest
 import numpy as np
 
-from ... import core
+from glue import core
 from .. import roi
 from .. import command as c
 from ..data_factories import tabular_data
 from .util import simple_session, simple_catalog
-from ...external.six.moves import range as xrange
+from glue.external.six.moves import range as xrange
 
 
 class TestCommandStack(object):

--- a/glue/core/tests/test_component.py
+++ b/glue/core/tests/test_component.py
@@ -14,9 +14,9 @@ from ..component import (Component, DerivedComponent, CoordinateComponent,
                          CategoricalComponent)
 from ..component_id import ComponentID
 
-from ... import core
-from ...tests.helpers import requires_astropy
-from ...external import six
+from glue import core
+from glue.tests.helpers import requires_astropy
+from glue.external import six
 
 
 VIEWS = (np.s_[:], np.s_[1], np.s_[::-1], np.s_[0, :])

--- a/glue/core/tests/test_coordinate_links.py
+++ b/glue/core/tests/test_coordinate_links.py
@@ -7,7 +7,7 @@ from ..coordinates import coordinates_from_header
 from ..link_helpers import LinkSame
 from .util import make_file
 
-from ...tests.helpers import requires_astropy, ASTROPY_INSTALLED
+from glue.tests.helpers import requires_astropy, ASTROPY_INSTALLED
 
 if ASTROPY_INSTALLED:
     from astropy.io import fits

--- a/glue/core/tests/test_coordinates.py
+++ b/glue/core/tests/test_coordinates.py
@@ -13,7 +13,7 @@ from ..coordinates import (coordinates_from_header,
                            Coordinates,
                            header_from_string)
 
-from ...tests.helpers import requires_astropy
+from glue.tests.helpers import requires_astropy
 
 
 @requires_astropy

--- a/glue/core/tests/test_data.py
+++ b/glue/core/tests/test_data.py
@@ -15,8 +15,8 @@ from ..hub import Hub
 from ..exceptions import IncompatibleAttribute
 from ..component_link import ComponentLink
 from ..registry import Registry
-from ... import core
-from ...external import six
+from glue import core
+from glue.external import six
 
 
 class _TestCoordinates(Coordinates):

--- a/glue/core/tests/test_fitters.py
+++ b/glue/core/tests/test_fitters.py
@@ -9,7 +9,7 @@ needs_modeling = pytest.mark.skipif("False", reason='')
 from ..fitters import (PolynomialFitter, IntOption,
                        BasicGaussianFitter)
 
-from ...tests.helpers import requires_scipy, requires_astropy_ge_03, ASTROPY_GE_03_INSTALLED
+from glue.tests.helpers import requires_scipy, requires_astropy_ge_03, ASTROPY_GE_03_INSTALLED
 
 if ASTROPY_GE_03_INSTALLED:
     from astropy.modeling.models import Gaussian1D

--- a/glue/core/tests/test_link_helpers.py
+++ b/glue/core/tests/test_link_helpers.py
@@ -8,7 +8,7 @@ import numpy as np
 from .. import link_helpers as lh
 from ..link_helpers import (LinkTwoWay, MultiLink,
                             LinkSame, LinkAligned)
-from ...core import ComponentID, Data, Component, DataCollection
+from glue.core import ComponentID, Data, Component, DataCollection
 
 R, D, L, B = (ComponentID('ra'), ComponentID('dec'),
               ComponentID('lon'), ComponentID('lat'))

--- a/glue/core/tests/test_pandas.py
+++ b/glue/core/tests/test_pandas.py
@@ -11,7 +11,7 @@ from ..data import Data
 from ..component_id import ComponentID
 from ..component import (Component, DerivedComponent, CoordinateComponent,
                          CategoricalComponent)
-from ... import core
+from glue import core
 
 
 class TestPandasConversion(object):

--- a/glue/core/tests/test_session_back_compat.py
+++ b/glue/core/tests/test_session_back_compat.py
@@ -3,7 +3,7 @@
 import os
 import numpy as np
 
-from ...tests.helpers import requires_astropy, requires_h5py
+from glue.tests.helpers import requires_astropy, requires_h5py
 
 from ..state import GlueUnSerializer
 

--- a/glue/core/tests/test_state.py
+++ b/glue/core/tests/test_state.py
@@ -6,19 +6,19 @@ import pytest
 
 from ..state import (GlueSerializer, GlueUnSerializer,
                      saver, loader, VersionedDict)
-from ...external import six
+from glue.external import six
 
-from ... import core
-from ...qt.glue_application import GlueApplication
-from ...qt.widgets.scatter_widget import ScatterWidget
-from ...qt.widgets.image_widget import ImageWidget
-from ...qt.widgets.histogram_widget import HistogramWidget
+from glue import core
+from glue.qt.glue_application import GlueApplication
+from glue.qt.widgets.scatter_widget import ScatterWidget
+from glue.qt.widgets.image_widget import ImageWidget
+from glue.qt.widgets.histogram_widget import HistogramWidget
 from .util import make_file
 from ..data_factories import load_data
 from ..data_factories.tests.test_fits import TEST_FITS_DATA
 from io import BytesIO
 
-from ...tests.helpers import requires_astropy
+from glue.tests.helpers import requires_astropy
 
 
 def clone(object, include_data=False):

--- a/glue/core/tests/test_subset.py
+++ b/glue/core/tests/test_subset.py
@@ -21,7 +21,7 @@ from ..message import SubsetDeleteMessage
 from ..registry import Registry
 from .test_state import clone
 
-from ...tests.helpers import requires_astropy
+from glue.tests.helpers import requires_astropy
 
 
 class TestSubset(object):

--- a/glue/core/tests/util.py
+++ b/glue/core/tests/util.py
@@ -7,8 +7,8 @@ import zlib
 
 from mock import MagicMock
 
-from ... import core
-from ...core.application_base import Application
+from glue import core
+from glue.core.application_base import Application
 
 
 @contextmanager

--- a/glue/core/util.py
+++ b/glue/core/util.py
@@ -8,8 +8,8 @@ from itertools import count
 import numpy as np
 import pandas as pd
 
-from ..external.six.moves import reduce
-from ..external.six import string_types
+from glue.external.six.moves import reduce
+from glue.external.six import string_types
 
 
 __all__ = ["identity", "relim", "split_component_view", "join_component_view",
@@ -132,7 +132,7 @@ def facet_subsets(data_collection, cid, lo=None, hi=None, steps=5,
     Labels the subsets ``m_1`` and ``m_2``
 
     """
-    from .exceptions import IncompatibleAttribute
+    from glue.core.exceptions import IncompatibleAttribute
     if lo is None or hi is None:
         for data in data_collection:
             try:

--- a/glue/core/visual.py
+++ b/glue/core/visual.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from ..config import settings
+from glue.config import settings
 
 # Define acceptable line styles
 VALID_LINESTYLES = ['solid', 'dashed', 'dash-dot', 'dotted', 'none']

--- a/glue/default_config.py
+++ b/glue/default_config.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from .config import qt_client, data_factory, link_function
+from glue.config import qt_client, data_factory, link_function
 
 
 """Declare any extra link functions like this"""

--- a/glue/main.py
+++ b/glue/main.py
@@ -4,9 +4,9 @@ from __future__ import absolute_import, division, print_function
 
 import sys
 import optparse
-from .logger import logger
+from glue.logger import logger
 
-from . import __version__
+from glue import __version__
 
 
 def parse(argv):
@@ -96,8 +96,8 @@ def die_on_error(msg):
                 return func(*args, **kwargs)
             except Exception as e:
                 import traceback
-                from . import qt
-                from .utils.qt import QMessageBoxPatched as QMessageBox
+                from glue import qt
+                from glue.utils.qt import QMessageBoxPatched as QMessageBox
                 m = "%s\n%s" % (msg, e)
                 detail = str(traceback.format_exc())
                 if len(m) > 500:
@@ -117,15 +117,15 @@ def die_on_error(msg):
 @die_on_error("Error restoring Glue session")
 def restore_session(gluefile):
     """Load a .glu file and return a DataCollection, Hub tuple"""
-    from .qt.glue_application import GlueApplication
+    from glue.qt.glue_application import GlueApplication
     return GlueApplication.restore_session(gluefile)
 
 
 @die_on_error("Error reading data file")
 def load_data_files(datafiles):
     """Load data files and return a DataCollection"""
-    from .core.data_collection import DataCollection
-    from .core.data_factories import auto_data, load_data
+    from glue.core.data_collection import DataCollection
+    from glue.core.data_factories import auto_data, load_data
 
     dc = DataCollection()
     for df in datafiles:
@@ -134,7 +134,7 @@ def load_data_files(datafiles):
 
 
 def run_tests():
-    from . import test
+    from glue import test
     test()
 
 
@@ -151,7 +151,7 @@ def start_glue(gluefile=None, config=None, datafiles=None):
     :type datafiles: list of str
     """
     import glue
-    from .qt.glue_application import GlueApplication
+    from glue.qt.glue_application import GlueApplication
 
     # Start off by loading plugins. We need to do this before restoring
     # the session or loading the configuration since these may use existing
@@ -199,8 +199,8 @@ def execute_script(script):
 
 def get_splash():
     """Instantiate a splash screen"""
-    from .external.qt.QtGui import QSplashScreen, QPixmap
-    from .external.qt.QtCore import Qt
+    from glue.external.qt.QtGui import QSplashScreen, QPixmap
+    from glue.external.qt.QtCore import Qt
     import os
 
     pth = os.path.join(os.path.dirname(__file__), 'logo.png')
@@ -264,7 +264,7 @@ def load_plugins():
     import setuptools
     logger.info("Loading external plugins using setuptools=={0}".format(setuptools.__version__))
 
-    from ._plugin_helpers import iter_plugin_entry_points, PluginConfig
+    from glue._plugin_helpers import iter_plugin_entry_points, PluginConfig
     config = PluginConfig.load()
 
     for item in iter_plugin_entry_points():

--- a/glue/plugins/coordinate_helpers/deprecated.py
+++ b/glue/plugins/coordinate_helpers/deprecated.py
@@ -1,7 +1,7 @@
 from astropy import units as u
 from astropy.coordinates import FK5, Galactic
 
-from ...core.link_helpers import MultiLink
+from glue.core.link_helpers import MultiLink
 
 
 def fk52gal(ra, dec):

--- a/glue/plugins/coordinate_helpers/link_helpers.py
+++ b/glue/plugins/coordinate_helpers/link_helpers.py
@@ -3,8 +3,8 @@
 
 # Coordinate transforms (requires Astropy>)
 
-from ...config import link_function, link_helper
-from ...core.link_helpers import MultiLink
+from glue.config import link_function, link_helper
+from glue.core.link_helpers import MultiLink
 
 from astropy import units as u
 from astropy.coordinates import ICRS, FK5, FK4, Galactic

--- a/glue/plugins/coordinate_helpers/tests/test_link_helpers.py
+++ b/glue/plugins/coordinate_helpers/tests/test_link_helpers.py
@@ -1,13 +1,13 @@
 import numpy as np
 
 import pytest
-from ....tests.helpers import ASTROPY_GE_04_INSTALLED
+from glue.tests.helpers import ASTROPY_GE_04_INSTALLED
 
 if not ASTROPY_GE_04_INSTALLED:
     pytest.skip()
 
-from ....core.tests.test_link_helpers import check_link, check_using
-from ....core import ComponentLink, ComponentID
+from glue.core.tests.test_link_helpers import check_link, check_using
+from glue.core import ComponentLink, ComponentID
 
 from ..link_helpers import (Galactic_to_FK5, FK4_to_FK5, ICRS_to_FK5,
                             Galactic_to_FK4, ICRS_to_FK4, ICRS_to_Galactic)

--- a/glue/plugins/dendro_viewer/__init__.py
+++ b/glue/plugins/dendro_viewer/__init__.py
@@ -1,4 +1,4 @@
 def setup():
     from .qt_widget import DendroWidget
-    from ...config import qt_client
+    from glue.config import qt_client
     qt_client.add(DendroWidget)

--- a/glue/plugins/dendro_viewer/client.py
+++ b/glue/plugins/dendro_viewer/client.py
@@ -4,15 +4,15 @@ A plot to visualize trees
 
 import numpy as np
 
-from ...core.data import IncompatibleAttribute, Data
-from ...core.callback_property import CallbackProperty, add_callback, delay_callback
-from ...core.roi import PointROI
-from ...core.subset import CategorySubsetState
-from ...core.edit_subset_mode import EditSubsetMode
-from ...utils import nonpartial, lookup_class
-from ...clients.viz_client import GenericMplClient
+from glue.core.data import IncompatibleAttribute, Data
+from glue.core.callback_property import CallbackProperty, add_callback, delay_callback
+from glue.core.roi import PointROI
+from glue.core.subset import CategorySubsetState
+from glue.core.edit_subset_mode import EditSubsetMode
+from glue.utils import nonpartial, lookup_class
+from glue.clients.viz_client import GenericMplClient
 
-from .layer_artist import DendroLayerArtist
+from glue.plugins.dendro_viewer.layer_artist import DendroLayerArtist
 
 
 class DendroClient(GenericMplClient):

--- a/glue/plugins/dendro_viewer/data_factory.py
+++ b/glue/plugins/dendro_viewer/data_factory.py
@@ -7,11 +7,11 @@ import numpy as np
 
 from astrodendro import Dendrogram
 
-from ...core.data import Data
-from ...core.data_factories.fits import is_fits
-from ...core.data_factories.hdf5 import is_hdf5
+from glue.core.data import Data
+from glue.core.data_factories.fits import is_fits
+from glue.core.data_factories.hdf5 import is_hdf5
 
-from ...config import data_factory
+from glue.config import data_factory
 
 __all__ = ['load_dendro', 'is_dendro']
 

--- a/glue/plugins/dendro_viewer/layer_artist.py
+++ b/glue/plugins/dendro_viewer/layer_artist.py
@@ -2,9 +2,9 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 
-from ...clients.layer_artist import LayerArtist, ChangedTrigger
-from ...core.subset import Subset
-from ...core.exceptions import IncompatibleAttribute
+from glue.clients.layer_artist import LayerArtist, ChangedTrigger
+from glue.core.subset import Subset
+from glue.core.exceptions import IncompatibleAttribute
 
 
 class DendroLayerArtist(LayerArtist):

--- a/glue/plugins/dendro_viewer/qt_widget.py
+++ b/glue/plugins/dendro_viewer/qt_widget.py
@@ -1,16 +1,16 @@
-from ... import core
-from ...external.qt import QtGui
+from glue import core
+from glue.external.qt import QtGui
 
-from ...qt.widgets.data_viewer import DataViewer
-from ...qt.widgets.mpl_widget import MplWidget, defer_draw
-from ...qt.widget_properties import (ButtonProperty, CurrentComboProperty,
+from glue.qt.widgets.data_viewer import DataViewer
+from glue.qt.widgets.mpl_widget import MplWidget, defer_draw
+from glue.qt.widget_properties import (ButtonProperty, CurrentComboProperty,
                                  connect_bool_button, connect_current_combo)
-from ...qt.glue_toolbar import GlueToolbar
+from glue.qt.glue_toolbar import GlueToolbar
 
-from ...qt.qtutil import load_ui, nonpartial
-from ...qt.mouse_mode import PickMode
+from glue.qt.qtutil import load_ui, nonpartial
+from glue.qt.mouse_mode import PickMode
 
-from .client import DendroClient
+from glue.plugins.dendro_viewer.client import DendroClient
 
 
 class DendroWidget(DataViewer):
@@ -145,7 +145,7 @@ class DendroWidget(DataViewer):
     @defer_draw
     def restore_layers(self, rec, context):
 
-        from ...core.callback_property import delay_callback
+        from glue.core.callback_property import delay_callback
 
 
         with delay_callback(self.client, 'height_attr',

--- a/glue/plugins/dendro_viewer/tests/test_data_factory.py
+++ b/glue/plugins/dendro_viewer/tests/test_data_factory.py
@@ -6,11 +6,11 @@ import pytest
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from ....core import data_factories as df
+from glue.core import data_factories as df
 
-from ....core.data_factories.helpers import find_factory
-from ....core.tests.util import make_file
-from ....tests.helpers import requires_astrodendro
+from glue.core.data_factories.helpers import find_factory
+from glue.core.tests.util import make_file
+from glue.tests.helpers import requires_astrodendro
 
 DATA = os.path.join(os.path.dirname(__file__), 'data')
 

--- a/glue/plugins/dendro_viewer/tests/test_dendro_client.py
+++ b/glue/plugins/dendro_viewer/tests/test_dendro_client.py
@@ -3,10 +3,10 @@ import numpy as np
 from numpy.testing import assert_array_equal
 from mock import MagicMock
 
-from ....clients.tests.util import renderless_figure
-from ....core import Data, Subset, DataCollection, Hub
-from ....core.roi import PointROI
-from ....core.edit_subset_mode import EditSubsetMode
+from glue.clients.tests.util import renderless_figure
+from glue.core import Data, Subset, DataCollection, Hub
+from glue.core.roi import PointROI
+from glue.core.edit_subset_mode import EditSubsetMode
 
 from ..client import DendroClient
 

--- a/glue/plugins/dendro_viewer/tests/test_qt_widget.py
+++ b/glue/plugins/dendro_viewer/tests/test_qt_widget.py
@@ -1,11 +1,11 @@
 # pylint: disable=I0011,W0613,W0201,W0212,E1101,E1103
 import pytest
 
-from ....qt.widgets.tests import simple_session
-from .... import core
+from glue.qt.widgets.tests import simple_session
+from glue import core
 
 from ..qt_widget import DendroWidget
-from ....qt.widgets.tests.test_data_viewer import BaseTestDataViewer
+from glue.qt.widgets.tests.test_data_viewer import BaseTestDataViewer
 
 def mock_data():
     return core.Data(label='d1', x=[1, 2, 3], y=[2, 3, 4])

--- a/glue/plugins/export_d3po.py
+++ b/glue/plugins/export_d3po.py
@@ -3,8 +3,8 @@ from __future__ import absolute_import, division, print_function
 import json
 import os
 
-from ..qt.widgets import ScatterWidget, HistogramWidget
-from ..core import Subset
+from glue.qt.widgets import ScatterWidget, HistogramWidget
+from glue.core import Subset
 
 
 def save_page(page, page_number, label, subset):
@@ -247,7 +247,7 @@ def launch(path):
 
 
 def setup():
-    from ..config import exporters
+    from glue.config import exporters
     exporters.add('D3PO', save_d3po, can_save_d3po, outmode='directory')
 
 

--- a/glue/plugins/export_plotly.py
+++ b/glue/plugins/export_plotly.py
@@ -6,8 +6,8 @@ try:
 except ImportError:
     plotly = None
 
-from ..qt.widgets import ScatterWidget, HistogramWidget
-from ..core.layout import Rectangle, snap_to_grid
+from glue.qt.widgets import ScatterWidget, HistogramWidget
+from glue.core.layout import Rectangle, snap_to_grid
 
 
 SYM = {'o': 'circle', 's': 'square', '+': 'cross', '^': 'triangle-up',
@@ -304,7 +304,7 @@ def save_plotly(application, label):
     plotly.plot(*args, **kwargs)
 
 def setup():
-    from ..config import exporters, settings
+    from glue.config import exporters, settings
     exporters.add('Plotly', save_plotly, can_save_plotly, outmode='label')
     settings.add('PLOTLY_USER', 'Glue')
     settings.add('PLOTLY_APIKEY', 't24aweai14')

--- a/glue/plugins/ginga_viewer/__init__.py
+++ b/glue/plugins/ginga_viewer/__init__.py
@@ -4,5 +4,5 @@ def setup():
     except ImportError:
         raise ImportError("ginga is required")
     else:
-        from ...config import qt_client
+        from glue.config import qt_client
         qt_client.add(GingaWidget)

--- a/glue/plugins/ginga_viewer/client.py
+++ b/glue/plugins/ginga_viewer/client.py
@@ -5,12 +5,12 @@ from time import time
 
 import numpy as np
 
-from ...core.exceptions import IncompatibleAttribute
-from ...core.util import Pointer, split_component_view
-from ...utils import view_shape, stack_view, color2rgb
+from glue.core.exceptions import IncompatibleAttribute
+from glue.core.util import Pointer, split_component_view
+from glue.utils import view_shape, stack_view, color2rgb
 
-from ...clients.image_client import ImageClient
-from ...clients.layer_artist import (LayerArtistBase,
+from glue.clients.image_client import ImageClient
+from glue.clients.layer_artist import (LayerArtistBase,
                                     ImageLayerBase, SubsetImageLayerBase)
 
 from ginga.util import wcsmod

--- a/glue/plugins/ginga_viewer/qt_widget.py
+++ b/glue/plugins/ginga_viewer/qt_widget.py
@@ -4,12 +4,12 @@ import sys
 import os.path
 import numpy as np
 
-from ...external.qt.QtGui import (QAction,
+from glue.external.qt.QtGui import (QAction,
                                   QToolButton, QToolBar, QIcon,
                                   QActionGroup, QWidget,
                                   QVBoxLayout, QColor, QImage, QPixmap)
 
-from ...external.qt.QtCore import Qt, QSize
+from glue.external.qt.QtCore import Qt, QSize
 
 from ginga.qtw.ImageViewCanvasQt import ImageViewCanvas
 from ginga.qtw import ColorBar
@@ -23,19 +23,19 @@ from ginga.misc import log
 from ginga import cmap as ginga_cmap
 # ginga_cmap.add_matplotlib_cmaps()
 
-from ...qt.widgets.image_widget import ImageWidgetBase
+from glue.qt.widgets.image_widget import ImageWidgetBase
 
-from .client import GingaClient
+from glue.plugins.ginga_viewer.client import GingaClient
 
-from ...core import roi as roimod
-from ...core.callback_property import add_callback
+from glue.core import roi as roimod
+from glue.core.callback_property import add_callback
 
-from ...qt.qtutil import get_icon, nonpartial
+from glue.qt.qtutil import get_icon, nonpartial
 
-from ..tools.pv_slicer import PVSlicerTool
-from ..tools.spectrum_tool import SpectrumTool
+from glue.plugins.tools.pv_slicer import PVSlicerTool
+from glue.plugins.tools.spectrum_tool import SpectrumTool
 
-from ...config import tool_registry
+from glue.config import tool_registry
 
 # Find out location of ginga module so we can some of its icons
 ginga_home = os.path.split(sys.modules['ginga'].__file__)[0]

--- a/glue/plugins/ginga_viewer/tests/test_client.py
+++ b/glue/plugins/ginga_viewer/tests/test_client.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, division
 
 import pytest
-from ....tests.helpers import GINGA_INSTALLED
+from glue.tests.helpers import GINGA_INSTALLED
 
 if not GINGA_INSTALLED:
     pytest.skip()
@@ -12,9 +12,9 @@ from numpy.testing import assert_allclose, assert_array_equal
 from ginga.qtw.ImageViewCanvasQt import ImageViewCanvas
 from ginga.misc import log
 
-from ....core import Data
+from glue.core import Data
 
-from ....clients.tests.test_image_client import _TestImageClientBase
+from glue.clients.tests.test_image_client import _TestImageClientBase
 
 from ..client import GingaClient, SubsetImage, BaseImage
 
@@ -22,7 +22,7 @@ from ..client import GingaClient, SubsetImage, BaseImage
 class TestGingaClient(_TestImageClientBase):
 
     def new_client(self, dc=None, canvas=None):
-        from ....qt import get_qapp
+        from glue.qt import get_qapp
         get_qapp()
         dc = dc or self.collect
         l = log.get_logger(name='ginga', log_stderr=True)

--- a/glue/plugins/ginga_viewer/tests/test_qt_widget.py
+++ b/glue/plugins/ginga_viewer/tests/test_qt_widget.py
@@ -1,12 +1,12 @@
 from __future__ import print_function, division
 
 import pytest
-from ....tests.helpers import GINGA_INSTALLED
+from glue.tests.helpers import GINGA_INSTALLED
 
 if not GINGA_INSTALLED:
     pytest.skip()
 
-from ....qt.widgets.tests.test_image_widget import _TestImageWidgetBase
+from glue.qt.widgets.tests.test_image_widget import _TestImageWidgetBase
 
 from ..qt_widget import GingaWidget
 

--- a/glue/plugins/tests/test_d3po.py
+++ b/glue/plugins/tests/test_d3po.py
@@ -7,9 +7,9 @@ from shutil import rmtree
 import numpy as np
 
 from ..export_d3po import make_data_file
-from ...core import Data, Subset
+from glue.core import Data, Subset
 
-from ...tests.helpers import requires_astropy
+from glue.tests.helpers import requires_astropy
 
 
 @requires_astropy

--- a/glue/plugins/tests/test_plotly.py
+++ b/glue/plugins/tests/test_plotly.py
@@ -1,9 +1,9 @@
 import pytest
 import numpy as np
 
-from ...core import Data, DataCollection
-from ...qt.glue_application import GlueApplication
-from ...qt.widgets import ScatterWidget, ImageWidget, HistogramWidget
+from glue.core import Data, DataCollection
+from glue.qt.glue_application import GlueApplication
+from glue.qt.widgets import ScatterWidget, ImageWidget, HistogramWidget
 from ..export_plotly import build_plotly_call
 
 

--- a/glue/plugins/tools/pv_slicer.py
+++ b/glue/plugins/tools/pv_slicer.py
@@ -1,12 +1,12 @@
 import numpy as np
-from ...qt.mouse_mode import PathMode
-from ...qt.widgets.image_widget import StandaloneImageWidget
-from ...qt.widgets.mpl_widget import defer_draw
+from glue.qt.mouse_mode import PathMode
+from glue.qt.widgets.image_widget import StandaloneImageWidget
+from glue.qt.widgets.mpl_widget import defer_draw
 
 
 def setup():
-    from ...config import tool_registry
-    from ...qt.widgets import ImageWidget
+    from glue.config import tool_registry
+    from glue.qt.widgets import ImageWidget
     tool_registry.add(PVSlicerTool, widget_cls=ImageWidget)
 
 
@@ -180,7 +180,7 @@ def _slice_from_path(x, y, data, attribute, slc):
     :note: For >3D cubes, the "V-axis" of the PV slice is the longest
            cube axis ignoring the x/y axes of `slc`
     """
-    from ...external.pvextractor import Path, extract_pv_slice
+    from glue.external.pvextractor import Path, extract_pv_slice
     p = Path(list(zip(x, y)))
 
     cube = data[attribute]

--- a/glue/plugins/tools/spectrum_tool.py
+++ b/glue/plugins/tools/spectrum_tool.py
@@ -3,8 +3,8 @@ import logging
 
 import numpy as np
 
-from ...external.qt.QtCore import Qt, Signal
-from ...external.qt.QtGui import (QMainWindow, QWidget,
+from glue.external.qt.QtCore import Qt, Signal
+from glue.external.qt.QtGui import (QMainWindow, QWidget,
                                  QHBoxLayout, QTabWidget,
                                  QComboBox, QFormLayout, QPushButton,
                                  QAction, QTextEdit, QFont, QDialog,
@@ -13,28 +13,28 @@ from ...external.qt.QtGui import (QMainWindow, QWidget,
                                  QLabel, QFileDialog)
 
 
-from ...clients.profile_viewer import ProfileViewer
-from ...qt.widgets.mpl_widget import MplWidget
-from ...qt.mouse_mode import SpectrumExtractorMode
-from ...core.callback_property import add_callback, ignore_callback
-from ...core.util import Pointer
-from ...core import Subset
-from ...core.exceptions import IncompatibleAttribute
-from ...qt.glue_toolbar import GlueToolbar
-from ...qt.qtutil import load_ui, nonpartial, Worker
-from ...qt.widget_properties import CurrentComboProperty
-from ...core.aggregate import Aggregate
-from ...qt.mime import LAYERS_MIME_TYPE
-from ...qt.simpleforms import build_form_item
-from ...config import fit_plugin
-from ...external.six.moves import range as xrange
-from ...qt.widgets.glue_mdi_area import GlueMdiSubWindow
-from ...qt.decorators import messagebox_on_error
+from glue.clients.profile_viewer import ProfileViewer
+from glue.qt.widgets.mpl_widget import MplWidget
+from glue.qt.mouse_mode import SpectrumExtractorMode
+from glue.core.callback_property import add_callback, ignore_callback
+from glue.core.util import Pointer
+from glue.core import Subset
+from glue.core.exceptions import IncompatibleAttribute
+from glue.qt.glue_toolbar import GlueToolbar
+from glue.qt.qtutil import load_ui, nonpartial, Worker
+from glue.qt.widget_properties import CurrentComboProperty
+from glue.core.aggregate import Aggregate
+from glue.qt.mime import LAYERS_MIME_TYPE
+from glue.qt.simpleforms import build_form_item
+from glue.config import fit_plugin
+from glue.external.six.moves import range as xrange
+from glue.qt.widgets.glue_mdi_area import GlueMdiSubWindow
+from glue.qt.decorators import messagebox_on_error
 
 
 def setup():
-    from ...config import tool_registry
-    from ...qt.widgets import ImageWidget
+    from glue.config import tool_registry
+    from glue.qt.widgets import ImageWidget
     tool_registry.add(SpectrumTool, widget_cls=ImageWidget)
 
 

--- a/glue/plugins/tools/tests/test_pv.py
+++ b/glue/plugins/tools/tests/test_pv.py
@@ -4,11 +4,11 @@ from mock import MagicMock
 
 from ..pv_slicer import _slice_from_path, _slice_label, _slice_index, PVSliceWidget
 
-from ....qt.widgets.image_widget import StandaloneImageWidget
+from glue.qt.widgets.image_widget import StandaloneImageWidget
 
-from ....core import Data
+from glue.core import Data
 
-from ....tests.helpers import requires_astropy, requires_scipy
+from glue.tests.helpers import requires_astropy, requires_scipy
 
 
 @requires_astropy

--- a/glue/plugins/tools/tests/test_spectrum_tool.py
+++ b/glue/plugins/tools/tests/test_spectrum_tool.py
@@ -2,18 +2,18 @@ import pytest
 import numpy as np
 from mock import MagicMock
 
-from ....core.tests.util import simple_session
-from ....core import Data, Coordinates
-from ....core.roi import RectangularROI
-from ....qt.widgets import ImageWidget
-from ....tests.helpers import requires_astropy
+from glue.core.tests.util import simple_session
+from glue.core import Data, Coordinates
+from glue.core.roi import RectangularROI
+from glue.qt.widgets import ImageWidget
+from glue.tests.helpers import requires_astropy
 
 from ..spectrum_tool import Extractor, ConstraintsWidget, FitSettingsWidget, SpectrumTool, CollapseContext
-from ....core.fitters import PolynomialFitter
+from glue.core.fitters import PolynomialFitter
 
 needs_modeling = lambda x: x
 try:
-    from ....core.fitters import SimpleAstropyGaussianFitter
+    from glue.core.fitters import SimpleAstropyGaussianFitter
 except ImportError:
     needs_modeling = pytest.mark.skipif(True, reason='Needs astropy >= 0.3')
 
@@ -240,7 +240,7 @@ class TestCollapseContext(BaseTestSpectrumTool):
 class TestCollapseContextWCS(TestCollapseContext):
 
     def setup_data(self):
-        from ....core.coordinates import coordinates_from_wcs
+        from glue.core.coordinates import coordinates_from_wcs
         from astropy.wcs import WCS
         wcs = WCS(naxis=3)
 

--- a/glue/qglue.py
+++ b/glue/qglue.py
@@ -14,13 +14,13 @@ import sys
 import numpy as np
 
 try:
-    from .core import Data
+    from glue.core import Data
 except ImportError:
     # let qglue import, even though this won't work
     # qglue will throw an ImportError
     Data = None
 
-from .external import six
+from glue.external import six
 
 __all__ = ['qglue']
 
@@ -81,7 +81,7 @@ def _parse_data_numpy(data, label):
 
 
 def _parse_data_path(path, label):
-    from .core.data_factories import load_data, as_list
+    from glue.core.data_factories import load_data, as_list
 
     data = load_data(path)
     for d in as_list(data):
@@ -90,7 +90,7 @@ def _parse_data_path(path, label):
 
 
 def _parse_data_hdulist(data, label):
-    from .core.data_factories.fits import fits_reader
+    from glue.core.data_factories.fits import fits_reader
     return fits_reader(data, label=label)
 
 
@@ -132,8 +132,8 @@ except ImportError:
 
 
 def _parse_links(dc, links):
-    from .core.link_helpers import MultiLink
-    from .core import ComponentLink
+    from glue.core.link_helpers import MultiLink
+    from glue.core import ComponentLink
 
     data = dict((d.label, d) for d in dc)
     result = []
@@ -210,8 +210,8 @@ def qglue(**kwargs):
 
     :returns: A :class:`~glue.qt.glue_application.GlueApplication` object
     """
-    from .core import DataCollection
-    from .qt.glue_application import GlueApplication
+    from glue.core import DataCollection
+    from glue.qt.glue_application import GlueApplication
 
     links = kwargs.pop('links', None)
 

--- a/glue/qt/__init__.py
+++ b/glue/qt/__init__.py
@@ -1,7 +1,7 @@
 import os
 
 # For backward compatibility, we import get_qapp here
-from ..external.qt import get_qapp
+from glue.external.qt import get_qapp
 
 
 def teardown():

--- a/glue/qt/actions.py
+++ b/glue/qt/actions.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
-from ..external.qt.QtGui import QAction
-from .qtutil import get_icon
+from glue.external.qt.QtGui import QAction
+from glue.qt.qtutil import get_icon
 
 
 def act(name, parent, tip='', icon=None, shortcut=None):

--- a/glue/qt/component_selector.py
+++ b/glue/qt/component_selector.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import, division, print_function
 
-from ..external.qt.QtGui import QWidget, QListWidgetItem
-from ..external.qt.QtCore import Signal
+from glue.external.qt.QtGui import QWidget, QListWidgetItem
+from glue.external.qt.QtCore import Signal
 
-from .qtutil import load_ui
+from glue.qt.qtutil import load_ui
 
 
 class ComponentSelector(QWidget):
@@ -125,8 +125,8 @@ class ComponentSelector(QWidget):
 def main():  # pragma: no cover
     import glue
     import numpy as np
-    from . import get_qapp
-    from ..external.qt.QtGui import QApplication
+    from glue.qt import get_qapp
+    from glue.external.qt.QtGui import QApplication
 
     d = glue.core.Data(label="hi")
     d2 = glue.core.Data(label="there")

--- a/glue/qt/custom_viewer.py
+++ b/glue/qt/custom_viewer.py
@@ -75,20 +75,20 @@ from copy import copy
 
 import numpy as np
 
-from ..clients import LayerArtist, GenericMplClient
-from ..core import Data
-from ..core.edit_subset_mode import EditSubsetMode
-from ..utils import nonpartial, as_list, all_artists, new_artists, remove_artists
-from .. import core
+from glue.clients import LayerArtist, GenericMplClient
+from glue.core import Data
+from glue.core.edit_subset_mode import EditSubsetMode
+from glue.utils import nonpartial, as_list, all_artists, new_artists, remove_artists
+from glue import core
 
-from .widgets.data_viewer import DataViewer
-from . import widget_properties as wp
-from ..external import six
-from ..external.qt import QtGui
-from ..external.qt.QtCore import Qt
-from .widgets import MplWidget
-from .glue_toolbar import GlueToolbar
-from .mouse_mode import PolyMode, RectangleMode
+from glue.qt.widgets.data_viewer import DataViewer
+from glue.qt import widget_properties as wp
+from glue.external import six
+from glue.external.qt import QtGui
+from glue.external.qt.QtCore import Qt
+from glue.qt.widgets import MplWidget
+from glue.qt.glue_toolbar import GlueToolbar
+from glue.qt.mouse_mode import PolyMode, RectangleMode
 
 CUSTOM_WIDGETS = []
 

--- a/glue/qt/data_collection_model.py
+++ b/glue/qt/data_collection_model.py
@@ -1,17 +1,17 @@
 # pylint: disable=E1101,F0401
-from ..external.qt.QtCore import (QAbstractItemModel, QModelIndex,
+from glue.external.qt.QtCore import (QAbstractItemModel, QModelIndex,
                                   QObject, Qt, QTimer, Signal, QSize)
-from ..external.qt.QtGui import (QFont, QTreeView, QItemSelectionModel,
+from glue.external.qt.QtGui import (QFont, QTreeView, QItemSelectionModel,
                                  QAbstractItemView, QStyledItemDelegate)
-from ..external.qt import is_pyqt5
+from glue.external.qt import is_pyqt5
 
-from .qtutil import layer_icon
-from .mime import LAYERS_MIME_TYPE, PyMimeData
-from ..core.decorators import memoize
-from ..core import message as m
-from ..core.hub import HubListener
-from .. import core
-from .widgets.style_dialog import StyleDialog
+from glue.qt.qtutil import layer_icon
+from glue.qt.mime import LAYERS_MIME_TYPE, PyMimeData
+from glue.core.decorators import memoize
+from glue.core import message as m
+from glue.core.hub import HubListener
+from glue import core
+from glue.qt.widgets.style_dialog import StyleDialog
 
 DATA_IDX = 0
 SUBSET_IDX = 1
@@ -526,9 +526,9 @@ class LabeledDelegate(QStyledItemDelegate):
 
 if __name__ == "__main__":
     
-    from . import get_qapp
-    from ..external.qt.QtGui import QTreeView
-    from ..core import Data, DataCollection
+    from glue.qt import get_qapp
+    from glue.external.qt.QtGui import QTreeView
+    from glue.core import Data, DataCollection
 
     app = get_qapp()
 

--- a/glue/qt/decorators.py
+++ b/glue/qt/decorators.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 from functools import wraps
 import traceback
-from ..utils.qt import QMessageBoxPatched as QMessageBox
+from glue.utils.qt import QMessageBoxPatched as QMessageBox
 
 
 def set_cursor(shape):
@@ -13,7 +13,7 @@ def set_cursor(shape):
     def wrapper(func):
         @wraps(func)
         def result(*args, **kwargs):
-            from . import get_qapp
+            from glue.qt import get_qapp
             app = get_qapp()
             app.setOverrideCursor(shape)
             try:

--- a/glue/qt/feedback.py
+++ b/glue/qt/feedback.py
@@ -1,12 +1,12 @@
 """
 Widgets for sending feedback reports
 """
-from ..external.six.moves.urllib.request import Request, urlopen
-from ..external.six.moves.urllib.parse import urlencode
+from glue.external.six.moves.urllib.request import Request, urlopen
+from glue.external.six.moves.urllib.parse import urlencode
 import sys
 
-from ..external.qt.QtGui import QTextCursor
-from .qtutil import load_ui
+from glue.external.qt.QtGui import QTextCursor
+from glue.qt.qtutil import load_ui
 
 __all__ = ['submit_bug_report']
 
@@ -32,7 +32,7 @@ def _diagnostics():
     """
     Return a some system informaton useful for debugging
     """
-    from ..external.qt import QtCore
+    from glue.external.qt import QtCore
     from matplotlib import __version__ as mplversion
     from numpy import __version__ as npversion
     from astropy import __version__ as apversion

--- a/glue/qt/glue_application.py
+++ b/glue/qt/glue_application.py
@@ -7,34 +7,34 @@ import sys
 import warnings
 import webbrowser
 
-from ..external.qt.QtGui import (QKeySequence, QMainWindow, QGridLayout,
+from glue.external.qt.QtGui import (QKeySequence, QMainWindow, QGridLayout,
                                  QMenu, QAction,
                                  QFileDialog, QInputDialog,
                                  QToolButton, QVBoxLayout, QWidget, QPixmap,
                                  QBrush, QPainter, QLabel, QHBoxLayout,
                                  QTextEdit, QTextCursor, QPushButton,
                                  QListWidgetItem, QIcon)
-from ..external.qt.QtCore import Qt, QSize, QSettings, Signal
-from ..utils.qt import QMessageBoxPatched as QMessageBox
+from glue.external.qt.QtCore import Qt, QSize, QSettings, Signal
+from glue.utils.qt import QMessageBoxPatched as QMessageBox
 
-from ..core import command, Data
-from .. import env
-from ..main import load_plugins
-from ..qt import get_qapp
-from .decorators import set_cursor, messagebox_on_error
-from ..core.application_base import Application
+from glue.core import command, Data
+from glue import env
+from glue.main import load_plugins
+from glue.qt import get_qapp
+from glue.qt.decorators import set_cursor, messagebox_on_error
+from glue.core.application_base import Application
 
-from .actions import act
-from .qtutil import (pick_class, data_wizard,
+from glue.qt.actions import act
+from glue.qt.qtutil import (pick_class, data_wizard,
                      GlueTabBar, load_ui, get_icon, nonpartial)
-from .widgets.glue_mdi_area import GlueMdiArea, GlueMdiSubWindow
-from .widgets.edit_subset_mode_toolbar import EditSubsetModeToolBar
-from .widgets.layer_tree_widget import PlotAction, LayerTreeWidget
-from .widgets.data_viewer import DataViewer
-from .widgets.settings_editor import SettingsEditor
-from .widgets.mpl_widget import defer_draw
-from .feedback import submit_bug_report
-from .plugin_manager import QtPluginManager
+from glue.qt.widgets.glue_mdi_area import GlueMdiArea, GlueMdiSubWindow
+from glue.qt.widgets.edit_subset_mode_toolbar import EditSubsetModeToolBar
+from glue.qt.widgets.layer_tree_widget import PlotAction, LayerTreeWidget
+from glue.qt.widgets.data_viewer import DataViewer
+from glue.qt.widgets.settings_editor import SettingsEditor
+from glue.qt.widgets.mpl_widget import defer_draw
+from glue.qt.feedback import submit_bug_report
+from glue.qt.plugin_manager import QtPluginManager
 
 __all__ = ['GlueApplication']
 DOCS_URL = 'http://www.glueviz.org'
@@ -590,7 +590,7 @@ class GlueApplication(Application, QMainWindow):
         self._actions['data_new'] = a
 
         # We now populate the "Import data" menu
-        from ..config import importer
+        from glue.config import importer
 
         acts = []
 
@@ -609,7 +609,7 @@ class GlueApplication(Application, QMainWindow):
 
         self._actions['data_importers'] = acts
 
-        from ..config import exporters
+        from glue.config import exporters
         if len(exporters) > 0:
             acts = []
             for e in exporters:
@@ -648,7 +648,7 @@ class GlueApplication(Application, QMainWindow):
         self._actions['redo'] = a
 
         # Create actions for menubar plugins
-        from ..config import menubar_plugin
+        from glue.config import menubar_plugin
         acts = []
         for label, function in menubar_plugin:
             a = act(label, self, tip=label)
@@ -667,8 +667,8 @@ class GlueApplication(Application, QMainWindow):
         """ Create a new visualization window in the current tab
         """
 
-        from ..config import qt_client
-        from .widgets import ScatterWidget, ImageWidget
+        from glue.config import qt_client
+        from glue.qt.widgets import ScatterWidget, ImageWidget
 
         if data and data.ndim == 1 and ScatterWidget in qt_client.members:
             default = qt_client.members.index(ScatterWidget)
@@ -803,7 +803,7 @@ class GlueApplication(Application, QMainWindow):
         self._ui.layerWidget.button_row.addWidget(self._terminal_button)
 
         try:
-            from .widgets.terminal import glue_terminal
+            from glue.qt.widgets.terminal import glue_terminal
             widget = glue_terminal(data_collection=self._data,
                                    dc=self._data,
                                    hub=self._hub,
@@ -917,7 +917,7 @@ class GlueApplication(Application, QMainWindow):
         qmb.exec_()
 
     def plugin_manager(self):
-        from ..main import _installed_plugins
+        from glue.main import _installed_plugins
         pm = QtPluginManager(installed=_installed_plugins)
         pm.ui.exec_()
 

--- a/glue/qt/glue_toolbar.py
+++ b/glue/qt/glue_toolbar.py
@@ -3,17 +3,17 @@ from __future__ import absolute_import, division, print_function
 import os
 import matplotlib
 
-from ..external.qt import QtCore, QtGui, is_pyqt5
-from ..external.qt.QtGui import QMenu
-from ..external.qt.QtCore import Qt, Signal
+from glue.external.qt import QtCore, QtGui, is_pyqt5
+from glue.external.qt.QtGui import QMenu
+from glue.external.qt.QtCore import Qt, Signal
 
 if is_pyqt5():
     from matplotlib.backends.backend_qt5 import NavigationToolbar2QT
 else:
     from matplotlib.backends.backend_qt4 import NavigationToolbar2QT
 
-from ..core.callback_property import add_callback
-from .qtutil import get_icon, nonpartial
+from glue.core.callback_property import add_callback
+from glue.qt.qtutil import get_icon, nonpartial
 
 
 class GlueToolbar(NavigationToolbar2QT):

--- a/glue/qt/layer_artist_model.py
+++ b/glue/qt/layer_artist_model.py
@@ -11,19 +11,19 @@ these layers, and provides GUI access to the model
 
 from __future__ import absolute_import, division, print_function
 
-from ..external.qt.QtGui import (QColor,
+from glue.external.qt.QtGui import (QColor,
                                  QListView, QAbstractItemView, QAction,
                                  QPalette, QKeySequence)
 
-from ..external.qt.QtCore import (Qt, QAbstractListModel, QModelIndex,
+from glue.external.qt.QtCore import (Qt, QAbstractListModel, QModelIndex,
                                   QSize, QTimer)
 
-from .qtutil import (layer_artist_icon, nonpartial, PythonListModel)
+from glue.qt.qtutil import (layer_artist_icon, nonpartial, PythonListModel)
 
-from .mime import PyMimeData, LAYERS_MIME_TYPE
-from ..clients.layer_artist import LayerArtistBase, LayerArtistContainer
+from glue.qt.mime import PyMimeData, LAYERS_MIME_TYPE
+from glue.clients.layer_artist import LayerArtistBase, LayerArtistContainer
 
-from .widgets.style_dialog import StyleDialog
+from glue.qt.widgets.style_dialog import StyleDialog
 
 
 class LayerArtistModel(PythonListModel):

--- a/glue/qt/link_editor.py
+++ b/glue/qt/link_editor.py
@@ -1,10 +1,10 @@
 from __future__ import absolute_import, division, print_function
 
-from ..external.qt.QtGui import QDialog, QListWidgetItem, QWidget
+from glue.external.qt.QtGui import QDialog, QListWidgetItem, QWidget
 
-from .. import core
+from glue import core
 
-from .qtutil import load_ui
+from glue.qt.qtutil import load_ui
 
 
 class LinkEditor(object):
@@ -116,7 +116,7 @@ class LinkEditor(object):
 
 def main():
     import numpy as np
-    from ..core import Data, DataCollection
+    from glue.core import Data, DataCollection
 
     x = np.array([1, 2, 3])
     d = Data(label='data', x=x, y=x * 2)

--- a/glue/qt/link_equation.py
+++ b/glue/qt/link_equation.py
@@ -3,13 +3,13 @@ from __future__ import absolute_import, division, print_function
 from inspect import getargspec
 from collections import OrderedDict
 
-from ..external.qt.QtGui import (QWidget, QHBoxLayout, QVBoxLayout,
+from glue.external.qt.QtGui import (QWidget, QHBoxLayout, QVBoxLayout,
                                  QLabel, QLineEdit)
 
-from ..external.qt.QtGui import QSpacerItem, QSizePolicy
+from glue.external.qt.QtGui import QSpacerItem, QSizePolicy
 
-from .. import core
-from .qtutil import load_ui, is_pyside
+from glue import core
+from glue.qt.qtutil import load_ui, is_pyside
 
 
 def function_label(function):
@@ -115,7 +115,7 @@ class LinkEquation(QWidget):
 
     def __init__(self, parent=None):
         super(LinkEquation, self).__init__(parent)
-        from ..config import link_function, link_helper
+        from glue.config import link_function, link_helper
 
         # Set up mapping of function/helper name -> function/helper tuple. For the helpers, we use the 'display' name if available.
         def get_name(item):

--- a/glue/qt/mime.py
+++ b/glue/qt/mime.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from ..external.qt.QtCore import QMimeData, QByteArray
+from glue.external.qt.QtCore import QMimeData, QByteArray
 
 
 class PyMimeData(QMimeData):

--- a/glue/qt/mouse_mode.py
+++ b/glue/qt/mouse_mode.py
@@ -19,14 +19,14 @@ The basic usage pattern is thus:
 
 from __future__ import absolute_import, division, print_function
 
-from ..external.qt.QtGui import QAction, QDoubleValidator
+from glue.external.qt.QtGui import QAction, QDoubleValidator
 
-from ..core import util
-from ..core import roi
-from ..core.callback_property import CallbackProperty
-from . import get_qapp
-from .qtutil import get_icon, nonpartial, load_ui
-from . import qt_roi
+from glue.core import util
+from glue.core import roi
+from glue.core.callback_property import CallbackProperty
+from glue.qt import get_qapp
+from glue.qt.qtutil import get_icon, nonpartial, load_ui
+from glue.qt import qt_roi
 
 
 class MouseMode(object):

--- a/glue/qt/plugin_manager.py
+++ b/glue/qt/plugin_manager.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import, division, print_function
 
-from ..external.qt import QtGui, QtCore
-from .._plugin_helpers import PluginConfig
+from glue.external.qt import QtGui, QtCore
+from glue._plugin_helpers import PluginConfig
 
-from .qtutil import load_ui
+from glue.qt.qtutil import load_ui
 
 __all__ = ["QtPluginManager"]
 
@@ -61,7 +61,7 @@ class QtPluginManager(object):
         except Exception:
             import traceback
             detail = str(traceback.format_exc())
-            from ..utils.qt import QMessageBoxPatched as QMessageBox
+            from glue.utils.qt import QMessageBoxPatched as QMessageBox
             message = QMessageBox(QMessageBox.Critical,
                                   "Error",
                                   "Could not save plugin configuration")

--- a/glue/qt/qt_backend.py
+++ b/glue/qt/qt_backend.py
@@ -1,6 +1,6 @@
-from ..backends import TimerBase
+from glue.backends import TimerBase
 
-from ..external.qt.QtCore import QTimer
+from glue.external.qt.QtCore import QTimer
 
 
 class Timer(TimerBase):

--- a/glue/qt/qt_roi.py
+++ b/glue/qt/qt_roi.py
@@ -1,9 +1,9 @@
 import numpy as np
 
-from ..core import roi
-from ..external.qt import QtGui, QtCore
-from ..external.qt.QtCore import Qt
-from .qtutil import mpl_to_qt4_color
+from glue.core import roi
+from glue.external.qt import QtGui, QtCore
+from glue.external.qt.QtCore import Qt
+from glue.qt.qtutil import mpl_to_qt4_color
 
 
 class QtROI(object):

--- a/glue/qt/qtutil.py
+++ b/glue/qt/qtutil.py
@@ -12,26 +12,26 @@ from matplotlib.colors import ColorConverter
 from matplotlib import cm
 import numpy as np
 
-from ..external.axescache import AxesCache
-from ..external.qt import QtGui
-from ..external.qt.QtCore import (Qt, QThread, QAbstractListModel, QModelIndex)
-from ..external.qt.QtGui import (QColor, QInputDialog, QColorDialog,
+from glue.external.axescache import AxesCache
+from glue.external.qt import QtGui
+from glue.external.qt.QtCore import (Qt, QThread, QAbstractListModel, QModelIndex)
+from glue.external.qt.QtGui import (QColor, QInputDialog, QColorDialog,
                                  QListWidget, QTreeWidget, QPushButton,
                                  QTabBar, QBitmap, QIcon, QPixmap, QImage,
                                  QWidget,
                                  QLabel, QGridLayout,
                                  QRadioButton, QButtonGroup, QCheckBox)
-from ..utils.qt import QMessageBoxPatched as QMessageBox
+from glue.utils.qt import QMessageBoxPatched as QMessageBox
 
-from .decorators import set_cursor
-from .mime import PyMimeData, LAYERS_MIME_TYPE
-from ..external.qt import is_pyside
-from ..external.qt.QtCore import Signal
-from .. import core
-from . import ui, icons
+from glue.qt.decorators import set_cursor
+from glue.qt.mime import PyMimeData, LAYERS_MIME_TYPE
+from glue.external.qt import is_pyside
+from glue.external.qt.QtCore import Signal
+from glue import core
+from glue.qt import ui, icons
 
 # We import nonpartial here for convenience
-from ..utils import nonpartial
+from glue.utils import nonpartial
 
 
 def mpl_to_qt4_color(color, alpha=1.0):
@@ -113,7 +113,7 @@ class GlueDataDialog(object):
 
     def __init__(self, parent=None):
         self._fd = QtGui.QFileDialog(parent)
-        from ..config import data_factory
+        from glue.config import data_factory
         self.filters = [(f, self._filter(f))
                         for f in data_factory.members if not f.deprecated]
         self.setNameFilter()
@@ -164,7 +164,7 @@ class GlueDataDialog(object):
 
         :rtype: A list of constructed data objects
         """
-        from ..core.data_factories import data_label, load_data
+        from glue.core.data_factories import data_label, load_data
         paths, fac = self._get_paths_and_factory()
         result = []
 
@@ -360,7 +360,7 @@ def layer_icon(layer):
 
 def layer_artist_icon(artist):
     """Create a QIcon for a LayerArtist instance"""
-    from ..clients.layer_artist import ImageLayerArtist
+    from glue.clients.layer_artist import ImageLayerArtist
 
     if not artist.enabled:
         bm = QBitmap(icon_path('glue_delete'))
@@ -651,10 +651,10 @@ def _custom_widgets():
     yield GlueActionButton
     yield RGBEdit
 
-    from .component_selector import ComponentSelector
+    from glue.qt.component_selector import ComponentSelector
     yield ComponentSelector
 
-    from .link_equation import LinkEquation
+    from glue.qt.link_equation import LinkEquation
     yield LinkEquation
 
 
@@ -682,7 +682,7 @@ def load_ui(path, parent=None):
     if not os.path.exists(path):
         path = global_ui_path(path)
 
-    from ..external.qt import load_ui
+    from glue.external.qt import load_ui
     return load_ui(path, parent, custom_widgets=_custom_widgets())
 
 
@@ -847,7 +847,7 @@ def cache_axes(axes, toolbar):
 
 if __name__ == "__main__":
 
-    from . import get_qapp
+    from glue.qt import get_qapp
 
     class Foo(object):
         layer_visible = {}

--- a/glue/qt/simpleforms.py
+++ b/glue/qt/simpleforms.py
@@ -1,8 +1,8 @@
-from ..external.qt.QtGui import QSpinBox, QDoubleSpinBox, QCheckBox
-from ..external.qt.QtCore import QObject, Signal
+from glue.external.qt.QtGui import QSpinBox, QDoubleSpinBox, QCheckBox
+from glue.external.qt.QtCore import QObject, Signal
 
-from ..core.simpleforms import IntOption, FloatOption, BoolOption
-from .qtutil import nonpartial
+from glue.core.simpleforms import IntOption, FloatOption, BoolOption
+from glue.qt.qtutil import nonpartial
 
 _dispatch = {}
 

--- a/glue/qt/tests/test_application.py
+++ b/glue/qt/tests/test_application.py
@@ -18,14 +18,14 @@ except:
     ipy_version = '0.0'
 
 from ..glue_application import GlueApplication
-from ...external.qt.QtCore import QMimeData, QUrl
+from glue.external.qt.QtCore import QMimeData, QUrl
 from ..widgets.scatter_widget import ScatterWidget
 from ..widgets.image_widget import ImageWidget
-from ...core import Data
+from glue.core import Data
 
-from ...external.six import PY3
+from glue.external.six import PY3
 
-from ...tests.helpers import requires_ipython_ge_012
+from glue.tests.helpers import requires_ipython_ge_012
 
 os.environ['GLUE_TESTING'] = 'True'
 
@@ -177,7 +177,7 @@ class TestGlueApplication(object):
         assert viewer.viewer_size == (100, 200)
 
     def test_new_data_defaults(self):
-        from ...config import qt_client
+        from glue.config import qt_client
 
         with patch('glue.qt.glue_application.pick_class') as pc:
             pc.return_value = None

--- a/glue/qt/tests/test_component_selector.py
+++ b/glue/qt/tests/test_component_selector.py
@@ -5,8 +5,8 @@ from __future__ import absolute_import, division, print_function
 from numpy import array
 
 from ..component_selector import ComponentSelector
-from ... import core
-from ...core.data import ComponentID
+from glue import core
+from glue.core.data import ComponentID
 
 
 def data_collection():

--- a/glue/qt/tests/test_custom_viewer.py
+++ b/glue/qt/tests/test_custom_viewer.py
@@ -6,17 +6,17 @@ from numpy.testing import assert_array_equal
 from matplotlib.axes import Axes
 import numpy as np
 
-from ... import custom_viewer
-from ...core import Data
-from ...core.subset import SubsetState
-from ...core.tests.util import simple_session
+from glue import custom_viewer
+from glue.core import Data
+from glue.core.subset import SubsetState
+from glue.core.tests.util import simple_session
 from ..custom_viewer import FormElement, NumberElement, \
     ChoiceElement, CustomViewer, \
     CustomSubsetState, AttributeInfo, \
     FloatElement, TextBoxElement, SettingsOracle, \
     MissingSettingError, FrozenSettings
 from ..glue_application import GlueApplication
-from ...core.tests.test_state import check_clone_app, clone
+from glue.core.tests.test_state import check_clone_app, clone
 
 
 def _make_widget(viewer):

--- a/glue/qt/tests/test_data_collection_model.py
+++ b/glue/qt/tests/test_data_collection_model.py
@@ -1,5 +1,5 @@
-from ...external.qt.QtCore import Qt
-from ...core import DataCollection, Data
+from glue.external.qt.QtCore import Qt
+from glue.core import DataCollection, Data
 from ..data_collection_model import DataCollectionModel
 from ..qtutil import LAYERS_MIME_TYPE
 

--- a/glue/qt/tests/test_layer_artist_model.py
+++ b/glue/qt/tests/test_layer_artist_model.py
@@ -1,13 +1,13 @@
 from __future__ import absolute_import, division, print_function
 
-from ...external.qt.QtCore import Qt
+from glue.external.qt.QtCore import Qt
 
 from mock import MagicMock
 
 from ..layer_artist_model import LayerArtistModel, LayerArtistView
-from ...clients.layer_artist import LayerArtist as _LayerArtist
-from ...core import Data
-from ...external.qt import is_pyqt5
+from glue.clients.layer_artist import LayerArtist as _LayerArtist
+from glue.core import Data
+from glue.external.qt import is_pyqt5
 
 
 class LayerArtist(_LayerArtist):

--- a/glue/qt/tests/test_link_equation.py
+++ b/glue/qt/tests/test_link_equation.py
@@ -5,8 +5,8 @@ import pytest
 
 from ..link_equation import (function_label, helper_label,
                              LinkEquation, ArgumentWidget)
-from ...config import link_function, link_helper
-from ...core import ComponentID
+from glue.config import link_function, link_helper
+from glue.core import ComponentID
 
 
 @link_function('testing function', ['y'])

--- a/glue/qt/tests/test_mime.py
+++ b/glue/qt/tests/test_mime.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import, division, print_function
 
-from ...external.qt.QtGui import QWidget, QDrag
-from ...external.qt.QtCore import QMimeData, Qt
-from ...external.qt.QtTest import QTest
+from glue.external.qt.QtGui import QWidget, QDrag
+from glue.external.qt.QtCore import QMimeData, Qt
+from glue.external.qt.QtTest import QTest
 
 from .. import mime
 

--- a/glue/qt/tests/test_plugin_manager.py
+++ b/glue/qt/tests/test_plugin_manager.py
@@ -1,21 +1,21 @@
 import os
 import pytest
 from mock import patch
-from ...external.qt import QtCore
+from glue.external.qt import QtCore
 
 from ..plugin_manager import QtPluginManager
-from ... import _plugin_helpers as ph
-from ...utils.qt import QMessageBoxPatched
-from ...main import load_plugins
+from glue import _plugin_helpers as ph
+from glue.utils.qt import QMessageBoxPatched
+from glue.main import load_plugins
 
 
 def setup_function(func):
-    from ... import config
+    from glue import config
     func.CFG_DIR_ORIG = config.CFG_DIR
 
 
 def teardown_function(func):
-    from ... import config
+    from glue import config
     config.CFG_DIR = func.CFG_DIR_ORIG
 
 
@@ -23,7 +23,7 @@ def test_basic_empty(tmpdir):
 
     # Test that things work when the plugin cfg file is empty
 
-    from ... import config
+    from glue import config
     config.CFG_DIR = tmpdir.join('.glue').strpath
 
     w = QtPluginManager()
@@ -36,7 +36,7 @@ def test_basic(tmpdir):
 
     # Test that things work when the plugin cfg file is populated
 
-    from ... import config
+    from glue import config
     config.CFG_DIR = tmpdir.join('.glue').strpath
 
     load_plugins()
@@ -58,7 +58,7 @@ def test_basic(tmpdir):
 
 def test_permission_fail(tmpdir):
 
-    from ... import config
+    from glue import config
     config.CFG_DIR = tmpdir.join('.glue').strpath
 
     # Make a *file* at that location so that reading the plugin file will fail

--- a/glue/qt/tests/test_qtutil.py
+++ b/glue/qt/tests/test_qtutil.py
@@ -7,12 +7,12 @@ from mock import MagicMock, patch
 
 import matplotlib.pyplot as plt
 
-from ...external.qt import QtGui
-from ...external.qt.QtCore import Qt
+from glue.external.qt import QtGui
+from glue.external.qt.QtCore import Qt
 
-from ...config import data_factory
-from ...core import Data, Subset
-from ...clients.layer_artist import RGBImageLayerArtist
+from glue.config import data_factory
+from glue.core import Data, Subset
+from glue.clients.layer_artist import RGBImageLayerArtist
 
 from .. import qtutil
 from ..qtutil import GlueDataDialog

--- a/glue/qt/tests/test_toolbar.py
+++ b/glue/qt/tests/test_toolbar.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import, division, print_function
 
 import matplotlib.pyplot as plt
-from ...external.qt.QtGui import QMainWindow, QIcon
+from glue.external.qt.QtGui import QMainWindow, QIcon
 from ..widgets import MplWidget
 from ..glue_toolbar import GlueToolbar
 from ..mouse_mode import MouseMode
@@ -30,7 +30,7 @@ class MouseModeTest(MouseMode):
 class TestToolbar(object):
 
     def setup_method(self, method):
-        from ...external.qt.QtGui import QApplication
+        from glue.external.qt.QtGui import QApplication
         assert QApplication.instance() is not None
         self.win = QMainWindow()
         widget, axes = self._make_plot_widget(self.win)

--- a/glue/qt/tests/test_widget_properties.py
+++ b/glue/qt/tests/test_widget_properties.py
@@ -14,7 +14,7 @@ from ..widget_properties import (CurrentComboDataProperty,
                                  connect_float_edit,
                                  connect_int_spin)
 
-from ...external.qt.QtGui import (QCheckBox,
+from glue.external.qt.QtGui import (QCheckBox,
                                   QLineEdit,
                                   QComboBox,
                                   QLabel,
@@ -22,7 +22,7 @@ from ...external.qt.QtGui import (QCheckBox,
                                   QTabWidget,
                                   QWidget)
 
-from ...external.echo import CallbackProperty
+from glue.external.echo import CallbackProperty
 
 
 def test_combo_data():

--- a/glue/qt/ui/layertree.py
+++ b/glue/qt/ui/layertree.py
@@ -1,6 +1,6 @@
-from ...external.qt import QtCore, QtGui, is_pyqt5
-from ..data_collection_model import DataCollectionView
-from ..qtutil import GlueActionButton, get_icon
+from glue.external.qt import QtCore, QtGui, is_pyqt5
+from glue.qt.data_collection_model import DataCollectionView
+from glue.qt.qtutil import GlueActionButton, get_icon
 
 
 class Ui_LayerTree(object):

--- a/glue/qt/widget_properties.py
+++ b/glue/qt/widget_properties.py
@@ -21,10 +21,10 @@ from __future__ import absolute_import, division, print_function
 
 from functools import partial
 
-from .qtutil import pretty_number
-from ..external.qt import QtGui
-from ..external.six.moves import reduce
-from ..core.callback_property import add_callback
+from glue.qt.qtutil import pretty_number
+from glue.external.qt import QtGui
+from glue.external.six.moves import reduce
+from glue.core.callback_property import add_callback
 
 
 class WidgetProperty(object):

--- a/glue/qt/widgets/custom_component_widget.py
+++ b/glue/qt/widgets/custom_component_widget.py
@@ -2,14 +2,14 @@ from __future__ import absolute_import, division, print_function
 
 import re
 
-from ...external.qt.QtGui import QDialog, QMessageBox
-from ...external.qt import QtCore
+from glue.external.qt.QtGui import QDialog, QMessageBox
+from glue.external.qt import QtCore
 
-from ... import core
-from ...core import parse
-from ...utils.qt import CompletionTextEdit
+from glue import core
+from glue.core import parse
+from glue.utils.qt import CompletionTextEdit
 
-from ..qtutil import load_ui
+from glue.qt.qtutil import load_ui
 
 
 
@@ -229,8 +229,8 @@ class CustomComponentWidget(object):
                 break
 
 def main():
-    from ...core.data import Data
-    from ...core.data_collection import DataCollection
+    from glue.core.data import Data
+    from glue.core.data_collection import DataCollection
     import numpy as np
 
     x = np.random.random((5, 5))

--- a/glue/qt/widgets/data_slice_widget.py
+++ b/glue/qt/widgets/data_slice_widget.py
@@ -1,15 +1,15 @@
 from functools import partial
 from collections import Counter
 
-from ...external.qt.QtGui import (QWidget, QSlider, QLabel, QComboBox, QFrame,
+from glue.external.qt.QtGui import (QWidget, QSlider, QLabel, QComboBox, QFrame,
                                   QHBoxLayout, QVBoxLayout, QPushButton, 
                                   QLineEdit)
-from ...external.qt.QtCore import Qt, Signal
+from glue.external.qt.QtCore import Qt, Signal
 
-from ..widget_properties import (TextProperty,
+from glue.qt.widget_properties import (TextProperty,
                                  ValueProperty,
                                  CurrentComboProperty)
-from ..qtutil import nonpartial, load_ui
+from glue.qt.qtutil import nonpartial, load_ui
 
 
 class SliceWidget(QWidget):

--- a/glue/qt/widgets/data_viewer.py
+++ b/glue/qt/widgets/data_viewer.py
@@ -2,18 +2,18 @@ from __future__ import absolute_import, division, print_function
 
 import os
 
-from ...external.qt.QtGui import (
+from glue.external.qt.QtGui import (
     QMainWindow, QMessageBox, QWidget)
 
-from ...external.qt.QtCore import Qt
+from glue.external.qt.QtCore import Qt
 
-from ...core.application_base import ViewerBase
-from ..decorators import set_cursor
+from glue.core.application_base import ViewerBase
+from glue.qt.decorators import set_cursor
 
-from ..layer_artist_model import QtLayerArtistContainer, LayerArtistView
-from .. import get_qapp
-from ..mime import LAYERS_MIME_TYPE, LAYER_MIME_TYPE
-from .glue_mdi_area import GlueMdiSubWindow
+from glue.qt.layer_artist_model import QtLayerArtistContainer, LayerArtistView
+from glue.qt import get_qapp
+from glue.qt.mime import LAYERS_MIME_TYPE, LAYER_MIME_TYPE
+from glue.qt.widgets.glue_mdi_area import GlueMdiSubWindow
 
 __all__ = ['DataViewer']
 

--- a/glue/qt/widgets/edit_subset_mode_toolbar.py
+++ b/glue/qt/widgets/edit_subset_mode_toolbar.py
@@ -1,11 +1,11 @@
 from __future__ import absolute_import, division, print_function
 
-from ...external.qt import QtGui
+from glue.external.qt import QtGui
 
-from ...core.edit_subset_mode import (EditSubsetMode, OrMode, AndNotMode,
+from glue.core.edit_subset_mode import (EditSubsetMode, OrMode, AndNotMode,
                                       AndMode, XorMode, ReplaceMode)
-from ..actions import act
-from ..qtutil import nonpartial
+from glue.qt.actions import act
+from glue.qt.qtutil import nonpartial
 
 
 def set_mode(mode):

--- a/glue/qt/widgets/glue_mdi_area.py
+++ b/glue/qt/widgets/glue_mdi_area.py
@@ -1,10 +1,10 @@
 from __future__ import absolute_import, division, print_function
 
-from ...external.qt import QtGui
-from ...external.qt.QtCore import Qt, Signal
+from glue.external.qt import QtGui
+from glue.external.qt.QtCore import Qt, Signal
 
-from ... import core
-from ..mime import LAYER_MIME_TYPE, LAYERS_MIME_TYPE
+from glue import core
+from glue.qt.mime import LAYER_MIME_TYPE, LAYERS_MIME_TYPE
 
 
 class GlueMdiArea(QtGui.QMdiArea):

--- a/glue/qt/widgets/histogram_widget.py
+++ b/glue/qt/widgets/histogram_widget.py
@@ -2,19 +2,19 @@ from __future__ import absolute_import, division, print_function
 
 from functools import partial
 
-from ...external.qt import QtGui
-from ...external.qt.QtCore import Qt
+from glue.external.qt import QtGui
+from glue.external.qt.QtCore import Qt
 
-from ...core import message as msg
-from ...clients.histogram_client import HistogramClient
-from ..widget_properties import (connect_int_spin, ButtonProperty,
+from glue.core import message as msg
+from glue.clients.histogram_client import HistogramClient
+from glue.qt.widget_properties import (connect_int_spin, ButtonProperty,
                                  FloatLineProperty, connect_float_edit,
                                  ValueProperty, connect_bool_button)
-from ..glue_toolbar import GlueToolbar
-from ..mouse_mode import HRangeMode
-from .data_viewer import DataViewer
-from .mpl_widget import MplWidget, defer_draw
-from ..qtutil import pretty_number, load_ui
+from glue.qt.glue_toolbar import GlueToolbar
+from glue.qt.mouse_mode import HRangeMode
+from glue.qt.widgets.data_viewer import DataViewer
+from glue.qt.widgets.mpl_widget import MplWidget, defer_draw
+from glue.qt.qtutil import pretty_number, load_ui
 
 __all__ = ['HistogramWidget']
 

--- a/glue/qt/widgets/image_widget.py
+++ b/glue/qt/widgets/image_widget.py
@@ -1,31 +1,31 @@
 from __future__ import absolute_import, division, print_function
 
-from ...external.qt.QtGui import (QAction, QLabel, QCursor, QMainWindow,
+from glue.external.qt.QtGui import (QAction, QLabel, QCursor, QMainWindow,
                                   QToolButton, QIcon, QMessageBox
                                   )
 
-from ...external.qt.QtCore import Qt, QRect, Signal
+from glue.external.qt.QtCore import Qt, QRect, Signal
 
-from .data_viewer import DataViewer
-from ... import core
+from glue.qt.widgets.data_viewer import DataViewer
+from glue import core
 
-from ...clients.image_client import MplImageClient
-from ...clients.ds9norm import DS9Normalize
-from ...external.modest_image import imshow
+from glue.clients.image_client import MplImageClient
+from glue.clients.ds9norm import DS9Normalize
+from glue.external.modest_image import imshow
 
-from ...clients.layer_artist import Pointer
-from ...core.callback_property import add_callback, delay_callback
+from glue.clients.layer_artist import Pointer
+from glue.core.callback_property import add_callback, delay_callback
 
-from .data_slice_widget import DataSlice
+from glue.qt.widgets.data_slice_widget import DataSlice
 
-from ..mouse_mode import (RectangleMode, CircleMode, PolyMode,
+from glue.qt.mouse_mode import (RectangleMode, CircleMode, PolyMode,
                           ContrastMode)
-from ..glue_toolbar import GlueToolbar
-from .mpl_widget import MplWidget, defer_draw
+from glue.qt.glue_toolbar import GlueToolbar
+from glue.qt.widgets.mpl_widget import MplWidget, defer_draw
 
-from ..qtutil import cmap2pixmap, load_ui, get_icon, nonpartial, update_combobox
-from ..widget_properties import CurrentComboProperty, ButtonProperty, connect_current_combo, _find_combo_data
-from .glue_mdi_area import GlueMdiSubWindow
+from glue.qt.qtutil import cmap2pixmap, load_ui, get_icon, nonpartial, update_combobox
+from glue.qt.widget_properties import CurrentComboProperty, ButtonProperty, connect_current_combo, _find_combo_data
+from glue.qt.widgets.glue_mdi_area import GlueMdiSubWindow
 
 WARN_THRESH = 10000000  # warn when contouring large images
 
@@ -99,7 +99,7 @@ class ImageWidgetBase(DataViewer):
         """
         Set up additional tools for this widget
         """
-        from ... import config
+        from glue import config
         self._tools = []
         for tool in config.tool_registry.members[self.__class__]:
             self._tools.append(tool(self))
@@ -478,7 +478,7 @@ class ColormapAction(QAction):
 
 def _colormap_mode(parent, on_trigger):
 
-    from ... import config
+    from glue import config
 
     # actions for each colormap
     acts = []
@@ -528,7 +528,7 @@ class StandaloneImageWidget(QMainWindow):
             self.set_image(image=image, wcs=wcs, **kwargs)
 
     def _setup_axes(self):
-        from ...clients.viz_client import init_mpl
+        from glue.clients.viz_client import init_mpl
         _, self._axes = init_mpl(self.central_widget.canvas.fig, axes=None, wcs=True)
         self._axes.set_aspect('equal', adjustable='datalim')
 

--- a/glue/qt/widgets/layer_tree_widget.py
+++ b/glue/qt/widgets/layer_tree_widget.py
@@ -5,25 +5,25 @@ editing the data collection
 
 from __future__ import absolute_import, division, print_function
 
-from ...external.qt.QtGui import (QWidget, QMenu,
+from glue.external.qt.QtGui import (QWidget, QMenu,
                                   QAction, QKeySequence, QFileDialog)
 
 
-from ...external.qt.QtCore import Qt, Signal, QObject
-from ...external.six.moves import reduce
+from glue.external.qt.QtCore import Qt, Signal, QObject
+from glue.external.six.moves import reduce
 
-from ..ui.layertree import Ui_LayerTree
+from glue.qt.ui.layertree import Ui_LayerTree
 
-from ... import core
+from glue import core
 
-from ..link_editor import LinkEditor
-from .. import qtutil
-from ..qtutil import get_icon, nonpartial
-from .custom_component_widget import CustomComponentWidget
-from ..actions import act as _act
-from ...core.edit_subset_mode import AndMode, OrMode, XorMode, AndNotMode
-from .subset_facet import SubsetFacet
-from ...config import single_subset_action
+from glue.qt.link_editor import LinkEditor
+from glue.qt import qtutil
+from glue.qt.qtutil import get_icon, nonpartial
+from glue.qt.widgets.custom_component_widget import CustomComponentWidget
+from glue.qt.actions import act as _act
+from glue.core.edit_subset_mode import AndMode, OrMode, XorMode, AndNotMode
+from glue.qt.widgets.subset_facet import SubsetFacet
+from glue.config import single_subset_action
 
 
 @core.decorators.singleton
@@ -520,7 +520,7 @@ class LayerTreeWidget(QWidget, Ui_LayerTree):
     def _load_data(self):
         """ Interactively loads data from a data set. Adds
         as new layer """
-        from ..glue_application import GlueApplication
+        from glue.qt.glue_application import GlueApplication
 
         layers = qtutil.data_wizard()
         GlueApplication.add_datasets(self.data_collection, layers)

--- a/glue/qt/widgets/message_widget.py
+++ b/glue/qt/widgets/message_widget.py
@@ -2,11 +2,11 @@ from __future__ import absolute_import, division, print_function
 
 from time import ctime
 
-from ...external.qt.QtGui import QWidget, QTableWidgetItem
+from glue.external.qt.QtGui import QWidget, QTableWidgetItem
 
-from ... import core
+from glue import core
 
-from ..qtutil import load_ui
+from glue.qt.qtutil import load_ui
 
 
 class MessageWidget(QWidget, core.hub.HubListener):

--- a/glue/qt/widgets/mpl_widget.py
+++ b/glue/qt/widgets/mpl_widget.py
@@ -4,8 +4,8 @@ from __future__ import absolute_import, division, print_function
 
 from functools import partial, wraps
 
-from ...external.qt import QtGui, is_pyqt5
-from ...external.qt.QtCore import Signal, Qt, QTimer
+from glue.external.qt import QtGui, is_pyqt5
+from glue.external.qt.QtCore import Signal, Qt, QTimer
 
 if is_pyqt5():
     from matplotlib.backends.backend_qt5 import FigureManagerQT as FigureManager
@@ -20,7 +20,7 @@ else:
 import matplotlib
 from matplotlib.figure import Figure
 
-from ...utils import DeferredMethod
+from glue.utils import DeferredMethod
 
 
 def defer_draw(func):

--- a/glue/qt/widgets/scatter_widget.py
+++ b/glue/qt/widgets/scatter_widget.py
@@ -1,21 +1,21 @@
 from __future__ import absolute_import, division, print_function
 
-from ...external.qt import QtGui
-from ...external.qt.QtCore import Qt
-from ... import core
+from glue.external.qt import QtGui
+from glue.external.qt.QtCore import Qt
+from glue import core
 
-from ...clients.scatter_client import ScatterClient
-from ..glue_toolbar import GlueToolbar
-from ..mouse_mode import (RectangleMode, CircleMode,
+from glue.clients.scatter_client import ScatterClient
+from glue.qt.glue_toolbar import GlueToolbar
+from glue.qt.mouse_mode import (RectangleMode, CircleMode,
                           PolyMode, HRangeMode, VRangeMode)
 
-from .data_viewer import DataViewer
-from .mpl_widget import MplWidget, defer_draw
-from ..widget_properties import (ButtonProperty, FloatLineProperty,
+from glue.qt.widgets.data_viewer import DataViewer
+from glue.qt.widgets.mpl_widget import MplWidget, defer_draw
+from glue.qt.widget_properties import (ButtonProperty, FloatLineProperty,
                                  CurrentComboProperty,
                                  connect_bool_button, connect_float_edit)
 
-from ..qtutil import load_ui, cache_axes, nonpartial
+from glue.qt.qtutil import load_ui, cache_axes, nonpartial
 
 __all__ = ['ScatterWidget']
 

--- a/glue/qt/widgets/settings_editor.py
+++ b/glue/qt/widgets/settings_editor.py
@@ -1,5 +1,5 @@
-from ...external.qt.QtGui import QTableWidget, QTableWidgetItem
-from ...external.qt.QtCore import Qt
+from glue.external.qt.QtGui import QTableWidget, QTableWidgetItem
+from glue.external.qt.QtCore import Qt
 
 
 class SettingsEditor(object):

--- a/glue/qt/widgets/style_dialog.py
+++ b/glue/qt/widgets/style_dialog.py
@@ -1,14 +1,14 @@
 from __future__ import absolute_import, division, print_function
 
-from ..qtutil import (mpl_to_qt4_color, symbol_icon, POINT_ICONS,
+from glue.qt.qtutil import (mpl_to_qt4_color, symbol_icon, POINT_ICONS,
                       qt4_to_mpl_color)
 
-from ...external.qt.QtGui import (QFormLayout, QDialogButtonBox, QColorDialog,
+from glue.external.qt.QtGui import (QFormLayout, QDialogButtonBox, QColorDialog,
                                   QWidget, QLineEdit, QListWidget,
                                   QListWidgetItem, QPixmap, QDialog, QLabel,
                                   QSpinBox, QComboBox)
 
-from ...external.qt.QtCore import QSize, Signal, Qt
+from glue.external.qt.QtCore import QSize, Signal, Qt
 
 
 class ColorWidget(QLabel):
@@ -146,7 +146,7 @@ class StyleDialog(QDialog):
 
 if __name__ == "__main__":
     
-    from ..core import Data
+    from glue.qt.core import Data
 
     d = Data(label='data label', x=[1, 2, 3, 4])
     StyleDialog.edit_style(d)

--- a/glue/qt/widgets/subset_facet.py
+++ b/glue/qt/widgets/subset_facet.py
@@ -1,13 +1,13 @@
 from __future__ import absolute_import, division, print_function
 
-from ...external.qt.QtGui import (QDialog, QDoubleValidator, QIcon)
+from glue.external.qt.QtGui import (QDialog, QDoubleValidator, QIcon)
 import numpy as np
 from matplotlib import cm
 
 
-from ..qtutil import pretty_number, cmap2pixmap, load_ui
-from ...core.util import colorize_subsets, facet_subsets, Pointer
-from ..widget_properties import (ButtonProperty, FloatLineProperty,
+from glue.qt.qtutil import pretty_number, cmap2pixmap, load_ui
+from glue.core.util import colorize_subsets, facet_subsets, Pointer
+from glue.qt.widget_properties import (ButtonProperty, FloatLineProperty,
                                  ValueProperty)
 
 

--- a/glue/qt/widgets/table_widget.py
+++ b/glue/qt/widgets/table_widget.py
@@ -1,15 +1,15 @@
 from __future__ import absolute_import, division, print_function
 
-from .data_viewer import DataViewer
+from glue.qt.widgets.data_viewer import DataViewer
 
-from ...external.qt.QtGui import QTableView, QAbstractItemView, QItemSelectionModel, QItemSelection, QSortFilterProxyModel
-from ...external.qt.QtCore import Qt, QAbstractTableModel, QAbstractItemModel, QObject
+from glue.external.qt.QtGui import QTableView, QAbstractItemView, QItemSelectionModel, QItemSelection, QSortFilterProxyModel
+from glue.external.qt.QtCore import Qt, QAbstractTableModel, QAbstractItemModel, QObject
 
-from ...core import message as msg
-from ...core.edit_subset_mode import EditSubsetMode
-from ...core.subset import ElementSubsetState
+from glue.core import message as msg
+from glue.core.edit_subset_mode import EditSubsetMode
+from glue.core.subset import ElementSubsetState
 
-from ..qtutil import load_ui
+from glue.qt.qtutil import load_ui
 
 import numpy as np
 
@@ -191,7 +191,7 @@ class TableWidget(DataViewer):
         if the data set is big. To sidestep that,
         we swap out with a tiny data set before closing
         """
-        from ...core import Data
+        from glue.core import Data
         d = Data(x=[0])
         self.ui.table.setModel(DataTableModel(d))
         event.accept()

--- a/glue/qt/widgets/terminal.py
+++ b/glue/qt/widgets/terminal.py
@@ -25,11 +25,11 @@ from distutils.version import LooseVersion
 from contextlib import contextmanager
 
 # must import these first, to set up Qt properly
-from ...external.qt import QtCore
-from ...external.qt.QtGui import QInputDialog
-from ...version import __version__
-from ...utils import as_variable_name
-from .glue_mdi_area import GlueMdiSubWindow
+from glue.external.qt import QtCore
+from glue.external.qt.QtGui import QInputDialog
+from glue.version import __version__
+from glue.utils import as_variable_name
+from glue.qt.widgets.glue_mdi_area import GlueMdiSubWindow
 
 from zmq import ZMQError
 from zmq.eventloop.zmqstream import ZMQStream

--- a/glue/qt/widgets/tests/__init__.py
+++ b/glue/qt/widgets/tests/__init__.py
@@ -1,1 +1,1 @@
-from ....core.tests.util import simple_session
+from glue.core.tests.util import simple_session

--- a/glue/qt/widgets/tests/test_data_slice.py
+++ b/glue/qt/widgets/tests/test_data_slice.py
@@ -1,7 +1,7 @@
 import numpy as np
 from mock import MagicMock
 
-from .... import core
+from glue import core
 from ..data_slice_widget import SliceWidget, DataSlice
 
 

--- a/glue/qt/widgets/tests/test_data_viewer.py
+++ b/glue/qt/widgets/tests/test_data_viewer.py
@@ -4,12 +4,12 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 
-from ....core import Data, DataCollection
+from glue.core import Data, DataCollection
 from ..data_viewer import DataViewer
 from ..histogram_widget import HistogramWidget
 from ..scatter_widget import ScatterWidget
 from ..image_widget import ImageWidget
-from ...glue_application import GlueApplication
+from glue.qt.glue_application import GlueApplication
 
 from . import simple_session
 

--- a/glue/qt/widgets/tests/test_histogram_widget.py
+++ b/glue/qt/widgets/tests/test_histogram_widget.py
@@ -6,7 +6,7 @@ import pytest
 
 from . import simple_session
 from ..histogram_widget import HistogramWidget, _hash
-from .... import core
+from glue import core
 
 
 def mock_data():

--- a/glue/qt/widgets/tests/test_image_widget.py
+++ b/glue/qt/widgets/tests/test_image_widget.py
@@ -10,10 +10,10 @@ from mock import MagicMock
 
 from ..image_widget import ImageWidget
 
-from .... import core
-from ....core.tests.test_state import TestApplication
-from ...glue_application import GlueApplication
-from ....external.qt import get_qapp
+from glue import core
+from glue.core.tests.test_state import TestApplication
+from glue.qt.glue_application import GlueApplication
+from glue.external.qt import get_qapp
 
 from . import simple_session
 

--- a/glue/qt/widgets/tests/test_layer_tree_widget.py
+++ b/glue/qt/widgets/tests/test_layer_tree_widget.py
@@ -2,17 +2,17 @@
 
 from __future__ import absolute_import, division, print_function
 
-from ....external.qt.QtGui import QMainWindow
-from ....external.qt.QtTest import QTest
-from ....external.qt.QtCore import Qt
+from glue.external.qt.QtGui import QMainWindow
+from glue.external.qt.QtTest import QTest
+from glue.external.qt.QtCore import Qt
 
 from mock import MagicMock, patch
 
 from ..layer_tree_widget import (LayerTreeWidget, Clipboard,
                                  save_subset, PlotAction)
 
-from ....tests import example_data
-from .... import core
+from glue.tests import example_data
+from glue import core
 
 
 class TestLayerTree(object):

--- a/glue/qt/widgets/tests/test_scatter_widget.py
+++ b/glue/qt/widgets/tests/test_scatter_widget.py
@@ -9,7 +9,7 @@ from mock import patch
 
 from ..scatter_widget import ScatterWidget
 from ..mpl_widget import MplCanvas
-from .... import core
+from glue import core
 from . import simple_session
 
 from matplotlib import __version__ as mpl_version  # pylint:disable=W0611

--- a/glue/qt/widgets/tests/test_style_dialog.py
+++ b/glue/qt/widgets/tests/test_style_dialog.py
@@ -1,6 +1,6 @@
-from ....external.qt.QtCore import QPoint
-from ....external.qt.QtGui import QMainWindow
-from ....core import Data
+from glue.external.qt.QtCore import QPoint
+from glue.external.qt.QtGui import QMainWindow
+from glue.core import Data
 
 from . import simple_session
 from ..style_dialog import StyleDialog

--- a/glue/qt/widgets/tests/test_subset_facet.py
+++ b/glue/qt/widgets/tests/test_subset_facet.py
@@ -2,7 +2,7 @@ from mock import patch
 from matplotlib import cm
 
 from ..subset_facet import SubsetFacet
-from ....core import Data, DataCollection
+from glue.core import Data, DataCollection
 
 patched_facet = patch('glue.qt.widgets.subset_facet.facet_subsets')
 

--- a/glue/qt/widgets/tests/test_table_widget.py
+++ b/glue/qt/widgets/tests/test_table_widget.py
@@ -3,9 +3,9 @@ from __future__ import absolute_import, division, print_function
 import pytest
 
 from ..table_widget import DataTableModel
-from ....core import Data
+from glue.core import Data
 
-from ....external.qt.QtCore import Qt
+from glue.external.qt.QtCore import Qt
 
 
 class TestDataTableModel(object):

--- a/glue/qt/widgets/tests/test_terminal.py
+++ b/glue/qt/widgets/tests/test_terminal.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 from mock import MagicMock, patch
 
-from ....tests.helpers import requires_ipython_ge_012, IPYTHON_GE_012_INSTALLED
+from glue.tests.helpers import requires_ipython_ge_012, IPYTHON_GE_012_INSTALLED
 
 if IPYTHON_GE_012_INSTALLED:
     from ..terminal import glue_terminal

--- a/glue/tests/example_data.py
+++ b/glue/tests/example_data.py
@@ -2,8 +2,8 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 
-from ..core.data import Data
-from ..core.component import Component, CategoricalComponent
+from glue.core.data import Data
+from glue.core.component import Component, CategoricalComponent
 
 def test_histogram_data():
     data = Data(label="Test Data")

--- a/glue/utils/array.py
+++ b/glue/utils/array.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 import numpy as np
 import pandas as pd
 
-from ..external.six import string_types
+from glue.external.six import string_types
 
 __all__ = ['unique', 'shape_to_string', 'view_shape', 'stack_view',
            'coerce_numeric', 'check_sorted']

--- a/glue/utils/matplotlib.py
+++ b/glue/utils/matplotlib.py
@@ -7,7 +7,7 @@ from functools import wraps
 import numpy as np
 from matplotlib.backends.backend_agg import FigureCanvasAgg
 
-from .misc import DeferredMethod
+from glue.utils.misc import DeferredMethod
 
 __all__ = ['all_artists', 'new_artists', 'remove_artists', 'get_extent',
            'view_cascade', 'fast_limits', 'defer_draw',

--- a/glue/utils/qt/autocomplete_widget.py
+++ b/glue/utils/qt/autocomplete_widget.py
@@ -6,7 +6,7 @@
 #
 # http://qt-project.org/doc/qt-4.8/tools-customcompleter.html
 
-from ...external.qt import QtGui, QtCore
+from glue.external.qt import QtGui, QtCore
 
 
 __all__ = ["CompletionTextEdit"]

--- a/glue/utils/qt/qmessagebox_widget.py
+++ b/glue/utils/qt/qmessagebox_widget.py
@@ -1,7 +1,7 @@
 # A patched version of QMessageBox that allows copying the error
 
 import os
-from ...external.qt import QtGui
+from glue.external.qt import QtGui
 
 __all__ = ['QMessageBoxPatched']
 

--- a/glue/utils/qt/tests/test_qmessagebox_widget.py
+++ b/glue/utils/qt/tests/test_qmessagebox_widget.py
@@ -1,6 +1,6 @@
 from .. import QMessageBoxPatched as QMessageBox
-from ....qt import get_qapp
-from ....external.qt import QtGui
+from glue.qt import get_qapp
+from glue.external.qt import QtGui
 
 
 def test_main():

--- a/glue/utils/tests/test_array.py
+++ b/glue/utils/tests/test_array.py
@@ -1,7 +1,7 @@
 import pytest
 import numpy as np
 
-from ...external.six import string_types, PY2
+from glue.external.six import string_types, PY2
 
 from ..array import view_shape, coerce_numeric, stack_view, unique, shape_to_string, check_sorted
 

--- a/glue/utils/tests/test_matplotlib.py
+++ b/glue/utils/tests/test_matplotlib.py
@@ -5,7 +5,7 @@ from numpy.testing import assert_allclose
 import matplotlib.pyplot as plt
 from matplotlib.patches import Circle
 
-from ...tests.helpers import requires_scipy
+from glue.tests.helpers import requires_scipy
 
 from ..matplotlib import (point_contour, fast_limits, all_artists, new_artists,
                           remove_artists, view_cascade, get_extent, color2rgb,

--- a/glue/version.py
+++ b/glue/version.py
@@ -1,7 +1,7 @@
 __version__ = '0.7.0.dev'
 
 try:
-    from ._githash import __githash__, __dev_value__
+    from glue._githash import __githash__, __dev_value__
     __version__ += __dev_value__
 except Exception:
     pass


### PR DESCRIPTION
This switches all glue imports to absolute imports except in the following cases:

- local imports in ``__init__.py`` files
- local imports in ``test_*.py`` files and imports that only go up one level

The idea is that in the latter case, the tests will usually always be in the same place relative to the files the tests apply for, so in that case it makes sense to use relative imports.

However, in all other cases, when trying to refactor the code, I found that the relative imports really make the code much harder to understand (and harder to move files around).

With absolute imports, it will be much easier to check that certain parts of glue are not imported by other parts (for example nothing in ``glue.core`` should import from ``glue.qt``, etc.).

Incidentally, I'm guilty of switching from absolute to relative initially (in b999181f8f7120abaee928bfe7a94743780ff324, c7b369d3731bdd47e4d12ca2ff360fec8e0b51ae, 50402a6c6925b8b2078a679cae77a3635ee59406, and ccf77e29570a28b0dcdd276a05cc5d84164c305e) but I've now learned from my mistake :grin: