### PR TITLE
Improve Qt imports

### DIFF
--- a/glue/main.py
+++ b/glue/main.py
@@ -199,13 +199,13 @@ def execute_script(script):
 
 def get_splash():
     """Instantiate a splash screen"""
-    from glue.external.qt.QtGui import QSplashScreen, QPixmap
+    from glue.external.qt import QtGui
     from glue.external.qt.QtCore import Qt
     import os
 
     pth = os.path.join(os.path.dirname(__file__), 'logo.png')
-    pm = QPixmap(pth)
-    splash = QSplashScreen(pm, Qt.WindowStaysOnTopHint)
+    pm = QtGui.QPixmap(pth)
+    splash = QtGui.QSplashScreen(pm, Qt.WindowStaysOnTopHint)
     splash.show()
 
     return splash

--- a/glue/plugins/ginga_viewer/qt_widget.py
+++ b/glue/plugins/ginga_viewer/qt_widget.py
@@ -5,6 +5,7 @@ import os.path
 import numpy as np
 
 from glue.external.qt import QtGui, QtCore
+from glue.external.qt.QtCore import Qt
 
 from ginga.qtw.ImageViewCanvasQt import ImageViewCanvas
 from ginga.qtw import ColorBar

--- a/glue/plugins/ginga_viewer/qt_widget.py
+++ b/glue/plugins/ginga_viewer/qt_widget.py
@@ -4,12 +4,7 @@ import sys
 import os.path
 import numpy as np
 
-from glue.external.qt.QtGui import (QAction,
-                                  QToolButton, QToolBar, QIcon,
-                                  QActionGroup, QWidget,
-                                  QVBoxLayout, QColor, QImage, QPixmap)
-
-from glue.external.qt.QtCore import Qt, QSize
+from glue.external.qt import QtGui, QtCore
 
 from ginga.qtw.ImageViewCanvasQt import ImageViewCanvas
 from ginga.qtw import ColorBar
@@ -107,8 +102,8 @@ class GingaWidget(ImageWidgetBase):
 
     def make_central_widget(self):
 
-        topw = QWidget()
-        layout = QVBoxLayout()
+        topw = QtGui.QWidget()
+        layout = QtGui.QVBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
         layout.addWidget(self.canvas.get_widget(), stretch=1)
@@ -134,12 +129,12 @@ class GingaWidget(ImageWidgetBase):
         self.colorbar.set_range(loval, hival)
 
     def make_toolbar(self):
-        tb = QToolBar(parent=self)
-        tb.setIconSize(QSize(25, 25))
+        tb = QtGui.QToolBar(parent=self)
+        tb.setIconSize(QtCore.QSize(25, 25))
         tb.layout().setSpacing(1)
         tb.setFocusPolicy(Qt.StrongFocus)
 
-        agroup = QActionGroup(tb)
+        agroup = QtGui.QActionGroup(tb)
         agroup.setExclusive(True)
         for (mode_text, mode_icon, mode_cb) in self._mouse_modes():
             # TODO: add icons similar to the Matplotlib toolbar
@@ -153,13 +148,13 @@ class GingaWidget(ImageWidgetBase):
         action.setCheckable(True)
         action.toggled.connect(lambda tf: self.mode_cb('pan', tf))
         agroup.addAction(action)
-        icon = QIcon(os.path.join(ginga_icon_dir, 'hand_48.png'))
+        icon = QtGui.QIcon(os.path.join(ginga_icon_dir, 'hand_48.png'))
         action = tb.addAction(icon, "Free Pan")
         self.mode_actns['freepan'] = action
         action.setCheckable(True)
         action.toggled.connect(lambda tf: self.mode_cb('freepan', tf))
         agroup.addAction(action)
-        icon = QIcon(os.path.join(ginga_icon_dir, 'rotate_48.png'))
+        icon = QtGui.QIcon(os.path.join(ginga_icon_dir, 'rotate_48.png'))
         action = tb.addAction(icon, "Rotate")
         self.mode_actns['rotate'] = action
         action.setCheckable(True)
@@ -170,7 +165,7 @@ class GingaWidget(ImageWidgetBase):
         action.setCheckable(True)
         action.toggled.connect(lambda tf: self.mode_cb('contrast', tf))
         agroup.addAction(action)
-        icon = QIcon(os.path.join(ginga_icon_dir, 'cuts_48.png'))
+        icon = QtGui.QIcon(os.path.join(ginga_icon_dir, 'cuts_48.png'))
         action = tb.addAction(icon, "Cuts")
         self.mode_actns['cuts'] = action
         action.setCheckable(True)
@@ -284,13 +279,13 @@ class GingaWidget(ImageWidgetBase):
         return True
 
 
-class ColormapAction(QAction):
+class ColormapAction(QtGui.QAction):
 
     def __init__(self, label, cmap, parent):
         super(ColormapAction, self).__init__(label, parent)
         self.cmap = cmap
         pm = cmap2pixmap(cmap)
-        self.setIcon(QIcon(pm))
+        self.setIcon(QtGui.QIcon(pm))
 
 
 def _colormap_mode(parent, on_trigger):
@@ -305,12 +300,12 @@ def _colormap_mode(parent, on_trigger):
         acts.append(a)
 
     # Toolbar button
-    tb = QToolButton()
+    tb = QtGui.QToolButton()
     tb.setWhatsThis("Set color scale")
     tb.setToolTip("Set color scale")
     icon = get_icon('glue_rainbow')
     tb.setIcon(icon)
-    tb.setPopupMode(QToolButton.InstantPopup)
+    tb.setPopupMode(QtGui.QToolButton.InstantPopup)
     tb.addActions(acts)
 
     return tb
@@ -423,24 +418,24 @@ tool_registry.add(GingaSpectrumTool, GingaWidget)
 
 
 def cmap2pixmap(cmap, steps=50):
-    """Convert a Ginga colormap into a QPixmap
+    """Convert a Ginga colormap into a QtGui.QPixmap
 
     :param cmap: The colormap to use
     :type cmap: Ginga colormap instance (e.g. ginga.cmap.get_cmap('gray'))
     :param steps: The number of color steps in the output. Default=50
     :type steps: int
 
-    :rtype: QPixmap
+    :rtype: QtGui.QPixmap
     """
     inds = np.linspace(0, 1, steps)
     n = len(cmap.clst) - 1
     tups = [cmap.clst[int(x * n)] for x in inds]
-    rgbas = [QColor(int(r * 255), int(g * 255),
+    rgbas = [QtGui.QColor(int(r * 255), int(g * 255),
                     int(b * 255), 255).rgba() for r, g, b in tups]
-    im = QImage(steps, 1, QImage.Format_Indexed8)
+    im = QtGui.QImage(steps, 1, QtGui.QImage.Format_Indexed8)
     im.setColorTable(rgbas)
     for i in range(steps):
         im.setPixel(i, 0, i)
     im = im.scaled(128, 32)
-    pm = QPixmap.fromImage(im)
+    pm = QtGui.QPixmap.fromImage(im)
     return pm

--- a/glue/plugins/tools/spectrum_tool.py
+++ b/glue/plugins/tools/spectrum_tool.py
@@ -4,13 +4,7 @@ import logging
 import numpy as np
 
 from glue.external.qt.QtCore import Qt, Signal
-from glue.external.qt.QtGui import (QMainWindow, QWidget,
-                                 QHBoxLayout, QTabWidget,
-                                 QComboBox, QFormLayout, QPushButton,
-                                 QAction, QTextEdit, QFont, QDialog,
-                                 QDialogButtonBox, QLineEdit,
-                                 QDoubleValidator, QCheckBox, QGridLayout,
-                                 QLabel, QFileDialog)
+from glue.external.qt import QtGui
 
 
 from glue.clients.profile_viewer import ProfileViewer
@@ -260,7 +254,7 @@ class NavContext(SpectrumContext):
         pass
 
     def _setup_widget(self):
-        self.widget = QTextEdit()
+        self.widget = QtGui.QTextEdit()
         self.widget.setHtml("To <b> slide </b> through the cube, "
                             "drag the handle or double-click<br><br><br>"
                             "To make a <b> new profile </b>, "
@@ -280,21 +274,21 @@ class CollapseContext(SpectrumContext):
         self.grip = self.main.profile.new_range_grip()
 
     def _setup_widget(self):
-        w = QWidget()
-        l = QFormLayout()
+        w = QtGui.QWidget()
+        l = QtGui.QFormLayout()
         w.setLayout(l)
 
-        combo = QComboBox()
+        combo = QtGui.QComboBox()
         combo.addItem("Mean", userData=Aggregate.mean)
         combo.addItem("Median", userData=Aggregate.median)
         combo.addItem("Max", userData=Aggregate.max)
         combo.addItem("Centroid", userData=Aggregate.mom1)
         combo.addItem("Linewidth", userData=Aggregate.mom2)
 
-        run = QPushButton("Collapse")
-        save = QPushButton("Save as FITS file")
+        run = QtGui.QPushButton("Collapse")
+        save = QtGui.QPushButton("Save as FITS file")
 
-        buttons = QHBoxLayout()
+        buttons = QtGui.QHBoxLayout()
         buttons.addWidget(run)
         buttons.addWidget(save)
 
@@ -339,7 +333,7 @@ class CollapseContext(SpectrumContext):
     @messagebox_on_error("Failed to export projection")
     def _choose_save(self):
 
-        out, _ = QFileDialog.getSaveFileName(filter='FITS Files (*.fits)')
+        out, _ = QtGui.QFileDialog.getSaveFileName(filter='FITS Files (*.fits)')
         if out is None:
             return
 
@@ -385,7 +379,7 @@ class CollapseContext(SpectrumContext):
         fits.writeto(pth, self._agg, header, clobber=True)
 
 
-class ConstraintsWidget(QWidget):
+class ConstraintsWidget(QtGui.QWidget):
 
     """
     A widget to display and tweak the constraints of a :class:`~glue.core.fitters.BaseFitter1D`
@@ -398,56 +392,56 @@ class ConstraintsWidget(QWidget):
         constraints : dict
             The `contstraints` property of a :class:`~glue.core.fitters.BaseFitter1D`
             object
-        parent : QWidget (optional)
+        parent : QtGui.QWidget (optional)
             The parent of this widget
         """
         super(ConstraintsWidget, self).__init__(parent)
         self.constraints = constraints
 
-        self.layout = QGridLayout()
+        self.layout = QtGui.QGridLayout()
         self.layout.setContentsMargins(2, 2, 2, 2)
         self.layout.setSpacing(4)
 
         self.setLayout(self.layout)
 
-        self.layout.addWidget(QLabel("Estimate"), 0, 1)
-        self.layout.addWidget(QLabel("Fixed"), 0, 2)
-        self.layout.addWidget(QLabel("Bounded"), 0, 3)
-        self.layout.addWidget(QLabel("Lower Bound"), 0, 4)
-        self.layout.addWidget(QLabel("Upper Bound"), 0, 5)
+        self.layout.addWidget(QtGui.QLabel("Estimate"), 0, 1)
+        self.layout.addWidget(QtGui.QLabel("Fixed"), 0, 2)
+        self.layout.addWidget(QtGui.QLabel("Bounded"), 0, 3)
+        self.layout.addWidget(QtGui.QLabel("Lower Bound"), 0, 4)
+        self.layout.addWidget(QtGui.QLabel("Upper Bound"), 0, 5)
 
         self._widgets = {}
         names = sorted(list(self.constraints.keys()))
 
         for k in names:
             row = []
-            w = QLabel(k)
+            w = QtGui.QLabel(k)
             row.append(w)
 
-            v = QDoubleValidator()
-            e = QLineEdit()
+            v = QtGui.QDoubleValidator()
+            e = QtGui.QLineEdit()
             e.setValidator(v)
             e.setText(str(constraints[k]['value'] or ''))
             row.append(e)
 
-            w = QCheckBox()
+            w = QtGui.QCheckBox()
             w.setChecked(constraints[k]['fixed'])
             fix = w
             row.append(w)
 
-            w = QCheckBox()
+            w = QtGui.QCheckBox()
             limits = constraints[k]['limits']
             w.setChecked(limits is not None)
             bound = w
             row.append(w)
 
-            e = QLineEdit()
+            e = QtGui.QLineEdit()
             e.setValidator(v)
             if limits is not None:
                 e.setText(str(limits[0]))
             row.append(e)
 
-            e = QLineEdit()
+            e = QtGui.QLineEdit()
             e.setValidator(v)
             if limits is not None:
                 e.setText(str(limits[1]))
@@ -490,7 +484,7 @@ class ConstraintsWidget(QWidget):
             fitter.set_constraint(name, **s)
 
 
-class FitSettingsWidget(QDialog):
+class FitSettingsWidget(QtGui.QDialog):
 
     def __init__(self, fitter, parent=None):
         super(FitSettingsWidget, self).__init__(parent)
@@ -503,7 +497,7 @@ class FitSettingsWidget(QDialog):
     def _build_form(self):
         fitter = self.fitter
 
-        l = QFormLayout()
+        l = QtGui.QFormLayout()
         options = fitter.options
         self.widgets = {}
         self.forms = {}
@@ -521,8 +515,8 @@ class FitSettingsWidget(QDialog):
         else:
             self.constraints = None
 
-        self.okcancel = QDialogButtonBox(QDialogButtonBox.Ok |
-                                         QDialogButtonBox.Cancel)
+        self.okcancel = QtGui.QDialogButtonBox(QtGui.QDialogButtonBox.Ok |
+                                         QtGui.QDialogButtonBox.Cancel)
         l.addRow(self.okcancel)
         self.setLayout(l)
 
@@ -556,7 +550,7 @@ class FitContext(SpectrumContext):
         self.ui = load_ui('spectrum_fit_panel')
         self.ui.uncertainty_combo.hide()
         self.ui.uncertainty_label.hide()
-        font = QFont("Courier")
+        font = QtGui.QFont("Courier")
         font.setStyleHint(font.Monospace)
         self.ui.results_box.document().setDefaultFont(font)
         self.ui.results_box.setLineWrapMode(self.ui.results_box.NoWrap)
@@ -621,7 +615,7 @@ class FitContext(SpectrumContext):
         self.canvas.draw()
 
 
-class SpectrumMainWindow(QMainWindow):
+class SpectrumMainWindow(QtGui.QMainWindow):
 
     """
     The main window that the spectrum viewer is embedded in.
@@ -708,8 +702,8 @@ class SpectrumTool(object):
         self.widget = SpectrumMainWindow()
         self.widget.window_closed.connect(self.reset)
 
-        w = QWidget()
-        l = QHBoxLayout()
+        w = QtGui.QWidget()
+        l = QtGui.QHBoxLayout()
         l.setSpacing(2)
         l.setContentsMargins(2, 2, 2, 2)
         w.setLayout(l)
@@ -727,7 +721,7 @@ class SpectrumTool(object):
                           FitContext(self),
                           CollapseContext(self)]
 
-        tabs = QTabWidget()
+        tabs = QtGui.QTabWidget()
         tabs.addTab(self._contexts[0].widget, 'Navigate')
         tabs.addTab(self._contexts[1].widget, 'Fit')
         tabs.addTab(self._contexts[2].widget, 'Collapse')
@@ -766,7 +760,7 @@ class SpectrumTool(object):
         tb.mode_activated.connect(self.profile.disconnect)
         tb.mode_deactivated.connect(self.profile.connect)
 
-        self._menu_toggle_action = QAction("Options", tb)
+        self._menu_toggle_action = QtGui.QAction("Options", tb)
         self._menu_toggle_action.setCheckable(True)
         self._menu_toggle_action.toggled.connect(self._toggle_menu)
 

--- a/glue/qt/actions.py
+++ b/glue/qt/actions.py
@@ -1,12 +1,12 @@
 from __future__ import absolute_import, division, print_function
 
-from glue.external.qt.QtGui import QAction
+from glue.external.qt import QtGui
 from glue.qt.qtutil import get_icon
 
 
 def act(name, parent, tip='', icon=None, shortcut=None):
     """ Factory for making a new action """
-    a = QAction(name, parent)
+    a = QtGui.QAction(name, parent)
     a.setToolTip(tip)
     if icon:
         a.setIcon(get_icon(icon))

--- a/glue/qt/component_selector.py
+++ b/glue/qt/component_selector.py
@@ -1,12 +1,12 @@
 from __future__ import absolute_import, division, print_function
 
-from glue.external.qt.QtGui import QWidget, QListWidgetItem
+from glue.external.qt import QtGui
 from glue.external.qt.QtCore import Signal
 
 from glue.qt.qtutil import load_ui
 
 
-class ComponentSelector(QWidget):
+class ComponentSelector(QtGui.QWidget):
     """ An interface to view the components and data of a DataCollection
 
     Components can be draged and dropped.
@@ -76,7 +76,7 @@ class ComponentSelector(QWidget):
         c_list = self._ui.component_selector
         c_list.clear()
         for c in cids:
-            item = QListWidgetItem(c.label)
+            item = QtGui.QListWidgetItem(c.label)
             c_list.addItem(item)
             c_list.set_data(item, c)
 
@@ -126,7 +126,7 @@ def main():  # pragma: no cover
     import glue
     import numpy as np
     from glue.qt import get_qapp
-    from glue.external.qt.QtGui import QApplication
+    from glue.external.qt import QtGui
 
     d = glue.core.Data(label="hi")
     d2 = glue.core.Data(label="there")

--- a/glue/qt/custom_viewer.py
+++ b/glue/qt/custom_viewer.py
@@ -75,6 +75,10 @@ from copy import copy
 
 import numpy as np
 
+from glue.external import six
+from glue.external.qt import QtGui, QtCore
+from glue.external.qt.QtCore import Qt
+
 from glue.clients import LayerArtist, GenericMplClient
 from glue.core import Data
 from glue.core.edit_subset_mode import EditSubsetMode
@@ -83,9 +87,6 @@ from glue import core
 
 from glue.qt.widgets.data_viewer import DataViewer
 from glue.qt import widget_properties as wp
-from glue.external import six
-from glue.external.qt import QtGui
-from glue.external.qt.QtCore import Qt
 from glue.qt.widgets import MplWidget
 from glue.qt.glue_toolbar import GlueToolbar
 from glue.qt.mouse_mode import PolyMode, RectangleMode

--- a/glue/qt/feedback.py
+++ b/glue/qt/feedback.py
@@ -5,7 +5,7 @@ from glue.external.six.moves.urllib.request import Request, urlopen
 from glue.external.six.moves.urllib.parse import urlencode
 import sys
 
-from glue.external.qt.QtGui import QTextCursor
+from glue.external.qt import QtGui
 from glue.qt.qtutil import load_ui
 
 __all__ = ['submit_bug_report']
@@ -66,7 +66,7 @@ class FeedbackWidget(object):
                               feedback,
                               _diagnostics()])
         self._ui.report_area.insertPlainText('\n' + feedback)
-        self._ui.report_area.moveCursor(QTextCursor.Start)
+        self._ui.report_area.moveCursor(QtGui.QTextCursor.Start)
 
     def exec_(self):
         """

--- a/glue/qt/glue_application.py
+++ b/glue/qt/glue_application.py
@@ -7,14 +7,9 @@ import sys
 import warnings
 import webbrowser
 
-from glue.external.qt.QtGui import (QKeySequence, QMainWindow, QGridLayout,
-                                 QMenu, QAction,
-                                 QFileDialog, QInputDialog,
-                                 QToolButton, QVBoxLayout, QWidget, QPixmap,
-                                 QBrush, QPainter, QLabel, QHBoxLayout,
-                                 QTextEdit, QTextCursor, QPushButton,
-                                 QListWidgetItem, QIcon)
-from glue.external.qt.QtCore import Qt, QSize, QSettings, Signal
+from glue.external.qt import QtGui, QtCore
+from glue.external.qt.QtCore import Qt
+
 from glue.utils.qt import QMessageBoxPatched as QMessageBox
 
 from glue.core import command, Data
@@ -68,26 +63,26 @@ def status_pixmap(attention=False):
     """
     color = Qt.red if attention else Qt.lightGray
 
-    pm = QPixmap(15, 15)
-    p = QPainter(pm)
-    b = QBrush(color)
+    pm = QtGui.QPixmap(15, 15)
+    p = QtGui.QPainter(pm)
+    b = QtGui.QBrush(color)
     p.fillRect(-1, -1, 20, 20, b)
     return pm
 
 
-class ClickableLabel(QLabel):
+class ClickableLabel(QtGui.QLabel):
 
     """
-    A QLabel you can click on to generate events
+    A QtGui.QLabel you can click on to generate events
     """
 
-    clicked = Signal()
+    clicked = QtCore.Signal()
 
     def mousePressEvent(self, event):
         self.clicked.emit()
 
 
-class GlueLogger(QWidget):
+class GlueLogger(QtGui.QWidget):
 
     """
     A window to display error messages
@@ -95,13 +90,13 @@ class GlueLogger(QWidget):
 
     def __init__(self, parent=None):
         super(GlueLogger, self).__init__(parent)
-        self._text = QTextEdit()
+        self._text = QtGui.QTextEdit()
         self._text.setTextInteractionFlags(Qt.TextSelectableByMouse)
 
-        clear = QPushButton("Clear")
+        clear = QtGui.QPushButton("Clear")
         clear.clicked.connect(self._clear)
 
-        report = QPushButton("Send Bug Report")
+        report = QtGui.QPushButton("Send Bug Report")
         report.clicked.connect(self._send_report)
 
         self.stderr = sys.stderr
@@ -113,8 +108,8 @@ class GlueLogger(QWidget):
         self._status.setPixmap(status_pixmap())
         self._status.setContentsMargins(0, 0, 0, 0)
 
-        l = QVBoxLayout()
-        h = QHBoxLayout()
+        l = QtGui.QVBoxLayout()
+        h = QtGui.QHBoxLayout()
         l.setContentsMargins(2, 2, 2, 2)
         l.setSpacing(2)
         h.setContentsMargins(0, 0, 0, 0)
@@ -139,7 +134,7 @@ class GlueLogger(QWidget):
         Interface for sys.excepthook
         """
         self.stderr.write(message)
-        self._text.moveCursor(QTextCursor.End)
+        self._text.moveCursor(QtGui.QTextCursor.End)
         self._text.insertPlainText(message)
         self._status.setPixmap(status_pixmap(attention=True))
 
@@ -180,12 +175,12 @@ class GlueLogger(QWidget):
             self.hide()
 
 
-class GlueApplication(Application, QMainWindow):
+class GlueApplication(Application, QtGui.QMainWindow):
 
     """ The main GUI application for the Qt frontend"""
 
     def __init__(self, data_collection=None, session=None):
-        QMainWindow.__init__(self)
+        QtGui.QMainWindow.__init__(self)
         Application.__init__(self, data_collection=data_collection,
                              session=session)
 
@@ -193,7 +188,7 @@ class GlueApplication(Application, QMainWindow):
         self.app.setQuitOnLastWindowClosed(True)
         pth = os.path.abspath(os.path.dirname(__file__))
         pth = os.path.join(pth, 'icons', 'app_icon.png')
-        self.app.setWindowIcon(QIcon(pth))
+        self.app.setWindowIcon(QtGui.QIcon(pth))
 
         # Even though we loaded the plugins in start_glue, we re-load them here
         # in case glue was started directly by initializing this class.
@@ -233,7 +228,7 @@ class GlueApplication(Application, QMainWindow):
 
         lw = LayerTreeWidget()
         lw.set_checkable(False)
-        vb = QVBoxLayout()
+        vb = QtGui.QVBoxLayout()
         vb.setContentsMargins(0, 0, 0, 0)
         vb.addWidget(lw)
         self._ui.data_layers.setLayout(vb)
@@ -280,7 +275,7 @@ class GlueApplication(Application, QMainWindow):
 
     def new_tab(self):
         """Spawn a new tab page"""
-        layout = QGridLayout()
+        layout = QtGui.QGridLayout()
         layout.setSpacing(1)
         layout.setContentsMargins(0, 0, 0, 0)
         widget = GlueMdiArea(self)
@@ -326,7 +321,7 @@ class GlueApplication(Application, QMainWindow):
         
         Returns the window that this widget is wrapped in.
 
-        :param new_widget: new QWidget to add
+        :param new_widget: new QtGui.QWidget to add
 
         :param label: label for the new window. Optional
         :type label: str
@@ -363,11 +358,11 @@ class GlueApplication(Application, QMainWindow):
         :type value: str
         """
         super(GlueApplication, self).set_setting(key, value)
-        settings = QSettings('glue-viz', 'glue')
+        settings = QtCore.QSettings('glue-viz', 'glue')
         settings.setValue(key, value)
 
     def _load_settings(self, path=None):
-        settings = QSettings('glue-viz', 'glue')
+        settings = QtCore.QSettings('glue-viz', 'glue')
         for k, v in self.settings:
             if settings.contains(k):
                 super(GlueApplication, self).set_setting(k, settings.value(k))
@@ -383,11 +378,11 @@ class GlueApplication(Application, QMainWindow):
 
     def _get_plot_dashboards(self, sub_window):
         if not isinstance(sub_window, GlueMdiSubWindow):
-            return QWidget(), QWidget(), ""
+            return QtGui.QWidget(), QtGui.QWidget(), ""
 
         widget = sub_window.widget()
         if not isinstance(widget, DataViewer):
-            return QWidget(), QWidget(), ""
+            return QtGui.QWidget(), QtGui.QWidget(), ""
 
         return widget.layer_view(), widget.options_widget(), str(widget)
 
@@ -397,7 +392,7 @@ class GlueApplication(Application, QMainWindow):
                               (self._ui.plot_options, "Plot Options")]:
             layout = widget.layout()
             if layout is None:
-                layout = QVBoxLayout()
+                layout = QtGui.QVBoxLayout()
                 layout.setContentsMargins(4, 4, 4, 4)
                 widget.setLayout(layout)
             while layout.count():
@@ -447,7 +442,7 @@ class GlueApplication(Application, QMainWindow):
 
     def _create_menu(self):
         mbar = self.menuBar()
-        menu = QMenu(mbar)
+        menu = QtGui.QMenu(mbar)
         menu.setTitle("&File")
 
         menu.addAction(self._actions['data_new'])
@@ -467,21 +462,21 @@ class GlueApplication(Application, QMainWindow):
         menu.addAction("Edit &Settings", self._edit_settings)
         mbar.addMenu(menu)
 
-        menu = QMenu(mbar)
+        menu = QtGui.QMenu(mbar)
         menu.setTitle("&Edit ")
         menu.addAction(self._actions['undo'])
         menu.addAction(self._actions['redo'])
         mbar.addMenu(menu)
 
-        menu = QMenu(mbar)
+        menu = QtGui.QMenu(mbar)
         menu.setTitle("&View ")
 
-        a = QAction("&Console Log", menu)
+        a = QtGui.QAction("&Console Log", menu)
         a.triggered.connect(self._ui.log._show)
         menu.addAction(a)
         mbar.addMenu(menu)
 
-        menu = QMenu(mbar)
+        menu = QtGui.QMenu(mbar)
         menu.setTitle("&Canvas")
         menu.addAction(self._actions['tab_new'])
         menu.addAction(self._actions['viewer_new'])
@@ -490,31 +485,31 @@ class GlueApplication(Application, QMainWindow):
         menu.addAction(self._actions['tab_rename'])
         mbar.addMenu(menu)
 
-        menu = QMenu(mbar)
+        menu = QtGui.QMenu(mbar)
         menu.setTitle("Data &Manager")
         menu.addActions(self._ui.layerWidget.actions())
 
         mbar.addMenu(menu)
 
-        menu = QMenu(mbar)
+        menu = QtGui.QMenu(mbar)
         menu.setTitle("&Toolbars")
         tbar = EditSubsetModeToolBar()
         self._mode_toolbar = tbar
         self.addToolBar(tbar)
         tbar.hide()
-        a = QAction("Selection Mode &Toolbar", menu)
+        a = QtGui.QAction("Selection Mode &Toolbar", menu)
         a.setCheckable(True)
         a.toggled.connect(tbar.setVisible)
         try:
             tbar.visibilityChanged.connect(a.setChecked)
-        except AttributeError:  # Qt < 4.7. Signal not supported
+        except AttributeError:  # Qt < 4.7. QtCore.Signal not supported
             pass
 
         menu.addAction(a)
         menu.addActions(tbar.actions())
         mbar.addMenu(menu)
 
-        menu = QMenu(mbar)
+        menu = QtGui.QMenu(mbar)
         menu.setTitle("&Plugins")
         menu.addAction(self._actions['plugin_manager'])
         menu.addSeparator()
@@ -527,11 +522,11 @@ class GlueApplication(Application, QMainWindow):
 
         # trigger inclusion of Mac Native "Help" tool
         menu = mbar.addMenu("&Help")
-        a = QAction("&Online Documentation", menu)
+        a = QtGui.QAction("&Online Documentation", menu)
         a.triggered.connect(nonpartial(webbrowser.open, DOCS_URL))
         menu.addAction(a)
 
-        a = QAction("Send &Feedback", menu)
+        a = QtGui.QAction("Send &Feedback", menu)
         a.triggered.connect(nonpartial(submit_bug_report))
         menu.addAction(a)
 
@@ -553,13 +548,13 @@ class GlueApplication(Application, QMainWindow):
 
         a = act("&New Data Viewer", self,
                 tip="Open a new visualization window in the current tab",
-                shortcut=QKeySequence.New
+                shortcut=QtGui.QKeySequence.New
                 )
         a.triggered.connect(nonpartial(self.choose_new_data_viewer))
         self._actions['viewer_new'] = a
 
         a = act('New &Tab', self,
-                shortcut=QKeySequence.AddTab,
+                shortcut=QtGui.QKeySequence.AddTab,
                 tip='Add a new tab')
         a.triggered.connect(nonpartial(self.new_tab))
         self._actions['tab_new'] = a
@@ -584,7 +579,7 @@ class GlueApplication(Application, QMainWindow):
         # Add file loader as first item in File menu for convenience. We then
         # also add it again below in the Import menu for consistency.
         a = act("&Open Data Set", self, tip="Open a new data set",
-                shortcut=QKeySequence.Open)
+                shortcut=QtGui.QKeySequence.Open)
         a.triggered.connect(nonpartial(self._choose_load_data,
                                        data_wizard))
         self._actions['data_new'] = a
@@ -635,14 +630,14 @@ class GlueApplication(Application, QMainWindow):
 
         a = act("Undo", self,
                 tip='Undo last action',
-                shortcut=QKeySequence.Undo)
+                shortcut=QtGui.QKeySequence.Undo)
         a.triggered.connect(nonpartial(self.undo))
         a.setEnabled(False)
         self._actions['undo'] = a
 
         a = act("Redo", self,
                 tip='Redo last action',
-                shortcut=QKeySequence.Redo)
+                shortcut=QtGui.QKeySequence.Redo)
         a.triggered.connect(nonpartial(self.redo))
         a.setEnabled(False)
         self._actions['redo'] = a
@@ -694,7 +689,7 @@ class GlueApplication(Application, QMainWindow):
         """
 
         # include file filter twice, so it shows up in Dialog
-        outfile, file_filter = QFileDialog.getSaveFileName(self,
+        outfile, file_filter = QtGui.QFileDialog.getSaveFileName(self,
                                                            filter="Glue Session (*.glu);; Glue Session including data (*.glu)")
 
         # This indicates that the user cancelled
@@ -711,13 +706,13 @@ class GlueApplication(Application, QMainWindow):
     def _choose_export_session(self, saver, checker, outmode):
         checker(self)
         if outmode in ['file', 'directory']:
-            outfile, file_filter = QFileDialog.getSaveFileName(self)
+            outfile, file_filter = QtGui.QFileDialog.getSaveFileName(self)
             if not outfile:
                 return
             return saver(self, outfile)
         else:
             assert outmode == 'label'
-            label, ok = QInputDialog.getText(self, 'Choose a label:',
+            label, ok = QtGui.QInputDialog.getText(self, 'Choose a label:',
                                              'Choose a label:')
             if not ok:
                 return
@@ -728,7 +723,7 @@ class GlueApplication(Application, QMainWindow):
     def _restore_session(self, show=True):
         """ Load a previously-saved state, and restart the session """
         fltr = "Glue sessions (*.glu)"
-        file_name, file_filter = QFileDialog.getOpenFileName(self,
+        file_name, file_filter = QtGui.QFileDialog.getOpenFileName(self,
                                                              filter=fltr)
         if not file_name:
             return
@@ -794,11 +789,11 @@ class GlueApplication(Application, QMainWindow):
         if hasattr(self, '_terminal_exception'):  # already failed to set up
             return
 
-        self._terminal_button = QToolButton(self._ui)
+        self._terminal_button = QtGui.QToolButton(self._ui)
         self._terminal_button.setToolTip("Toggle IPython Prompt")
         i = get_icon('IPythonConsole')
         self._terminal_button.setIcon(i)
-        self._terminal_button.setIconSize(QSize(25, 25))
+        self._terminal_button.setIconSize(QtCore.QSize(25, 25))
 
         self._ui.layerWidget.button_row.addWidget(self._terminal_button)
 
@@ -965,7 +960,7 @@ class GlueApplication(Application, QMainWindow):
         label = others[0].label if len(others) > 0 else data.label
         w.merged_label.setText(label)
 
-        entries = [QListWidgetItem(other.label) for other in others]
+        entries = [QtGui.QListWidgetItem(other.label) for other in others]
         for e in entries:
             e.setCheckState(Qt.Checked)
 

--- a/glue/qt/glue_toolbar.py
+++ b/glue/qt/glue_toolbar.py
@@ -4,7 +4,7 @@ import os
 import matplotlib
 
 from glue.external.qt import QtCore, QtGui, is_pyqt5
-from glue.external.qt.QtGui import QMenu
+from glue.external.qt import QtGui
 from glue.external.qt.QtCore import Qt, Signal
 
 if is_pyqt5():
@@ -182,7 +182,7 @@ class GlueToolbar(NavigationToolbar2QT):
 
         menu_actions = mode.menu_actions()
         if len(menu_actions) > 0:
-            menu = QMenu(self)
+            menu = QtGui.QMenu(self)
             for ma in mode.menu_actions():
                 ma.setParent(self)
                 menu.addAction(ma)

--- a/glue/qt/layer_artist_model.py
+++ b/glue/qt/layer_artist_model.py
@@ -11,12 +11,8 @@ these layers, and provides GUI access to the model
 
 from __future__ import absolute_import, division, print_function
 
-from glue.external.qt.QtGui import (QColor,
-                                 QListView, QAbstractItemView, QAction,
-                                 QPalette, QKeySequence)
-
-from glue.external.qt.QtCore import (Qt, QAbstractListModel, QModelIndex,
-                                  QSize, QTimer)
+from glue.external.qt import QtGui, QtCore
+from glue.external.qt.QtCore import Qt
 
 from glue.qt.qtutil import (layer_artist_icon, nonpartial, PythonListModel)
 
@@ -127,8 +123,8 @@ class LayerArtistModel(PythonListModel):
             return
 
         dest = row
-        if not self.beginMoveRows(QModelIndex(), loc, loc,
-                                  QModelIndex(), dest):
+        if not self.beginMoveRows(QtCore.QModelIndex(), loc, loc,
+                                  QtCore.QModelIndex(), dest):
             return
         if dest >= loc:
             row -= 1
@@ -163,7 +159,7 @@ class LayerArtistModel(PythonListModel):
 
     def add_artist(self, row, artist):
         """Add a new artist"""
-        self.beginInsertRows(QModelIndex(), row, row)
+        self.beginInsertRows(QtCore.QModelIndex(), row, row)
         self.artists.insert(row, artist)
         self.endInsertRows()
         self.rowsInserted.emit(self.index(row), row, row)
@@ -172,7 +168,7 @@ class LayerArtistModel(PythonListModel):
         return self.artists[row]
 
 
-class LayerArtistView(QListView):
+class LayerArtistView(QtGui.QListView):
 
     """A list view into an artist model. The zorder
     of each artist can be shuffled by dragging and dropping
@@ -182,10 +178,10 @@ class LayerArtistView(QListView):
         super(LayerArtistView, self).__init__(parent)
         self.setDragEnabled(True)
         self.setAcceptDrops(True)
-        self.setDragDropMode(QAbstractItemView.InternalMove)
-        self.setIconSize(QSize(15, 15))
-        self.setSelectionMode(QAbstractItemView.SingleSelection)
-        self.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.setDragDropMode(QtGui.QAbstractItemView.InternalMove)
+        self.setIconSize(QtCore.QSize(15, 15))
+        self.setSelectionMode(QtGui.QAbstractItemView.SingleSelection)
+        self.setSelectionBehavior(QtGui.QAbstractItemView.SelectRows)
         self.setContextMenuPolicy(Qt.ActionsContextMenu)
         self.setEditTriggers(self.NoEditTriggers)
 
@@ -193,7 +189,7 @@ class LayerArtistView(QListView):
         self._actions = {}
         self._create_actions()
 
-        self._timer = QTimer(self)
+        self._timer = QtCore.QTimer(self)
         self._timer.timeout.connect(self.viewport().update)
         self._timer.start(1000)
 
@@ -224,9 +220,9 @@ class LayerArtistView(QListView):
 
     def _set_palette(self):
         p = self.palette()
-        c = QColor(240, 240, 240)
-        p.setColor(QPalette.Highlight, c)
-        p.setColor(QPalette.HighlightedText, QColor(Qt.black))
+        c = QtGui.QColor(240, 240, 240)
+        p.setColor(QtGui.QPalette.Highlight, c)
+        p.setColor(QtGui.QPalette.HighlightedText, QtGui.QColor(Qt.black))
         self.setPalette(p)
 
     def _update_actions(self):
@@ -249,12 +245,12 @@ class LayerArtistView(QListView):
         StyleDialog.dropdown_editor(item, pos, edit_label=False)
 
     def _create_actions(self):
-        act = QAction('Edit style', self)
+        act = QtGui.QAction('Edit style', self)
         act.triggered.connect(nonpartial(self._edit_style))
         self.addAction(act)
 
-        act = QAction('Remove', self)
-        act.setShortcut(QKeySequence(Qt.Key_Backspace))
+        act = QtGui.QAction('Remove', self)
+        act.setShortcut(QtGui.QKeySequence(Qt.Key_Backspace))
         act.setShortcutContext(Qt.WidgetShortcut)
         act.triggered.connect(
             lambda *args: self.model().removeRow(self.current_row()))

--- a/glue/qt/link_editor.py
+++ b/glue/qt/link_editor.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from glue.external.qt.QtGui import QDialog, QListWidgetItem, QWidget
+from glue.external.qt import QtGui
 
 from glue import core
 
@@ -76,7 +76,7 @@ class LinkEditor(object):
 
     def _add_link(self, link):
         current = self._ui.current_links
-        item = QListWidgetItem(str(link))
+        item = QtGui.QListWidgetItem(str(link))
         current.addItem(item)
         item.setHidden(link.hidden)
         current.set_data(item, link)

--- a/glue/qt/link_equation.py
+++ b/glue/qt/link_equation.py
@@ -3,10 +3,7 @@ from __future__ import absolute_import, division, print_function
 from inspect import getargspec
 from collections import OrderedDict
 
-from glue.external.qt.QtGui import (QWidget, QHBoxLayout, QVBoxLayout,
-                                 QLabel, QLineEdit)
-
-from glue.external.qt.QtGui import QSpacerItem, QSizePolicy
+from glue.external.qt import QtGui
 
 from glue import core
 from glue.qt.qtutil import load_ui, is_pyside
@@ -34,18 +31,18 @@ def helper_label(helper):
     return helper.info
 
 
-class ArgumentWidget(QWidget):
+class ArgumentWidget(QtGui.QWidget):
 
     def __init__(self, argument, parent=None):
         super(ArgumentWidget, self).__init__(parent)
-        self.layout = QHBoxLayout()
+        self.layout = QtGui.QHBoxLayout()
         self.layout.setContentsMargins(1, 0, 1, 1)
         self.setLayout(self.layout)
-        label = QLabel(argument)
+        label = QtGui.QLabel(argument)
         self._label = label
         self._component_id = None
         self.layout.addWidget(label)
-        self.editor = QLineEdit()
+        self.editor = QtGui.QLineEdit()
         self.editor.setReadOnly(True)
         try:
             self.editor.setPlaceholderText("Drag a component from above")
@@ -96,7 +93,7 @@ class ArgumentWidget(QWidget):
         event.accept()
 
 
-class LinkEquation(QWidget):
+class LinkEquation(QtGui.QWidget):
 
     """ Interactively define ComponentLinks from existing functions
 
@@ -133,7 +130,7 @@ class LinkEquation(QWidget):
         # pyqt4 can't take self as second argument here
         # for some reason. Manually embed
         self._ui = load_ui('link_equation', None)
-        l = QHBoxLayout()
+        l = QtGui.QHBoxLayout()
         l.addWidget(self._ui)
         self.setLayout(l)
 
@@ -155,14 +152,14 @@ class LinkEquation(QWidget):
             type(self.function).__name__ == 'LinkFunction'
 
     def _init_widgets(self):
-        layout = QVBoxLayout()
+        layout = QtGui.QVBoxLayout()
         layout.setSpacing(1)
         self._ui.input_canvas.setLayout(layout)
-        layout = QVBoxLayout()
+        layout = QtGui.QVBoxLayout()
         layout.setContentsMargins(1, 0, 1, 1)
         self._ui.output_canvas.setLayout(layout)
         layout.addWidget(self._output_widget)
-        spacer = QSpacerItem(5, 5, QSizePolicy.Minimum, QSizePolicy.Expanding)
+        spacer = QtGui.QSpacerItem(5, 5, QtGui.QSizePolicy.Minimum, QtGui.QSizePolicy.Expanding)
         layout.addItem(spacer)
 
     @property
@@ -268,8 +265,8 @@ class LinkEquation(QWidget):
         for a in args:
             self._add_argument_widget(a)
 
-        self.spacer = QSpacerItem(5, 5, QSizePolicy.Minimum,
-                                  QSizePolicy.Expanding)
+        self.spacer = QtGui.QSpacerItem(5, 5, QtGui.QSizePolicy.Minimum,
+                                  QtGui.QSizePolicy.Expanding)
         self._ui.input_canvas.layout().addItem(self.spacer)
 
     def _setup_editor_helper(self):
@@ -284,8 +281,8 @@ class LinkEquation(QWidget):
         for a in args:
             self._add_argument_widget(a)
 
-        self.spacer = QSpacerItem(5, 5, QSizePolicy.Minimum,
-                                  QSizePolicy.Expanding)
+        self.spacer = QtGui.QSpacerItem(5, 5, QtGui.QSizePolicy.Minimum,
+                                  QtGui.QSizePolicy.Expanding)
         self._ui.input_canvas.layout().addItem(self.spacer)
 
     def _add_argument_widget(self, argument):

--- a/glue/qt/mime.py
+++ b/glue/qt/mime.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import, division, print_function
 
-from glue.external.qt.QtCore import QMimeData, QByteArray
+from glue.external.qt import QtCore
 
 
-class PyMimeData(QMimeData):
+class PyMimeData(QtCore.QMimeData):
     """
     A custom MimeData object that stores live python objects
 
@@ -37,14 +37,14 @@ class PyMimeData(QMimeData):
         return fmt in self._instances or super(PyMimeData, self).hasFormat(fmt)
 
     def setData(self, mime, data):
-        super(PyMimeData, self).setData(mime, QByteArray('1'))
+        super(PyMimeData, self).setData(mime, QtCore.QByteArray('1'))
         self._instances[mime] = data
 
     def data(self, mime_type):
         """ Retrieve the data stored at the specified mime_type
 
         If mime_type is application/py_instance, a python object
-        is returned. Otherwise, a QByteArray is returned """
+        is returned. Otherwise, a QtCore.QByteArray is returned """
         if str(mime_type) in self._instances:
             return self._instances[mime_type]
 

--- a/glue/qt/mouse_mode.py
+++ b/glue/qt/mouse_mode.py
@@ -19,7 +19,7 @@ The basic usage pattern is thus:
 
 from __future__ import absolute_import, division, print_function
 
-from glue.external.qt.QtGui import QAction, QDoubleValidator
+from glue.external.qt import QtGui
 
 from glue.core import util
 from glue.core import roi
@@ -130,7 +130,7 @@ class MouseMode(object):
             self._key_callback(self)
 
     def menu_actions(self):
-        """ List of QActions to be attached to this mode as a context menu """
+        """ List of QtGui.QActions to be attached to this mode as a context menu """
         return []
 
 
@@ -472,7 +472,7 @@ class ContrastMode(MouseMode):
 
     def choose_vmin_vmax(self):
         dialog = load_ui('contrastlimits', None)
-        v = QDoubleValidator()
+        v = QtGui.QDoubleValidator()
         dialog.vmin.setValidator(v)
         dialog.vmax.setValidator(v)
 
@@ -514,51 +514,51 @@ class ContrastMode(MouseMode):
     def menu_actions(self):
         result = []
 
-        a = QAction("minmax", None)
+        a = QtGui.QAction("minmax", None)
         a.triggered.connect(nonpartial(self.set_clip_percentile, 0, 100))
         result.append(a)
 
-        a = QAction("99%", None)
+        a = QtGui.QAction("99%", None)
         a.triggered.connect(nonpartial(self.set_clip_percentile, 1, 99))
         result.append(a)
 
-        a = QAction("95%", None)
+        a = QtGui.QAction("95%", None)
         a.triggered.connect(nonpartial(self.set_clip_percentile, 5, 95))
         result.append(a)
 
-        a = QAction("90%", None)
+        a = QtGui.QAction("90%", None)
         a.triggered.connect(nonpartial(self.set_clip_percentile, 10, 90))
         result.append(a)
 
-        rng = QAction("Set range...", None)
+        rng = QtGui.QAction("Set range...", None)
         rng.triggered.connect(nonpartial(self.choose_vmin_vmax))
         result.append(rng)
 
-        a = QAction("", None)
+        a = QtGui.QAction("", None)
         a.setSeparator(True)
         result.append(a)
 
-        a = QAction("linear", None)
+        a = QtGui.QAction("linear", None)
         a.triggered.connect(nonpartial(setattr, self, 'stretch', 'linear'))
         result.append(a)
 
-        a = QAction("log", None)
+        a = QtGui.QAction("log", None)
         a.triggered.connect(nonpartial(setattr, self, 'stretch', 'log'))
         result.append(a)
 
-        a = QAction("power", None)
+        a = QtGui.QAction("power", None)
         a.triggered.connect(nonpartial(setattr, self, 'stretch', 'power'))
         result.append(a)
 
-        a = QAction("square root", None)
+        a = QtGui.QAction("square root", None)
         a.triggered.connect(nonpartial(setattr, self, 'stretch', 'sqrt'))
         result.append(a)
 
-        a = QAction("squared", None)
+        a = QtGui.QAction("squared", None)
         a.triggered.connect(nonpartial(setattr, self, 'stretch', 'squared'))
         result.append(a)
 
-        a = QAction("asinh", None)
+        a = QtGui.QAction("asinh", None)
         a.triggered.connect(nonpartial(setattr, self, 'stretch', 'arcsinh'))
         result.append(a)
 

--- a/glue/qt/plugin_manager.py
+++ b/glue/qt/plugin_manager.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import, division, print_function
 
-from glue.external.qt import QtGui, QtCore
+from glue.external.qt import QtGui
+from glue.external.qt.QtCore import Qt
+
 from glue._plugin_helpers import PluginConfig
 
 from glue.qt.qtutil import load_ui
@@ -36,11 +38,11 @@ class QtPluginManager(object):
         for plugin in sorted(config.plugins):
             check = QtGui.QTreeWidgetItem(self.ui.tree.invisibleRootItem(),
                                           ["", plugin])
-            check.setFlags(check.flags() | QtCore.Qt.ItemIsUserCheckable)
+            check.setFlags(check.flags() | Qt.ItemIsUserCheckable)
             if config.plugins[plugin]:
-                check.setCheckState(0, QtCore.Qt.Checked)
+                check.setCheckState(0, Qt.Checked)
             else:
-                check.setCheckState(0, QtCore.Qt.Unchecked)
+                check.setCheckState(0, Qt.Unchecked)
             self._checkboxes[plugin] = check
 
         self.ui.tree.resizeColumnToContents(0)

--- a/glue/qt/qt_backend.py
+++ b/glue/qt/qt_backend.py
@@ -1,12 +1,12 @@
 from glue.backends import TimerBase
 
-from glue.external.qt.QtCore import QTimer
+from glue.external.qt import QtCore
 
 
 class Timer(TimerBase):
 
     def __init__(self, interval, callback):
-        self._timer = QTimer()
+        self._timer = QtCore.QTimer()
         self._timer.setInterval(interval)
         self._timer.timeout.connect(callback)
 

--- a/glue/qt/qt_roi.py
+++ b/glue/qt/qt_roi.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from glue.core import roi
 from glue.external.qt import QtGui, QtCore
-from glue.external.qt.QtCore import Qt
+from glue.external.qt import QtCore
 from glue.qt.qtutil import mpl_to_qt4_color
 
 

--- a/glue/qt/simpleforms.py
+++ b/glue/qt/simpleforms.py
@@ -1,4 +1,4 @@
-from glue.external.qt.QtGui import QSpinBox, QDoubleSpinBox, QCheckBox
+from glue.external.qt import QtGui
 from glue.external.qt.QtCore import QObject, Signal
 
 from glue.core.simpleforms import IntOption, FloatOption, BoolOption
@@ -40,11 +40,11 @@ class NumberFormItem(FormItem):
 
 
 class IntFormItem(NumberFormItem):
-    widget_cls = QSpinBox
+    widget_cls = QtGui.QSpinBox
 
 
 class FloatFormItem(NumberFormItem):
-    widget_cls = QDoubleSpinBox
+    widget_cls = QtGui.QDoubleSpinBox
 
 
 class BoolFormItem(FormItem):
@@ -53,7 +53,7 @@ class BoolFormItem(FormItem):
         super(BoolFormItem, self).__init__(instance, option)
 
         value = option.__get__(instance)
-        self.widget = QCheckBox()
+        self.widget = QtGui.QCheckBox()
         self.widget.setChecked(value)
         self.widget.clicked.connect(nonpartial(self.changed.emit))
 

--- a/glue/qt/tests/test_application.py
+++ b/glue/qt/tests/test_application.py
@@ -18,7 +18,7 @@ except:
     ipy_version = '0.0'
 
 from ..glue_application import GlueApplication
-from glue.external.qt.QtCore import QMimeData, QUrl
+from glue.external.qt import QtCore
 from ..widgets.scatter_widget import ScatterWidget
 from ..widgets.image_widget import ImageWidget
 from glue.core import Data
@@ -49,7 +49,7 @@ class TestGlueApplication(object):
 
     def test_save_session(self):
         self.app.save_session = MagicMock()
-        with patch('glue.qt.glue_application.QFileDialog') as fd:
+        with patch('glue.qt.glue_application.QtGui.QFileDialog') as fd:
             fd.getSaveFileName.return_value = '/tmp/junk', 'jnk'
             self.app._choose_save_session()
             self.app.save_session.assert_called_once_with('/tmp/junk.glu', include_data=False)
@@ -57,14 +57,14 @@ class TestGlueApplication(object):
     def test_save_session_cancel(self):
         """shouldnt try to save file if no file name provided"""
         self.app.save_session = MagicMock()
-        with patch('glue.qt.glue_application.QFileDialog') as fd:
+        with patch('glue.qt.glue_application.QtGui.QFileDialog') as fd:
             fd.getSaveFileName.return_value = '', 'jnk'
             self.app._choose_save_session()
             assert self.app.save_session.call_count == 0
 
     def test_choose_save_session_ioerror(self):
         """should show box on ioerror"""
-        with patch('glue.qt.glue_application.QFileDialog') as fd:
+        with patch('glue.qt.glue_application.QtGui.QFileDialog') as fd:
             if sys.version_info[0] == 2:
                 mock_open = '__builtin__.open'
             else:
@@ -194,8 +194,8 @@ class TestGlueApplication(object):
             assert qt_client.members[kwargs['default']] == ImageWidget
 
     def test_drop_load_data(self):
-        m = QMimeData()
-        m.setUrls([QUrl('test.fits')])
+        m = QtCore.QMimeData()
+        m.setUrls([QtCore.QUrl('test.fits')])
         e = MagicMock()
         e.mimeData.return_value = m
         load = MagicMock()

--- a/glue/qt/tests/test_data_collection_model.py
+++ b/glue/qt/tests/test_data_collection_model.py
@@ -1,5 +1,7 @@
 from glue.external.qt.QtCore import Qt
+
 from glue.core import DataCollection, Data
+
 from ..data_collection_model import DataCollectionModel
 from ..qtutil import LAYERS_MIME_TYPE
 

--- a/glue/qt/tests/test_layer_artist_model.py
+++ b/glue/qt/tests/test_layer_artist_model.py
@@ -1,13 +1,14 @@
 from __future__ import absolute_import, division, print_function
 
-from glue.external.qt.QtCore import Qt
-
 from mock import MagicMock
 
-from ..layer_artist_model import LayerArtistModel, LayerArtistView
+from glue.external.qt import is_pyqt5
+from glue.external.qt.QtCore import Qt
+
 from glue.clients.layer_artist import LayerArtist as _LayerArtist
 from glue.core import Data
-from glue.external.qt import is_pyqt5
+
+from ..layer_artist_model import LayerArtistModel, LayerArtistView
 
 
 class LayerArtist(_LayerArtist):

--- a/glue/qt/tests/test_mime.py
+++ b/glue/qt/tests/test_mime.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from glue.external.qt.QtGui import QWidget, QDrag
+from glue.external.qt import QtGui
 from glue.external.qt.QtCore import QMimeData, Qt
 from glue.external.qt.QtTest import QTest
 
@@ -9,7 +9,7 @@ from .. import mime
 import pytest
 
 
-class TestWidget(QWidget):
+class TestWidget(QtGui.QWidget):
     def __init__(self, out_mime, parent=None):
         super(TestWidget, self).__init__(parent)
         self.setAcceptDrops(True)
@@ -27,7 +27,7 @@ class TestWidget(QWidget):
 
     def mousePressEvent(self, event):
         print('mouse event')
-        drag = QDrag(self)
+        drag = QtGui.QDrag(self)
         drag.setMimeData(self.out_mime)
         drop_action = drag.exec_()
         print(drop_action)

--- a/glue/qt/tests/test_qtutil.py
+++ b/glue/qt/tests/test_qtutil.py
@@ -149,7 +149,7 @@ def test_qt4_to_mpl_color():
 
 
 def test_edit_color():
-    with patch('glue.qt.qtutil.QColorDialog') as d:
+    with patch('glue.qt.qtutil.QtGui.QColorDialog') as d:
         d.getColor.return_value = QtGui.QColor(0, 1, 0)
         d.isValid.return_value = True
         s = Subset(None)
@@ -158,14 +158,14 @@ def test_edit_color():
 
 
 def test_edit_color_cancel():
-    with patch('glue.qt.qtutil.QColorDialog') as d:
+    with patch('glue.qt.qtutil.QtGui.QColorDialog') as d:
         d.getColor.return_value = QtGui.QColor(0, -1, 0)
         s = Subset(None)
         qtutil.edit_layer_color(s)
 
 
 def test_edit_symbol():
-    with patch('glue.qt.qtutil.QInputDialog') as d:
+    with patch('glue.qt.qtutil.QtGui.QInputDialog') as d:
         d.getItem.return_value = ('*', True)
         s = Subset(None)
         qtutil.edit_layer_symbol(s)
@@ -173,7 +173,7 @@ def test_edit_symbol():
 
 
 def test_edit_symbol_cancel():
-    with patch('glue.qt.qtutil.QInputDialog') as d:
+    with patch('glue.qt.qtutil.QtGui.QInputDialog') as d:
         d.getItem.return_value = ('*', False)
         s = Subset(None)
         qtutil.edit_layer_symbol(s)
@@ -181,7 +181,7 @@ def test_edit_symbol_cancel():
 
 
 def test_edit_point_size():
-    with patch('glue.qt.qtutil.QInputDialog') as d:
+    with patch('glue.qt.qtutil.QtGui.QInputDialog') as d:
         d.getInt.return_value = 123, True
         s = Subset(None)
         qtutil.edit_layer_point_size(s)
@@ -189,7 +189,7 @@ def test_edit_point_size():
 
 
 def test_edit_point_size_cancel():
-    with patch('glue.qt.qtutil.QInputDialog') as d:
+    with patch('glue.qt.qtutil.QtGui.QInputDialog') as d:
         d.getInt.return_value = 123, False
         s = Subset(None)
         qtutil.edit_layer_point_size(s)
@@ -197,7 +197,7 @@ def test_edit_point_size_cancel():
 
 
 def test_edit_layer_label():
-    with patch('glue.qt.qtutil.QInputDialog') as d:
+    with patch('glue.qt.qtutil.QtGui.QInputDialog') as d:
         d.getText.return_value = ('accepted label', True)
         s = Subset(None)
         qtutil.edit_layer_label(s)
@@ -205,7 +205,7 @@ def test_edit_layer_label():
 
 
 def test_edit_layer_label_cancel():
-    with patch('glue.qt.qtutil.QInputDialog') as d:
+    with patch('glue.qt.qtutil.QtGui.QInputDialog') as d:
         d.getText.return_value = ('rejected label', False)
         s = Subset(None)
         qtutil.edit_layer_label(s)
@@ -215,7 +215,7 @@ def test_edit_layer_label_cancel():
 def test_pick_item():
     items = ['a', 'b', 'c']
     labels = ['1', '2', '3']
-    with patch('glue.qt.qtutil.QInputDialog') as d:
+    with patch('glue.qt.qtutil.QtGui.QInputDialog') as d:
         d.getItem.return_value = '1', True
         assert qtutil.pick_item(items, labels) == 'a'
         d.getItem.return_value = '2', True
@@ -239,7 +239,7 @@ def test_pick_class():
 
 
 def test_get_text():
-    with patch('glue.qt.qtutil.QInputDialog') as d:
+    with patch('glue.qt.qtutil.QtGui.QInputDialog') as d:
         d.getText.return_value = 'abc', True
         assert qtutil.get_text() == 'abc'
 

--- a/glue/qt/tests/test_toolbar.py
+++ b/glue/qt/tests/test_toolbar.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import, division, print_function
 
 import matplotlib.pyplot as plt
-from glue.external.qt.QtGui import QMainWindow, QIcon
+from glue.external.qt import QtGui
 from ..widgets import MplWidget
 from ..glue_toolbar import GlueToolbar
 from ..mouse_mode import MouseMode
@@ -30,9 +30,9 @@ class MouseModeTest(MouseMode):
 class TestToolbar(object):
 
     def setup_method(self, method):
-        from glue.external.qt.QtGui import QApplication
-        assert QApplication.instance() is not None
-        self.win = QMainWindow()
+        from glue.external.qt import QtGui
+        assert QtGui.QApplication.instance() is not None
+        self.win = QtGui.QMainWindow()
         widget, axes = self._make_plot_widget(self.win)
         self.canvas = widget.canvas
         self.axes = axes

--- a/glue/qt/tests/test_widget_properties.py
+++ b/glue/qt/tests/test_widget_properties.py
@@ -14,13 +14,7 @@ from ..widget_properties import (CurrentComboDataProperty,
                                  connect_float_edit,
                                  connect_int_spin)
 
-from glue.external.qt.QtGui import (QCheckBox,
-                                  QLineEdit,
-                                  QComboBox,
-                                  QLabel,
-                                  QSlider,
-                                  QTabWidget,
-                                  QWidget)
+from glue.external.qt import QtGui
 
 from glue.external.echo import CallbackProperty
 
@@ -32,7 +26,7 @@ def test_combo_data():
         co = CurrentComboDataProperty('_combo')
 
         def __init__(self):
-            self._combo = QComboBox()
+            self._combo = QtGui.QComboBox()
             self._combo.addItem('a', 'a')
             self._combo.addItem('b', 'b')
 
@@ -58,7 +52,7 @@ def test_combo_text():
         co = CurrentComboTextProperty('_combo')
 
         def __init__(self):
-            self._combo = QComboBox()
+            self._combo = QtGui.QComboBox()
             self._combo.addItem('a')
             self._combo.addItem('b')
 
@@ -86,7 +80,7 @@ def test_text():
     class TestClass(object):
         lab = TextProperty('_label')
         def __init__(self):
-            self._label = QLabel()
+            self._label = QtGui.QLabel()
 
     tc = TestClass()
     tc.lab = 'hello'
@@ -99,7 +93,7 @@ def test_button():
     class TestClass(object):
         but = ButtonProperty('_button')
         def __init__(self):
-            self._button = QCheckBox()
+            self._button = QtGui.QCheckBox()
 
     tc = TestClass()
 
@@ -123,7 +117,7 @@ def test_float():
     class TestClass(object):
         flt = FloatLineProperty('_float')
         def __init__(self):
-            self._float = QLineEdit()
+            self._float = QtGui.QLineEdit()
 
     tc = TestClass()
 
@@ -142,7 +136,7 @@ def test_value():
     class TestClass(object):
         val = ValueProperty('_slider')
         def __init__(self):
-            self._slider = QSlider()
+            self._slider = QtGui.QSlider()
 
     tc = TestClass()
 
@@ -157,7 +151,7 @@ def test_value_mapping():
         val = ValueProperty('_slider', mapping=(lambda x: 2 * x,
                                                 lambda x: 0.5 * x))
         def __init__(self):
-            self._slider = QSlider()
+            self._slider = QtGui.QSlider()
 
     tc = TestClass()
 
@@ -171,9 +165,9 @@ def test_tab():
     class TestClass(object):
         tab = CurrentTabProperty('_tab')
         def __init__(self):
-            self._tab = QTabWidget()
-            self._tab.addTab(QWidget(), 'tab1')
-            self._tab.addTab(QWidget(), 'tab2')
+            self._tab = QtGui.QTabWidget()
+            self._tab.addTab(QtGui.QWidget(), 'tab1')
+            self._tab.addTab(QtGui.QWidget(), 'tab2')
 
     tc = TestClass()
 
@@ -197,7 +191,7 @@ def test_connect_bool_button():
 
     t = Test()
 
-    box = QCheckBox()
+    box = QtGui.QCheckBox()
     connect_bool_button(t, 'a', box)
 
     box.setChecked(True)
@@ -220,7 +214,7 @@ def test_connect_current_combo():
 
     t = Test()
 
-    combo = QComboBox()
+    combo = QtGui.QComboBox()
     combo.addItem('a', 'a')
     combo.addItem('b', 'b')
 
@@ -257,7 +251,7 @@ def test_connect_float_edit():
 
     t = Test()
 
-    line = QLineEdit()
+    line = QtGui.QLineEdit()
 
     connect_float_edit(t, 'a', line)
 
@@ -280,7 +274,7 @@ def test_connect_int_spin():
 
     t = Test()
 
-    slider = QSlider()
+    slider = QtGui.QSlider()
 
     connect_int_spin(t, 'a', slider)
 

--- a/glue/qt/widgets/custom_component_widget.py
+++ b/glue/qt/widgets/custom_component_widget.py
@@ -2,8 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import re
 
-from glue.external.qt.QtGui import QDialog, QMessageBox
-from glue.external.qt import QtCore
+from glue.external.qt import QtGui, QtCore
 
 from glue import core
 from glue.core import parse
@@ -81,7 +80,7 @@ class ColorizedCompletionTextEdit(CompletionTextEdit):
 
         tc.setPosition(pos)
         self.setTextCursor(tc)
-        self.setAlignment(QtCore.Qt.AlignCenter)
+        self.setAlignment(Qt.AlignCenter)
 
 
 
@@ -99,7 +98,7 @@ class CustomComponentWidget(object):
         # because we want to use a custom widget that supports auto-complete.
         self.ui.expression = ColorizedCompletionTextEdit()
         self.ui.verticalLayout_3.addWidget(self.ui.expression)
-        self.ui.expression.setAlignment(QtCore.Qt.AlignCenter)
+        self.ui.expression.setAlignment(Qt.AlignCenter)
         self.ui.expression.setObjectName("expression")
         self.ui.expression.setToolTip("Define a new component. You can either "
                                       "type out the full name of a component\n"
@@ -210,16 +209,16 @@ class CustomComponentWidget(object):
         widget = CustomComponentWidget(collection)
         while True:
             widget.ui.show()
-            if widget.ui.exec_() == QDialog.Accepted:
+            if widget.ui.exec_() == QtGui.QDialog.Accepted:
                 if len(str(widget.ui.expression.toPlainText())) == 0:
-                    QMessageBox.critical(widget.ui, "Error", "No expression set",
-                                         buttons=QMessageBox.Ok)
+                    QtGui.QMessageBox.critical(widget.ui, "Error", "No expression set",
+                                         buttons=QtGui.QMessageBox.Ok)
                 elif widget._number_targets == 0:
-                    QMessageBox.critical(widget.ui, "Error", "Please specify the target dataset(s)",
-                                         buttons=QMessageBox.Ok)
+                    QtGui.QMessageBox.critical(widget.ui, "Error", "Please specify the target dataset(s)",
+                                         buttons=QtGui.QMessageBox.Ok)
                 elif len(widget.ui.new_label.text()) == 0:
-                    QMessageBox.critical(widget.ui, "Error", "Please specify the new component name",
-                                         buttons=QMessageBox.Ok)
+                    QtGui.QMessageBox.critical(widget.ui, "Error", "Please specify the new component name",
+                                         buttons=QtGui.QMessageBox.Ok)
                 else:
                     link = widget._create_link()
                     if link:

--- a/glue/qt/widgets/data_slice_widget.py
+++ b/glue/qt/widgets/data_slice_widget.py
@@ -1,10 +1,7 @@
 from functools import partial
 from collections import Counter
 
-from glue.external.qt.QtGui import (QWidget, QSlider, QLabel, QComboBox, QFrame,
-                                  QHBoxLayout, QVBoxLayout, QPushButton, 
-                                  QLineEdit)
-from glue.external.qt.QtCore import Qt, Signal
+from glue.external.qt import QtGui, QtCore
 
 from glue.qt.widget_properties import (TextProperty,
                                  ValueProperty,
@@ -12,13 +9,13 @@ from glue.qt.widget_properties import (TextProperty,
 from glue.qt.qtutil import nonpartial, load_ui
 
 
-class SliceWidget(QWidget):
+class SliceWidget(QtGui.QWidget):
     label = TextProperty('_ui_label')
     slice_center = ValueProperty('_ui_slider.slider')
     mode = CurrentComboProperty('_ui_mode')
 
-    slice_changed = Signal(int)
-    mode_changed = Signal(str)
+    slice_changed = QtCore.Signal(int)
+    mode_changed = QtCore.Signal(str)
 
     def __init__(self, label='', pix2world=None, lo=0, hi=10,
                  parent=None, aggregation=None):
@@ -28,16 +25,16 @@ class SliceWidget(QWidget):
         if pix2world is not None:
             raise NotImplemented("Pix2world option not implemented")
 
-        layout = QVBoxLayout()
+        layout = QtGui.QVBoxLayout()
         layout.setContentsMargins(3, 1, 3, 1)
         layout.setSpacing(0)
 
-        top = QHBoxLayout()
+        top = QtGui.QHBoxLayout()
         top.setContentsMargins(3, 3, 3, 3)
-        label = QLabel(label)
+        label = QtGui.QLabel(label)
         top.addWidget(label)
 
-        mode = QComboBox()
+        mode = QtGui.QComboBox()
         mode.addItem('x', 'x')
         mode.addItem('y', 'y')
         mode.addItem('slice', 'slice')
@@ -110,17 +107,17 @@ class SliceWidget(QWidget):
         return self._frozen
 
 
-class DataSlice(QWidget):
+class DataSlice(QtGui.QWidget):
 
     """
     A DatSlice widget provides an inteface for selection
     slices through an N-dimensional dataset
 
-    Signals
+    QtCore.Signals
     -------
     slice_changed : triggered when the slice through the data changes
     """
-    slice_changed = Signal()
+    slice_changed = QtCore.Signal()
 
     def __init__(self, data=None, parent=None):
         """
@@ -130,7 +127,7 @@ class DataSlice(QWidget):
         self._slices = []
         self._data = None
 
-        layout = QVBoxLayout()
+        layout = QtGui.QVBoxLayout()
         layout.setSpacing(4)
         layout.setContentsMargins(0, 3, 0, 3)
         self.layout = layout
@@ -195,9 +192,9 @@ class DataSlice(QWidget):
         for s in self._slices[::-1]:
             self.layout.addWidget(s)
             if s is not self._slices[0]:
-                line = QFrame()
-                line.setFrameShape(QFrame.HLine)
-                line.setFrameShadow(QFrame.Sunken)
+                line = QtGui.QFrame()
+                line.setFrameShape(QtGui.QFrame.HLine)
+                line.setFrameShadow(QtGui.QFrame.Sunken)
                 self.layout.addWidget(line)
             s.show()  # this somehow fixes #342
 

--- a/glue/qt/widgets/data_viewer.py
+++ b/glue/qt/widgets/data_viewer.py
@@ -2,9 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import os
 
-from glue.external.qt.QtGui import (
-    QMainWindow, QMessageBox, QWidget)
-
+from glue.external.qt import QtGui, QtCore
 from glue.external.qt.QtCore import Qt
 
 from glue.core.application_base import ViewerBase
@@ -18,7 +16,7 @@ from glue.qt.widgets.glue_mdi_area import GlueMdiSubWindow
 __all__ = ['DataViewer']
 
 
-class DataViewer(ViewerBase, QMainWindow):
+class DataViewer(ViewerBase, QtGui.QMainWindow):
 
     """Base class for all Qt DataViewer widgets.
 
@@ -34,7 +32,7 @@ class DataViewer(ViewerBase, QMainWindow):
         """
         :type session: :class:`~glue.core.Session`
         """
-        QMainWindow.__init__(self, parent)
+        QtGui.QMainWindow.__init__(self, parent)
         ViewerBase.__init__(self, session)
         self.setWindowIcon(get_qapp().windowIcon())
         self._view = LayerArtistView()
@@ -131,7 +129,7 @@ class DataViewer(ViewerBase, QMainWindow):
         if self._mdi_wrapper is not None:
             self._mdi_wrapper.move(x, y)
         else:
-            QMainWindow.move(self, x, y)
+            QtGui.QMainWindow.move(self, x, y)
 
     @property
     def viewer_size(self):
@@ -165,22 +163,22 @@ class DataViewer(ViewerBase, QMainWindow):
         :rtype: bool. True if user wishes to close. False otherwise
         """
         if self._warn_close and (not os.environ.get('GLUE_TESTING')) and self.isVisible():
-            buttons = QMessageBox.Ok | QMessageBox.Cancel
-            dialog = QMessageBox.warning(self, "Confirm Close",
+            buttons = QtGui.QMessageBox.Ok | QtGui.QMessageBox.Cancel
+            dialog = QtGui.QMessageBox.warning(self, "Confirm Close",
                                          "Do you want to close this window?",
                                          buttons=buttons,
-                                         defaultButton=QMessageBox.Cancel)
-            return dialog == QMessageBox.Ok
+                                         defaultButton=QtGui.QMessageBox.Cancel)
+            return dialog == QtGui.QMessageBox.Ok
         return True
 
     def _confirm_large_data(self, data):
         warn_msg = ("WARNING: Data set has %i points, and may render slowly."
                     " Continue?" % data.size)
         title = "Add large data set?"
-        ok = QMessageBox.Ok
-        cancel = QMessageBox.Cancel
+        ok = QtGui.QMessageBox.Ok
+        cancel = QtGui.QMessageBox.Cancel
         buttons = ok | cancel
-        result = QMessageBox.question(self, title, warn_msg,
+        result = QtGui.QMessageBox.question(self, title, warn_msg,
                                       buttons=buttons,
                                       defaultButton=cancel)
         return result == ok
@@ -189,7 +187,7 @@ class DataViewer(ViewerBase, QMainWindow):
         return self._view
 
     def options_widget(self):
-        return QWidget()
+        return QtGui.QWidget()
 
     def addToolBar(self, tb):
         super(DataViewer, self).addToolBar(tb)

--- a/glue/qt/widgets/glue_mdi_area.py
+++ b/glue/qt/widgets/glue_mdi_area.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
-from glue.external.qt import QtGui
-from glue.external.qt.QtCore import Qt, Signal
+from glue.external.qt import QtGui, QtCore
+from glue.external.qt.QtCore import Qt
 
 from glue import core
 from glue.qt.mime import LAYER_MIME_TYPE, LAYERS_MIME_TYPE
@@ -88,7 +88,7 @@ class GlueMdiArea(QtGui.QMdiArea):
 
 
 class GlueMdiSubWindow(QtGui.QMdiSubWindow):
-    closed = Signal()
+    closed = QtCore.Signal()
 
     def closeEvent(self, event):
         super(GlueMdiSubWindow, self).closeEvent(event)

--- a/glue/qt/widgets/histogram_widget.py
+++ b/glue/qt/widgets/histogram_widget.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 from functools import partial
 
-from glue.external.qt import QtGui
+from glue.external.qt import QtGui, QtCore
 from glue.external.qt.QtCore import Qt
 
 from glue.core import message as msg

--- a/glue/qt/widgets/image_widget.py
+++ b/glue/qt/widgets/image_widget.py
@@ -1,10 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
-from glue.external.qt.QtGui import (QAction, QLabel, QCursor, QMainWindow,
-                                  QToolButton, QIcon, QMessageBox
-                                  )
-
-from glue.external.qt.QtCore import Qt, QRect, Signal
+from glue.external.qt import QtGui, QtCore
+from glue.external.qt.QtCore import Qt
 
 from glue.qt.widgets.data_viewer import DataViewer
 from glue import core
@@ -68,7 +65,7 @@ class ImageWidgetBase(DataViewer):
 
     def _setup_widgets(self):
         self.central_widget = self.make_central_widget()
-        self.label_widget = QLabel("", self.central_widget)
+        self.label_widget = QtGui.QLabel("", self.central_widget)
         self.setCentralWidget(self.central_widget)
         self.ui = load_ui('imagewidget', None)
         self.option_widget = self.ui
@@ -125,14 +122,14 @@ class ImageWidgetBase(DataViewer):
             # If there is not already any image data set, we can't add 1-D
             # datasets (tables/catalogs) to the image widget yet.
             if data.data.ndim == 1 and self.client.display_data is None:
-                QMessageBox.information(self.window(), "Note",
+                QtGui.QMessageBox.information(self.window(), "Note",
                                         "Cannot create image viewer from a 1-D "
                                         "dataset. You will need to first "
                                         "create an image viewer using data "
                                         "with 2 or more dimensions, after "
                                         "which you will be able to overlay 1-D "
                                         "data as a scatter plot.",
-                                        buttons=QMessageBox.Ok)
+                                        buttons=QtGui.QMessageBox.Ok)
                 return
 
             r = self.client.add_layer(data)
@@ -350,10 +347,10 @@ class ImageWidgetBase(DataViewer):
         warn_msg = ("WARNING: Image has %i pixels, and may render slowly."
                     " Continue?" % data.size)
         title = "Contour large image?"
-        ok = QMessageBox.Ok
-        cancel = QMessageBox.Cancel
+        ok = QtGui.QMessageBox.Ok
+        cancel = QtGui.QMessageBox.Cancel
         buttons = ok | cancel
-        result = QMessageBox.question(self, title, warn_msg,
+        result = QtGui.QMessageBox.question(self, title, warn_msg,
                                       buttons=buttons,
                                       defaultButton=cancel)
         return result == ok
@@ -442,7 +439,7 @@ class ImageWidget(ImageWidgetBase):
 
     def paintEvent(self, event):
         super(ImageWidget, self).paintEvent(event)
-        pos = self.central_widget.canvas.mapFromGlobal(QCursor.pos())
+        pos = self.central_widget.canvas.mapFromGlobal(QtGui.QCursor.pos())
         x, y = pos.x(), self.central_widget.canvas.height() - pos.y()
         self._update_intensity_label(x, y)
 
@@ -458,7 +455,7 @@ class ImageWidget(ImageWidgetBase):
 
         fm = self.label_widget.fontMetrics()
         w, h = fm.width(lbl), fm.height()
-        g = QRect(20, self.central_widget.geometry().height() - h, w, h)
+        g = QtCore.QRect(20, self.central_widget.geometry().height() - h, w, h)
         self.label_widget.setGeometry(g)
 
     def _connect(self):
@@ -467,13 +464,13 @@ class ImageWidget(ImageWidgetBase):
         self.central_widget.canvas.resize_end.connect(self.client.check_update)
 
 
-class ColormapAction(QAction):
+class ColormapAction(QtGui.QAction):
 
     def __init__(self, label, cmap, parent):
         super(ColormapAction, self).__init__(label, parent)
         self.cmap = cmap
         pm = cmap2pixmap(cmap)
-        self.setIcon(QIcon(pm))
+        self.setIcon(QtGui.QIcon(pm))
 
 
 def _colormap_mode(parent, on_trigger):
@@ -488,24 +485,24 @@ def _colormap_mode(parent, on_trigger):
         acts.append(a)
 
     # Toolbar button
-    tb = QToolButton()
+    tb = QtGui.QToolButton()
     tb.setWhatsThis("Set color scale")
     tb.setToolTip("Set color scale")
     icon = get_icon('glue_rainbow')
     tb.setIcon(icon)
-    tb.setPopupMode(QToolButton.InstantPopup)
+    tb.setPopupMode(QtGui.QToolButton.InstantPopup)
     tb.addActions(acts)
 
     return tb
 
 
-class StandaloneImageWidget(QMainWindow):
+class StandaloneImageWidget(QtGui.QMainWindow):
 
     """
     A simplified image viewer, without any brushing or linking,
     but with the ability to adjust contrast and resample.
     """
-    window_closed = Signal()
+    window_closed = QtCore.Signal()
 
     def __init__(self, image=None, wcs=None, parent=None, **kwargs):
         """

--- a/glue/qt/widgets/layer_tree_widget.py
+++ b/glue/qt/widgets/layer_tree_widget.py
@@ -5,11 +5,9 @@ editing the data collection
 
 from __future__ import absolute_import, division, print_function
 
-from glue.external.qt.QtGui import (QWidget, QMenu,
-                                  QAction, QKeySequence, QFileDialog)
+from glue.external.qt import QtGui, QtCore
+from glue.external.qt.QtCore import Qt
 
-
-from glue.external.qt.QtCore import Qt, Signal, QObject
 from glue.external.six.moves import reduce
 
 from glue.qt.ui.layertree import Ui_LayerTree
@@ -33,7 +31,7 @@ class Clipboard(object):
         self.contents = None
 
 
-class LayerAction(QAction):
+class LayerAction(QtGui.QAction):
     _title = ''
     _icon = None
     _tooltip = None
@@ -140,7 +138,7 @@ class NewAction(LayerAction):
     _title = "New Subset"
     _tooltip = "Create a new subset"
     _icon = "glue_subset"
-    _shortcut = QKeySequence('Ctrl+Shift+N')
+    _shortcut = QtGui.QKeySequence('Ctrl+Shift+N')
 
     def _can_trigger(self):
         return len(self.data_collection) > 0
@@ -153,7 +151,7 @@ class NewAction(LayerAction):
 class ClearAction(LayerAction):
     _title = "Clear subset"
     _tooltip = "Clear current subset"
-    _shortcut = QKeySequence('Ctrl+K')
+    _shortcut = QtGui.QKeySequence('Ctrl+K')
 
     def _can_trigger(self):
         return self.single_selection_subset_group()
@@ -167,7 +165,7 @@ class ClearAction(LayerAction):
 class DeleteAction(LayerAction):
     _title = "Delete Layer"
     _tooltip = "Delete the selected data and/or subset Groups"
-    _shortcut = QKeySequence(Qt.Key_Backspace)
+    _shortcut = QtGui.QKeySequence(Qt.Key_Backspace)
 
     def _can_trigger(self):
         selection = self.selected_layers()
@@ -232,7 +230,7 @@ class SaveAction(LayerAction):
 class CopyAction(LayerAction):
     _title = "Copy subset"
     _tooltip = "Copy the definition for the selected subset"
-    _shortcut = QKeySequence.Copy
+    _shortcut = QtGui.QKeySequence.Copy
 
     def _can_trigger(self):
         return self.single_selection_subset_group()
@@ -246,7 +244,7 @@ class CopyAction(LayerAction):
 class PasteAction(LayerAction):
     _title = "Paste subset"
     _tooltip = "Overwrite selected subset with contents from clipboard"
-    _shortcut = QKeySequence.Paste
+    _shortcut = QtGui.QKeySequence.Paste
 
     def _can_trigger(self):
         if not self.single_selection_subset_group():
@@ -272,24 +270,24 @@ class PasteSpecialAction(PasteAction):
         self.setMenu(self.menu())
 
     def menu(self):
-        m = QMenu()
+        m = QtGui.QMenu()
 
-        a = QAction("Or", m)
+        a = QtGui.QAction("Or", m)
         a.setIcon(get_icon('glue_or'))
         a.triggered.connect(nonpartial(self._paste, OrMode))
         m.addAction(a)
 
-        a = QAction("And", m)
+        a = QtGui.QAction("And", m)
         a.setIcon(get_icon('glue_and'))
         a.triggered.connect(nonpartial(self._paste, AndMode))
         m.addAction(a)
 
-        a = QAction("XOR", m)
+        a = QtGui.QAction("XOR", m)
         a.setIcon(get_icon('glue_xor'))
         a.triggered.connect(nonpartial(self._paste, XorMode))
         m.addAction(a)
 
-        a = QAction("Not", m)
+        a = QtGui.QAction("Not", m)
         a.setIcon(get_icon('glue_andnot'))
         a.triggered.connect(nonpartial(self._paste, AndNotMode))
         m.addAction(a)
@@ -371,11 +369,11 @@ class SingleSubsetUserAction(UserAction):
         return self._callback(subset, self.data_collection)
 
 
-class LayerCommunicator(QObject):
-    layer_check_changed = Signal(object, bool)
+class LayerCommunicator(QtCore.QObject):
+    layer_check_changed = QtCore.Signal(object, bool)
 
 
-class LayerTreeWidget(QWidget, Ui_LayerTree):
+class LayerTreeWidget(QtGui.QWidget, Ui_LayerTree):
 
     """The layertree widget provides a way to visualize the various
     data and subset layers in a Glue session.
@@ -387,7 +385,7 @@ class LayerTreeWidget(QWidget, Ui_LayerTree):
 
     def __init__(self, parent=None):
         Ui_LayerTree.__init__(self)
-        QWidget.__init__(self, parent)
+        QtGui.QWidget.__init__(self, parent)
 
         self._signals = LayerCommunicator()
         self._is_checkable = True
@@ -472,7 +470,7 @@ class LayerTreeWidget(QWidget, Ui_LayerTree):
     def _create_actions(self):
         tree = self.layerTree
 
-        sep = QAction("", tree)
+        sep = QtGui.QAction("", tree)
         sep.setSeparator(True)
         tree.addAction(sep)
 
@@ -489,7 +487,7 @@ class LayerTreeWidget(QWidget, Ui_LayerTree):
         self._actions['maskify'] = MaskifySubsetAction(self)
 
         # new component definer
-        separator = QAction("sep", tree)
+        separator = QtGui.QAction("sep", tree)
         separator.setSeparator(True)
         tree.addAction(separator)
 
@@ -542,7 +540,7 @@ class LayerTreeWidget(QWidget, Ui_LayerTree):
 
 def save_subset(subset):
     assert isinstance(subset, core.subset.Subset)
-    fname, fltr = QFileDialog.getSaveFileName(caption="Select an output name",
+    fname, fltr = QtGui.QFileDialog.getSaveFileName(caption="Select an output name",
                                               filter='FITS mask (*.fits);; Fits mask (*.fits)')
     fname = str(fname)
     if not fname:

--- a/glue/qt/widgets/message_widget.py
+++ b/glue/qt/widgets/message_widget.py
@@ -2,18 +2,18 @@ from __future__ import absolute_import, division, print_function
 
 from time import ctime
 
-from glue.external.qt.QtGui import QWidget, QTableWidgetItem
+from glue.external.qt import QtGui
 
 from glue import core
 
 from glue.qt.qtutil import load_ui
 
 
-class MessageWidget(QWidget, core.hub.HubListener):
+class MessageWidget(QtGui.QWidget, core.hub.HubListener):
     """ This simple class displays all messages broadcast
     by a hub. It is mainly intended for debugging """
     def __init__(self):
-        QWidget.__init__(self)
+        QtGui.QWidget.__init__(self)
         self.ui = load_ui('messagewidget', self)
         self.ui.messageTable.setColumnCount(3)
         labels = ['Time', 'Message', 'Sender']
@@ -28,11 +28,11 @@ class MessageWidget(QWidget, core.hub.HubListener):
     def process_message(self, message):
         row = self.ui.messageTable.rowCount() * 0
         self.ui.messageTable.insertRow(0)
-        tm = QTableWidgetItem(ctime().split()[3])
+        tm = QtGui.QTableWidgetItem(ctime().split()[3])
         typ = str(type(message)).split("'")[-2].split('.')[-1]
-        mtyp = QTableWidgetItem(typ)
+        mtyp = QtGui.QTableWidgetItem(typ)
         typ = str(type(message.sender)).split("'")[-2].split('.')[-1]
-        sender = QTableWidgetItem(typ)
+        sender = QtGui.QTableWidgetItem(typ)
         self.ui.messageTable.setItem(row, 0, tm)
         self.ui.messageTable.setItem(row, 1, mtyp)
         self.ui.messageTable.setItem(row, 2, sender)

--- a/glue/qt/widgets/mpl_widget.py
+++ b/glue/qt/widgets/mpl_widget.py
@@ -4,8 +4,8 @@ from __future__ import absolute_import, division, print_function
 
 from functools import partial, wraps
 
-from glue.external.qt import QtGui, is_pyqt5
-from glue.external.qt.QtCore import Signal, Qt, QTimer
+from glue.external.qt import QtGui, QtCore, is_pyqt5
+from glue.external.qt.QtCore import Qt
 
 if is_pyqt5():
     from matplotlib.backends.backend_qt5 import FigureManagerQT as FigureManager
@@ -48,11 +48,11 @@ class MplCanvas(FigureCanvas):
 
     """Class to represent the FigureCanvas widget"""
 
-    rightDrag = Signal(float, float)
-    leftDrag = Signal(float, float)
-    homeButton = Signal()
-    resize_begin = Signal()
-    resize_end = Signal()
+    rightDrag = QtCore.Signal(float, float)
+    leftDrag = QtCore.Signal(float, float)
+    homeButton = QtCore.Signal()
+    resize_begin = QtCore.Signal()
+    resize_end = QtCore.Signal()
 
     def __init__(self):
         self._draw_count = 0
@@ -71,7 +71,7 @@ class MplCanvas(FigureCanvas):
         self.manager = FigureManager(self, 0)
         matplotlib.interactive(interactive)
 
-        self._resize_timer = QTimer()
+        self._resize_timer = QtCore.QTimer()
         self._resize_timer.setInterval(250)
         self._resize_timer.setSingleShot(True)
         self._resize_timer.timeout.connect(self._on_timeout)
@@ -129,8 +129,8 @@ class MplWidget(QtGui.QWidget):
     """Widget defined in Qt Designer"""
 
     # signals
-    rightDrag = Signal(float, float)
-    leftDrag = Signal(float, float)
+    rightDrag = QtCore.Signal(float, float)
+    leftDrag = QtCore.Signal(float, float)
 
     def __init__(self, parent=None):
         # initialization of Qt MainWindow widget

--- a/glue/qt/widgets/scatter_widget.py
+++ b/glue/qt/widgets/scatter_widget.py
@@ -1,7 +1,8 @@
 from __future__ import absolute_import, division, print_function
 
-from glue.external.qt import QtGui
+from glue.external.qt import QtGui, QtCore
 from glue.external.qt.QtCore import Qt
+
 from glue import core
 
 from glue.clients.scatter_client import ScatterClient

--- a/glue/qt/widgets/settings_editor.py
+++ b/glue/qt/widgets/settings_editor.py
@@ -1,17 +1,17 @@
-from glue.external.qt.QtGui import QTableWidget, QTableWidgetItem
+from glue.external.qt import QtGui
 from glue.external.qt.QtCore import Qt
 
 
 class SettingsEditor(object):
 
     def __init__(self, app):
-        w = QTableWidget(parent=None)
+        w = QtGui.QTableWidget(parent=None)
         w.setColumnCount(2)
         w.setRowCount(len(list(app.settings)))
         w.setHorizontalHeaderLabels(["Setting", "Value"])
         for row, (key, value) in enumerate(app.settings):
-            k = QTableWidgetItem(key)
-            v = QTableWidgetItem(str(value))
+            k = QtGui.QTableWidgetItem(key)
+            v = QtGui.QTableWidgetItem(str(value))
             k.setFlags(k.flags() ^ (Qt.ItemIsEditable | Qt.ItemIsSelectable))
             w.setItem(row, 0, k)
             w.setItem(row, 1, v)

--- a/glue/qt/widgets/style_dialog.py
+++ b/glue/qt/widgets/style_dialog.py
@@ -3,23 +3,19 @@ from __future__ import absolute_import, division, print_function
 from glue.qt.qtutil import (mpl_to_qt4_color, symbol_icon, POINT_ICONS,
                       qt4_to_mpl_color)
 
-from glue.external.qt.QtGui import (QFormLayout, QDialogButtonBox, QColorDialog,
-                                  QWidget, QLineEdit, QListWidget,
-                                  QListWidgetItem, QPixmap, QDialog, QLabel,
-                                  QSpinBox, QComboBox)
-
-from glue.external.qt.QtCore import QSize, Signal, Qt
+from glue.external.qt import QtGui, QtCore
+from glue.external.qt.QtCore import Qt
 
 
-class ColorWidget(QLabel):
-    mousePressed = Signal()
+class ColorWidget(QtGui.QLabel):
+    mousePressed = QtCore.Signal()
 
     def mousePressEvent(self, event):
         self.mousePressed.emit()
         event.accept()
 
 
-class StyleDialog(QDialog):
+class StyleDialog(QtGui.QDialog):
 
     """Dialog which edits the style of a layer (Data or Subset)
 
@@ -37,24 +33,24 @@ class StyleDialog(QDialog):
         self._connect()
 
     def _setup_widgets(self):
-        self.layout = QFormLayout()
+        self.layout = QtGui.QFormLayout()
 
-        self.size_widget = QSpinBox()
+        self.size_widget = QtGui.QSpinBox()
         self.size_widget.setMinimum(1)
         self.size_widget.setMaximum(40)
         self.size_widget.setValue(self.layer.style.markersize)
 
-        self.label_widget = QLineEdit()
+        self.label_widget = QtGui.QLineEdit()
         self.label_widget.setText(self.layer.label)
         self.label_widget.selectAll()
 
-        self.symbol_widget = QComboBox()
+        self.symbol_widget = QtGui.QComboBox()
         for idx, symbol in enumerate(self._symbols):
             icon = symbol_icon(symbol)
             self.symbol_widget.addItem(icon, '')
             if symbol is self.layer.style.marker:
                 self.symbol_widget.setCurrentIndex(idx)
-        self.symbol_widget.setIconSize(QSize(20, 20))
+        self.symbol_widget.setIconSize(QtCore.QSize(20, 20))
         self.symbol_widget.setMinimumSize(10, 32)
 
         self.color_widget = ColorWidget()
@@ -63,8 +59,8 @@ class StyleDialog(QDialog):
         color = mpl_to_qt4_color(color, alpha=self.layer.style.alpha)
         self.set_color(color)
 
-        self.okcancel = QDialogButtonBox(QDialogButtonBox.Ok |
-                                         QDialogButtonBox.Cancel)
+        self.okcancel = QtGui.QDialogButtonBox(QtGui.QDialogButtonBox.Ok |
+                                         QtGui.QDialogButtonBox.Cancel)
 
         if self._edit_label:
             self.layout.addRow("Label", self.label_widget)
@@ -86,9 +82,9 @@ class StyleDialog(QDialog):
         self.setFocusPolicy(Qt.StrongFocus)
 
     def query_color(self, *args):
-        color = QColorDialog.getColor(self._color, self.color_widget,
+        color = QtGui.QColorDialog.getColor(self._color, self.color_widget,
                                       "",
-                                      QColorDialog.ShowAlphaChannel)
+                                      QtGui.QColorDialog.ShowAlphaChannel)
         if color.isValid():
             self.set_color(color)
 

--- a/glue/qt/widgets/subset_facet.py
+++ b/glue/qt/widgets/subset_facet.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from glue.external.qt.QtGui import (QDialog, QDoubleValidator, QIcon)
+from glue.external.qt import QtGui
 import numpy as np
 from matplotlib import cm
 
@@ -33,12 +33,12 @@ class SubsetFacet(object):
         if default is not None:
             self.ui.component_selector.data = default
 
-        val = QDoubleValidator(-1e100, 1e100, 4, None)
+        val = QtGui.QDoubleValidator(-1e100, 1e100, 4, None)
         self.ui.component_selector.component_changed.connect(self._set_limits)
 
         combo = self.ui.color_scale
         for cmap in [cm.cool, cm.RdYlBu, cm.RdYlGn, cm.RdBu, cm.Purples]:
-            combo.addItem(QIcon(cmap2pixmap(cmap)), cmap.name, cmap)
+            combo.addItem(QtGui.QIcon(cmap2pixmap(cmap)), cmap.name, cmap)
 
     def _set_limits(self):
         data = self.ui.component_selector.data
@@ -81,5 +81,5 @@ class SubsetFacet(object):
         self = cls(collect, parent=parent, default=default)
         value = self.exec_()
 
-        if value == QDialog.Accepted:
+        if value == QtGui.QDialog.Accepted:
             self._apply()

--- a/glue/qt/widgets/table_widget.py
+++ b/glue/qt/widgets/table_widget.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 from glue.qt.widgets.data_viewer import DataViewer
 
-from glue.external.qt.QtGui import QTableView, QAbstractItemView, QItemSelectionModel, QItemSelection, QSortFilterProxyModel
+from glue.external.qt import QtGui
 from glue.external.qt.QtCore import Qt, QAbstractTableModel, QAbstractItemModel, QObject
 
 from glue.core import message as msg
@@ -146,7 +146,7 @@ class TableWidget(DataViewer):
 
         self.ui.table.clearSelection()
         selection_mode = self.ui.table.selectionMode()
-        self.ui.table.setSelectionMode(QAbstractItemView.MultiSelection);
+        self.ui.table.setSelectionMode(QtGui.QAbstractItemView.MultiSelection);
 
         # The following is more efficient than just calling selectRow
         model = self.ui.table.selectionModel()
@@ -154,7 +154,7 @@ class TableWidget(DataViewer):
             index = self.model.order[index]
             model_index = self.model.createIndex(index, 0)
             model.select(model_index,
-                         QItemSelectionModel.Select | QItemSelectionModel.Rows)
+                         QtGui.QItemSelectionModel.Select | QtGui.QItemSelectionModel.Rows)
 
         self.ui.table.setSelectionMode(selection_mode)
 

--- a/glue/qt/widgets/terminal.py
+++ b/glue/qt/widgets/terminal.py
@@ -25,8 +25,7 @@ from distutils.version import LooseVersion
 from contextlib import contextmanager
 
 # must import these first, to set up Qt properly
-from glue.external.qt import QtCore
-from glue.external.qt.QtGui import QInputDialog
+from glue.external.qt import QtGui, QtCore
 from glue.version import __version__
 from glue.utils import as_variable_name
 from glue.qt.widgets.glue_mdi_area import GlueMdiSubWindow
@@ -191,7 +190,7 @@ class DragAndDropTerminal(RichIPythonWidget):
         except (IndexError, AttributeError):
             lbl = 'x'
         lbl = as_variable_name(lbl)
-        var, ok = QInputDialog.getText(self, "Choose a variable name",
+        var, ok = QtGui.QInputDialog.getText(self, "Choose a variable name",
                                        "Choose a variable name", text=lbl)
         if ok:
             # unpack single-item lists for convenience

--- a/glue/qt/widgets/tests/test_layer_tree_widget.py
+++ b/glue/qt/widgets/tests/test_layer_tree_widget.py
@@ -2,7 +2,7 @@
 
 from __future__ import absolute_import, division, print_function
 
-from glue.external.qt.QtGui import QMainWindow
+from glue.external.qt import QtGui
 from glue.external.qt.QtTest import QTest
 from glue.external.qt.QtCore import Qt
 
@@ -24,7 +24,7 @@ class TestLayerTree(object):
         self.collect = core.data_collection.DataCollection(list(self.data))
         self.hub = self.collect.hub
         self.widget = LayerTreeWidget()
-        self.win = QMainWindow()
+        self.win = QtGui.QMainWindow()
         self.win.setCentralWidget(self.widget)
         self.widget.setup(self.collect)
         for key, value in self.widget._actions.items():
@@ -231,14 +231,14 @@ class TestLayerTree(object):
 
     def test_save_subset(self):
         subset = MagicMock(core.Subset)
-        with patch('glue.qt.widgets.layer_tree_widget.QFileDialog') as d:
+        with patch('glue.qt.widgets.layer_tree_widget.QtGui.QFileDialog') as d:
             d.getSaveFileName.return_value = ('test.fits', None)
             save_subset(subset)
         subset.write_mask.assert_called_once_with('test.fits')
 
     def test_save_subset_cancel(self):
         subset = MagicMock(core.Subset)
-        with patch('glue.qt.widgets.layer_tree_widget.QFileDialog') as d:
+        with patch('glue.qt.widgets.layer_tree_widget.QtGui.QFileDialog') as d:
             d.getSaveFileName.return_value = ('', '')
             save_subset(subset)
         assert subset.write_mask.call_count == 0

--- a/glue/qt/widgets/tests/test_style_dialog.py
+++ b/glue/qt/widgets/tests/test_style_dialog.py
@@ -1,4 +1,4 @@
-from glue.external.qt.QtCore import QPoint
+from glue.external.qt import QtCore
 from glue.external.qt.QtGui import QMainWindow
 from glue.core import Data
 
@@ -24,5 +24,5 @@ def test_style_dialog():
                  x=[[1, 2], [3, 4]],
                  y=[[2, 3], [4, 5]])
 
-    pos = QPoint(10, 10)
+    pos = QtCore.QPoint(10, 10)
     st = NonBlockingStyleDialog.dropdown_editor(image, pos)

--- a/glue/qt/widgets/tests/test_table_widget.py
+++ b/glue/qt/widgets/tests/test_table_widget.py
@@ -2,10 +2,10 @@ from __future__ import absolute_import, division, print_function
 
 import pytest
 
-from ..table_widget import DataTableModel
+from glue.external.qt.QtCore import Qt
 from glue.core import Data
 
-from glue.external.qt.QtCore import Qt
+from ..table_widget import DataTableModel
 
 
 class TestDataTableModel(object):

--- a/glue/qt/widgets/tests/test_terminal.py
+++ b/glue/qt/widgets/tests/test_terminal.py
@@ -31,7 +31,7 @@ class TestTerminal(object):
 
     def test_drops_update_namespace(self):
         """DnD adds variable name to namespace"""
-        with patch('glue.qt.widgets.terminal.QInputDialog') as dialog:
+        with patch('glue.qt.widgets.terminal.QtGui.QInputDialog') as dialog:
             dialog.getText.return_value = 'accept_var', True
 
             gt = glue_terminal()
@@ -44,7 +44,7 @@ class TestTerminal(object):
     def test_cancel_drop(self):
         """Drop not added if user cancels dialog box"""
 
-        with patch('glue.qt.widgets.terminal.QInputDialog') as dialog:
+        with patch('glue.qt.widgets.terminal.QtGui.QInputDialog') as dialog:
             dialog.getText.return_value = 'cancel_var', False
 
             gt = glue_terminal()

--- a/glue/utils/qt/autocomplete_widget.py
+++ b/glue/utils/qt/autocomplete_widget.py
@@ -39,7 +39,7 @@ class CompletionTextEdit(QtGui.QTextEdit):
 
         self.completer.setWidget(self)
         self.completer.setCompletionMode(QtGui.QCompleter.PopupCompletion)
-        self.completer.setCaseSensitivity(QtCore.Qt.CaseInsensitive)
+        self.completer.setCaseSensitivity(Qt.CaseInsensitive)
         self.completer.activated.connect(self.insert_completion)
 
     def insert_completion(self, completion):
@@ -71,16 +71,16 @@ class CompletionTextEdit(QtGui.QTextEdit):
 
         if self.completer and self.completer.popup().isVisible():
             if event.key() in (
-                    QtCore.Qt.Key_Enter,
-                    QtCore.Qt.Key_Return,
-                    QtCore.Qt.Key_Escape,
-                    QtCore.Qt.Key_Tab,
-                    QtCore.Qt.Key_Backtab):
+                    Qt.Key_Enter,
+                    Qt.Key_Return,
+                    Qt.Key_Escape,
+                    Qt.Key_Tab,
+                    Qt.Key_Backtab):
                 event.ignore()
                 return
 
         # Check if TAB has been pressed
-        is_shortcut = event.key() == QtCore.Qt.Key_Tab
+        is_shortcut = event.key() == Qt.Key_Tab
 
         if not self.completer or not is_shortcut:
             QtGui.QTextEdit.keyPressEvent(self, event)


### PR DESCRIPTION
Following https://github.com/glue-viz/glue/pull/827 I've been working on further cleaning up the imports - one place where the imports are hard to maintain, so this adjusts the Qt imports to always do at most:

```
from glue.external.qt import QtGui, QtCore
from glue.external.qt.QtCore import Qt
```

then access classes via e.g. ``QtGui.QWidget``, etc (this style is used a lot in other codes)

This will need to be rebased once #827 is merged.

