### PR TITLE
Reorder imports to follow PEP8 recommendation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,9 +111,6 @@ before_install:
   # Deal with issue on Travis builders
   - if [[ $TRAVIS_OS_NAME == linux ]]; then sudo rm -rf /dev/shm; sudo ln -s /run/shm /dev/shm; fi
 
-  # Setup system for headless GUI handling
-  - if [[ $TRAVIS_OS_NAME == linux ]]; then export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start; fi
-
   # setup tools to trigger mac buildbot
   - if [ $APP_TRIGGER ]; then source .setup_app_trigger.sh; fi
   - if [ $TRAVIS_BRANCH = master ]; then export S3_DIR=latest; else export S3_DIR=$TRAVIS_BRANCH; fi

--- a/glue/_plugin_helpers.py
+++ b/glue/_plugin_helpers.py
@@ -6,8 +6,11 @@
 # evaluated at compile time rather than at runtime, so the patched version
 # wouldn't be used.
 
+from __future__ import absolute_import, division, print_function
+
 import os
 from collections import defaultdict
+
 
 def iter_plugin_entry_points():
     from pkg_resources import iter_entry_points
@@ -34,7 +37,7 @@ class PluginConfig(object):
         from glue import config
         cfg_dir = config.CFG_DIR
 
-        plugin_cfg =  os.path.join(cfg_dir, 'plugins.cfg')
+        plugin_cfg = os.path.join(cfg_dir, 'plugins.cfg')
 
         from glue.external.six.moves import configparser
 
@@ -59,7 +62,7 @@ class PluginConfig(object):
         from glue import config
         cfg_dir = config.CFG_DIR
 
-        plugin_cfg =  os.path.join(cfg_dir, 'plugins.cfg')
+        plugin_cfg = os.path.join(cfg_dir, 'plugins.cfg')
 
         from glue.external.six.moves import configparser
 

--- a/glue/backends.py
+++ b/glue/backends.py
@@ -3,6 +3,8 @@ A common interface for accessing backend UI functionality.
 
 At the moment, the only backend is Qt
 """
+from __future__ import absolute_import, division, print_function
+
 from abc import abstractmethod
 _backend = None
 

--- a/glue/clients/__init__.py
+++ b/glue/clients/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from matplotlib import rcParams, rcdefaults
 
 # standardize mpl setup

--- a/glue/clients/histogram_client.py
+++ b/glue/clients/histogram_client.py
@@ -2,17 +2,18 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 
-from glue.core.client import Client
-from glue.core import message as msg
-from glue.core.data import Data
-from glue.core.subset import RangeSubsetState, CategoricalRoiSubsetState
-from glue.core.exceptions import IncompatibleDataException, IncompatibleAttribute
+from glue.core.callback_property import CallbackProperty
 from glue.core.edit_subset_mode import EditSubsetMode
+from glue.core.exceptions import IncompatibleDataException, IncompatibleAttribute
+from glue.core.subset import RangeSubsetState, CategoricalRoiSubsetState
+from glue.core.data import Data
+from glue.core import message as msg
+from glue.core.client import Client
 from glue.clients.layer_artist import HistogramLayerArtist, LayerArtistContainer
 from glue.clients.util import update_ticks, visible_limits
-from glue.core.callback_property import CallbackProperty
-from glue.utils import lookup_class
 from glue.clients.viz_client import init_mpl
+from glue.utils import lookup_class
+
 
 class UpdateProperty(CallbackProperty):
 

--- a/glue/clients/image_client.py
+++ b/glue/clients/image_client.py
@@ -6,22 +6,21 @@ from functools import wraps
 import numpy as np
 
 from glue.external.modest_image import extract_matched_slices
-from glue.core.exceptions import IncompatibleAttribute
-from glue.core.data import Data
-from glue.core.subset import Subset, RoiSubsetState
-from glue.core.roi import PolygonalROI
-from glue.core.message import ComponentReplacedMessage
+from glue.core.edit_subset_mode import EditSubsetMode
 from glue.core.callback_property import (
     callback_property, CallbackProperty)
-from glue.core.edit_subset_mode import EditSubsetMode
-from glue.utils import lookup_class, defer_draw
-
-from glue.clients.viz_client import VizClient, init_mpl
+from glue.core.message import ComponentReplacedMessage
+from glue.core.roi import PolygonalROI
+from glue.core.subset import Subset, RoiSubsetState
+from glue.core.data import Data
+from glue.core.exceptions import IncompatibleAttribute
 from glue.clients.layer_artist import (ScatterLayerArtist, LayerArtistContainer,
-                           ImageLayerArtist, SubsetImageLayerArtist,
-                           RGBImageLayerArtist,
-                           ImageLayerBase, RGBImageLayerBase,
-                           SubsetImageLayerBase, ScatterLayerBase)
+                                       ImageLayerArtist, SubsetImageLayerArtist,
+                                       RGBImageLayerArtist,
+                                       ImageLayerBase, RGBImageLayerBase,
+                                       SubsetImageLayerBase, ScatterLayerBase)
+from glue.clients.viz_client import VizClient, init_mpl
+from glue.utils import lookup_class, defer_draw
 
 
 def requires_data(func):

--- a/glue/clients/layer_artist.py
+++ b/glue/clients/layer_artist.py
@@ -18,13 +18,14 @@ from abc import ABCMeta, abstractproperty, abstractmethod
 
 import numpy as np
 from matplotlib.cm import gray
+
 from glue.external import six
-from glue.core.exceptions import IncompatibleAttribute
-from glue.core.util import PropertySetMixin, Pointer
 from glue.core.subset import Subset
+from glue.core.util import PropertySetMixin, Pointer
+from glue.core.exceptions import IncompatibleAttribute
+from glue.clients.ds9norm import DS9Normalize
 from glue.clients.util import small_view, small_view_array
 from glue.utils import view_cascade, get_extent, color2rgb
-from glue.clients.ds9norm import DS9Normalize
 
 
 __all__ = ['LayerArtistBase', 'LayerArtist',

--- a/glue/clients/profile_viewer.py
+++ b/glue/clients/profile_viewer.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import numpy as np
 from matplotlib.transforms import blended_transform_factory
 

--- a/glue/clients/scatter_client.py
+++ b/glue/clients/scatter_client.py
@@ -4,19 +4,19 @@ from functools import partial
 
 import numpy as np
 
-from glue.core.client import Client
-from glue.core.data import Data, IncompatibleAttribute, ComponentID
-from glue.core.subset import RoiSubsetState, RangeSubsetState, CategoricalRoiSubsetState, AndState
-from glue.core.roi import PolygonalROI, RangeROI, RectangularROI
-from glue.core.util import relim
-from glue.core.edit_subset_mode import EditSubsetMode
+from glue.core.callback_property import (CallbackProperty, add_callback,
+                                         delay_callback)
 from glue.core.message import ComponentReplacedMessage
-from glue.utils import lookup_class
-from glue.clients.viz_client import init_mpl
+from glue.core.edit_subset_mode import EditSubsetMode
+from glue.core.util import relim
+from glue.core.roi import PolygonalROI, RangeROI, RectangularROI
+from glue.core.subset import RoiSubsetState, RangeSubsetState, CategoricalRoiSubsetState, AndState
+from glue.core.data import Data, IncompatibleAttribute, ComponentID
+from glue.core.client import Client
 from glue.clients.layer_artist import ScatterLayerArtist, LayerArtistContainer
 from glue.clients.util import update_ticks, visible_limits
-from glue.core.callback_property import (CallbackProperty, add_callback,
-                                      delay_callback)
+from glue.clients.viz_client import init_mpl
+from glue.utils import lookup_class
 
 
 class ScatterClient(Client):

--- a/glue/clients/tests/test_ds9norm.py
+++ b/glue/clients/tests/test_ds9norm.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
-import numpy as np
 import pytest
+import numpy as np
 
 from ..ds9norm import *
 

--- a/glue/clients/tests/test_histogram_client.py
+++ b/glue/clients/tests/test_histogram_client.py
@@ -4,20 +4,19 @@ from __future__ import absolute_import, division, print_function
 
 import pytest
 import numpy as np
-
 from mock import MagicMock
+
+from glue.core.subset import RangeSubsetState, CategoricalRoiSubsetState
+from glue.core.component_id import ComponentID
+from glue.core.component import CategoricalComponent
+from glue.core.data import Data
+from glue.core.exceptions import IncompatibleDataException
+from glue.core.data_collection import DataCollection
 
 from ..histogram_client import HistogramClient
 from ..layer_artist import HistogramLayerArtist
-
-from glue.core.data_collection import DataCollection
-from glue.core.exceptions import IncompatibleDataException
-from glue.core.data import Data
-from glue.core.component import CategoricalComponent
-from glue.core.component_id import ComponentID
-from glue.core.subset import RangeSubsetState, CategoricalRoiSubsetState
-
 from .util import renderless_figure
+
 
 FIGURE = renderless_figure()
 
@@ -383,7 +382,6 @@ class TestCategoricalHistogram(TestHistogramClient):
         assert isinstance(state, CategoricalRoiSubsetState)
         np.testing.assert_equal(self.data.subsets[0].subset_state.roi.categories,
                                 np.array(['b', 'c', 'd', 'e']))
-
 
     # REMOVED TESTS
     def test_xlog_axes_labels(self):

--- a/glue/clients/tests/test_image_client.py
+++ b/glue/clients/tests/test_image_client.py
@@ -3,19 +3,18 @@
 from __future__ import absolute_import, division, print_function
 
 import pytest
-
-from mock import MagicMock
 import numpy as np
+from mock import MagicMock
 
-from glue.tests import example_data
-from glue import core
-from glue.core.exceptions import IncompatibleAttribute
 from glue.core.link_helpers import LinkSame
+from glue.core.exceptions import IncompatibleAttribute
+from glue import core
+from glue.tests import example_data
 
-from ..layer_artist import RGBImageLayerArtist, ImageLayerArtist
 from ..image_client import MplImageClient
-
+from ..layer_artist import RGBImageLayerArtist, ImageLayerArtist
 from .util import renderless_figure
+
 
 FIGURE = renderless_figure()
 

--- a/glue/clients/tests/test_layer_artist.py
+++ b/glue/clients/tests/test_layer_artist.py
@@ -1,6 +1,9 @@
-from .util import renderless_figure
-from ..layer_artist import ScatterLayerArtist
+from __future__ import absolute_import, division, print_function
+
 from glue.core import Data
+
+from ..layer_artist import ScatterLayerArtist
+from .util import renderless_figure
 
 FIGURE = renderless_figure()
 

--- a/glue/clients/tests/test_profile_viewer.py
+++ b/glue/clients/tests/test_profile_viewer.py
@@ -1,11 +1,14 @@
+from __future__ import absolute_import, division, print_function
+
 from collections import namedtuple
 
-from mock import MagicMock
 import pytest
 import numpy as np
+from mock import MagicMock
 
 from ..profile_viewer import ProfileViewer
 from .util import renderless_figure
+
 
 FIG = renderless_figure()
 Event = namedtuple('Event', 'xdata ydata inaxes button dblclick')

--- a/glue/clients/tests/test_scatter_client.py
+++ b/glue/clients/tests/test_scatter_client.py
@@ -2,25 +2,27 @@
 
 from __future__ import absolute_import, division, print_function
 
-import pytest
-
-import numpy as np
-from matplotlib.ticker import AutoLocator, MaxNLocator, LogLocator
-from matplotlib.ticker import LogFormatterMathtext, ScalarFormatter, FuncFormatter
-from mock import MagicMock
 from timeit import timeit
 from functools import partial
 
-from glue.tests import example_data
-from glue.core.subset import RangeSubsetState, CategoricalRoiSubsetState, AndState
-from glue.core.roi import RectangularROI, XRangeROI, YRangeROI
-from glue.core.data import Data
-from glue.core.data_collection import DataCollection
-from glue.core.component import Component, CategoricalComponent
-from glue.core.component_id import ComponentID
+import pytest
+import numpy as np
+from mock import MagicMock
+from matplotlib.ticker import AutoLocator, MaxNLocator, LogLocator
+from matplotlib.ticker import LogFormatterMathtext, ScalarFormatter, FuncFormatter
+
 from glue.core.edit_subset_mode import EditSubsetMode
+from glue.core.component_id import ComponentID
+from glue.core.component import Component, CategoricalComponent
+from glue.core.data_collection import DataCollection
+from glue.core.data import Data
+from glue.core.roi import RectangularROI, XRangeROI, YRangeROI
+from glue.core.subset import RangeSubsetState, CategoricalRoiSubsetState, AndState
+from glue.tests import example_data
+
 from ..scatter_client import ScatterClient
 from .util import renderless_figure
+
 
 # share matplotlib instance, and disable rendering, for speed
 FIGURE = renderless_figure()

--- a/glue/clients/tests/util.py
+++ b/glue/clients/tests/util.py
@@ -1,5 +1,7 @@
-import matplotlib.pyplot as plt
+from __future__ import absolute_import, division, print_function
+
 from mock import MagicMock
+import matplotlib.pyplot as plt
 
 
 def renderless_figure():

--- a/glue/clients/viz_client.py
+++ b/glue/clients/viz_client.py
@@ -1,10 +1,12 @@
 from __future__ import absolute_import, division, print_function
 
 import matplotlib.pyplot as plt
-from glue.core.client import Client
+
 from glue.core import Data
-from glue.utils.matplotlib import freeze_margins
+from glue.core.client import Client
 from glue.clients.layer_artist import LayerArtistContainer
+from glue.utils.matplotlib import freeze_margins
+
 
 __all__ = ['VizClient', 'GenericMplClient']
 

--- a/glue/config.py
+++ b/glue/config.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import, division, print_function
 
 import os
-import sys
 import imp
+import sys
 import logging
 from collections import namedtuple
 """

--- a/glue/conftest.py
+++ b/glue/conftest.py
@@ -1,4 +1,8 @@
+from __future__ import absolute_import, division, print_function
+
 import os
+
+from glue.config import CFG_DIR as CFG_DIR_ORIG
 
 
 def pytest_addoption(parser):
@@ -32,8 +36,6 @@ def pytest_report_header(config):
     from glue._deps import get_status
     return os.linesep + glue_version + os.linesep + os.linesep + get_status()
 
-
-from glue.config import CFG_DIR as CFG_DIR_ORIG
 
 def pytest_unconfigure(config):
     from glue import config

--- a/glue/core/__init__.py
+++ b/glue/core/__init__.py
@@ -1,15 +1,19 @@
+from __future__ import absolute_import, division, print_function
+
 from .client import Client
+from .command import Command, CommandStack
+from .component import Component
+from .component_id import ComponentID
 from .component_link import ComponentLink
 from .coordinates import Coordinates
-from .component_id import ComponentID
-from .component import Component
 from .data import Data
 from .data_collection import DataCollection
 from .hub import Hub, HubListener
 from .link_manager import LinkManager
-from .subset import Subset
-from .visual import VisualAttributes
-from .command import Command, CommandStack
 from .session import Session
-from .application_base import Application
+from .subset import Subset
 from .subset_group import SubsetGroup
+from .visual import VisualAttributes
+
+# We import this last to avoid circular imports
+from .application_base import Application

--- a/glue/core/aggregate.py
+++ b/glue/core/aggregate.py
@@ -1,6 +1,9 @@
 """
 Classes to perform aggregations over cubes
 """
+
+from __future__ import absolute_import, division, print_function
+
 try:
     from itertools import izip
 except ImportError:  # python3
@@ -9,6 +12,7 @@ except ImportError:  # python3
 from functools import wraps
 
 import numpy as np
+
 from glue.external.six.moves import range as xrange
 
 

--- a/glue/core/application_base.py
+++ b/glue/core/application_base.py
@@ -1,18 +1,19 @@
 from __future__ import absolute_import, division, print_function
 
-from functools import wraps, partial
 import traceback
+from functools import wraps, partial
 
-from glue.core.data_collection import DataCollection
-from glue.core.data_factories import load_data
-from glue.core import command
-from glue.core import Data, Subset
-from glue.core.hub import HubListener
-from glue.core.util import PropertySetMixin
-from glue.utils import as_list
-from glue.core.edit_subset_mode import EditSubsetMode
 from glue.core.session import Session
+from glue.core.edit_subset_mode import EditSubsetMode
+from glue.core.util import PropertySetMixin
+from glue.core.hub import HubListener
+from glue.core import Data, Subset
+from glue.core import command
+from glue.core.data_factories import load_data
+from glue.core.data_collection import DataCollection
 from glue.config import settings
+from glue.utils import as_list
+
 
 __all__ = ['Application', 'ViewerBase']
 

--- a/glue/core/callback_property.py
+++ b/glue/core/callback_property.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
 from glue.external.echo import (CallbackProperty, add_callback,
-                             delay_callback, ignore_callback,
-                             remove_callback, callback_property)
+                                delay_callback, ignore_callback,
+                                remove_callback, callback_property)

--- a/glue/core/client.py
+++ b/glue/core/client.py
@@ -1,15 +1,16 @@
 from __future__ import absolute_import, division, print_function
 
-from glue.core.hub import HubListener
-from glue.core.data import Data
-from glue.core.subset import Subset
-from glue.core.data_collection import DataCollection
 from glue.core.message import (DataUpdateMessage,
-                      SubsetUpdateMessage,
-                      SubsetCreateMessage,
-                      SubsetDeleteMessage,
-                      DataCollectionDeleteMessage,
-                      NumericalDataChangedMessage)
+                               SubsetUpdateMessage,
+                               SubsetCreateMessage,
+                               SubsetDeleteMessage,
+                               DataCollectionDeleteMessage,
+                               NumericalDataChangedMessage)
+from glue.core.data_collection import DataCollection
+from glue.core.subset import Subset
+from glue.core.data import Data
+from glue.core.hub import HubListener
+
 
 __all__ = ['Client', 'BasicClient']
 

--- a/glue/core/command.py
+++ b/glue/core/command.py
@@ -1,10 +1,11 @@
 from __future__ import absolute_import, division, print_function
 
-from abc import ABCMeta, abstractmethod
 import logging
+from abc import ABCMeta, abstractmethod
 
-from glue.core.data_factories import load_data
 from glue.core.util import CallbackMixin
+from glue.core.data_factories import load_data
+
 
 MAX_UNDO = 50
 """

--- a/glue/core/component.py
+++ b/glue/core/component.py
@@ -6,9 +6,9 @@ import warnings
 import numpy as np
 import pandas as pd
 
+from glue.core.util import row_lookup
 from glue.utils import unique, shape_to_string, coerce_numeric, check_sorted
 
-from glue.core.util import row_lookup
 
 __all__ = ['Component', 'DerivedComponent',
            'CategoricalComponent', 'CoordinateComponent']

--- a/glue/core/component_id.py
+++ b/glue/core/component_id.py
@@ -5,9 +5,9 @@ import operator
 import numpy as np
 
 from glue.external import six
-
-from glue.core.subset import InequalitySubsetState
 from glue.core.component_link import BinaryComponentLink
+from glue.core.subset import InequalitySubsetState
+
 
 __all__ = ['ComponentID', 'ComponentIDDict']
 

--- a/glue/core/component_link.py
+++ b/glue/core/component_link.py
@@ -1,15 +1,16 @@
 from __future__ import absolute_import, division, print_function
 
+import numbers
 import logging
 import operator
-import numbers
 
 import numpy as np
 
-from glue.core.util import join_component_view
-from glue.core.subset import InequalitySubsetState
-from glue.core.contracts import contract, ContractsMeta
 from glue.external.six import add_metaclass
+from glue.core.contracts import contract, ContractsMeta
+from glue.core.subset import InequalitySubsetState
+from glue.core.util import join_component_view
+
 
 __all__ = ['ComponentLink', 'BinaryComponentLink']
 

--- a/glue/core/contracts.py
+++ b/glue/core/contracts.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 """
 An interface to PyContracts, to annotate functions with type information
 
@@ -17,11 +16,13 @@ Glue code should only import contract through this module,
 and never directly from the contracts package.
 """
 
-from numpy import ndarray, s_
-from pandas import Series
+from __future__ import absolute_import, division, print_function
 
-from glue.config import enable_contracts
+from pandas import Series
+from numpy import ndarray, s_
+
 from glue.external.six import string_types
+from glue.config import enable_contracts
 
 
 def _build_custom_contracts():

--- a/glue/core/coordinates.py
+++ b/glue/core/coordinates.py
@@ -4,6 +4,7 @@ import logging
 
 import numpy as np
 
+
 __all__ = ['Coordinates', 'WCSCoordinates']
 
 

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -5,28 +5,26 @@ from collections import OrderedDict
 import numpy as np
 import pandas as pd
 
-from glue.config import settings
 from glue.external import six
+from glue.core.message import (DataUpdateMessage,
+                               DataAddComponentMessage, NumericalDataChangedMessage,
+                               SubsetCreateMessage, ComponentsChangedMessage,
+                               ComponentReplacedMessage)
+from glue.core.decorators import clear_cache
+from glue.core.util import split_component_view
+from glue.core.hub import Hub
+from glue.core.subset import Subset, SubsetState
+from glue.core.component_link import ComponentLink, CoordinateComponentLink
+from glue.core.exceptions import IncompatibleAttribute
+from glue.core.visual import VisualAttributes
+from glue.core.coordinates import Coordinates
+from glue.core.contracts import contract
+from glue.config import settings
 from glue.utils import view_shape
 
-from glue.core.contracts import contract
-from glue.core.coordinates import Coordinates
-from glue.core.visual import VisualAttributes
-from glue.core.exceptions import IncompatibleAttribute
-
-from glue.core.component_link import ComponentLink, CoordinateComponentLink
-
-from glue.core.subset import Subset, SubsetState
-from glue.core.hub import Hub
-from glue.core.util import split_component_view
-from glue.core.decorators import clear_cache
-from glue.core.message import (DataUpdateMessage,
-                      DataAddComponentMessage, NumericalDataChangedMessage,
-                      SubsetCreateMessage, ComponentsChangedMessage,
-                      ComponentReplacedMessage)
 
 # Note: leave all the following imports for component and component_id since
-# they are here for backward-compatibility (the code used to live in this 
+# they are here for backward-compatibility (the code used to live in this
 # file)
 from glue.core.component import Component, CoordinateComponent, DerivedComponent
 from glue.core.component_id import ComponentID, ComponentIDDict

--- a/glue/core/data_collection.py
+++ b/glue/core/data_collection.py
@@ -1,16 +1,16 @@
 from __future__ import absolute_import, division, print_function
 
-from glue.core.hub import Hub, HubListener
-from glue.core.data import Data
-from glue.core.link_manager import LinkManager
-from glue.core.registry import Registry
-from glue.core.message import (DataCollectionAddMessage,
-                      DataCollectionDeleteMessage,
-                      DataAddComponentMessage)
 from glue.core.util import disambiguate
-
+from glue.core.message import (DataCollectionAddMessage,
+                               DataCollectionDeleteMessage,
+                               DataAddComponentMessage)
+from glue.core.registry import Registry
+from glue.core.link_manager import LinkManager
+from glue.core.data import Data
+from glue.core.hub import Hub, HubListener
 from glue.config import settings
 from glue.utils import as_list
+
 
 __all__ = ['DataCollection']
 

--- a/glue/core/data_factories/__init__.py
+++ b/glue/core/data_factories/__init__.py
@@ -1,13 +1,14 @@
 from __future__ import absolute_import, division, print_function
 
-from .helpers import *
+from .astropy_table import *
+from .dendrogram import *
+from .excel import *
 from .fits import *
 from .hdf5 import *
-from .astropy_table import *
-from .pandas import *
-from .excel import *
+from .helpers import *
 from .image import *
+from .pandas import *
 from .tables import *
-from .dendrogram import *
+
 
 # from .deprecated import *

--- a/glue/core/data_factories/astropy_table.py
+++ b/glue/core/data_factories/astropy_table.py
@@ -2,10 +2,10 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 
+from glue.core.data_factories.helpers import has_extension
 from glue.core.data import Component, Data
 from glue.config import data_factory
 
-from glue.core.data_factories.helpers import has_extension
 
 __all__ = ['astropy_tabular_data', 'sextractor_factory', 'cds_factory',
            'daophot_factory', 'ipac_factory', 'aastex_factory',
@@ -18,7 +18,7 @@ __all__ = ['astropy_tabular_data', 'sextractor_factory', 'cds_factory',
 def is_readable_by_astropy(filename, **kwargs):
     # This identifier is not efficient, because it involves actually trying
     # to read in the table. However, we only use this as the identifier for
-    # the astropy_tabular_data factory which has a priority of 0 and is 
+    # the astropy_tabular_data factory which has a priority of 0 and is
     # therefore only used as a last attempt if all else fails.
     try:
         astropy_table_read(filename, **kwargs)
@@ -29,7 +29,7 @@ def is_readable_by_astropy(filename, **kwargs):
 
 
 def astropy_table_read(*args, **kwargs):
-    
+
     from astropy.table import Table
 
     # In Python 3, as of Astropy 0.4, if the format is not specified, the
@@ -37,7 +37,7 @@ def astropy_table_read(*args, **kwargs):
     # This is only a problem for ASCII formats however, because it is due
     # to the fact that the file object in io.ascii does not rewind to the
     # start between guesses (due to a bug), so here we can explicitly try
-    # the ASCII format if the format keyword was not already present. But 
+    # the ASCII format if the format keyword was not already present. But
     # also more generally, we should first try the ASCII readers.
     if 'format' not in kwargs:
         try:

--- a/glue/core/data_factories/dendrogram.py
+++ b/glue/core/data_factories/dendrogram.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 from glue.core.data_factories.helpers import has_extension
 
+
 __all__ = []
 
 try:

--- a/glue/core/data_factories/deprecated.py
+++ b/glue/core/data_factories/deprecated.py
@@ -1,12 +1,12 @@
 from __future__ import absolute_import, division, print_function
 
-from glue.core.data import Component, Data
-from glue.utils import file_format
-from glue.core.coordinates import coordinates_from_header
-from glue.config import data_factory
-
-from glue.core.data_factories.fits import is_fits, is_image_hdu
 from glue.core.data_factories.hdf5 import is_hdf5, extract_hdf5_datasets
+from glue.core.data_factories.fits import is_fits, is_image_hdu
+from glue.core.coordinates import coordinates_from_header
+from glue.core.data import Component, Data
+from glue.config import data_factory
+from glue.utils import file_format
+
 
 __all__ = ['is_gridded_data', 'gridded_data']
 

--- a/glue/core/data_factories/excel.py
+++ b/glue/core/data_factories/excel.py
@@ -2,10 +2,10 @@ from __future__ import absolute_import, division, print_function
 
 import os
 
+from glue.core.data_factories.helpers import has_extension
+from glue.core.data_factories.pandas import panda_process
 from glue.config import data_factory
 
-from glue.core.data_factories.pandas import panda_process
-from glue.core.data_factories.helpers import has_extension
 
 __all__ = []
 

--- a/glue/core/data_factories/fits.py
+++ b/glue/core/data_factories/fits.py
@@ -4,9 +4,10 @@ import warnings
 from os.path import basename
 from collections import OrderedDict
 
-from glue.config import data_factory
-from glue.core.data import Component, Data
 from glue.core.coordinates import coordinates_from_header
+from glue.core.data import Component, Data
+from glue.config import data_factory
+
 
 __all__ = ['is_fits', 'fits_reader', 'is_casalike', 'casalike_cube']
 

--- a/glue/core/data_factories/hdf5.py
+++ b/glue/core/data_factories/hdf5.py
@@ -7,6 +7,7 @@ from collections import OrderedDict
 from glue.core.data import Component, Data
 from glue.config import data_factory
 
+
 __all__ = ['is_hdf5', 'hdf5_reader']
 
 

--- a/glue/core/data_factories/helpers.py
+++ b/glue/core/data_factories/helpers.py
@@ -27,11 +27,12 @@ from __future__ import absolute_import, division, print_function
 import os
 import warnings
 
-from glue.core.data import Component, Data
-from glue.utils import as_list
-from glue.backends import get_backend
-from glue.config import auto_refresh, data_factory
 from glue.core.contracts import contract
+from glue.core.data import Component, Data
+from glue.config import auto_refresh, data_factory
+from glue.backends import get_backend
+from glue.utils import as_list
+
 
 __all__ = ['FileWatcher', 'LoadLog',
            'auto_data', 'data_label', 'find_factory',

--- a/glue/core/data_factories/image.py
+++ b/glue/core/data_factories/image.py
@@ -2,11 +2,11 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 
-from glue.core.data import Data
-
-from glue.core.data_factories.helpers import has_extension
 from glue.core.coordinates import coordinates_from_wcs
+from glue.core.data_factories.helpers import has_extension
+from glue.core.data import Data
 from glue.config import data_factory
+
 
 IMG_FMT = ['jpg', 'jpeg', 'bmp', 'png', 'tiff', 'tif']
 

--- a/glue/core/data_factories/pandas.py
+++ b/glue/core/data_factories/pandas.py
@@ -2,13 +2,12 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 
-from glue.core.data import Data
-from glue.core.component import Component, CategoricalComponent
-
-from glue.core.data_factories.helpers import has_extension
-
 from glue.external import six
+from glue.core.data_factories.helpers import has_extension
+from glue.core.component import Component, CategoricalComponent
+from glue.core.data import Data
 from glue.config import data_factory
+
 
 __all__ = ['pandas_read_table']
 
@@ -89,4 +88,3 @@ def pandas_read_table(path, **kwargs):
     if fallback is not None:
         return panda_process(fallback)
     raise IOError("Could not parse %s using pandas" % path)
-

--- a/glue/core/data_factories/tables.py
+++ b/glue/core/data_factories/tables.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import, division, print_function
 
+from glue.core.data_factories.helpers import has_extension
 from glue.config import data_factory
 
-from glue.core.data_factories.helpers import has_extension
 
 __all__ = ['tabular_data']
 
@@ -22,4 +22,3 @@ def tabular_data(path, **kwargs):
             pass
     else:
         raise IOError("Could not parse file: %s" % path)
-

--- a/glue/core/data_factories/tests/test_data_factories.py
+++ b/glue/core/data_factories/tests/test_data_factories.py
@@ -3,19 +3,17 @@ from __future__ import absolute_import, division, print_function
 import warnings
 
 import pytest
-from mock import MagicMock
 import numpy as np
+from mock import MagicMock
 from numpy.testing import assert_allclose, assert_array_equal
 
-from glue.core import data_factories as df
-from glue.core.data import Data
-from glue.core.component import CategoricalComponent
 from glue.core.tests.util import make_file
-
-from glue.tests.helpers import (requires_astropy, requires_astropy_ge_03,
-                               requires_pil_or_skimage)
-
+from glue.core.component import CategoricalComponent
+from glue.core.data import Data
+from glue.core import data_factories as df
 from glue.config import data_factory
+from glue.tests.helpers import (requires_astropy, requires_astropy_ge_03,
+                                requires_pil_or_skimage)
 
 
 def test_load_data_auto_assigns_label():

--- a/glue/core/data_factories/tests/test_excel.py
+++ b/glue/core/data_factories/tests/test_excel.py
@@ -4,12 +4,13 @@ import os
 
 from numpy.testing import assert_array_equal
 
+from glue.core.tests.util import make_file
+from glue.core import data_factories as df
 from glue.tests.helpers import requires_xlrd
 
-from glue.core import data_factories as df
-from glue.core.tests.util import make_file
 
 DATA = os.path.join(os.path.dirname(__file__), 'data')
+
 
 @requires_xlrd
 def test_load_data():

--- a/glue/core/data_factories/tests/test_fits.py
+++ b/glue/core/data_factories/tests/test_fits.py
@@ -1,17 +1,18 @@
 from __future__ import absolute_import, division, print_function
 
 import os
-from collections import namedtuple
 from copy import deepcopy
+from collections import namedtuple
 
 import numpy as np
 from numpy.testing import assert_array_equal
 
+from glue.core import data_factories as df
 from glue.core.tests.util import make_file
 from glue.tests.helpers import requires_astropy, requires_astropy_ge_04
 
-from glue.core import data_factories as df
 from ..fits import fits_reader
+
 
 DATA = os.path.join(os.path.dirname(__file__), 'data')
 

--- a/glue/core/data_factories/tests/test_hdf5.py
+++ b/glue/core/data_factories/tests/test_hdf5.py
@@ -1,11 +1,14 @@
+from __future__ import absolute_import, division, print_function
+
 import pytest
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from glue.core import data_factories as df
-from ..helpers import auto_data
 from glue.core.tests.util import make_file
+from glue.core import data_factories as df
 from glue.tests.helpers import requires_h5py, requires_astropy
+
+from ..helpers import auto_data
 
 
 @requires_h5py

--- a/glue/core/decorators.py
+++ b/glue/core/decorators.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 from functools import wraps
 
+
 __all__ = ['memoize', 'singleton', 'memoize_attr_check']
 
 

--- a/glue/core/edit_subset_mode.py
+++ b/glue/core/edit_subset_mode.py
@@ -11,11 +11,11 @@ from __future__ import absolute_import, division, print_function
 
 import logging
 
-from glue.core.decorators import singleton
-from glue.core.data import Data
-from glue.core.data_collection import DataCollection
-from glue.utils import as_list
 from glue.core.contracts import contract
+from glue.core.data_collection import DataCollection
+from glue.core.data import Data
+from glue.core.decorators import singleton
+from glue.utils import as_list
 
 
 @singleton

--- a/glue/core/fitters.py
+++ b/glue/core/fitters.py
@@ -6,10 +6,11 @@ See the guide on :ref:`writing custom fit plugins <fit_plugins>` for
 help with using custom fitting utilities in Glue.
 """
 
+from __future__ import absolute_import, division, print_function
+
 import numpy as np
 
 from glue.core.simpleforms import IntOption, Option
-
 
 __all__ = ['BaseFitter1D',
            'PolynomialFitter',

--- a/glue/core/glue_pickle.py
+++ b/glue/core/glue_pickle.py
@@ -1,8 +1,11 @@
+from __future__ import absolute_import, division, print_function
+
 import logging
-from glue.external.six.moves.cPickle import dumps, loads
 
 try:
     from dill import dumps, loads
 except ImportError:
     logging.getLogger(__name__).warn("Dill library not installed. "
                                      "Falling back to cPickle")
+
+from glue.external.six.moves.cPickle import dumps, loads

--- a/glue/core/hub.py
+++ b/glue/core/hub.py
@@ -4,8 +4,9 @@ import logging
 from inspect import getmro
 from collections import defaultdict
 
-from glue.core.message import Message
 from glue.core.exceptions import InvalidSubscriber, InvalidMessage
+from glue.core.message import Message
+
 
 __all__ = ['Hub', 'HubListener']
 

--- a/glue/core/layout.py
+++ b/glue/core/layout.py
@@ -3,6 +3,8 @@ This module provides some routines for performing layout
 calculations to organize rectangular windows in a larger canvas
 """
 
+from __future__ import absolute_import, division, print_function
+
 from collections import Counter
 
 from glue.external import six

--- a/glue/core/link_helpers.py
+++ b/glue/core/link_helpers.py
@@ -14,9 +14,9 @@ multiple ComponentLinks easily. They are meant to be passed to
 
 from __future__ import absolute_import, division, print_function
 
-from glue.core.component_link import ComponentLink
-from glue.core.data import ComponentID
 from glue.external import six
+from glue.core.data import ComponentID
+from glue.core.component_link import ComponentLink
 
 
 __all__ = ['LinkCollection', 'LinkSame', 'LinkTwoWay', 'MultiLink',

--- a/glue/core/link_manager.py
+++ b/glue/core/link_manager.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 """
 The LinkManager class is responsible for maintaining the conistency
 of the "web of links" in a DataCollection. It discovers how to
@@ -15,13 +14,16 @@ Link:        <---x2y---><--y2z-->
 The LinkManager autocreates a link from D1.id['x'] to D3.id['z']
 by chaining x2y and y2z.
 """
+
+from __future__ import absolute_import, division, print_function
+
 import logging
 
-from glue.core.data import Data, DerivedComponent
-from glue.core.component_link import ComponentLink
-from glue.core.link_helpers import LinkCollection
 from glue.external import six
 from glue.core.contracts import contract
+from glue.core.link_helpers import LinkCollection
+from glue.core.component_link import ComponentLink
+from glue.core.data import Data, DerivedComponent
 
 
 def accessible_links(cids, links):

--- a/glue/core/parse.py
+++ b/glue/core/parse.py
@@ -2,9 +2,10 @@ from __future__ import absolute_import, division, print_function
 
 import re
 
-from glue.core.data import ComponentID
-from glue.core.subset import Subset, SubsetState
 from glue.core.component_link import ComponentLink
+from glue.core.subset import Subset, SubsetState
+from glue.core.data import ComponentID
+
 
 TAG_RE = re.compile('\{\s*(?P<tag>\S+)\s*\}')
 

--- a/glue/core/registry.py
+++ b/glue/core/registry.py
@@ -1,10 +1,10 @@
 from __future__ import absolute_import, division, print_function
 
-from collections import defaultdict
 from functools import wraps
+from collections import defaultdict
 
-from glue.core.decorators import singleton
 from glue.core.util import disambiguate
+from glue.core.decorators import singleton
 
 
 @singleton

--- a/glue/core/roi.py
+++ b/glue/core/roi.py
@@ -1,16 +1,16 @@
 from __future__ import absolute_import, division, print_function
 
-
 import copy
 
 import numpy as np
-
 from matplotlib.patches import Ellipse, Polygon, Rectangle, Path as mplPath
 from matplotlib.transforms import IdentityTransform, blended_transform_factory
 
+from glue.core.exceptions import UndefinedROI
+
+
 np.seterr(all='ignore')
 
-from glue.core.exceptions import UndefinedROI
 
 __all__ = ['Roi', 'RectangularROI', 'CircularROI', 'PolygonalROI',
            'AbstractMplRoi', 'MplRectangularROI', 'MplCircularROI',

--- a/glue/core/session.py
+++ b/glue/core/session.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
-from glue.core import DataCollection, CommandStack
+from glue.core.command import CommandStack
+from glue.core.data_collection import DataCollection
 
 
 class Session(object):

--- a/glue/core/state.py
+++ b/glue/core/state.py
@@ -54,30 +54,30 @@ starting from 1.
 from __future__ import absolute_import, division, print_function
 
 import os
-from itertools import count
-from collections import defaultdict
 import json
 import types
 import logging
+from io import BytesIO
+from itertools import count
+from collections import defaultdict
+from base64 import b64encode, b64decode
 from inspect import isgeneratorfunction
 
 import numpy as np
 
-from glue.core.subset import (OPSYM, SYMOP, CompositeSubsetState,
-                     SubsetState, Subset, RoiSubsetState,
-                     InequalitySubsetState, RangeSubsetState)
+from glue.external import six
+from glue import core
 from glue.core.data import (Data, Component, ComponentID, DerivedComponent,
-                   CoordinateComponent)
+                            CoordinateComponent)
+from glue.core.subset import (OPSYM, SYMOP, CompositeSubsetState,
+                              SubsetState, Subset, RoiSubsetState,
+                              InequalitySubsetState, RangeSubsetState)
 from glue.core import (VisualAttributes, ComponentLink, DataCollection)
 from glue.core.component_link import CoordinateComponentLink
-from glue.utils import lookup_class
 from glue.core.roi import Roi
 from glue.core import glue_pickle as gp
-from glue import core
 from glue.core.subset_group import coerce_subset_groups
-from glue.external import six
-from io import BytesIO
-from base64 import b64encode, b64decode
+from glue.utils import lookup_class
 
 
 literals = tuple([type(None), float, int, bytes, bool, list, tuple])

--- a/glue/core/subset.py
+++ b/glue/core/subset.py
@@ -1,22 +1,22 @@
 from __future__ import absolute_import, division, print_function
 
-import operator
 import numbers
+import operator
 
 import numpy as np
 
-from glue.core.visual import VisualAttributes
-from glue.core.decorators import memoize
-from glue.core.message import SubsetDeleteMessage, SubsetUpdateMessage
-from glue.core.exceptions import IncompatibleAttribute
-from glue.core.registry import Registry
-from glue.core.util import split_component_view
-from glue.utils import view_shape
 from glue.external.six import PY3
-from glue.core.contracts import contract
 from glue.core.roi import CategoricalRoi
-
+from glue.core.contracts import contract
+from glue.core.util import split_component_view
+from glue.core.registry import Registry
+from glue.core.exceptions import IncompatibleAttribute
+from glue.core.message import SubsetDeleteMessage, SubsetUpdateMessage
+from glue.core.decorators import memoize
+from glue.core.visual import VisualAttributes
 from glue.config import settings
+from glue.utils import view_shape
+
 
 __all__ = ['Subset', 'SubsetState', 'RoiSubsetState', 'CompositeSubsetState',
            'OrState', 'AndState', 'XorState', 'InvertState',

--- a/glue/core/subset_group.py
+++ b/glue/core/subset_group.py
@@ -13,20 +13,21 @@ Client code should *only* create Subset Groups via
 DataCollection.new_subset_group. It should *not* call Data.add_subset
 or Data.new_subset directly
 """
+from __future__ import absolute_import, division, print_function
+
 from warnings import warn
 
-from glue.core import Subset
-from glue.core.subset import SubsetState
-from glue.core.util import Pointer
-from glue.core.hub import HubListener
-from glue.core.visual import VisualAttributes
-from glue.core.message import (DataCollectionAddMessage,
-                      DataCollectionDeleteMessage
-                      )
-from glue.core.contracts import contract
-
-from glue.config import settings
 from glue.external import six
+from glue.core.contracts import contract
+from glue.core.message import (DataCollectionAddMessage,
+                               DataCollectionDeleteMessage)
+from glue.core.visual import VisualAttributes
+from glue.core.hub import HubListener
+from glue.core.util import Pointer
+from glue.core.subset import SubsetState
+from glue.core import Subset
+from glue.config import settings
+
 
 __all__ = ['GroupedSubset', 'SubsetGroup']
 

--- a/glue/core/tests/test_aggregate.py
+++ b/glue/core/tests/test_aggregate.py
@@ -1,10 +1,11 @@
+from __future__ import absolute_import, division, print_function
+
+import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 
-import pytest
-
-from ..aggregate import Aggregate
 from .. import Data
+from ..aggregate import Aggregate
 
 
 class TestFunctions(object):

--- a/glue/core/tests/test_application_base.py
+++ b/glue/core/tests/test_application_base.py
@@ -2,8 +2,8 @@ from __future__ import absolute_import, division, print_function
 
 from mock import MagicMock
 
-from ..application_base import Application
 from .. import Data
+from ..application_base import Application
 
 
 class MockApplication(Application):

--- a/glue/core/tests/test_client.py
+++ b/glue/core/tests/test_client.py
@@ -1,10 +1,10 @@
-#pylint: disable=I0011,W0613,W0201,W0212,E1101,E1103,W0612
+# pylint: disable=I0011,W0613,W0201,W0212,E1101,E1103,W0612
 
 from __future__ import absolute_import, division, print_function
 
+import pytest
 from mock import MagicMock
 
-import pytest
 from ..client import Client, BasicClient
 from ..data import Data
 from ..data_collection import DataCollection

--- a/glue/core/tests/test_command.py
+++ b/glue/core/tests/test_command.py
@@ -1,15 +1,16 @@
 from __future__ import absolute_import, division, print_function
 
-from mock import MagicMock
 import pytest
 import numpy as np
+from mock import MagicMock
 
+from glue.external.six.moves import range as xrange
 from glue import core
-from .. import roi
+
 from .. import command as c
+from .. import roi
 from ..data_factories import tabular_data
 from .util import simple_session, simple_catalog
-from glue.external.six.moves import range as xrange
 
 
 class TestCommandStack(object):

--- a/glue/core/tests/test_communication.py
+++ b/glue/core/tests/test_communication.py
@@ -1,16 +1,17 @@
-#pylint: disable=I0011,W0613,W0201,W0212,E1101,E1103
+# pylint: disable=I0011,W0613,W0201,W0212,E1101,E1103
 
 from __future__ import absolute_import, division, print_function
 
 import pytest
 
-from ..hub import Hub
 from ..client import Client
 from ..data import Data
-from ..subset import Subset
 from ..data_collection import DataCollection
+from ..hub import Hub
 from ..message import (SubsetCreateMessage, SubsetDeleteMessage,
                        SubsetUpdateMessage, Message, DataUpdateMessage)
+from ..subset import Subset
+
 
 """
 Client communication protocol

--- a/glue/core/tests/test_component.py
+++ b/glue/core/tests/test_component.py
@@ -2,21 +2,21 @@
 
 from __future__ import absolute_import, division, print_function
 
+import warnings
 import operator
 
-import warnings
-from mock import MagicMock
 import pytest
 import numpy as np
+from mock import MagicMock
 
-from ..data import Data
+from glue.external import six
+from glue import core
+from glue.tests.helpers import requires_astropy
+
 from ..component import (Component, DerivedComponent, CoordinateComponent,
                          CategoricalComponent)
 from ..component_id import ComponentID
-
-from glue import core
-from glue.tests.helpers import requires_astropy
-from glue.external import six
+from ..data import Data
 
 
 VIEWS = (np.s_[:], np.s_[1], np.s_[::-1], np.s_[0, :])

--- a/glue/core/tests/test_component_link.py
+++ b/glue/core/tests/test_component_link.py
@@ -3,15 +3,14 @@
 from __future__ import absolute_import, division, print_function
 
 import pytest
-
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from ..data import ComponentID, Data, Component
 from ..component_link import ComponentLink, BinaryComponentLink
-from ..subset import InequalitySubsetState
-from ..link_helpers import LinkSame
+from ..data import ComponentID, Data, Component
 from ..data_collection import DataCollection
+from ..link_helpers import LinkSame
+from ..subset import InequalitySubsetState
 
 
 class TestComponentLink(object):

--- a/glue/core/tests/test_coordinate_links.py
+++ b/glue/core/tests/test_coordinate_links.py
@@ -2,12 +2,13 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 
+from glue.tests.helpers import requires_astropy, ASTROPY_INSTALLED
+
 from .. import Data, DataCollection
 from ..coordinates import coordinates_from_header
 from ..link_helpers import LinkSame
 from .util import make_file
 
-from glue.tests.helpers import requires_astropy, ASTROPY_INSTALLED
 
 if ASTROPY_INSTALLED:
     from astropy.io import fits

--- a/glue/core/tests/test_coordinates.py
+++ b/glue/core/tests/test_coordinates.py
@@ -1,19 +1,18 @@
-#pylint: disable=I0011,W0613,W0201,W0212,E1101,E1103
+# pylint: disable=I0011,W0613,W0201,W0212,E1101,E1103
 
 from __future__ import absolute_import, division, print_function
 
 import pytest
-
-from mock import patch
 import numpy as np
+from mock import patch
 from numpy.testing import assert_almost_equal
+
+from glue.tests.helpers import requires_astropy
 
 from ..coordinates import (coordinates_from_header,
                            WCSCoordinates,
                            Coordinates,
                            header_from_string)
-
-from glue.tests.helpers import requires_astropy
 
 
 @requires_astropy

--- a/glue/core/tests/test_data.py
+++ b/glue/core/tests/test_data.py
@@ -6,17 +6,18 @@ import pytest
 import numpy as np
 from mock import MagicMock
 
-from ..data import Data, pixel_label
-from ..component_id import ComponentID
-from ..component import Component, DerivedComponent, CategoricalComponent
-from ..coordinates import Coordinates
-from ..subset import Subset, SubsetState
-from ..hub import Hub
-from ..exceptions import IncompatibleAttribute
-from ..component_link import ComponentLink
-from ..registry import Registry
-from glue import core
 from glue.external import six
+from glue import core
+
+from ..component import Component, DerivedComponent, CategoricalComponent
+from ..component_id import ComponentID
+from ..component_link import ComponentLink
+from ..coordinates import Coordinates
+from ..data import Data, pixel_label
+from ..exceptions import IncompatibleAttribute
+from ..hub import Hub
+from ..registry import Registry
+from ..subset import Subset, SubsetState
 
 
 class _TestCoordinates(Coordinates):

--- a/glue/core/tests/test_data_collection.py
+++ b/glue/core/tests/test_data_collection.py
@@ -2,18 +2,18 @@
 
 from __future__ import absolute_import, division, print_function
 
-import numpy as np
-from numpy.testing import assert_array_equal
-from mock import MagicMock
 import pytest
+import numpy as np
+from mock import MagicMock
+from numpy.testing import assert_array_equal
 
+from ..component_link import ComponentLink
 from ..data import Data, Component, ComponentID, DerivedComponent
-from ..hub import HubListener
 from ..data_collection import DataCollection
+from ..hub import HubListener
 from ..message import (Message, DataCollectionAddMessage,
                        DataCollectionDeleteMessage,
                        ComponentsChangedMessage)
-from ..component_link import ComponentLink
 
 
 class HubLog(HubListener):

--- a/glue/core/tests/test_data_retrieval.py
+++ b/glue/core/tests/test_data_retrieval.py
@@ -1,4 +1,4 @@
-#pylint: disable=I0011,W0613,W0201,W0212,E1101,E1103
+# pylint: disable=I0011,W0613,W0201,W0212,E1101,E1103
 
 from __future__ import absolute_import, division, print_function
 

--- a/glue/core/tests/test_decorators.py
+++ b/glue/core/tests/test_decorators.py
@@ -1,4 +1,4 @@
-#pylint: disable=I0011,W0613,W0201,W0212,E1101,E1103, R0903
+# pylint: disable=I0011,W0613,W0201,W0212,E1101,E1103, R0903
 
 from __future__ import absolute_import, division, print_function
 

--- a/glue/core/tests/test_edit_subset_mode.py
+++ b/glue/core/tests/test_edit_subset_mode.py
@@ -4,14 +4,14 @@ from __future__ import absolute_import, division, print_function
 
 import itertools
 
-import numpy as np
 import pytest
+import numpy as np
 
+from ..data import Component, Data
+from ..data_collection import DataCollection
 from ..edit_subset_mode import (EditSubsetMode, ReplaceMode, OrMode, AndMode,
                                 XorMode, AndNotMode)
 from ..subset import ElementSubsetState, SubsetState
-from ..data import Component, Data
-from ..data_collection import DataCollection
 
 
 class TestEditSubsetMode(object):

--- a/glue/core/tests/test_fitters.py
+++ b/glue/core/tests/test_fitters.py
@@ -1,15 +1,17 @@
+
+
+from __future__ import absolute_import, division, print_function
+
 import pytest
-
-from mock import MagicMock
 import numpy as np
+from mock import MagicMock
 
-needs_modeling = pytest.mark.skipif("False", reason='')
-
+from glue.tests.helpers import requires_scipy, requires_astropy_ge_03, ASTROPY_GE_03_INSTALLED
 
 from ..fitters import (PolynomialFitter, IntOption,
                        BasicGaussianFitter)
+needs_modeling = pytest.mark.skipif("False", reason='')
 
-from glue.tests.helpers import requires_scipy, requires_astropy_ge_03, ASTROPY_GE_03_INSTALLED
 
 if ASTROPY_GE_03_INSTALLED:
     from astropy.modeling.models import Gaussian1D

--- a/glue/core/tests/test_hub.py
+++ b/glue/core/tests/test_hub.py
@@ -1,16 +1,16 @@
-#pylint: disable=I0011,W0613,W0201,W0212,E1101,E1103
+# pylint: disable=I0011,W0613,W0201,W0212,E1101,E1103
 
 from __future__ import absolute_import, division, print_function
 
 import pytest
 from mock import MagicMock
 
-from ..exceptions import InvalidSubscriber, InvalidMessage
-from ..message import SubsetMessage, Message
-from ..hub import Hub, HubListener
-from ..subset import Subset
 from ..data import Data
 from ..data_collection import DataCollection
+from ..exceptions import InvalidSubscriber, InvalidMessage
+from ..hub import Hub, HubListener
+from ..message import SubsetMessage, Message
+from ..subset import Subset
 
 
 class TestHub(object):

--- a/glue/core/tests/test_joins.py
+++ b/glue/core/tests/test_joins.py
@@ -1,5 +1,7 @@
-from numpy.testing import assert_array_equal
+from __future__ import absolute_import, division, print_function
+
 import pytest
+from numpy.testing import assert_array_equal
 
 from .. import Data, DataCollection
 from ..exceptions import IncompatibleAttribute

--- a/glue/core/tests/test_layout.py
+++ b/glue/core/tests/test_layout.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from ..layout import Rectangle, snap_to_grid
 
 

--- a/glue/core/tests/test_link_helpers.py
+++ b/glue/core/tests/test_link_helpers.py
@@ -1,14 +1,16 @@
-#pylint: disable=I0011,W0613,W0201,W0212,E1101,E1103
+# pylint: disable=I0011,W0613,W0201,W0212,E1101,E1103
 
 from __future__ import absolute_import, division, print_function
 
 import pytest
 import numpy as np
 
+from glue.core import ComponentID, Data, Component, DataCollection
+
 from .. import link_helpers as lh
 from ..link_helpers import (LinkTwoWay, MultiLink,
                             LinkSame, LinkAligned)
-from glue.core import ComponentID, Data, Component, DataCollection
+
 
 R, D, L, B = (ComponentID('ra'), ComponentID('dec'),
               ComponentID('lon'), ComponentID('lat'))

--- a/glue/core/tests/test_link_manager.py
+++ b/glue/core/tests/test_link_manager.py
@@ -4,12 +4,13 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 
-from ..data import Data, Component
 from ..component_link import ComponentLink
+from ..data import ComponentID, DerivedComponent
+from ..data import Data, Component
+from ..data_collection import DataCollection
 from ..link_manager import (LinkManager, accessible_links, discover_links,
                             find_dependents)
-from ..data import ComponentID, DerivedComponent
-from ..data_collection import DataCollection
+
 
 comp = Component(data=np.array([1, 2, 3]))
 

--- a/glue/core/tests/test_message.py
+++ b/glue/core/tests/test_message.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import pytest
+
 from .. import message as msg
 
 

--- a/glue/core/tests/test_pandas.py
+++ b/glue/core/tests/test_pandas.py
@@ -1,13 +1,14 @@
+from __future__ import absolute_import, division, print_function
 
-from mock import MagicMock
 import numpy as np
 import pandas as pd
+from mock import MagicMock
 from pandas.util.testing import (assert_series_equal,
                                  assert_frame_equal)
 
-from ..data import Data
 from ..component import (Component, DerivedComponent, CoordinateComponent,
                          CategoricalComponent)
+from ..data import Data
 
 
 class TestPandasConversion(object):

--- a/glue/core/tests/test_parse.py
+++ b/glue/core/tests/test_parse.py
@@ -6,9 +6,9 @@ import pytest
 import numpy as np
 from mock import MagicMock
 
+from .. import parse
 from ..data import ComponentID, Component, Data
 from ..subset import Subset
-from .. import parse
 
 
 class TestParse(object):

--- a/glue/core/tests/test_registry.py
+++ b/glue/core/tests/test_registry.py
@@ -1,4 +1,4 @@
-#pylint: disable=I0011,W0613,W0201,W0212,E1101,E1103
+# pylint: disable=I0011,W0613,W0201,W0212,E1101,E1103
 
 from __future__ import absolute_import, division, print_function
 

--- a/glue/core/tests/test_roi.py
+++ b/glue/core/tests/test_roi.py
@@ -1,19 +1,19 @@
-#pylint: disable=I0011,W0613,W0201,W0212,E1101,E1103
+# pylint: disable=I0011,W0613,W0201,W0212,E1101,E1103
 
 from __future__ import absolute_import, division, print_function
 
 import pytest
-
 import numpy as np
-from numpy.testing import assert_almost_equal
-from matplotlib.figure import Figure
 from mock import MagicMock
+from matplotlib.figure import Figure
+from numpy.testing import assert_almost_equal
 
+from .. import roi as r
 from ..component import CategoricalComponent
 from ..roi import (RectangularROI, UndefinedROI, CircularROI, PolygonalROI, CategoricalRoi,
                    MplCircularROI, MplRectangularROI, MplPolygonalROI, MplPickROI, PointROI,
                    XRangeROI, MplXRangeROI, YRangeROI, MplYRangeROI, RangeROI)
-from .. import roi as r
+
 
 FIG = Figure()
 AXES = FIG.add_subplot(111)

--- a/glue/core/tests/test_session_back_compat.py
+++ b/glue/core/tests/test_session_back_compat.py
@@ -1,12 +1,14 @@
 # Make sure that session files can be read in a backward-compatible manner
 
+from __future__ import absolute_import, division, print_function
+
 import os
+
 import numpy as np
 
 from glue.tests.helpers import requires_astropy, requires_h5py
 
 from ..state import GlueUnSerializer
-
 DATA = os.path.join(os.path.dirname(__file__), 'data')
 
 

--- a/glue/core/tests/test_simpleforms.py
+++ b/glue/core/tests/test_simpleforms.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import pytest
 
 from ..simpleforms import IntOption, FloatOption, BoolOption

--- a/glue/core/tests/test_state.py
+++ b/glue/core/tests/test_state.py
@@ -1,23 +1,23 @@
 from __future__ import absolute_import, division, print_function
 
-import numpy as np
 import json
-import pytest
-
-from ..state import (GlueSerializer, GlueUnSerializer,
-                     saver, loader, VersionedDict)
-from glue.external import six
-
-from glue import core
-from glue.qt.glue_application import GlueApplication
-from glue.qt.widgets.scatter_widget import ScatterWidget
-from glue.qt.widgets.histogram_widget import HistogramWidget
-from .util import make_file
-from ..data_factories import load_data
-from ..data_factories.tests.test_fits import TEST_FITS_DATA
 from io import BytesIO
 
+import pytest
+import numpy as np
+
+from glue.external import six
+from glue import core
+from glue.qt.glue_application import GlueApplication
+from glue.qt.widgets.histogram_widget import HistogramWidget
+from glue.qt.widgets.scatter_widget import ScatterWidget
 from glue.tests.helpers import requires_astropy
+
+from ..data_factories import load_data
+from ..data_factories.tests.test_fits import TEST_FITS_DATA
+from ..state import (GlueSerializer, GlueUnSerializer,
+                     saver, loader, VersionedDict)
+from .util import make_file
 
 
 def clone(object, include_data=False):

--- a/glue/core/tests/test_subset.py
+++ b/glue/core/tests/test_subset.py
@@ -9,19 +9,19 @@ import pytest
 import numpy as np
 from mock import MagicMock
 
+from glue.tests.helpers import requires_astropy
+
 from .. import DataCollection, ComponentLink
 from ..data import Data, Component
-from ..subset import (Subset, SubsetState,
-                      ElementSubsetState, RoiSubsetState, RangeSubsetState)
-from ..subset import OrState
-from ..subset import AndState
-from ..subset import XorState
-from ..subset import InvertState
 from ..message import SubsetDeleteMessage
 from ..registry import Registry
+from ..subset import (Subset, SubsetState,
+                      ElementSubsetState, RoiSubsetState, RangeSubsetState)
+from ..subset import AndState
+from ..subset import InvertState
+from ..subset import OrState
+from ..subset import XorState
 from .test_state import clone
-
-from glue.tests.helpers import requires_astropy
 
 
 class TestSubset(object):

--- a/glue/core/tests/test_subset_group.py
+++ b/glue/core/tests/test_subset_group.py
@@ -1,5 +1,7 @@
-from mock import MagicMock, patch
+from __future__ import absolute_import, division, print_function
+
 import numpy as np
+from mock import MagicMock, patch
 
 from .. import DataCollection, Data, SubsetGroup
 from .. import subset

--- a/glue/core/tests/test_util.py
+++ b/glue/core/tests/test_util.py
@@ -5,8 +5,8 @@ from __future__ import absolute_import, division, print_function
 import numpy as np
 from matplotlib.cm import gray
 
-from ..util import facet_subsets, colorize_subsets
 from .. import Data, DataCollection
+from ..util import facet_subsets, colorize_subsets
 
 
 class TestRelim(object):

--- a/glue/core/tests/util.py
+++ b/glue/core/tests/util.py
@@ -1,14 +1,14 @@
 from __future__ import absolute_import, division, print_function
 
-import tempfile
-from contextlib import contextmanager
 import os
 import zlib
+import tempfile
+from contextlib import contextmanager
 
 from mock import MagicMock
 
-from glue import core
 from glue.core.application_base import Application
+from glue import core
 
 
 @contextmanager

--- a/glue/core/util.py
+++ b/glue/core/util.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import, division, print_function
 
 import logging
-from contextlib import contextmanager
 from itertools import count
+from contextlib import contextmanager
 
 import numpy as np
 import pandas as pd

--- a/glue/core/visual.py
+++ b/glue/core/visual.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 from glue.config import settings
 
+
 # Define acceptable line styles
 VALID_LINESTYLES = ['solid', 'dashed', 'dash-dot', 'dotted', 'none']
 

--- a/glue/logger.py
+++ b/glue/logger.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from logging import getLogger, basicConfig
 basicConfig()
 logger = getLogger("glue")

--- a/glue/main.py
+++ b/glue/main.py
@@ -4,9 +4,9 @@ from __future__ import absolute_import, division, print_function
 
 import sys
 import optparse
-from glue.logger import logger
 
 from glue import __version__
+from glue.logger import logger
 
 
 def parse(argv):
@@ -178,10 +178,10 @@ def start_glue(gluefile=None, config=None, datafiles=None):
 
     session = glue.core.Session(data_collection=data, hub=hub)
     ga = GlueApplication(session=session)
-    #ga.show()
-    #splash.close()
-    #ga.raise_()
-    #QApplication.instance().processEvents()
+    # ga.show()
+    # splash.close()
+    # ga.raise_()
+    # QApplication.instance().processEvents()
     return ga.start()
 
 

--- a/glue/plugins/coordinate_helpers/deprecated.py
+++ b/glue/plugins/coordinate_helpers/deprecated.py
@@ -1,6 +1,7 @@
+from __future__ import absolute_import, division, print_function
+
 from astropy import units as u
 from astropy.coordinates import FK5, Galactic
-
 
 
 def fk52gal(ra, dec):

--- a/glue/plugins/coordinate_helpers/link_helpers.py
+++ b/glue/plugins/coordinate_helpers/link_helpers.py
@@ -3,11 +3,14 @@
 
 # Coordinate transforms (requires Astropy>)
 
-from glue.config import link_helper
-from glue.core.link_helpers import MultiLink
+from __future__ import absolute_import, division, print_function
 
 from astropy import units as u
 from astropy.coordinates import ICRS, FK5, FK4, Galactic
+
+from glue.core.link_helpers import MultiLink
+from glue.config import link_helper
+
 
 __all__ = ["BaseCelestialMultiLink", "Galactic_to_FK5", "FK4_to_FK5",
            "ICRS_to_FK5", "Galactic_to_FK4", "ICRS_to_FK4",
@@ -22,8 +25,8 @@ class BaseCelestialMultiLink(MultiLink):
 
     def __init__(self, in_lon, in_lat, out_lon, out_lat):
         MultiLink.__init__(self, [in_lon, in_lat],
-                                 [out_lon, out_lat],
-                                 self.forward, self.backward)
+                           [out_lon, out_lat],
+                           self.forward, self.backward)
 
     def forward(self, in_lon, in_lat):
         c = self.frame_in(in_lon * u.deg, in_lat * u.deg)
@@ -58,6 +61,7 @@ class ICRS_to_FK5(BaseCelestialMultiLink):
     display = "Celestial Coordinates: ICRS <-> FK5 (J2000)"
     frame_in = ICRS
     frame_out = FK5
+
 
 @link_helper('Link Galactic and FK4 (B1950) Equatorial coordinates',
              input_labels=['l', 'b', 'ra (fk4)', 'dec (fk4)'])

--- a/glue/plugins/coordinate_helpers/tests/test_link_helpers.py
+++ b/glue/plugins/coordinate_helpers/tests/test_link_helpers.py
@@ -1,34 +1,37 @@
-import numpy as np
+from __future__ import absolute_import, division, print_function
 
 import pytest
+import numpy as np
+
+from glue.core import ComponentID
+from glue.core.tests.test_link_helpers import check_link, check_using
 from glue.tests.helpers import ASTROPY_GE_04_INSTALLED
+
+from ..link_helpers import (Galactic_to_FK5, FK4_to_FK5, ICRS_to_FK5,
+                            Galactic_to_FK4, ICRS_to_FK4, ICRS_to_Galactic)
 
 if not ASTROPY_GE_04_INSTALLED:
     pytest.skip()
 
-from glue.core.tests.test_link_helpers import check_link, check_using
-from glue.core import ComponentID
-
-from ..link_helpers import (Galactic_to_FK5, FK4_to_FK5, ICRS_to_FK5,
-                            Galactic_to_FK4, ICRS_to_FK4, ICRS_to_Galactic)
 
 # We now store for each class the expected result of the conversion of (45,50)
 # from the input frame to output frame and then from the output frame to the
 # input frame.
 EXPECTED = {
-    Galactic_to_FK5: [(238.23062386,27.96352696),(143.12136866,-7.76422226)],
-    FK4_to_FK5: [(45.87780898,50.19529421),(44.12740884,49.80169907)],
-    ICRS_to_FK5: [(45.00001315,49.99999788),(44.99998685,50.00000212)],
-    Galactic_to_FK4: [(237.71557513,28.11113265),(143.52337155,-7.32105993)],
-    ICRS_to_FK4: [(44.12742195,49.801697),(45.87779583,50.19529642)],
-    ICRS_to_Galactic: [(143.12137717,-7.76422008),(238.23062019,27.96352359)],
+    Galactic_to_FK5: [(238.23062386, 27.96352696), (143.12136866, -7.76422226)],
+    FK4_to_FK5: [(45.87780898, 50.19529421), (44.12740884, 49.80169907)],
+    ICRS_to_FK5: [(45.00001315, 49.99999788), (44.99998685, 50.00000212)],
+    Galactic_to_FK4: [(237.71557513, 28.11113265), (143.52337155, -7.32105993)],
+    ICRS_to_FK4: [(44.12742195, 49.801697), (45.87779583, 50.19529642)],
+    ICRS_to_Galactic: [(143.12137717, -7.76422008), (238.23062019, 27.96352359)],
 }
 
 
 lon1, lat1, lon2, lat2 = (ComponentID('lon_in'), ComponentID('lat_in'),
                           ComponentID('lon_out'), ComponentID('lat_out'))
 
-@pytest.mark.parametrize(('conv_class', 'expected'),list(EXPECTED.items()))
+
+@pytest.mark.parametrize(('conv_class', 'expected'), list(EXPECTED.items()))
 def test_conversion(conv_class, expected):
 
     result = conv_class(lon1, lat1, lon2, lat2)

--- a/glue/plugins/dendro_viewer/client.py
+++ b/glue/plugins/dendro_viewer/client.py
@@ -2,17 +2,18 @@
 A plot to visualize trees
 """
 
+from __future__ import absolute_import, division, print_function
+
 import numpy as np
 
-from glue.core.data import IncompatibleAttribute, Data
-from glue.core.callback_property import CallbackProperty, add_callback, delay_callback
-from glue.core.roi import PointROI
-from glue.core.subset import CategorySubsetState
 from glue.core.edit_subset_mode import EditSubsetMode
-from glue.utils import nonpartial, lookup_class
+from glue.core.subset import CategorySubsetState
+from glue.core.roi import PointROI
+from glue.core.callback_property import CallbackProperty, add_callback, delay_callback
+from glue.core.data import IncompatibleAttribute, Data
 from glue.clients.viz_client import GenericMplClient
-
 from glue.plugins.dendro_viewer.layer_artist import DendroLayerArtist
+from glue.utils import nonpartial, lookup_class
 
 
 class DendroClient(GenericMplClient):

--- a/glue/plugins/dendro_viewer/data_factory.py
+++ b/glue/plugins/dendro_viewer/data_factory.py
@@ -3,15 +3,17 @@ Load files created by the astrodendro package.
 
 astrodendro must be installed in order to use this loader
 """
-import numpy as np
 
+from __future__ import absolute_import, division, print_function
+
+import numpy as np
 from astrodendro import Dendrogram
 
-from glue.core.data import Data
-from glue.core.data_factories.fits import is_fits
 from glue.core.data_factories.hdf5 import is_hdf5
-
+from glue.core.data_factories.fits import is_fits
+from glue.core.data import Data
 from glue.config import data_factory
+
 
 __all__ = ['load_dendro', 'is_dendro']
 
@@ -107,5 +109,3 @@ def load_dendro(file):
     im = Data(intensity=dg.data, structure=dg.index_map)
     im.join_on_key(dendro, 'structure', dendro.pixel_component_ids[0])
     return [dendro, im]
-
-

--- a/glue/plugins/dendro_viewer/layer_artist.py
+++ b/glue/plugins/dendro_viewer/layer_artist.py
@@ -2,9 +2,9 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 
-from glue.clients.layer_artist import LayerArtist, ChangedTrigger
-from glue.core.subset import Subset
 from glue.core.exceptions import IncompatibleAttribute
+from glue.core.subset import Subset
+from glue.clients.layer_artist import LayerArtist, ChangedTrigger
 
 
 class DendroLayerArtist(LayerArtist):

--- a/glue/plugins/dendro_viewer/qt_widget.py
+++ b/glue/plugins/dendro_viewer/qt_widget.py
@@ -1,16 +1,15 @@
-from glue import core
-from glue.external.qt import QtGui
+from __future__ import absolute_import, division, print_function
 
+from glue.external.qt import QtGui
+from glue import core
+from glue.plugins.dendro_viewer.client import DendroClient
+from glue.qt.glue_toolbar import GlueToolbar
+from glue.qt.mouse_mode import PickMode
+from glue.qt.qtutil import load_ui, nonpartial
+from glue.qt.widget_properties import (ButtonProperty, CurrentComboProperty,
+                                       connect_bool_button, connect_current_combo)
 from glue.qt.widgets.data_viewer import DataViewer
 from glue.qt.widgets.mpl_widget import MplWidget, defer_draw
-from glue.qt.widget_properties import (ButtonProperty, CurrentComboProperty,
-                                 connect_bool_button, connect_current_combo)
-from glue.qt.glue_toolbar import GlueToolbar
-
-from glue.qt.qtutil import load_ui, nonpartial
-from glue.qt.mouse_mode import PickMode
-
-from glue.plugins.dendro_viewer.client import DendroClient
 
 
 class DendroWidget(DataViewer):
@@ -146,7 +145,6 @@ class DendroWidget(DataViewer):
     def restore_layers(self, rec, context):
 
         from glue.core.callback_property import delay_callback
-
 
         with delay_callback(self.client, 'height_attr',
                                          'parent_attr',

--- a/glue/plugins/dendro_viewer/tests/test_data_factory.py
+++ b/glue/plugins/dendro_viewer/tests/test_data_factory.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division
+from __future__ import absolute_import, division, print_function
 
 import os
 
@@ -6,11 +6,11 @@ import pytest
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from glue.core import data_factories as df
-
-from glue.core.data_factories.helpers import find_factory
 from glue.core.tests.util import make_file
+from glue.core.data_factories.helpers import find_factory
+from glue.core import data_factories as df
 from glue.tests.helpers import requires_astrodendro
+
 
 DATA = os.path.join(os.path.dirname(__file__), 'data')
 
@@ -57,20 +57,20 @@ def test_identifier_heuristics(tmpdir):
     assert not is_dendro(filename)
 
     hdulist[1].name = ''
-    hdulist[0].data = np.array([1,2,3])
+    hdulist[0].data = np.array([1, 2, 3])
 
     hdulist.writeto(filename, clobber=True)
     assert not is_dendro(filename)
 
     hdulist[0].data = None
-    hdulist[1].data = np.ones((3,4))
-    hdulist[2].data = np.ones((2,4))
-    hdulist[3].data = np.ones((3,5))
+    hdulist[1].data = np.ones((3, 4))
+    hdulist[2].data = np.ones((2, 4))
+    hdulist[3].data = np.ones((3, 5))
 
     hdulist.writeto(filename, clobber=True)
     assert not is_dendro(filename)
 
-    hdulist[2].data = np.ones((3,4))
+    hdulist[2].data = np.ones((3, 4))
 
     hdulist.writeto(filename, clobber=True)
     assert not is_dendro(filename)

--- a/glue/plugins/dendro_viewer/tests/test_dendro_client.py
+++ b/glue/plugins/dendro_viewer/tests/test_dendro_client.py
@@ -1,12 +1,15 @@
-from numpy.testing import assert_array_equal
-from mock import MagicMock
+from __future__ import absolute_import, division, print_function
 
-from glue.clients.tests.util import renderless_figure
-from glue.core import Data, DataCollection
-from glue.core.roi import PointROI
+from mock import MagicMock
+from numpy.testing import assert_array_equal
+
 from glue.core.edit_subset_mode import EditSubsetMode
+from glue.core.roi import PointROI
+from glue.core import Data, DataCollection
+from glue.clients.tests.util import renderless_figure
 
 from ..client import DendroClient
+
 
 # share matplotlib instance, and disable rendering, for speed
 FIGURE = renderless_figure()

--- a/glue/plugins/dendro_viewer/tests/test_qt_widget.py
+++ b/glue/plugins/dendro_viewer/tests/test_qt_widget.py
@@ -1,15 +1,19 @@
 # pylint: disable=I0011,W0613,W0201,W0212,E1101,E1103
 
-from glue.qt.widgets.tests import simple_session
+from __future__ import absolute_import, division, print_function
+
+import os
+
 from glue import core
+from glue.qt.widgets.tests import simple_session
+from glue.qt.widgets.tests.test_data_viewer import BaseTestDataViewer
 
 from ..qt_widget import DendroWidget
-from glue.qt.widgets.tests.test_data_viewer import BaseTestDataViewer
+
 
 def mock_data():
     return core.Data(label='d1', x=[1, 2, 3], y=[2, 3, 4])
 
-import os
 os.environ['GLUE_TESTING'] = 'True'
 
 

--- a/glue/plugins/export_d3po.py
+++ b/glue/plugins/export_d3po.py
@@ -1,10 +1,10 @@
 from __future__ import absolute_import, division, print_function
 
-import json
 import os
+import json
 
-from glue.qt.widgets import ScatterWidget, HistogramWidget
 from glue.core import Subset
+from glue.qt.widgets import ScatterWidget, HistogramWidget
 
 
 def save_page(page, page_number, label, subset):

--- a/glue/plugins/export_plotly.py
+++ b/glue/plugins/export_plotly.py
@@ -1,14 +1,16 @@
+from __future__ import absolute_import, division, print_function
+
 import logging
 
 import numpy as np
+
 try:
     from plotly import plotly
 except ImportError:
     plotly = None
 
-from glue.qt.widgets import ScatterWidget, HistogramWidget
 from glue.core.layout import Rectangle, snap_to_grid
-
+from glue.qt.widgets import ScatterWidget, HistogramWidget
 
 SYM = {'o': 'circle', 's': 'square', '+': 'cross', '^': 'triangle-up',
        '*': 'cross'}
@@ -302,6 +304,7 @@ def save_plotly(application, label):
 
     plotly.sign_in(user, apikey)
     plotly.plot(*args, **kwargs)
+
 
 def setup():
     from glue.config import exporters, settings

--- a/glue/plugins/ginga_viewer/client.py
+++ b/glue/plugins/ginga_viewer/client.py
@@ -1,23 +1,22 @@
-from __future__ import print_function, division
+from __future__ import absolute_import, division, print_function
 
 import logging
 from time import time
 
 import numpy as np
+from ginga.misc import Bunch
+from ginga.util import wcsmod
+from ginga import AstroImage, BaseImage
 
-from glue.core.exceptions import IncompatibleAttribute
 from glue.core.util import Pointer, split_component_view
-from glue.utils import view_shape, stack_view, color2rgb
-
+from glue.core.exceptions import IncompatibleAttribute
 from glue.clients.image_client import ImageClient
 from glue.clients.layer_artist import (LayerArtistBase,
-                                    ImageLayerBase, SubsetImageLayerBase)
+                                       ImageLayerBase, SubsetImageLayerBase)
+from glue.utils import view_shape, stack_view, color2rgb
 
-from ginga.util import wcsmod
-from ginga.misc import Bunch
 
 wcsmod.use('astropy')
-from ginga import AstroImage, BaseImage
 
 
 class GingaClient(ImageClient):

--- a/glue/plugins/ginga_viewer/qt_widget.py
+++ b/glue/plugins/ginga_viewer/qt_widget.py
@@ -1,37 +1,33 @@
-from __future__ import print_function, division
+from __future__ import absolute_import, division, print_function
 
 import sys
 import os.path
+
 import numpy as np
-
-from glue.external.qt import QtGui, QtCore
-from glue.external.qt.QtCore import Qt
-
-from ginga.qtw.ImageViewCanvasQt import ImageViewCanvas
+from ginga.misc import log
 from ginga.qtw import ColorBar
+from ginga import cmap as ginga_cmap
+from ginga.qtw.ImageViewCanvasQt import ImageViewCanvas
+
+from glue.external.qt.QtCore import Qt
+from glue.external.qt import QtGui, QtCore
+from glue.core.callback_property import add_callback
+from glue.core import roi as roimod
+from glue.config import tool_registry
+from glue.plugins.ginga_viewer.client import GingaClient
+from glue.plugins.tools.pv_slicer import PVSlicerTool
+from glue.plugins.tools.spectrum_tool import SpectrumTool
+from glue.qt.qtutil import get_icon, nonpartial
+from glue.qt.widgets.image_widget import ImageWidgetBase
+
 
 try:
     from ginga.gw import Readout
 except ImportError:  # older versions of ginga
     from ginga.qtw import Readout
 
-from ginga.misc import log
-from ginga import cmap as ginga_cmap
 # ginga_cmap.add_matplotlib_cmaps()
 
-from glue.qt.widgets.image_widget import ImageWidgetBase
-
-from glue.plugins.ginga_viewer.client import GingaClient
-
-from glue.core import roi as roimod
-from glue.core.callback_property import add_callback
-
-from glue.qt.qtutil import get_icon, nonpartial
-
-from glue.plugins.tools.pv_slicer import PVSlicerTool
-from glue.plugins.tools.spectrum_tool import SpectrumTool
-
-from glue.config import tool_registry
 
 # Find out location of ginga module so we can some of its icons
 ginga_home = os.path.split(sys.modules['ginga'].__file__)[0]
@@ -48,7 +44,7 @@ class GingaWidget(ImageWidgetBase):
 
         self.logger = log.get_logger(name='ginga', level=20, null=True,
                                      # uncomment for debugging
-                                     #log_stderr=True
+                                     # log_stderr=True
                                      )
 
         self.canvas = ImageViewCanvas(self.logger, render='widget')
@@ -432,7 +428,7 @@ def cmap2pixmap(cmap, steps=50):
     n = len(cmap.clst) - 1
     tups = [cmap.clst[int(x * n)] for x in inds]
     rgbas = [QtGui.QColor(int(r * 255), int(g * 255),
-                    int(b * 255), 255).rgba() for r, g, b in tups]
+                          int(b * 255), 255).rgba() for r, g, b in tups]
     im = QtGui.QImage(steps, 1, QtGui.QImage.Format_Indexed8)
     im.setColorTable(rgbas)
     for i in range(steps):

--- a/glue/plugins/ginga_viewer/tests/test_client.py
+++ b/glue/plugins/ginga_viewer/tests/test_client.py
@@ -1,20 +1,18 @@
-from __future__ import print_function, division
+from __future__ import absolute_import, division, print_function
 
 import pytest
+import numpy as np
+from numpy.testing import assert_array_equal
+
+from glue.core import Data
+from glue.clients.tests.test_image_client import _TestImageClientBase
 from glue.tests.helpers import GINGA_INSTALLED
 
 if not GINGA_INSTALLED:
     pytest.skip()
 
-import numpy as np
-from numpy.testing import assert_array_equal
-
-from ginga.qtw.ImageViewCanvasQt import ImageViewCanvas
 from ginga.misc import log
-
-from glue.core import Data
-
-from glue.clients.tests.test_image_client import _TestImageClientBase
+from ginga.qtw.ImageViewCanvasQt import ImageViewCanvas
 
 from ..client import GingaClient, SubsetImage, BaseImage
 

--- a/glue/plugins/ginga_viewer/tests/test_qt_widget.py
+++ b/glue/plugins/ginga_viewer/tests/test_qt_widget.py
@@ -1,6 +1,7 @@
-from __future__ import print_function, division
+from __future__ import absolute_import, division, print_function
 
 import pytest
+
 from glue.tests.helpers import GINGA_INSTALLED
 
 if not GINGA_INSTALLED:

--- a/glue/plugins/tests/test_d3po.py
+++ b/glue/plugins/tests/test_d3po.py
@@ -1,15 +1,15 @@
 from __future__ import absolute_import, division, print_function
 
-from tempfile import mkdtemp
 import os
 from shutil import rmtree
+from tempfile import mkdtemp
 
 import numpy as np
 
-from ..export_d3po import make_data_file
 from glue.core import Data
-
 from glue.tests.helpers import requires_astropy
+
+from ..export_d3po import make_data_file
 
 
 @requires_astropy

--- a/glue/plugins/tests/test_plotly.py
+++ b/glue/plugins/tests/test_plotly.py
@@ -1,8 +1,11 @@
+from __future__ import absolute_import, division, print_function
+
 import numpy as np
 
 from glue.core import Data, DataCollection
 from glue.qt.glue_application import GlueApplication
 from glue.qt.widgets import HistogramWidget, ScatterWidget
+
 from ..export_plotly import build_plotly_call
 
 

--- a/glue/plugins/tools/pv_slicer.py
+++ b/glue/plugins/tools/pv_slicer.py
@@ -1,4 +1,7 @@
+from __future__ import absolute_import, division, print_function
+
 import numpy as np
+
 from glue.qt.mouse_mode import PathMode
 from glue.qt.widgets.image_widget import StandaloneImageWidget
 from glue.qt.widgets.mpl_widget import defer_draw

--- a/glue/plugins/tools/spectrum_tool.py
+++ b/glue/plugins/tools/spectrum_tool.py
@@ -1,29 +1,29 @@
-import traceback
+from __future__ import absolute_import, division, print_function
+
 import logging
+import traceback
 
 import numpy as np
 
-from glue.external.qt.QtCore import Qt, Signal
-from glue.external.qt import QtGui
-
-
-from glue.clients.profile_viewer import ProfileViewer
-from glue.qt.widgets.mpl_widget import MplWidget
-from glue.qt.mouse_mode import SpectrumExtractorMode
-from glue.core.callback_property import add_callback, ignore_callback
-from glue.core.util import Pointer
-from glue.core import Subset
-from glue.core.exceptions import IncompatibleAttribute
-from glue.qt.glue_toolbar import GlueToolbar
-from glue.qt.qtutil import load_ui, nonpartial, Worker
-from glue.qt.widget_properties import CurrentComboProperty
-from glue.core.aggregate import Aggregate
-from glue.qt.mime import LAYERS_MIME_TYPE
-from glue.qt.simpleforms import build_form_item
-from glue.config import fit_plugin
 from glue.external.six.moves import range as xrange
-from glue.qt.widgets.glue_mdi_area import GlueMdiSubWindow
+from glue.external.qt import QtGui
+from glue.external.qt.QtCore import Qt, Signal
+from glue.core.aggregate import Aggregate
+from glue.core.exceptions import IncompatibleAttribute
+from glue.core import Subset
+from glue.core.util import Pointer
+from glue.core.callback_property import add_callback, ignore_callback
+from glue.config import fit_plugin
+from glue.clients.profile_viewer import ProfileViewer
 from glue.qt.decorators import messagebox_on_error
+from glue.qt.glue_toolbar import GlueToolbar
+from glue.qt.mime import LAYERS_MIME_TYPE
+from glue.qt.mouse_mode import SpectrumExtractorMode
+from glue.qt.qtutil import load_ui, nonpartial, Worker
+from glue.qt.simpleforms import build_form_item
+from glue.qt.widget_properties import CurrentComboProperty
+from glue.qt.widgets.glue_mdi_area import GlueMdiSubWindow
+from glue.qt.widgets.mpl_widget import MplWidget
 
 
 def setup():
@@ -516,7 +516,7 @@ class FitSettingsWidget(QtGui.QDialog):
             self.constraints = None
 
         self.okcancel = QtGui.QDialogButtonBox(QtGui.QDialogButtonBox.Ok |
-                                         QtGui.QDialogButtonBox.Cancel)
+                                               QtGui.QDialogButtonBox.Cancel)
         l.addRow(self.okcancel)
         self.setLayout(l)
 

--- a/glue/plugins/tools/tests/test_pv.py
+++ b/glue/plugins/tools/tests/test_pv.py
@@ -1,14 +1,14 @@
+from __future__ import absolute_import, division, print_function
+
 import numpy as np
-from numpy.testing import assert_allclose
 from mock import MagicMock
-
-from ..pv_slicer import _slice_from_path, _slice_label, _slice_index, PVSliceWidget
-
-from glue.qt.widgets.image_widget import StandaloneImageWidget
+from numpy.testing import assert_allclose
 
 from glue.core import Data
-
+from glue.qt.widgets.image_widget import StandaloneImageWidget
 from glue.tests.helpers import requires_astropy, requires_scipy
+
+from ..pv_slicer import _slice_from_path, _slice_label, _slice_index, PVSliceWidget
 
 
 @requires_astropy

--- a/glue/plugins/tools/tests/test_spectrum_tool.py
+++ b/glue/plugins/tools/tests/test_spectrum_tool.py
@@ -1,15 +1,17 @@
+from __future__ import absolute_import, division, print_function
+
 import pytest
 import numpy as np
 from mock import MagicMock
 
-from glue.core.tests.util import simple_session
-from glue.core import Data, Coordinates
+from glue.core.fitters import PolynomialFitter
 from glue.core.roi import RectangularROI
+from glue.core import Data, Coordinates
+from glue.core.tests.util import simple_session
 from glue.qt.widgets import ImageWidget
 from glue.tests.helpers import requires_astropy
 
 from ..spectrum_tool import Extractor, ConstraintsWidget, FitSettingsWidget, SpectrumTool, CollapseContext
-from glue.core.fitters import PolynomialFitter
 
 needs_modeling = lambda x: x
 try:

--- a/glue/qglue.py
+++ b/glue/qglue.py
@@ -8,10 +8,13 @@ Utility function to load a variety of python objects into glue
 
 from __future__ import absolute_import, division, print_function
 
-from contextlib import contextmanager
 import sys
+from contextlib import contextmanager
 
 import numpy as np
+
+from glue.external import six
+
 
 try:
     from glue.core import Data
@@ -20,7 +23,6 @@ except ImportError:
     # qglue will throw an ImportError
     Data = None
 
-from glue.external import six
 
 __all__ = ['qglue']
 

--- a/glue/qt/__init__.py
+++ b/glue/qt/__init__.py
@@ -1,4 +1,7 @@
+from __future__ import absolute_import, division, print_function
+
 import os
+import atexit
 
 # For backward compatibility, we import get_qapp here
 from glue.external.qt import get_qapp
@@ -11,5 +14,4 @@ def teardown():
         app.exit()
 
 _app = get_qapp()
-import atexit
 atexit.register(teardown)

--- a/glue/qt/component_selector.py
+++ b/glue/qt/component_selector.py
@@ -1,8 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
-from glue.external.qt import QtGui
 from glue.external.qt.QtCore import Signal
-
+from glue.external.qt import QtGui
 from glue.qt.qtutil import load_ui
 
 
@@ -34,7 +33,7 @@ class ComponentSelector(QtGui.QWidget):
         self._ui.setMinimumWidth(300)
 
     def _connect(self):
-        #attach Qt signals
+        # attach Qt signals
         ds = self._ui.data_selector
         ds.currentIndexChanged.connect(self._set_components)
         self._ui.component_selector.currentItemChanged.connect(

--- a/glue/qt/data_collection_model.py
+++ b/glue/qt/data_collection_model.py
@@ -1,15 +1,17 @@
 # pylint: disable=E1101,F0401
 
-from glue.external.qt import QtGui, QtCore, is_pyqt5
-from glue.external.qt.QtCore import Qt
+from __future__ import absolute_import, division, print_function
 
-from glue.qt.qtutil import layer_icon
-from glue.qt.mime import LAYERS_MIME_TYPE, PyMimeData
-from glue.core.decorators import memoize
-from glue.core import message as m
+from glue.external.qt.QtCore import Qt
+from glue.external.qt import QtGui, QtCore, is_pyqt5
 from glue.core.hub import HubListener
+from glue.core import message as m
+from glue.core.decorators import memoize
 from glue import core
+from glue.qt.mime import LAYERS_MIME_TYPE, PyMimeData
+from glue.qt.qtutil import layer_icon
 from glue.qt.widgets.style_dialog import StyleDialog
+
 
 DATA_IDX = 0
 SUBSET_IDX = 1
@@ -523,7 +525,7 @@ class LabeledDelegate(QtGui.QStyledItemDelegate):
 
 
 if __name__ == "__main__":
-    
+
     from glue.qt import get_qapp
     from glue.external.qt import QtGui
     from glue.core import Data, DataCollection

--- a/glue/qt/decorators.py
+++ b/glue/qt/decorators.py
@@ -1,7 +1,8 @@
 from __future__ import absolute_import, division, print_function
 
-from functools import wraps
 import traceback
+from functools import wraps
+
 from glue.utils.qt import QMessageBoxPatched as QMessageBox
 
 

--- a/glue/qt/feedback.py
+++ b/glue/qt/feedback.py
@@ -1,12 +1,15 @@
 """
 Widgets for sending feedback reports
 """
-from glue.external.six.moves.urllib.request import Request, urlopen
-from glue.external.six.moves.urllib.parse import urlencode
+from __future__ import absolute_import, division, print_function
+
 import sys
 
 from glue.external.qt import QtGui
+from glue.external.six.moves.urllib.parse import urlencode
+from glue.external.six.moves.urllib.request import Request, urlopen
 from glue.qt.qtutil import load_ui
+
 
 __all__ = ['submit_bug_report']
 

--- a/glue/qt/glue_application.py
+++ b/glue/qt/glue_application.py
@@ -7,29 +7,27 @@ import sys
 import warnings
 import webbrowser
 
-from glue.external.qt import QtGui, QtCore
 from glue.external.qt.QtCore import Qt
-
-from glue.utils.qt import QMessageBoxPatched as QMessageBox
-
+from glue.external.qt import QtGui, QtCore
+from glue.core.application_base import Application
 from glue.core import command, Data
 from glue import env
 from glue.main import load_plugins
 from glue.qt import get_qapp
-from glue.qt.decorators import set_cursor, messagebox_on_error
-from glue.core.application_base import Application
-
 from glue.qt.actions import act
-from glue.qt.qtutil import (pick_class, data_wizard,
-                     GlueTabBar, load_ui, get_icon, nonpartial)
-from glue.qt.widgets.glue_mdi_area import GlueMdiArea, GlueMdiSubWindow
-from glue.qt.widgets.edit_subset_mode_toolbar import EditSubsetModeToolBar
-from glue.qt.widgets.layer_tree_widget import PlotAction, LayerTreeWidget
-from glue.qt.widgets.data_viewer import DataViewer
-from glue.qt.widgets.settings_editor import SettingsEditor
-from glue.qt.widgets.mpl_widget import defer_draw
+from glue.qt.decorators import set_cursor, messagebox_on_error
 from glue.qt.feedback import submit_bug_report
 from glue.qt.plugin_manager import QtPluginManager
+from glue.qt.qtutil import (pick_class, data_wizard,
+                            GlueTabBar, load_ui, get_icon, nonpartial)
+from glue.qt.widgets.data_viewer import DataViewer
+from glue.qt.widgets.edit_subset_mode_toolbar import EditSubsetModeToolBar
+from glue.qt.widgets.glue_mdi_area import GlueMdiArea, GlueMdiSubWindow
+from glue.qt.widgets.layer_tree_widget import PlotAction, LayerTreeWidget
+from glue.qt.widgets.mpl_widget import defer_draw
+from glue.qt.widgets.settings_editor import SettingsEditor
+from glue.utils.qt import QMessageBoxPatched as QMessageBox
+
 
 __all__ = ['GlueApplication']
 DOCS_URL = 'http://www.glueviz.org'
@@ -318,7 +316,7 @@ class GlueApplication(Application, QtGui.QMainWindow):
                    hold_position=False):
         """
         Add a widget to one of the tabs.
-        
+
         Returns the window that this widget is wrapped in.
 
         :param new_widget: new QtGui.QWidget to add
@@ -690,7 +688,7 @@ class GlueApplication(Application, QtGui.QMainWindow):
 
         # include file filter twice, so it shows up in Dialog
         outfile, file_filter = QtGui.QFileDialog.getSaveFileName(self,
-                                                           filter="Glue Session (*.glu);; Glue Session including data (*.glu)")
+                                                                 filter="Glue Session (*.glu);; Glue Session including data (*.glu)")
 
         # This indicates that the user cancelled
         if not outfile:
@@ -713,7 +711,7 @@ class GlueApplication(Application, QtGui.QMainWindow):
         else:
             assert outmode == 'label'
             label, ok = QtGui.QInputDialog.getText(self, 'Choose a label:',
-                                             'Choose a label:')
+                                                   'Choose a label:')
             if not ok:
                 return
             return saver(self, label)
@@ -724,7 +722,7 @@ class GlueApplication(Application, QtGui.QMainWindow):
         """ Load a previously-saved state, and restart the session """
         fltr = "Glue sessions (*.glu)"
         file_name, file_filter = QtGui.QFileDialog.getOpenFileName(self,
-                                                             filter=fltr)
+                                                                   filter=fltr)
         if not file_name:
             return
 

--- a/glue/qt/glue_toolbar.py
+++ b/glue/qt/glue_toolbar.py
@@ -1,19 +1,18 @@
 from __future__ import absolute_import, division, print_function
 
 import os
+
 import matplotlib
 
-from glue.external.qt import QtCore, QtGui, is_pyqt5
-from glue.external.qt import QtGui
 from glue.external.qt.QtCore import Qt, Signal
+from glue.external.qt import QtCore, QtGui, is_pyqt5
+from glue.core.callback_property import add_callback
+from glue.qt.qtutil import get_icon, nonpartial
 
 if is_pyqt5():
     from matplotlib.backends.backend_qt5 import NavigationToolbar2QT
 else:
     from matplotlib.backends.backend_qt4 import NavigationToolbar2QT
-
-from glue.core.callback_property import add_callback
-from glue.qt.qtutil import get_icon, nonpartial
 
 
 class GlueToolbar(NavigationToolbar2QT):

--- a/glue/qt/layer_artist_model.py
+++ b/glue/qt/layer_artist_model.py
@@ -11,9 +11,8 @@ these layers, and provides GUI access to the model
 
 from __future__ import absolute_import, division, print_function
 
-from glue.external.qt import QtGui, QtCore
 from glue.external.qt.QtCore import Qt
-
+from glue.external.qt import QtGui, QtCore
 from glue.qt.qtutil import (layer_artist_icon, nonpartial, PythonListModel)
 
 from glue.qt.mime import PyMimeData, LAYERS_MIME_TYPE

--- a/glue/qt/link_editor.py
+++ b/glue/qt/link_editor.py
@@ -1,9 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 from glue.external.qt import QtGui
-
 from glue import core
-
 from glue.qt.qtutil import load_ui
 
 

--- a/glue/qt/link_equation.py
+++ b/glue/qt/link_equation.py
@@ -4,7 +4,6 @@ from inspect import getargspec
 from collections import OrderedDict
 
 from glue.external.qt import QtGui
-
 from glue import core
 from glue.qt.qtutil import load_ui, is_pyside
 
@@ -266,7 +265,7 @@ class LinkEquation(QtGui.QWidget):
             self._add_argument_widget(a)
 
         self.spacer = QtGui.QSpacerItem(5, 5, QtGui.QSizePolicy.Minimum,
-                                  QtGui.QSizePolicy.Expanding)
+                                        QtGui.QSizePolicy.Expanding)
         self._ui.input_canvas.layout().addItem(self.spacer)
 
     def _setup_editor_helper(self):
@@ -282,7 +281,7 @@ class LinkEquation(QtGui.QWidget):
             self._add_argument_widget(a)
 
         self.spacer = QtGui.QSpacerItem(5, 5, QtGui.QSizePolicy.Minimum,
-                                  QtGui.QSizePolicy.Expanding)
+                                        QtGui.QSizePolicy.Expanding)
         self._ui.input_canvas.layout().addItem(self.spacer)
 
     def _add_argument_widget(self, argument):

--- a/glue/qt/mime.py
+++ b/glue/qt/mime.py
@@ -51,7 +51,7 @@ class PyMimeData(QtCore.QMimeData):
         return super(PyMimeData, self).data(mime_type)
 
 
-#some standard glue mime types
+# some standard glue mime types
 LAYER_MIME_TYPE = 'glue/layer'
 LAYERS_MIME_TYPE = 'glue/layers'
 INSTANCE_MIME_TYPE = PyMimeData.MIME_TYPE

--- a/glue/qt/mouse_mode.py
+++ b/glue/qt/mouse_mode.py
@@ -20,12 +20,11 @@ The basic usage pattern is thus:
 from __future__ import absolute_import, division, print_function
 
 from glue.external.qt import QtGui
-
-from glue.core import roi
 from glue.core.callback_property import CallbackProperty
+from glue.core import roi
 from glue.qt import get_qapp
-from glue.qt.qtutil import get_icon, nonpartial, load_ui
 from glue.qt import qt_roi
+from glue.qt.qtutil import get_icon, nonpartial, load_ui
 
 
 class MouseMode(object):
@@ -229,8 +228,9 @@ class RoiMode(RoiModeBase):
             self._roi_tool.abort_selection(event)
             self._drag = False
             self._drawing = False
-            self._start_event  = None
+            self._start_event = None
         super(RoiMode, self).key(event)
+
 
 class PersistentRoiMode(RoiMode):
 

--- a/glue/qt/plugin_manager.py
+++ b/glue/qt/plugin_manager.py
@@ -1,11 +1,10 @@
 from __future__ import absolute_import, division, print_function
 
-from glue.external.qt import QtGui
 from glue.external.qt.QtCore import Qt
-
+from glue.external.qt import QtGui
 from glue._plugin_helpers import PluginConfig
-
 from glue.qt.qtutil import load_ui
+
 
 __all__ = ["QtPluginManager"]
 

--- a/glue/qt/qt_backend.py
+++ b/glue/qt/qt_backend.py
@@ -1,6 +1,7 @@
-from glue.backends import TimerBase
+from __future__ import absolute_import, division, print_function
 
 from glue.external.qt import QtCore
+from glue.backends import TimerBase
 
 
 class Timer(TimerBase):

--- a/glue/qt/qt_roi.py
+++ b/glue/qt/qt_roi.py
@@ -1,8 +1,10 @@
+from __future__ import absolute_import, division, print_function
+
 import numpy as np
 
-from glue.core import roi
-from glue.external.qt import QtGui, QtCore
 from glue.external.qt import QtCore
+from glue.external.qt import QtGui, QtCore
+from glue.core import roi
 from glue.qt.qtutil import mpl_to_qt4_color
 
 

--- a/glue/qt/qtutil.py
+++ b/glue/qt/qtutil.py
@@ -7,21 +7,20 @@ from __future__ import absolute_import, division, print_function
 
 import os
 
-import pkg_resources
-from matplotlib.colors import ColorConverter
-from matplotlib import cm
 import numpy as np
+import pkg_resources
+from matplotlib import cm
+from matplotlib.colors import ColorConverter
 
-from glue.external.axescache import AxesCache
-from glue.external.qt import QtGui, QtCore, is_pyside
 from glue.external.qt.QtCore import Qt
-
-from glue.utils.qt import QMessageBoxPatched as QMessageBox
-
-from glue.qt.decorators import set_cursor
-from glue.qt.mime import PyMimeData, LAYERS_MIME_TYPE
+from glue.external.qt import QtGui, QtCore, is_pyside
+from glue.external.axescache import AxesCache
 from glue import core
 from glue.qt import ui, icons
+from glue.qt.decorators import set_cursor
+from glue.qt.mime import PyMimeData, LAYERS_MIME_TYPE
+from glue.utils.qt import QMessageBoxPatched as QMessageBox
+
 
 # We import nonpartial here for convenience
 from glue.utils import nonpartial
@@ -175,7 +174,7 @@ def edit_layer_color(layer):
     """ Interactively edit a layer's color """
     initial = mpl_to_qt4_color(layer.style.color, alpha=layer.style.alpha)
     color = QtGui.QColorDialog.getColor(initial, None, "Change layer color",
-                                  options=QtGui.QColorDialog.ShowAlphaChannel)
+                                        options=QtGui.QColorDialog.ShowAlphaChannel)
     if color.isValid():
         layer.style.color = qt4_to_mpl_color(color)
         layer.style.alpha = color.alpha() / 256.
@@ -189,8 +188,8 @@ def edit_layer_symbol(layer):
     except IndexError:
         initial = 0
     symb, isok = QtGui.QInputDialog.getItem(None, 'Pick a Symbol',
-                                      'Pick a Symbol',
-                                      options, current=initial)
+                                            'Pick a Symbol',
+                                            options, current=initial)
     if isok and symb != layer.style.marker:
         layer.style.marker = symb
 
@@ -198,8 +197,8 @@ def edit_layer_symbol(layer):
 def edit_layer_point_size(layer):
     """ Interactively edit a layer's point size """
     size, isok = QtGui.QInputDialog.getInt(None, 'Point Size', 'Point Size',
-                                     value=layer.style.markersize,
-                                     min=1, max=1000, step=1)
+                                           value=layer.style.markersize,
+                                           min=1, max=1000, step=1)
     if isok and size != layer.style.markersize:
         layer.style.markersize = size
 
@@ -207,7 +206,7 @@ def edit_layer_point_size(layer):
 def edit_layer_label(layer):
     """ Interactively edit a layer's label """
     label, isok = QtGui.QInputDialog.getText(None, 'New Label:', 'New Label:',
-                                       text=layer.label)
+                                             text=layer.label)
     if isok and str(label) != layer.label:
         layer.label = str(label)
 
@@ -224,8 +223,8 @@ def pick_item(items, labels, title="Pick an item", label="Pick an item",
     Returns the selected item, or None
     """
     choice, isok = QtGui.QInputDialog.getItem(None, title, label,
-                                        labels, current=default,
-                                        editable=False)
+                                              labels, current=default,
+                                              editable=False)
     if isok:
         index = labels.index(str(choice))
         return items[index]
@@ -361,7 +360,7 @@ def layer_artist_icon(artist):
         bm = QtGui.QBitmap(icon_path('glue_image'))
     else:
         bm = QtGui.QBitmap(icon_path(POINT_ICONS.get(artist.layer.style.marker,
-                                               'glue_circle_point')))
+                                                     'glue_circle_point')))
     color = mpl_to_qt4_color(artist.layer.style.color)
 
     pm = tint_pixmap(bm, color)
@@ -452,7 +451,7 @@ def cmap2pixmap(cmap, steps=50):
     inds = np.linspace(0, 1, steps)
     rgbas = sm.to_rgba(inds)
     rgbas = [QtGui.QColor(int(r * 255), int(g * 255),
-                    int(b * 255), int(a * 255)).rgba() for r, g, b, a in rgbas]
+                          int(b * 255), int(a * 255)).rgba() for r, g, b, a in rgbas]
     im = QtGui.QImage(steps, 1, QtGui.QImage.Format_Indexed8)
     im.setColorTable(rgbas)
     for i in range(steps):

--- a/glue/qt/simpleforms.py
+++ b/glue/qt/simpleforms.py
@@ -1,8 +1,10 @@
-from glue.external.qt import QtGui
-from glue.external.qt.QtCore import QObject, Signal
+from __future__ import absolute_import, division, print_function
 
+from glue.external.qt.QtCore import QObject, Signal
+from glue.external.qt import QtGui
 from glue.core.simpleforms import IntOption, FloatOption, BoolOption
 from glue.qt.qtutil import nonpartial
+
 
 _dispatch = {}
 

--- a/glue/qt/tests/test_application.py
+++ b/glue/qt/tests/test_application.py
@@ -5,24 +5,25 @@ from __future__ import absolute_import, division, print_function
 import os
 import sys
 
-from mock import patch, MagicMock
 import numpy as np
+from mock import patch, MagicMock
 
 try:
     from IPython import __version__ as ipy_version
 except:
     ipy_version = '0.0'
 
-from ..glue_application import GlueApplication
 from glue.external.qt import QtCore
-from ..widgets.scatter_widget import ScatterWidget
-from ..widgets.image_widget import ImageWidget
 from glue.core import Data
-
-
 from glue.tests.helpers import requires_ipython_ge_012
 
+from ..glue_application import GlueApplication
+from ..widgets.image_widget import ImageWidget
+from ..widgets.scatter_widget import ScatterWidget
+
+
 os.environ['GLUE_TESTING'] = 'True'
+
 
 def tab_count(app):
     return app.tab_bar.count()

--- a/glue/qt/tests/test_component_selector.py
+++ b/glue/qt/tests/test_component_selector.py
@@ -1,12 +1,13 @@
-#pylint: disable=I0011,W0613,W0201,W0212,E1101,E1103
+# pylint: disable=I0011,W0613,W0201,W0212,E1101,E1103
 
 from __future__ import absolute_import, division, print_function
 
 from numpy import array
 
-from ..component_selector import ComponentSelector
-from glue import core
 from glue.core.data import ComponentID
+from glue import core
+
+from ..component_selector import ComponentSelector
 
 
 def data_collection():

--- a/glue/qt/tests/test_custom_viewer.py
+++ b/glue/qt/tests/test_custom_viewer.py
@@ -1,22 +1,26 @@
+from __future__ import absolute_import, division, print_function
+
 from collections import OrderedDict
 
 import pytest
+import numpy as np
+from matplotlib.axes import Axes
 from mock import MagicMock, patch
 from numpy.testing import assert_array_equal
-from matplotlib.axes import Axes
-import numpy as np
 
-from glue import custom_viewer
-from glue.core import Data
-from glue.core.subset import SubsetState
-from glue.core.tests.util import simple_session
-from ..custom_viewer import FormElement, NumberElement, \
-    ChoiceElement, CustomViewer, \
-    CustomSubsetState, AttributeInfo, \
-    FloatElement, TextBoxElement, SettingsOracle, \
-    MissingSettingError, FrozenSettings
-from ..glue_application import GlueApplication
 from glue.core.tests.test_state import check_clone_app, clone
+from glue.core.tests.util import simple_session
+from glue.core.subset import SubsetState
+from glue.core import Data
+from glue import custom_viewer
+
+from ..custom_viewer import (FormElement, NumberElement,
+                             ChoiceElement, CustomViewer,
+                             CustomSubsetState, AttributeInfo,
+                             FloatElement, TextBoxElement, SettingsOracle,
+                             MissingSettingError, FrozenSettings)
+
+from ..glue_application import GlueApplication
 
 
 def _make_widget(viewer):
@@ -382,10 +386,7 @@ class TestAttributeInfo(object):
         assert v._component == comp
 
 
-
 class TestSettingsOracle(object):
-
-
 
     def test_oracle_raises_original_error(self):
         class BadFormElement(TextBoxElement):
@@ -412,7 +413,6 @@ class TestSettingsOracle(object):
         with pytest.raises(MissingSettingError):
             oracle.value('missing')
 
-
     def test_load_reserved_words(self):
 
         _self = MagicMock()
@@ -420,19 +420,17 @@ class TestSettingsOracle(object):
         style = layer.style
         extra = MagicMock()
         oracle = SettingsOracle({}, _self=_self,
-                                    layer=layer,
-                                    extra=extra)
+                                layer=layer,
+                                extra=extra)
         assert oracle('self') == _self
         assert oracle('layer') == layer
         assert oracle('style') == style
         assert oracle('extra') == extra
 
-
     def test_setting_names(self):
 
         oracle = SettingsOracle({'Form': TextBoxElement('_text')})
         assert sorted(oracle.setting_names()) == sorted(['style', 'layer', 'Form'])
-
 
     def test_raises_if_overlapping_reserved_words(self):
 

--- a/glue/qt/tests/test_data_collection_model.py
+++ b/glue/qt/tests/test_data_collection_model.py
@@ -1,5 +1,6 @@
-from glue.external.qt.QtCore import Qt
+from __future__ import absolute_import, division, print_function
 
+from glue.external.qt.QtCore import Qt
 from glue.core import DataCollection, Data
 
 from ..data_collection_model import DataCollectionModel

--- a/glue/qt/tests/test_layer_artist_model.py
+++ b/glue/qt/tests/test_layer_artist_model.py
@@ -2,11 +2,10 @@ from __future__ import absolute_import, division, print_function
 
 from mock import MagicMock
 
-from glue.external.qt import is_pyqt5
 from glue.external.qt.QtCore import Qt
-
-from glue.clients.layer_artist import LayerArtist as _LayerArtist
+from glue.external.qt import is_pyqt5
 from glue.core import Data
+from glue.clients.layer_artist import LayerArtist as _LayerArtist
 
 from ..layer_artist_model import LayerArtistModel, LayerArtistView
 

--- a/glue/qt/tests/test_link_equation.py
+++ b/glue/qt/tests/test_link_equation.py
@@ -1,12 +1,13 @@
 from __future__ import absolute_import, division, print_function
 
-from mock import MagicMock
 import pytest
+from mock import MagicMock
+
+from glue.core import ComponentID
+from glue.config import link_function, link_helper
 
 from ..link_equation import (function_label, helper_label,
                              LinkEquation, ArgumentWidget)
-from glue.config import link_function, link_helper
-from glue.core import ComponentID
 
 
 @link_function('testing function', ['y'])
@@ -154,7 +155,7 @@ class TestLinkEquation(object):
         assert widget.signature == ([None, None], None)
 
     def test_signal_connections(self):
-        #testing that signal-slot connections don't crash
+        # testing that signal-slot connections don't crash
         widget = LinkEquation()
 
         signal = widget._ui.function.currentIndexChanged

--- a/glue/qt/tests/test_mime.py
+++ b/glue/qt/tests/test_mime.py
@@ -1,12 +1,12 @@
 from __future__ import absolute_import, division, print_function
 
-from glue.external.qt import QtGui
-from glue.external.qt.QtCore import Qt
+import pytest
+
 from glue.external.qt.QtTest import QTest
+from glue.external.qt.QtCore import Qt
+from glue.external.qt import QtGui
 
 from .. import mime
-
-import pytest
 
 
 class TestWidget(QtGui.QWidget):

--- a/glue/qt/tests/test_plugin_manager.py
+++ b/glue/qt/tests/test_plugin_manager.py
@@ -1,9 +1,12 @@
+from __future__ import absolute_import, division, print_function
+
 from mock import patch
 
-from ..plugin_manager import QtPluginManager
 from glue import _plugin_helpers as ph
-from glue.utils.qt import QMessageBoxPatched
 from glue.main import load_plugins
+from glue.utils.qt import QMessageBoxPatched
+
+from ..plugin_manager import QtPluginManager
 
 
 def setup_function(func):

--- a/glue/qt/tests/test_qtutil.py
+++ b/glue/qt/tests/test_qtutil.py
@@ -3,15 +3,13 @@
 from __future__ import absolute_import, division, print_function
 
 import pytest
+import matplotlib.pyplot as plt
 from mock import MagicMock, patch
 
-import matplotlib.pyplot as plt
-
-from glue.external.qt import QtGui
 from glue.external.qt.QtCore import Qt
-
-from glue.config import data_factory
+from glue.external.qt import QtGui
 from glue.core import Data, Subset
+from glue.config import data_factory
 from glue.clients.layer_artist import RGBImageLayerArtist
 
 from .. import qtutil
@@ -273,7 +271,7 @@ class TestRGBEdit(object):
     def setup_method(self, method):
         d = Data()
         self.fig = plt.figure()
-        self.ax = self.fig.add_subplot(1,1,1)
+        self.ax = self.fig.add_subplot(1, 1, 1)
         self.artist = RGBImageLayerArtist(d, self.ax)
         self.w = qtutil.RGBEdit(artist=self.artist)
 

--- a/glue/qt/tests/test_simpleforms.py
+++ b/glue/qt/tests/test_simpleforms.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from ..simpleforms import build_form_item, FloatOption, IntOption, BoolOption
 
 

--- a/glue/qt/tests/test_toolbar.py
+++ b/glue/qt/tests/test_toolbar.py
@@ -2,10 +2,10 @@
 
 from __future__ import absolute_import, division, print_function
 
-from ..widgets import MplWidget
 from ..glue_toolbar import GlueToolbar
 from ..mouse_mode import MouseMode
 from ..qtutil import get_icon
+from ..widgets import MplWidget
 
 
 class MouseModeTest(MouseMode):

--- a/glue/qt/tests/test_widget_properties.py
+++ b/glue/qt/tests/test_widget_properties.py
@@ -2,6 +2,9 @@ from __future__ import absolute_import, division, print_function
 
 import pytest
 
+from glue.external.echo import CallbackProperty
+from glue.external.qt import QtGui
+
 from ..widget_properties import (CurrentComboDataProperty,
                                  CurrentComboTextProperty,
                                  CurrentTabProperty,
@@ -13,10 +16,6 @@ from ..widget_properties import (CurrentComboDataProperty,
                                  connect_current_combo,
                                  connect_float_edit,
                                  connect_int_spin)
-
-from glue.external.qt import QtGui
-
-from glue.external.echo import CallbackProperty
 
 
 def test_combo_data():
@@ -79,6 +78,7 @@ def test_text():
 
     class TestClass(object):
         lab = TextProperty('_label')
+
         def __init__(self):
             self._label = QtGui.QLabel()
 
@@ -92,6 +92,7 @@ def test_button():
 
     class TestClass(object):
         but = ButtonProperty('_button')
+
         def __init__(self):
             self._button = QtGui.QCheckBox()
 
@@ -116,6 +117,7 @@ def test_float():
 
     class TestClass(object):
         flt = FloatLineProperty('_float')
+
         def __init__(self):
             self._float = QtGui.QLineEdit()
 
@@ -135,6 +137,7 @@ def test_value():
 
     class TestClass(object):
         val = ValueProperty('_slider')
+
         def __init__(self):
             self._slider = QtGui.QSlider()
 
@@ -150,6 +153,7 @@ def test_value_mapping():
     class TestClass(object):
         val = ValueProperty('_slider', mapping=(lambda x: 2 * x,
                                                 lambda x: 0.5 * x))
+
         def __init__(self):
             self._slider = QtGui.QSlider()
 
@@ -164,6 +168,7 @@ def test_tab():
 
     class TestClass(object):
         tab = CurrentTabProperty('_tab')
+
         def __init__(self):
             self._tab = QtGui.QTabWidget()
             self._tab.addTab(QtGui.QWidget(), 'tab1')

--- a/glue/qt/ui/layertree.py
+++ b/glue/qt/ui/layertree.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from glue.external.qt import QtCore, QtGui, is_pyqt5
 from glue.qt.data_collection_model import DataCollectionView
 from glue.qt.qtutil import GlueActionButton, get_icon

--- a/glue/qt/widget_properties.py
+++ b/glue/qt/widget_properties.py
@@ -21,10 +21,10 @@ from __future__ import absolute_import, division, print_function
 
 from functools import partial
 
-from glue.qt.qtutil import pretty_number
-from glue.external.qt import QtGui
 from glue.external.six.moves import reduce
+from glue.external.qt import QtGui
 from glue.core.callback_property import add_callback
+from glue.qt.qtutil import pretty_number
 
 
 class WidgetProperty(object):
@@ -93,7 +93,7 @@ class CurrentComboDataProperty(WidgetProperty):
         except ValueError:
             if value is None:
                 idx = -1
-            else:            
+            else:
                 raise ValueError("Cannot find data '{0}' in combo box".format(value))
         widget.setCurrentIndex(idx)
 
@@ -247,7 +247,7 @@ def connect_current_combo(client, prop, widget):
     """
 
     def _push_combo(value):
-        # NOTE: we can't use findData here because if the data is not a 
+        # NOTE: we can't use findData here because if the data is not a
         # string, PySide will crash
         try:
             idx = _find_combo_data(widget, value)

--- a/glue/qt/widgets/__init__.py
+++ b/glue/qt/widgets/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from .custom_component_widget import CustomComponentWidget
 from .histogram_widget import HistogramWidget
 from .image_widget import ImageWidget

--- a/glue/qt/widgets/custom_component_widget.py
+++ b/glue/qt/widgets/custom_component_widget.py
@@ -3,13 +3,10 @@ from __future__ import absolute_import, division, print_function
 import re
 
 from glue.external.qt import QtGui
-
-from glue import core
 from glue.core import parse
-from glue.utils.qt import CompletionTextEdit
-
+from glue import core
 from glue.qt.qtutil import load_ui
-
+from glue.utils.qt import CompletionTextEdit
 
 
 def disambiguate(label, labels):
@@ -81,7 +78,6 @@ class ColorizedCompletionTextEdit(CompletionTextEdit):
         tc.setPosition(pos)
         self.setTextCursor(tc)
         self.setAlignment(Qt.AlignCenter)
-
 
 
 class CustomComponentWidget(object):
@@ -169,6 +165,7 @@ class CustomComponentWidget(object):
         # To maintain backward compatibility with previous versions of glue,
         # we add curly brackets around the components in the expression.
         pattern = '[^\\s]*:[^\\s]*'
+
         def add_curly(m):
             return "{" + m.group(0) + "}"
         expression = re.sub(pattern, add_curly, expression)
@@ -212,13 +209,13 @@ class CustomComponentWidget(object):
             if widget.ui.exec_() == QtGui.QDialog.Accepted:
                 if len(str(widget.ui.expression.toPlainText())) == 0:
                     QtGui.QMessageBox.critical(widget.ui, "Error", "No expression set",
-                                         buttons=QtGui.QMessageBox.Ok)
+                                               buttons=QtGui.QMessageBox.Ok)
                 elif widget._number_targets == 0:
                     QtGui.QMessageBox.critical(widget.ui, "Error", "Please specify the target dataset(s)",
-                                         buttons=QtGui.QMessageBox.Ok)
+                                               buttons=QtGui.QMessageBox.Ok)
                 elif len(widget.ui.new_label.text()) == 0:
                     QtGui.QMessageBox.critical(widget.ui, "Error", "Please specify the new component name",
-                                         buttons=QtGui.QMessageBox.Ok)
+                                               buttons=QtGui.QMessageBox.Ok)
                 else:
                     link = widget._create_link()
                     if link:
@@ -226,6 +223,7 @@ class CustomComponentWidget(object):
                     break
             else:
                 break
+
 
 def main():
     from glue.core.data import Data

--- a/glue/qt/widgets/data_slice_widget.py
+++ b/glue/qt/widgets/data_slice_widget.py
@@ -1,12 +1,13 @@
+from __future__ import absolute_import, division, print_function
+
 from functools import partial
 from collections import Counter
 
 from glue.external.qt import QtGui, QtCore
-
-from glue.qt.widget_properties import (TextProperty,
-                                 ValueProperty,
-                                 CurrentComboProperty)
 from glue.qt.qtutil import nonpartial, load_ui
+from glue.qt.widget_properties import (TextProperty,
+                                       ValueProperty,
+                                       CurrentComboProperty)
 
 
 class SliceWidget(QtGui.QWidget):
@@ -52,7 +53,7 @@ class SliceWidget(QtGui.QWidget):
         slider.slider.setMaximum(hi)
         slider.slider.setValue((lo + hi) / 2)
         slider.slider.valueChanged.connect(lambda x:
-                                                  self.slice_changed.emit(self.mode))
+                                           self.slice_changed.emit(self.mode))
         slider.slider.valueChanged.connect(lambda x: slider.label.setText(str(x)))
 
         slider.label.setMinimumWidth(50)

--- a/glue/qt/widgets/data_viewer.py
+++ b/glue/qt/widgets/data_viewer.py
@@ -2,16 +2,15 @@ from __future__ import absolute_import, division, print_function
 
 import os
 
-from glue.external.qt import QtGui
 from glue.external.qt.QtCore import Qt
-
+from glue.external.qt import QtGui
 from glue.core.application_base import ViewerBase
-from glue.qt.decorators import set_cursor
-
-from glue.qt.layer_artist_model import QtLayerArtistContainer, LayerArtistView
 from glue.qt import get_qapp
+from glue.qt.decorators import set_cursor
+from glue.qt.layer_artist_model import QtLayerArtistContainer, LayerArtistView
 from glue.qt.mime import LAYERS_MIME_TYPE, LAYER_MIME_TYPE
 from glue.qt.widgets.glue_mdi_area import GlueMdiSubWindow
+
 
 __all__ = ['DataViewer']
 
@@ -165,9 +164,9 @@ class DataViewer(ViewerBase, QtGui.QMainWindow):
         if self._warn_close and (not os.environ.get('GLUE_TESTING')) and self.isVisible():
             buttons = QtGui.QMessageBox.Ok | QtGui.QMessageBox.Cancel
             dialog = QtGui.QMessageBox.warning(self, "Confirm Close",
-                                         "Do you want to close this window?",
-                                         buttons=buttons,
-                                         defaultButton=QtGui.QMessageBox.Cancel)
+                                               "Do you want to close this window?",
+                                               buttons=buttons,
+                                               defaultButton=QtGui.QMessageBox.Cancel)
             return dialog == QtGui.QMessageBox.Ok
         return True
 
@@ -179,8 +178,8 @@ class DataViewer(ViewerBase, QtGui.QMainWindow):
         cancel = QtGui.QMessageBox.Cancel
         buttons = ok | cancel
         result = QtGui.QMessageBox.question(self, title, warn_msg,
-                                      buttons=buttons,
-                                      defaultButton=cancel)
+                                            buttons=buttons,
+                                            defaultButton=cancel)
         return result == ok
 
     def layer_view(self):

--- a/glue/qt/widgets/edit_subset_mode_toolbar.py
+++ b/glue/qt/widgets/edit_subset_mode_toolbar.py
@@ -1,9 +1,8 @@
 from __future__ import absolute_import, division, print_function
 
 from glue.external.qt import QtGui
-
 from glue.core.edit_subset_mode import (EditSubsetMode, OrMode, AndNotMode,
-                                      AndMode, XorMode, ReplaceMode)
+                                        AndMode, XorMode, ReplaceMode)
 from glue.qt.actions import act
 from glue.qt.qtutil import nonpartial
 

--- a/glue/qt/widgets/glue_mdi_area.py
+++ b/glue/qt/widgets/glue_mdi_area.py
@@ -1,8 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
-from glue.external.qt import QtGui, QtCore
 from glue.external.qt.QtCore import Qt
-
+from glue.external.qt import QtGui, QtCore
 from glue import core
 from glue.qt.mime import LAYER_MIME_TYPE, LAYERS_MIME_TYPE
 

--- a/glue/qt/widgets/histogram_widget.py
+++ b/glue/qt/widgets/histogram_widget.py
@@ -2,19 +2,19 @@ from __future__ import absolute_import, division, print_function
 
 from functools import partial
 
-from glue.external.qt import QtGui
 from glue.external.qt.QtCore import Qt
-
+from glue.external.qt import QtGui
 from glue.core import message as msg
 from glue.clients.histogram_client import HistogramClient
-from glue.qt.widget_properties import (connect_int_spin, ButtonProperty,
-                                 FloatLineProperty, connect_float_edit,
-                                 ValueProperty, connect_bool_button)
 from glue.qt.glue_toolbar import GlueToolbar
 from glue.qt.mouse_mode import HRangeMode
+from glue.qt.qtutil import load_ui
+from glue.qt.widget_properties import (connect_int_spin, ButtonProperty,
+                                       FloatLineProperty, connect_float_edit,
+                                       ValueProperty, connect_bool_button)
 from glue.qt.widgets.data_viewer import DataViewer
 from glue.qt.widgets.mpl_widget import MplWidget, defer_draw
-from glue.qt.qtutil import load_ui
+
 
 __all__ = ['HistogramWidget']
 
@@ -139,7 +139,7 @@ class HistogramWidget(DataViewer):
             model.appendRow(item)
             for c in d.visible_components:
                 if (not d.get_component(c).categorical and
-                    not d.get_component(c).numeric):
+                        not d.get_component(c).numeric):
                     continue
                 if c is new:
                     found = True

--- a/glue/qt/widgets/image_widget.py
+++ b/glue/qt/widgets/image_widget.py
@@ -1,28 +1,23 @@
 from __future__ import absolute_import, division, print_function
 
-from glue.external.qt import QtGui, QtCore
-from glue.external.qt.QtCore import Qt
-
-from glue.qt.widgets.data_viewer import DataViewer
-from glue import core
-
-from glue.clients.image_client import MplImageClient
-from glue.clients.ds9norm import DS9Normalize
 from glue.external.modest_image import imshow
-
-from glue.clients.layer_artist import Pointer
+from glue.external.qt.QtCore import Qt
+from glue.external.qt import QtGui, QtCore
 from glue.core.callback_property import add_callback, delay_callback
-
-from glue.qt.widgets.data_slice_widget import DataSlice
-
-from glue.qt.mouse_mode import (RectangleMode, CircleMode, PolyMode,
-                          ContrastMode)
+from glue import core
+from glue.clients.ds9norm import DS9Normalize
+from glue.clients.image_client import MplImageClient
+from glue.clients.layer_artist import Pointer
 from glue.qt.glue_toolbar import GlueToolbar
-from glue.qt.widgets.mpl_widget import MplWidget, defer_draw
-
+from glue.qt.mouse_mode import (RectangleMode, CircleMode, PolyMode,
+                                ContrastMode)
 from glue.qt.qtutil import cmap2pixmap, load_ui, get_icon, nonpartial, update_combobox
 from glue.qt.widget_properties import CurrentComboProperty, ButtonProperty, connect_current_combo, _find_combo_data
+from glue.qt.widgets.data_slice_widget import DataSlice
+from glue.qt.widgets.data_viewer import DataViewer
 from glue.qt.widgets.glue_mdi_area import GlueMdiSubWindow
+from glue.qt.widgets.mpl_widget import MplWidget, defer_draw
+
 
 WARN_THRESH = 10000000  # warn when contouring large images
 
@@ -123,13 +118,13 @@ class ImageWidgetBase(DataViewer):
             # datasets (tables/catalogs) to the image widget yet.
             if data.data.ndim == 1 and self.client.display_data is None:
                 QtGui.QMessageBox.information(self.window(), "Note",
-                                        "Cannot create image viewer from a 1-D "
-                                        "dataset. You will need to first "
-                                        "create an image viewer using data "
-                                        "with 2 or more dimensions, after "
-                                        "which you will be able to overlay 1-D "
-                                        "data as a scatter plot.",
-                                        buttons=QtGui.QMessageBox.Ok)
+                                              "Cannot create image viewer from a 1-D "
+                                              "dataset. You will need to first "
+                                              "create an image viewer using data "
+                                              "with 2 or more dimensions, after "
+                                              "which you will be able to overlay 1-D "
+                                              "data as a scatter plot.",
+                                              buttons=QtGui.QMessageBox.Ok)
                 return
 
             r = self.client.add_layer(data)
@@ -351,8 +346,8 @@ class ImageWidgetBase(DataViewer):
         cancel = QtGui.QMessageBox.Cancel
         buttons = ok | cancel
         result = QtGui.QMessageBox.question(self, title, warn_msg,
-                                      buttons=buttons,
-                                      defaultButton=cancel)
+                                            buttons=buttons,
+                                            defaultButton=cancel)
         return result == ok
 
     def options_widget(self):

--- a/glue/qt/widgets/layer_tree_widget.py
+++ b/glue/qt/widgets/layer_tree_widget.py
@@ -5,22 +5,18 @@ editing the data collection
 
 from __future__ import absolute_import, division, print_function
 
-from glue.external.qt import QtGui, QtCore
 from glue.external.qt.QtCore import Qt
-
-
-from glue.qt.ui.layertree import Ui_LayerTree
-
-from glue import core
-
-from glue.qt.link_editor import LinkEditor
-from glue.qt import qtutil
-from glue.qt.qtutil import get_icon, nonpartial
-from glue.qt.widgets.custom_component_widget import CustomComponentWidget
-from glue.qt.actions import act as _act
+from glue.external.qt import QtGui, QtCore
 from glue.core.edit_subset_mode import AndMode, OrMode, XorMode, AndNotMode
-from glue.qt.widgets.subset_facet import SubsetFacet
 from glue.config import single_subset_action
+from glue import core
+from glue.qt import qtutil
+from glue.qt.actions import act as _act
+from glue.qt.link_editor import LinkEditor
+from glue.qt.qtutil import get_icon, nonpartial
+from glue.qt.ui.layertree import Ui_LayerTree
+from glue.qt.widgets.custom_component_widget import CustomComponentWidget
+from glue.qt.widgets.subset_facet import SubsetFacet
 
 
 @core.decorators.singleton
@@ -540,7 +536,7 @@ class LayerTreeWidget(QtGui.QWidget, Ui_LayerTree):
 def save_subset(subset):
     assert isinstance(subset, core.subset.Subset)
     fname, fltr = QtGui.QFileDialog.getSaveFileName(caption="Select an output name",
-                                              filter='FITS mask (*.fits);; Fits mask (*.fits)')
+                                                    filter='FITS mask (*.fits);; Fits mask (*.fits)')
     fname = str(fname)
     if not fname:
         return

--- a/glue/qt/widgets/message_widget.py
+++ b/glue/qt/widgets/message_widget.py
@@ -3,15 +3,14 @@ from __future__ import absolute_import, division, print_function
 from time import ctime
 
 from glue.external.qt import QtGui
-
 from glue import core
-
 from glue.qt.qtutil import load_ui
 
 
 class MessageWidget(QtGui.QWidget, core.hub.HubListener):
     """ This simple class displays all messages broadcast
     by a hub. It is mainly intended for debugging """
+
     def __init__(self):
         QtGui.QWidget.__init__(self)
         self.ui = load_ui('messagewidget', self)

--- a/glue/qt/widgets/mpl_widget.py
+++ b/glue/qt/widgets/mpl_widget.py
@@ -4,8 +4,12 @@ from __future__ import absolute_import, division, print_function
 
 from functools import wraps
 
-from glue.external.qt import QtGui, QtCore, is_pyqt5
+import matplotlib
+from matplotlib.figure import Figure
+
 from glue.external.qt.QtCore import Qt
+from glue.external.qt import QtGui, QtCore, is_pyqt5
+from glue.utils import DeferredMethod
 
 if is_pyqt5():
     from matplotlib.backends.backend_qt5 import FigureManagerQT as FigureManager
@@ -16,11 +20,6 @@ else:
     except ImportError:  # mpl < 1.4
         from matplotlib.backends.backend_qt4agg import FigureManagerQTAgg as FigureManager
     from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas
-
-import matplotlib
-from matplotlib.figure import Figure
-
-from glue.utils import DeferredMethod
 
 
 def defer_draw(func):

--- a/glue/qt/widgets/scatter_widget.py
+++ b/glue/qt/widgets/scatter_widget.py
@@ -1,22 +1,19 @@
 from __future__ import absolute_import, division, print_function
 
-from glue.external.qt import QtGui
 from glue.external.qt.QtCore import Qt
-
+from glue.external.qt import QtGui
 from glue import core
-
 from glue.clients.scatter_client import ScatterClient
 from glue.qt.glue_toolbar import GlueToolbar
 from glue.qt.mouse_mode import (RectangleMode, CircleMode,
-                          PolyMode, HRangeMode, VRangeMode)
-
+                                PolyMode, HRangeMode, VRangeMode)
+from glue.qt.qtutil import load_ui, cache_axes, nonpartial
+from glue.qt.widget_properties import (ButtonProperty, FloatLineProperty,
+                                       CurrentComboProperty,
+                                       connect_bool_button, connect_float_edit)
 from glue.qt.widgets.data_viewer import DataViewer
 from glue.qt.widgets.mpl_widget import MplWidget, defer_draw
-from glue.qt.widget_properties import (ButtonProperty, FloatLineProperty,
-                                 CurrentComboProperty,
-                                 connect_bool_button, connect_float_edit)
 
-from glue.qt.qtutil import load_ui, cache_axes, nonpartial
 
 __all__ = ['ScatterWidget']
 

--- a/glue/qt/widgets/settings_editor.py
+++ b/glue/qt/widgets/settings_editor.py
@@ -1,5 +1,7 @@
-from glue.external.qt import QtGui
+from __future__ import absolute_import, division, print_function
+
 from glue.external.qt.QtCore import Qt
+from glue.external.qt import QtGui
 
 
 class SettingsEditor(object):

--- a/glue/qt/widgets/style_dialog.py
+++ b/glue/qt/widgets/style_dialog.py
@@ -1,10 +1,9 @@
 from __future__ import absolute_import, division, print_function
 
-from glue.qt.qtutil import (mpl_to_qt4_color, symbol_icon, POINT_ICONS,
-                      qt4_to_mpl_color)
-
-from glue.external.qt import QtGui, QtCore
 from glue.external.qt.QtCore import Qt
+from glue.external.qt import QtGui, QtCore
+from glue.qt.qtutil import (mpl_to_qt4_color, symbol_icon, POINT_ICONS,
+                            qt4_to_mpl_color)
 
 
 class ColorWidget(QtGui.QLabel):
@@ -60,7 +59,7 @@ class StyleDialog(QtGui.QDialog):
         self.set_color(color)
 
         self.okcancel = QtGui.QDialogButtonBox(QtGui.QDialogButtonBox.Ok |
-                                         QtGui.QDialogButtonBox.Cancel)
+                                               QtGui.QDialogButtonBox.Cancel)
 
         if self._edit_label:
             self.layout.addRow("Label", self.label_widget)
@@ -83,8 +82,8 @@ class StyleDialog(QtGui.QDialog):
 
     def query_color(self, *args):
         color = QtGui.QColorDialog.getColor(self._color, self.color_widget,
-                                      "",
-                                      QtGui.QColorDialog.ShowAlphaChannel)
+                                            "",
+                                            QtGui.QColorDialog.ShowAlphaChannel)
         if color.isValid():
             self.set_color(color)
 
@@ -141,7 +140,7 @@ class StyleDialog(QtGui.QDialog):
 
 
 if __name__ == "__main__":
-    
+
     from glue.qt.core import Data
 
     d = Data(label='data label', x=[1, 2, 3, 4])

--- a/glue/qt/widgets/subset_facet.py
+++ b/glue/qt/widgets/subset_facet.py
@@ -1,14 +1,13 @@
 from __future__ import absolute_import, division, print_function
 
-from glue.external.qt import QtGui
 import numpy as np
 from matplotlib import cm
 
-
-from glue.qt.qtutil import pretty_number, cmap2pixmap, load_ui
+from glue.external.qt import QtGui
 from glue.core.util import colorize_subsets, facet_subsets, Pointer
+from glue.qt.qtutil import pretty_number, cmap2pixmap, load_ui
 from glue.qt.widget_properties import (ButtonProperty, FloatLineProperty,
-                                 ValueProperty)
+                                       ValueProperty)
 
 
 class SubsetFacet(object):

--- a/glue/qt/widgets/table_widget.py
+++ b/glue/qt/widgets/table_widget.py
@@ -2,16 +2,13 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 
-from glue.qt.widgets.data_viewer import DataViewer
-
-from glue.external.qt import QtGui, QtCore
 from glue.external.qt.QtCore import Qt
-
-from glue.core import message as msg
-from glue.core.edit_subset_mode import EditSubsetMode
+from glue.external.qt import QtGui, QtCore
 from glue.core.subset import ElementSubsetState
-
+from glue.core.edit_subset_mode import EditSubsetMode
+from glue.core import message as msg
 from glue.qt.qtutil import load_ui
+from glue.qt.widgets.data_viewer import DataViewer
 
 
 class DataTableModel(QtCore.QAbstractTableModel):
@@ -35,7 +32,7 @@ class DataTableModel(QtCore.QAbstractTableModel):
         return len(self.columns)
 
     def rowCount(self, index=None):
-        #Qt bug: Crashes on tables bigger than this
+        # Qt bug: Crashes on tables bigger than this
         return min(self._data.size, 71582788)
 
     def headerData(self, section, orientation, role):
@@ -146,7 +143,7 @@ class TableWidget(DataViewer):
 
         self.ui.table.clearSelection()
         selection_mode = self.ui.table.selectionMode()
-        self.ui.table.setSelectionMode(QtGui.QAbstractItemView.MultiSelection);
+        self.ui.table.setSelectionMode(QtGui.QAbstractItemView.MultiSelection)
 
         # The following is more efficient than just calling selectRow
         model = self.ui.table.selectionModel()

--- a/glue/qt/widgets/terminal.py
+++ b/glue/qt/widgets/terminal.py
@@ -15,27 +15,24 @@ Since v1.0dev, IPython implements embeddable in-process terminal widgets.
 This functionality doesn't exist in v0.12 and v0.13 -- this module provides
 a fallback implmentation for older IPython versions
 """
-from __future__ import print_function
 
 from __future__ import absolute_import, division, print_function
 
 import sys
 import atexit
-from distutils.version import LooseVersion
 from contextlib import contextmanager
+from distutils.version import LooseVersion
 
 # must import these first, to set up Qt properly
 from glue.external.qt import QtGui, QtCore
-from glue.version import __version__
-from glue.utils import as_variable_name
-from glue.qt.widgets.glue_mdi_area import GlueMdiSubWindow
-
-from zmq import ZMQError
-from zmq.eventloop.zmqstream import ZMQStream
-from zmq.eventloop import ioloop
 
 import IPython
 from IPython.core.usage import default_banner
+from zmq import ZMQError
+from zmq.eventloop import ioloop
+from zmq.eventloop.zmqstream import ZMQStream
+
+from glue.version import __version__
 
 IPYTHON_VERSION = LooseVersion(IPython.__version__)
 
@@ -84,6 +81,9 @@ else:
         from IPython.zmq.iostream import OutStream
         from IPython.frontend.qt.kernelmanager import QtKernelManager
         from IPython.frontend.qt.console.rich_ipython_widget import RichIPythonWidget
+
+from glue.qt.widgets.glue_mdi_area import GlueMdiSubWindow
+from glue.utils import as_variable_name
 
 
 def in_process_console(console_class=RichIPythonWidget, **kwargs):
@@ -191,7 +191,7 @@ class DragAndDropTerminal(RichIPythonWidget):
             lbl = 'x'
         lbl = as_variable_name(lbl)
         var, ok = QtGui.QInputDialog.getText(self, "Choose a variable name",
-                                       "Choose a variable name", text=lbl)
+                                             "Choose a variable name", text=lbl)
         if ok:
             # unpack single-item lists for convenience
             if isinstance(obj, list) and len(obj) == 1:

--- a/glue/qt/widgets/tests/__init__.py
+++ b/glue/qt/widgets/tests/__init__.py
@@ -1,1 +1,3 @@
+from __future__ import absolute_import, division, print_function
+
 from glue.core.tests.util import simple_session

--- a/glue/qt/widgets/tests/test_data_slice.py
+++ b/glue/qt/widgets/tests/test_data_slice.py
@@ -1,7 +1,10 @@
+from __future__ import absolute_import, division, print_function
+
 import numpy as np
 from mock import MagicMock
 
 from glue import core
+
 from ..data_slice_widget import SliceWidget, DataSlice
 
 

--- a/glue/qt/widgets/tests/test_data_viewer.py
+++ b/glue/qt/widgets/tests/test_data_viewer.py
@@ -3,17 +3,17 @@
 from __future__ import absolute_import, division, print_function
 
 import numpy as np
+from mock import MagicMock, patch
 
 from glue.core import Data, DataCollection
-from ..data_viewer import DataViewer
-from ..histogram_widget import HistogramWidget
-from ..scatter_widget import ScatterWidget
-from ..image_widget import ImageWidget
 from glue.qt.glue_application import GlueApplication
 
 from . import simple_session
+from ..data_viewer import DataViewer
+from ..histogram_widget import HistogramWidget
+from ..image_widget import ImageWidget
+from ..scatter_widget import ScatterWidget
 
-from mock import MagicMock, patch
 
 # TODO: We should maybe consider running these tests for all
 # registered Qt viewers.
@@ -47,7 +47,7 @@ class BaseTestDataViewer(object):
             from ..mpl_widget import MplCanvas
             draw = MplCanvas.draw
             MplCanvas.draw = MagicMock()
-        
+
             app.new_data_viewer(self.widget_cls, data=d)
 
             # each Canvas instance gives at most 1 draw call
@@ -58,7 +58,7 @@ class BaseTestDataViewer(object):
 
     def test_close_on_last_layer_remove(self):
         # regression test for 391
-        
+
         d1 = Data(x=np.random.random((2,) * self.ndim))
         d2 = Data(y=np.random.random((2,) * self.ndim))
         dc = DataCollection([d1, d2])

--- a/glue/qt/widgets/tests/test_histogram_widget.py
+++ b/glue/qt/widgets/tests/test_histogram_widget.py
@@ -1,18 +1,20 @@
-#pylint: disable=I0011,W0613,W0201,W0212,E1101,E1103
+# pylint: disable=I0011,W0613,W0201,W0212,E1101,E1103
 
 from __future__ import absolute_import, division, print_function
 
+import os
+
 import pytest
+
+from glue import core
 
 from . import simple_session
 from ..histogram_widget import HistogramWidget, _hash
-from glue import core
 
 
 def mock_data():
     return core.Data(label='d1', x=[1, 2, 3], y=[2, 3, 4])
 
-import os
 os.environ['GLUE_TESTING'] = 'True'
 
 

--- a/glue/qt/widgets/tests/test_image_widget.py
+++ b/glue/qt/widgets/tests/test_image_widget.py
@@ -2,22 +2,22 @@
 
 from __future__ import absolute_import, division, print_function
 
+import os
 import time
 
 import pytest
 import numpy as np
 from mock import MagicMock
 
-from ..image_widget import ImageWidget
-
-from glue import core
-from glue.core.tests.test_state import TestApplication
-from glue.qt.glue_application import GlueApplication
 from glue.external.qt import get_qapp
+from glue.core.tests.test_state import TestApplication
+from glue import core
+from glue.qt.glue_application import GlueApplication
 
 from . import simple_session
+from ..image_widget import ImageWidget
 
-import os
+
 os.environ['GLUE_TESTING'] = 'True'
 
 CI = os.environ.get('CI', 'false').lower() == 'true'
@@ -343,12 +343,12 @@ def test_combo_box_updates():
     dc = session.data_collection
 
     data1 = core.Data(label='im1',
-                        x=[[1, 2], [3, 4]],
-                        y=[[2, 3], [4, 5]])
+                      x=[[1, 2], [3, 4]],
+                      y=[[2, 3], [4, 5]])
 
     data2 = core.Data(label='im2',
-                        a=[[1, 2], [3, 4]],
-                        b=[[2, 3], [4, 5]])
+                      a=[[1, 2], [3, 4]],
+                      b=[[2, 3], [4, 5]])
 
     dc.append(data1)
     dc.append(data2)
@@ -373,7 +373,7 @@ def test_combo_box_updates():
     widget.attribute = data2.find_component_id('b')
 
     with pytest.raises(ValueError) as exc:
-        widget.attribute =  data1.find_component_id('x')
+        widget.attribute = data1.find_component_id('x')
     assert exc.value.args[0] == "Cannot find data 'x' in combo box"
 
     widget.data = data1
@@ -382,7 +382,7 @@ def test_combo_box_updates():
     widget.attribute = data1.find_component_id('y')
 
     with pytest.raises(ValueError) as exc:
-        widget.attribute =  data2.find_component_id('a')
+        widget.attribute = data2.find_component_id('a')
     assert exc.value.args[0] == "Cannot find data 'a' in combo box"
 
     assert widget.client.display_data is data1

--- a/glue/qt/widgets/tests/test_layer_tree_widget.py
+++ b/glue/qt/widgets/tests/test_layer_tree_widget.py
@@ -2,17 +2,16 @@
 
 from __future__ import absolute_import, division, print_function
 
-from glue.external.qt import QtGui
-from glue.external.qt.QtTest import QTest
-from glue.external.qt.QtCore import Qt
-
 from mock import MagicMock, patch
+
+from glue.external.qt.QtCore import Qt
+from glue.external.qt.QtTest import QTest
+from glue.external.qt import QtGui
+from glue import core
+from glue.tests import example_data
 
 from ..layer_tree_widget import (LayerTreeWidget, Clipboard,
                                  save_subset, PlotAction)
-
-from glue.tests import example_data
-from glue import core
 
 
 class TestLayerTree(object):

--- a/glue/qt/widgets/tests/test_scatter_widget.py
+++ b/glue/qt/widgets/tests/test_scatter_widget.py
@@ -6,13 +6,13 @@ from distutils.version import LooseVersion  # pylint:disable=W0611
 
 import pytest
 from mock import patch
-
-from ..scatter_widget import ScatterWidget
-from ..mpl_widget import MplCanvas
-from glue import core
-from . import simple_session
-
 from matplotlib import __version__ as mpl_version  # pylint:disable=W0611
+
+from glue import core
+
+from . import simple_session
+from ..mpl_widget import MplCanvas
+from ..scatter_widget import ScatterWidget
 
 
 class TestScatterWidget(object):

--- a/glue/qt/widgets/tests/test_settings.py
+++ b/glue/qt/widgets/tests/test_settings.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from ..settings_editor import SettingsEditor
 
 

--- a/glue/qt/widgets/tests/test_style_dialog.py
+++ b/glue/qt/widgets/tests/test_style_dialog.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from glue.external.qt import QtCore
 from glue.core import Data
 

--- a/glue/qt/widgets/tests/test_subset_facet.py
+++ b/glue/qt/widgets/tests/test_subset_facet.py
@@ -1,8 +1,12 @@
+from __future__ import absolute_import, division, print_function
+
 from mock import patch
 from matplotlib import cm
 
-from ..subset_facet import SubsetFacet
 from glue.core import Data, DataCollection
+
+from ..subset_facet import SubsetFacet
+
 
 patched_facet = patch('glue.qt.widgets.subset_facet.facet_subsets')
 

--- a/glue/qt/widgets/tests/test_terminal.py
+++ b/glue/qt/widgets/tests/test_terminal.py
@@ -4,6 +4,7 @@ from mock import MagicMock, patch
 
 from glue.tests.helpers import requires_ipython_ge_012, IPYTHON_GE_012_INSTALLED
 
+
 if IPYTHON_GE_012_INSTALLED:
     from ..terminal import glue_terminal
 

--- a/glue/tests/example_data.py
+++ b/glue/tests/example_data.py
@@ -2,8 +2,9 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 
-from glue.core.data import Data
 from glue.core.component import Component, CategoricalComponent
+from glue.core.data import Data
+
 
 def test_histogram_data():
     data = Data(label="Test Data")

--- a/glue/tests/helpers.py
+++ b/glue/tests/helpers.py
@@ -1,8 +1,10 @@
 # Define decorators that can be used for pytest tests
 
-import pytest
+from __future__ import absolute_import, division, print_function
 
 from distutils.version import LooseVersion
+
+import pytest
 
 
 def make_skipper(module, label=None, version=None):

--- a/glue/tests/test_main.py
+++ b/glue/tests/test_main.py
@@ -3,10 +3,9 @@ from __future__ import absolute_import, division, print_function
 import pytest
 from mock import patch
 
+from ..core import Data
 from ..main import (die_on_error, restore_session, load_data_files,
                     main, start_glue)
-
-from ..core import Data
 
 
 def test_die_on_error_exception():

--- a/glue/tests/test_qglue.py
+++ b/glue/tests/test_qglue.py
@@ -1,17 +1,15 @@
 from __future__ import absolute_import, division, print_function
 
+import pytest
 import numpy as np
 import pandas as pd
-
 from mock import MagicMock
-import pytest
 
 from .. import qglue
-from ..core.registry import Registry
-from ..core.exceptions import IncompatibleAttribute
 from ..core import Data
+from ..core.exceptions import IncompatibleAttribute
+from ..core.registry import Registry
 from ..qt.glue_application import GlueApplication
-
 from .helpers import requires_astropy
 
 

--- a/glue/utils/__init__.py
+++ b/glue/utils/__init__.py
@@ -6,6 +6,8 @@ Utilities here cannot import from anywhere else in glue, and can only import
 standard library or external dependencies.
 """
 
+from __future__ import absolute_import, division, print_function
+
 from .array import *
 from .matplotlib import *
 from .misc import *

--- a/glue/utils/array.py
+++ b/glue/utils/array.py
@@ -5,6 +5,7 @@ import pandas as pd
 
 from glue.external.six import string_types
 
+
 __all__ = ['unique', 'shape_to_string', 'view_shape', 'stack_view',
            'coerce_numeric', 'check_sorted']
 

--- a/glue/utils/matplotlib.py
+++ b/glue/utils/matplotlib.py
@@ -1,13 +1,13 @@
 from __future__ import absolute_import, division, print_function
 
 import logging
-
 from functools import wraps
 
 import numpy as np
 from matplotlib.backends.backend_agg import FigureCanvasAgg
 
 from glue.utils.misc import DeferredMethod
+
 
 __all__ = ['all_artists', 'new_artists', 'remove_artists', 'get_extent',
            'view_cascade', 'fast_limits', 'defer_draw',

--- a/glue/utils/misc.py
+++ b/glue/utils/misc.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 import string
 from functools import partial
 
+
 __all__ = ['DeferredMethod', 'nonpartial', 'lookup_class', 'as_variable_name',
            'as_list', 'file_format']
 

--- a/glue/utils/qt/__init__.py
+++ b/glue/utils/qt/__init__.py
@@ -1,2 +1,4 @@
+from __future__ import absolute_import, division, print_function
+
 from .autocomplete_widget import *
 from .qmessagebox_widget import *

--- a/glue/utils/qt/autocomplete_widget.py
+++ b/glue/utils/qt/autocomplete_widget.py
@@ -6,6 +6,8 @@
 #
 # http://qt-project.org/doc/qt-4.8/tools-customcompleter.html
 
+from __future__ import absolute_import, division, print_function
+
 from glue.external.qt import QtGui
 
 

--- a/glue/utils/qt/qmessagebox_widget.py
+++ b/glue/utils/qt/qmessagebox_widget.py
@@ -1,8 +1,10 @@
 # A patched version of QMessageBox that allows copying the error
 
-import os
-from glue.external.qt import QtGui
+from __future__ import absolute_import, division, print_function
 
+import os
+
+from glue.external.qt import QtGui
 __all__ = ['QMessageBoxPatched']
 
 

--- a/glue/utils/qt/tests/test_qmessagebox_widget.py
+++ b/glue/utils/qt/tests/test_qmessagebox_widget.py
@@ -1,5 +1,8 @@
-from .. import QMessageBoxPatched as QMessageBox
+from __future__ import absolute_import, division, print_function
+
 from glue.qt import get_qapp
+
+from .. import QMessageBoxPatched as QMessageBox
 
 
 def test_main():

--- a/glue/utils/tests/test_array.py
+++ b/glue/utils/tests/test_array.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import pytest
 import numpy as np
 

--- a/glue/utils/tests/test_matplotlib.py
+++ b/glue/utils/tests/test_matplotlib.py
@@ -1,9 +1,12 @@
-import pytest
 
+
+from __future__ import absolute_import, division, print_function
+
+import pytest
 import numpy as np
-from numpy.testing import assert_allclose
 import matplotlib.pyplot as plt
 from matplotlib.patches import Circle
+from numpy.testing import assert_allclose
 
 from glue.tests.helpers import requires_scipy
 
@@ -98,9 +101,9 @@ def test_color2rgb(color, rgb):
 
 def test_freeze_margins():
 
-    fig = plt.figure(figsize=(4,4))
+    fig = plt.figure(figsize=(4, 4))
 
-    ax = fig.add_subplot(1,1,1)
+    ax = fig.add_subplot(1, 1, 1)
     freeze_margins(ax, margins=[1, 1, 1, 1])
 
     bbox = ax.get_position()
@@ -117,7 +120,7 @@ def test_freeze_margins():
     np.testing.assert_allclose(bbox.x1, 0.75)
     np.testing.assert_allclose(bbox.y1, 0.75)
 
-    fig.set_size_inches(8,8)
+    fig.set_size_inches(8, 8)
     fig.canvas.resize_event()
 
     bbox = ax.get_position()

--- a/glue/utils/tests/test_misc.py
+++ b/glue/utils/tests/test_misc.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import pytest
 
 from ..misc import as_variable_name, file_format, DeferredMethod, nonpartial, lookup_class, as_list


### PR DESCRIPTION
Re-order imports to follow PEP8 recommendation. We now have:

- ``__future__`` import
- standard library imports
- third-party package imports
- local absolute imports
- local relative imports

In addition, this commit also includes some PEP8 whitespace fixes.

This also ensures that all files have a ``__future__`` import.

(I didn't do this by hand, but I did check the results by hand and did some manual fixes)