### PR TITLE
Improve reliability of loading of custom viewers

### DIFF
--- a/glue/config.py
+++ b/glue/config.py
@@ -337,8 +337,8 @@ class DataFactoryRegistry(Registry):
 
 
 class QtClientRegistry(Registry):
-
-    """Stores QT widgets to visualize data.
+    """
+    Stores QT widgets to visualize data.
 
     The members property is a list of Qt widget classes
 
@@ -348,15 +348,6 @@ class QtClientRegistry(Registry):
         class CustomWidget(QMainWindow):
             ...
     """
-
-    def default_members(self):
-        try:
-            from glue.viewers.custom.qt import CUSTOM_WIDGETS
-            return CUSTOM_WIDGETS
-        except ImportError as e:
-            logging.getLogger(__name__).warning(
-                "could not import glue.qt in ConfigObject")
-            return []
 
 
 class QtToolRegistry(DictRegistry):

--- a/glue/viewers/custom/qt/custom_viewer.py
+++ b/glue/viewers/custom/qt/custom_viewer.py
@@ -80,6 +80,7 @@ from glue.external.qt import QtGui
 from glue.external.qt.QtCore import Qt
 
 from glue.core.layer_artist import MatplotlibLayerArtist
+from glue.config import qt_client
 from glue.core import Data
 from glue.core.edit_subset_mode import EditSubsetMode
 from glue.utils import nonpartial, as_list, all_artists, new_artists, remove_artists
@@ -93,8 +94,6 @@ from glue.utils.qt.widget_properties import (ValueProperty, ButtonProperty,
                                              CurrentComboProperty)
 from glue.viewers.common.qt.toolbar import GlueToolbar
 from glue.viewers.common.qt.mouse_mode import PolyMode, RectangleMode
-
-CUSTOM_WIDGETS = []
 
 __all__ = ["AttributeInfo", "ViewerState", "UserDefinedFunction",
            "CustomViewer", "SettingsOracleInterface", "SettingsOracle",
@@ -577,7 +576,7 @@ class CustomViewer(object):
                           widget_dict)
 
         cls._widget_cls = widget_cls
-        CUSTOM_WIDGETS.append(widget_cls)
+        qt_client.add(widget_cls)
 
         # add new classes to module namespace
         # needed for proper state saving/restoring


### PR DESCRIPTION
Add custom data viewers to registry instead of to a global variable CUSTOM_WIDGETS because the registry can be first accessed before all the custom widgets have been defined if they are defined in plugins.