### PR TITLE
Add a helper to link widgets related to setting limits

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,9 @@ Full changelog
 v0.8 (unreleased)
 -----------------
 
-* No changes yet
+* Added a new helper class ``AttributeLimitsHelper`` to link widgets related to
+  setting limits and handle the caching of the limits as a function of
+  attribute. [#872]
 
 v0.7 (2016-03-10)
 -----------------

--- a/glue/viewers/common/qt/attribute_limits_helper.py
+++ b/glue/viewers/common/qt/attribute_limits_helper.py
@@ -139,9 +139,7 @@ class AttributeLimitsHelper(object):
 
     def _update_limits(self):
         if self.attribute in self._limits:
-            self.lower_value.blockSignals(True)
             self.scale_mode, self.vlo, self.vhi = self._limits[self.attribute]
-            self.lower_value.blockSignals(False)
         else:
             self.scale_mode = 'Min/Max'
             self._update_mode()

--- a/glue/viewers/common/qt/attribute_limits_helper.py
+++ b/glue/viewers/common/qt/attribute_limits_helper.py
@@ -120,11 +120,9 @@ class AttributeLimitsHelper(object):
 
     def _flip_limits(self):
         self.vlo, self.vhi = self.vhi, self.vlo
-        self.notify_callbacks()
 
     def _manual_edit(self):
         self._cache_limits()
-        self.notify_callbacks()
 
     def _update_mode(self):
         if self.scale_mode == 'Custom':
@@ -135,7 +133,6 @@ class AttributeLimitsHelper(object):
             self.upper_value.setEnabled(False)
             self._auto_limits()
             self._cache_limits()
-            self.notify_callbacks()
 
     def _cache_limits(self):
         self._limits[self.attribute] = self.scale_mode, self.vlo, self.vhi
@@ -150,6 +147,15 @@ class AttributeLimitsHelper(object):
             self._update_mode()
 
     def _auto_limits(self):
+
         exclude = (100 - self.percentile) / 2.
-        self.vlo = np.nanpercentile(self.data[self.attribute], exclude)
-        self.vhi = np.nanpercentile(self.data[self.attribute], 100 - exclude)
+
+        # For subsets, we want to compute the limits based on the full dataset,
+        # not just the subset.
+        if isinstance(self.data, Subset):
+            data_values = self.data.data[self.attribute]
+        else:
+            data_values = self.data[self.attribute]
+
+        self.vlo = np.nanpercentile(data_values, exclude)
+        self.vhi = np.nanpercentile(data_values, 100 - exclude)

--- a/glue/viewers/common/qt/attribute_limits_helper.py
+++ b/glue/viewers/common/qt/attribute_limits_helper.py
@@ -195,8 +195,13 @@ class AttributeLimitsHelper(object):
         else:
             data_values = self.data[self.attribute]
 
-        lower = np.nanpercentile(data_values, exclude)
-        upper = np.nanpercentile(data_values, 100 - exclude)
+        try:
+            lower = np.nanpercentile(data_values, exclude)
+            upper = np.nanpercentile(data_values, 100 - exclude)
+        except AttributeError:  # Numpy < 1.9
+            data_values = data_values[~np.isnan(data_values)]
+            lower = np.percentile(data_values, exclude)
+            upper = np.percentile(data_values, 100 - exclude)
 
         if self.subset_mode == 'data':
             self.set_limits(0, upper)

--- a/glue/viewers/common/qt/attribute_limits_helper.py
+++ b/glue/viewers/common/qt/attribute_limits_helper.py
@@ -14,18 +14,18 @@ __all__ = ['AttributeLimitsHelper']
 class AttributeLimitsHelper(object):
     """
     This class is a helper for attribute-dependent min/max level values.
-    
+
     Given an attribute combo as well as line edit widgets for the min/max
     values, this helper takes care of populating the attribute combo, setting
     the initial values of the min/max values, and keeping a cache of the
     min/max values as a function of attribute. This means that if the user
     edits the min/max values and then changes attribute then changes back, the
     original min/max values will be retained.
-    
+
     In addition, this helper class can optionally link a combo for the scale
     mode, for example using the min/max values or percentile values, as well as
     a button for flipping the min/max values.
-    
+
     Parameters
     ----------
     attribute_combo : ``QComboBox`` instance
@@ -42,31 +42,31 @@ class AttributeLimitsHelper(object):
         The dataset to attach to the helper - this will be used to populate the
         attribute combo as well as determine the limits automatically given the
         scale mode preset.
-        
+
     Notes
     -----
-    
+
     Once the helper is instantiated, the data associated with the helper can be
     set/changed with:
-    
+
     >>> helper = AttributeLimitsHelper(...)
     >>> helper.data = data
-    
+
     The data can also be passed to the initializer as described in the list of
     parameters above.
     """
-    
+
     attribute = CurrentComboProperty('attribute_combo')
-    scale_mode = CurrentComboTextProperty('combo_mode')
-    percentile = CurrentComboProperty('combo_mode')
+    scale_mode = CurrentComboTextProperty('mode_combo')
+    percentile = CurrentComboProperty('mode_combo')
     vlo = FloatLineProperty('lower_value')
     vhi = FloatLineProperty('upper_value')
 
     def __init__(self, attribute_combo, lower_value, upper_value,
-                       combo_mode=None, flip_button=None, data=None):
+                       mode_combo=None, flip_button=None, data=None):
 
         self.attribute_combo = attribute_combo
-        self.combo_mode = combo_mode
+        self.mode_combo = mode_combo
         self.lower_value = lower_value
         self.upper_value = upper_value
         self.flip_button = flip_button
@@ -76,13 +76,13 @@ class AttributeLimitsHelper(object):
         self.lower_value.editingFinished.connect(self._manual_edit)
         self.upper_value.editingFinished.connect(self._manual_edit)
 
-        if self.combo_mode is None:
+        if self.mode_combo is None:
             # Make hidden combo box to avoid having to always figure out if the
             # combo mode exists. This will then always be set to Min/Max.
-            self.combo_mode = QtGui.QComboBox()
+            self.mode_combo = QtGui.QComboBox()
 
         self._setup_mode_combo()
-        self.combo_mode.currentIndexChanged.connect(self._update_mode)
+        self.mode_combo.currentIndexChanged.connect(self._update_mode)
 
         if self.flip_button is not None:
             self.flip_button.clicked.connect(self._flip_limits)
@@ -109,14 +109,14 @@ class AttributeLimitsHelper(object):
         update_combobox(self.attribute_combo, label_data)
 
     def _setup_mode_combo(self):
-        self.combo_mode.clear()
-        self.combo_mode.addItem("Min/Max", userData=100)
-        self.combo_mode.addItem("99.5%", userData=99.5)
-        self.combo_mode.addItem("99%", userData=99)
-        self.combo_mode.addItem("95%", userData=95)
-        self.combo_mode.addItem("90%", userData=90)
-        self.combo_mode.addItem("Custom", userData=None)
-        self.combo_mode.setCurrentIndex(-1)
+        self.mode_combo.clear()
+        self.mode_combo.addItem("Min/Max", userData=100)
+        self.mode_combo.addItem("99.5%", userData=99.5)
+        self.mode_combo.addItem("99%", userData=99)
+        self.mode_combo.addItem("95%", userData=95)
+        self.mode_combo.addItem("90%", userData=90)
+        self.mode_combo.addItem("Custom", userData=None)
+        self.mode_combo.setCurrentIndex(-1)
 
     def _flip_limits(self):
         self.vlo, self.vhi = self.vhi, self.vlo
@@ -153,10 +153,3 @@ class AttributeLimitsHelper(object):
         exclude = (100 - self.percentile) / 2.
         self.vlo = np.nanpercentile(self.data[self.attribute], exclude)
         self.vhi = np.nanpercentile(self.data[self.attribute], 100 - exclude)
-
-    def connect(self, function):
-        self._callbacks.append(function)
-
-    def notify_callbacks(self):
-        for func in self._callbacks:
-            func()

--- a/glue/viewers/common/qt/attribute_limits_helper.py
+++ b/glue/viewers/common/qt/attribute_limits_helper.py
@@ -66,7 +66,7 @@ class AttributeLimitsHelper(object):
     vhi = FloatLineProperty('upper_value')
 
     def __init__(self, attribute_combo, lower_value, upper_value,
-                       mode_combo=None, flip_button=None, data=None):
+                 mode_combo=None, flip_button=None, data=None):
 
         self.attribute_combo = attribute_combo
         self.mode_combo = mode_combo

--- a/glue/viewers/common/qt/attribute_limits_helper.py
+++ b/glue/viewers/common/qt/attribute_limits_helper.py
@@ -1,0 +1,162 @@
+import numpy as np
+
+from glue.external.qt import QtGui
+from glue.core import Subset
+from glue.utils.qt import update_combobox
+from glue.utils.qt.widget_properties import (CurrentComboTextProperty,
+                                             CurrentComboProperty,
+                                             FloatLineProperty)
+
+
+__all__ = ['AttributeLimitsHelper']
+
+
+class AttributeLimitsHelper(object):
+    """
+    This class is a helper for attribute-dependent min/max level values.
+    
+    Given an attribute combo as well as line edit widgets for the min/max
+    values, this helper takes care of populating the attribute combo, setting
+    the initial values of the min/max values, and keeping a cache of the
+    min/max values as a function of attribute. This means that if the user
+    edits the min/max values and then changes attribute then changes back, the
+    original min/max values will be retained.
+    
+    In addition, this helper class can optionally link a combo for the scale
+    mode, for example using the min/max values or percentile values, as well as
+    a button for flipping the min/max values.
+    
+    Parameters
+    ----------
+    attribute_combo : ``QComboBox`` instance
+        The attribute combo - this will be populated once a dataset is assigned
+        to the helper.
+    lower_value, upper_value : ``QLineEdit`` instances
+        The fields for the lower/upper levels
+    mode_combo : ``QComboBox`` instance, optional
+        The scale mode combo - this will be populated by presets such as
+        Min/Max, various percentile levels, and Custom.
+    flip_button : ``QToolButton`` instance, optional
+        The flip button
+    data : :class:`glue.core.data.Data`
+        The dataset to attach to the helper - this will be used to populate the
+        attribute combo as well as determine the limits automatically given the
+        scale mode preset.
+        
+    Notes
+    -----
+    
+    Once the helper is instantiated, the data associated with the helper can be
+    set/changed with:
+    
+    >>> helper = AttributeLimitsHelper(...)
+    >>> helper.data = data
+    
+    The data can also be passed to the initializer as described in the list of
+    parameters above.
+    """
+    
+    attribute = CurrentComboProperty('attribute_combo')
+    scale_mode = CurrentComboTextProperty('combo_mode')
+    percentile = CurrentComboProperty('combo_mode')
+    vlo = FloatLineProperty('lower_value')
+    vhi = FloatLineProperty('upper_value')
+
+    def __init__(self, attribute_combo, lower_value, upper_value,
+                       combo_mode=None, flip_button=None, data=None):
+
+        self.attribute_combo = attribute_combo
+        self.combo_mode = combo_mode
+        self.lower_value = lower_value
+        self.upper_value = upper_value
+        self.flip_button = flip_button
+
+        self.attribute_combo.currentIndexChanged.connect(self._update_limits)
+
+        self.lower_value.editingFinished.connect(self._manual_edit)
+        self.upper_value.editingFinished.connect(self._manual_edit)
+
+        if self.combo_mode is None:
+            # Make hidden combo box to avoid having to always figure out if the
+            # combo mode exists. This will then always be set to Min/Max.
+            self.combo_mode = QtGui.QComboBox()
+
+        self._setup_mode_combo()
+        self.combo_mode.currentIndexChanged.connect(self._update_mode)
+
+        if self.flip_button is not None:
+            self.flip_button.clicked.connect(self._flip_limits)
+
+        self._limits = {}
+        self._callbacks = []
+
+    @property
+    def data(self):
+        return self._data
+
+    @data.setter
+    def data(self, value):
+        self._data = value
+        self._setup_attribute_combo()
+
+    def _setup_attribute_combo(self):
+        self.attribute_combo.clear()
+        if isinstance(self.data, Subset):
+            components = self.data.data.visible_components
+        else:
+            components = self.data.visible_components
+        label_data = [(comp.label, comp) for comp in components]
+        update_combobox(self.attribute_combo, label_data)
+
+    def _setup_mode_combo(self):
+        self.combo_mode.clear()
+        self.combo_mode.addItem("Min/Max", userData=100)
+        self.combo_mode.addItem("99.5%", userData=99.5)
+        self.combo_mode.addItem("99%", userData=99)
+        self.combo_mode.addItem("95%", userData=95)
+        self.combo_mode.addItem("90%", userData=90)
+        self.combo_mode.addItem("Custom", userData=None)
+        self.combo_mode.setCurrentIndex(-1)
+
+    def _flip_limits(self):
+        self.vlo, self.vhi = self.vhi, self.vlo
+        self.notify_callbacks()
+
+    def _manual_edit(self):
+        self._cache_limits()
+        self.notify_callbacks()
+
+    def _update_mode(self):
+        if self.scale_mode == 'Custom':
+            self.lower_value.setEnabled(True)
+            self.upper_value.setEnabled(True)
+        else:
+            self.lower_value.setEnabled(False)
+            self.upper_value.setEnabled(False)
+            self._auto_limits()
+            self._cache_limits()
+            self.notify_callbacks()
+
+    def _cache_limits(self):
+        self._limits[self.attribute] = self.scale_mode, self.vlo, self.vhi
+
+    def _update_limits(self):
+        if self.attribute in self._limits:
+            self.lower_value.blockSignals(True)
+            self.scale_mode, self.vlo, self.vhi = self._limits[self.attribute]
+            self.lower_value.blockSignals(False)
+        else:
+            self.scale_mode = 'Min/Max'
+            self._update_mode()
+
+    def _auto_limits(self):
+        exclude = (100 - self.percentile) / 2.
+        self.vlo = np.nanpercentile(self.data[self.attribute], exclude)
+        self.vhi = np.nanpercentile(self.data[self.attribute], 100 - exclude)
+
+    def connect(self, function):
+        self._callbacks.append(function)
+
+    def notify_callbacks(self):
+        for func in self._callbacks:
+            func()

--- a/glue/viewers/common/qt/attribute_limits_helper.py
+++ b/glue/viewers/common/qt/attribute_limits_helper.py
@@ -29,6 +29,14 @@ class AttributeLimitsHelper(object):
     mode, for example using the min/max values or percentile values, as well as
     a button for flipping the min/max values.
 
+    Finally, this helper is aware of the differences between Data and Subset -
+    for subsets, the ``subset_mode`` attribute can be set to either 'outline'
+    or 'data'. For 'outline', the limits are frozen to (0, 1), since in this
+    mode, the mask of subsets is meant to be shown directly, with values either
+    0 (False) or 1 (True). For 'data', the lower limit is frozen to 0 while the
+    upper limit is computed as for data - this mode is intended for use when
+    showing data * subset_mask, hence why the lower limit is set to 0.
+
     Parameters
     ----------
     attribute_combo : ``QComboBox`` instance
@@ -156,7 +164,7 @@ class AttributeLimitsHelper(object):
 
     def _update_limits(self):
         if self.subset_mode == 'outline':
-            self.set_limits(0, 2)
+            self.set_limits(0, 1)
         elif self.attribute in self._limits:
             self.scale_mode, lower, upper = self._limits[self.attribute]
             self.set_limits(lower, upper)
@@ -175,7 +183,7 @@ class AttributeLimitsHelper(object):
             return
 
         if self.subset_mode == 'outline':
-            self.set_limits(0, 2)
+            self.set_limits(0, 1)
             return
 
         exclude = (100 - self.percentile) / 2.

--- a/glue/viewers/common/qt/attribute_limits_helper.py
+++ b/glue/viewers/common/qt/attribute_limits_helper.py
@@ -74,7 +74,7 @@ class AttributeLimitsHelper(object):
     vhi = FloatLineProperty('upper_value')
 
     def __init__(self, attribute_combo, lower_value, upper_value,
-                 mode_combo=None, flip_button=None, data=None):
+                 mode_combo=None, flip_button=None, data=None, limits_cache=None):
 
         self.attribute_combo = attribute_combo
         self.mode_combo = mode_combo
@@ -98,7 +98,10 @@ class AttributeLimitsHelper(object):
         if self.flip_button is not None:
             self.flip_button.clicked.connect(self._flip_limits)
 
-        self._limits = {}
+        if limits_cache is None:
+            limits_cache = {}
+
+        self._limits = limits_cache
         self._callbacks = []
 
     @property

--- a/glue/viewers/common/qt/tests/test_attribute_limits_helper.py
+++ b/glue/viewers/common/qt/tests/test_attribute_limits_helper.py
@@ -139,7 +139,7 @@ class TestAttributeLimitsHelper():
 
         self.helper.subset_mode = 'outline'
         assert self.helper.vlo == 0
-        assert self.helper.vhi == 2
+        assert self.helper.vhi == 1
 
         self.helper.subset_mode = 'data'
         assert self.helper.vlo == 0

--- a/glue/viewers/common/qt/tests/test_attribute_limits_helper.py
+++ b/glue/viewers/common/qt/tests/test_attribute_limits_helper.py
@@ -1,0 +1,98 @@
+import numpy as np
+
+from glue.external.qt import QtGui
+from glue.core.data import Data
+
+from ..attribute_limits_helper import AttributeLimitsHelper
+
+# TEMPORARY
+from glue.external.qt import get_qapp
+get_qapp()
+
+class TestAttributeLimitsHelper():
+
+    def setup_method(self, method):
+
+        self.attribute_combo = QtGui.QComboBox()
+        self.lower_value = QtGui.QLineEdit()
+        self.upper_value = QtGui.QLineEdit()
+        self.mode_combo = QtGui.QComboBox()
+        self.flip_button = QtGui.QToolButton()
+        
+        self.helper = AttributeLimitsHelper(self.attribute_combo,
+                                            self.lower_value, self.upper_value,
+                                            mode_combo=self.mode_combo,
+                                            flip_button=self.flip_button)
+        
+        self.data = Data(x=np.linspace(-100, 100, 10000),
+                         y=np.linspace(2, 3, 10000), label='test_data')
+        
+        self.helper.data = self.data
+        
+        self.x_id = self.data.visible_components[0]
+        self.y_id = self.data.visible_components[1]
+
+    def test_attributes(self):
+        assert self.attribute_combo.count() == 2
+        assert self.attribute_combo.itemText(0) == 'x'
+        assert self.attribute_combo.itemData(0) is self.x_id
+        assert self.attribute_combo.itemText(1) == 'y'
+        assert self.attribute_combo.itemData(1) is self.y_id
+                
+    def test_minmax(self):
+        assert self.helper.vlo == -100
+        assert self.helper.vhi == +100
+
+    def test_change_attribute(self):
+        self.helper.attribute = self.y_id
+        assert self.helper.vlo == 2
+        assert self.helper.vhi == 3
+        self.helper.attribute = self.x_id
+        assert self.helper.vlo == -100
+        assert self.helper.vhi == +100
+
+    def test_change_scale_mode(self):
+        
+        # Changing scale mode updates the limits
+        self.helper.scale_mode = '99.5%'
+        assert self.helper.vlo == -99.5
+        assert self.helper.vhi == +99.5
+        self.helper.scale_mode = '99%'
+        assert self.helper.vlo == -99
+        assert self.helper.vhi == +99
+        self.helper.scale_mode = '90%'
+        assert self.helper.vlo == -90
+        assert self.helper.vhi == +90
+        
+        # When switching to custom, the last limits are retained
+        self.helper.scale_mode = 'Custom'
+        assert self.helper.vlo == -90
+        assert self.helper.vhi == +90
+
+    def test_scale_mode_cached(self):
+        # Make sure that if we change scale and change attribute, the scale
+        # modes are cached on a per-attribute basis.
+        self.helper.scale_mode = '99.5%'
+        self.helper.attribute = self.y_id
+        assert self.helper.scale_mode == 'Min/Max'
+        self.helper.scale_mode = '99%'
+        self.helper.attribute = self.x_id
+        assert self.helper.scale_mode == '99.5%'
+        self.helper.attribute = self.y_id
+        assert self.helper.scale_mode == '99%'
+        
+    def test_flip_button(self):
+        
+        # Flipping should swap lower and upper value
+        self.flip_button.clicked.emit(True)
+        assert self.helper.vlo == +100
+        assert self.helper.vhi == -100
+        
+        # Make sure that values were re-cached when flipping
+        self.helper.attribute = self.y_id
+        assert self.helper.vlo == 2
+        assert self.helper.vhi == 3
+        self.helper.attribute = self.x_id
+        assert self.helper.vlo == +100
+        assert self.helper.vhi == -100
+    

--- a/glue/viewers/common/qt/tests/test_attribute_limits_helper.py
+++ b/glue/viewers/common/qt/tests/test_attribute_limits_helper.py
@@ -24,10 +24,16 @@ class TestAttributeLimitsHelper():
         self.mode_combo = QtGui.QComboBox()
         self.flip_button = QtGui.QToolButton()
 
+        self.log_button = QtGui.QToolButton()
+        self.log_button.setCheckable(True)
+        
+        # TODO: Need to make log button checkable here for test to work
+
         self.helper = AttributeLimitsHelper(self.attribute_combo,
                                             self.lower_value, self.upper_value,
                                             mode_combo=self.mode_combo,
-                                            flip_button=self.flip_button)
+                                            flip_button=self.flip_button,
+                                            log_button=self.log_button)
 
         self.data = Data(x=np.linspace(-100, 100, 10000),
                          y=np.linspace(2, 3, 10000), label='test_data')
@@ -104,15 +110,25 @@ class TestAttributeLimitsHelper():
     def test_manual_edit(self):
 
         # Make sure that values are re-cached when edited manually
-        self.helper.mode_combo = 'Custom'
+        print(self.helper.mode_combo)
+        self.helper.scale_mode = 'Custom'
+        print(self.helper.mode_combo)
         self.lower_value.setText('-122')
         self.upper_value.setText('234')
+        print("CHANGING")
+        self.helper.vlog = True
+        print("DONE")
         assert self.helper.vlo == -122
         assert self.helper.vhi == 234
+        assert self.helper.vlog
         self.helper.attribute = self.y_id
+        assert self.helper.vlo == 2
+        assert self.helper.vhi == 3
+        assert not self.helper.vlog
         self.helper.attribute = self.x_id
         assert self.helper.vlo == -122
         assert self.helper.vhi == 234
+        assert self.helper.vlog
 
     def test_subset_mode(self):
 

--- a/glue/viewers/common/qt/tests/test_attribute_limits_helper.py
+++ b/glue/viewers/common/qt/tests/test_attribute_limits_helper.py
@@ -13,6 +13,7 @@ from ..attribute_limits_helper import AttributeLimitsHelper
 from glue.external.qt import get_qapp
 get_qapp()
 
+
 class TestAttributeLimitsHelper():
 
     def setup_method(self, method):

--- a/glue/viewers/common/qt/tests/test_attribute_limits_helper.py
+++ b/glue/viewers/common/qt/tests/test_attribute_limits_helper.py
@@ -18,17 +18,17 @@ class TestAttributeLimitsHelper():
         self.upper_value = QtGui.QLineEdit()
         self.mode_combo = QtGui.QComboBox()
         self.flip_button = QtGui.QToolButton()
-        
+
         self.helper = AttributeLimitsHelper(self.attribute_combo,
                                             self.lower_value, self.upper_value,
                                             mode_combo=self.mode_combo,
                                             flip_button=self.flip_button)
-        
+
         self.data = Data(x=np.linspace(-100, 100, 10000),
                          y=np.linspace(2, 3, 10000), label='test_data')
-        
+
         self.helper.data = self.data
-        
+
         self.x_id = self.data.visible_components[0]
         self.y_id = self.data.visible_components[1]
 
@@ -38,7 +38,7 @@ class TestAttributeLimitsHelper():
         assert self.attribute_combo.itemData(0) is self.x_id
         assert self.attribute_combo.itemText(1) == 'y'
         assert self.attribute_combo.itemData(1) is self.y_id
-                
+
     def test_minmax(self):
         assert self.helper.vlo == -100
         assert self.helper.vhi == +100
@@ -52,7 +52,7 @@ class TestAttributeLimitsHelper():
         assert self.helper.vhi == +100
 
     def test_change_scale_mode(self):
-        
+
         # Changing scale mode updates the limits
         self.helper.scale_mode = '99.5%'
         assert self.helper.vlo == -99.5
@@ -63,7 +63,7 @@ class TestAttributeLimitsHelper():
         self.helper.scale_mode = '90%'
         assert self.helper.vlo == -90
         assert self.helper.vhi == +90
-        
+
         # When switching to custom, the last limits are retained
         self.helper.scale_mode = 'Custom'
         assert self.helper.vlo == -90
@@ -80,14 +80,14 @@ class TestAttributeLimitsHelper():
         assert self.helper.scale_mode == '99.5%'
         self.helper.attribute = self.y_id
         assert self.helper.scale_mode == '99%'
-        
+
     def test_flip_button(self):
-        
+
         # Flipping should swap lower and upper value
         self.flip_button.clicked.emit(True)
         assert self.helper.vlo == +100
         assert self.helper.vhi == -100
-        
+
         # Make sure that values were re-cached when flipping
         self.helper.attribute = self.y_id
         assert self.helper.vlo == 2
@@ -95,4 +95,16 @@ class TestAttributeLimitsHelper():
         self.helper.attribute = self.x_id
         assert self.helper.vlo == +100
         assert self.helper.vhi == -100
-    
+
+    def test_manual_edit(self):
+
+        # Make sure that values are re-cached when edited manually
+        self.helper.mode_combo = 'Custom'
+        self.lower_value.setText('-122')
+        self.upper_value.setText('234')
+        assert self.helper.vlo == -122
+        assert self.helper.vhi == 234
+        self.helper.attribute = self.y_id
+        self.helper.attribute = self.x_id
+        assert self.helper.vlo == -122
+        assert self.helper.vhi == 234

--- a/glue/viewers/common/qt/tests/test_attribute_limits_helper.py
+++ b/glue/viewers/common/qt/tests/test_attribute_limits_helper.py
@@ -1,7 +1,11 @@
+import operator
+
+import pytest
 import numpy as np
 
 from glue.external.qt import QtGui
 from glue.core.data import Data
+from glue.core.subset import InequalitySubsetState
 
 from ..attribute_limits_helper import AttributeLimitsHelper
 
@@ -108,3 +112,34 @@ class TestAttributeLimitsHelper():
         self.helper.attribute = self.x_id
         assert self.helper.vlo == -122
         assert self.helper.vhi == 234
+
+    def test_subset_mode(self):
+
+        with pytest.raises(ValueError) as exc:
+            self.helper.subset_mode = 'data'
+        assert exc.value.args[0] == "subset_mode should be set to None when data is not a subset"
+
+        subset_state = InequalitySubsetState(self.x_id, 10, operator.gt)
+
+        self.data.new_subset(subset_state)
+
+        subset = self.data.subsets[0]
+
+        self.helper.data = subset
+
+        with pytest.raises(ValueError) as exc:
+            self.helper.subset_mode = None
+        assert exc.value.args[0] == "subset_mode should either be 'outline', 'data' when data is a subset"
+
+        self.helper.subset_mode = 'data'
+        assert self.helper.vlo == 0
+        assert self.helper.vhi == 100
+        self.helper.vhi = 56
+
+        self.helper.subset_mode = 'outline'
+        assert self.helper.vlo == 0
+        assert self.helper.vhi == 2
+
+        self.helper.subset_mode = 'data'
+        assert self.helper.vlo == 0
+        assert self.helper.vhi == 56


### PR DESCRIPTION
For a number of widgets, we need to implement the logic of caching attribute limits for different data attributes, linking an autoscaling option to the limits, flipping the limits, etc. This PR adds a helper class to manage this in one place.

This is an alternative to https://github.com/glue-viz/glue/pull/871 - the advantage of the helper class is that it does not impose any particular layout (whereas the layout in #871 did not always fit in to particular widgets). It also allows some of the things, such as the scale mode and flip button, to be optional.

An example of using this is in https://github.com/glue-viz/glue-3d-viewer/pull/83 - in particular, note that the Python files there are significantly simplified.

The helper here can also be used inside Glue core in various places, such as the image layer artist editor, or histogram limits for instance.