### PR TITLE
Fix __str__ for Data

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,8 @@ v0.7 (unreleased)
 * Added documentation about how to use layer artists in custom Qt data viewers.
   [#814]
 
+* Fixed missing newline in Data.__str__. [#877]
+
 * A large fraction of the code has been re-organized, which may lead to some
   imports in ``config.py`` files no longer working. However, no functionality
   has been removed, so this can be fixed by updating the imports to reflect the

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -572,7 +572,7 @@ class Data(object):
             self.hub.broadcast(msg)
 
     def __str__(self):
-        s = "Data Set: %s" % self.label
+        s = "Data Set: %s\n" % self.label
         s += "Number of dimensions: %i\n" % self.ndim
         s += "Shape: %s\n" % ' x '.join([str(x) for x in self.shape])
         s += "Components:\n"

--- a/glue/core/tests/test_data.py
+++ b/glue/core/tests/test_data.py
@@ -549,3 +549,20 @@ def test_add_binary_component():
     d.add_component(z, label='z')
 
     np.testing.assert_array_equal(d['z'], [3, 5, 7])
+
+
+EXPECTED_STR = """
+Data Set: mydata
+Number of dimensions: 1
+Shape: 3
+Components:
+ 0) x
+ 1) Pixel Axis 0
+ 2) World 0
+ 3) y
+""".strip()
+
+def test_data_str():
+    # Regression test for Data.__str__
+    d = Data(x=[1,2,3], y=[2,3,4], label='mydata')
+    assert str(d) == EXPECTED_STR


### PR DESCRIPTION
The number of dimensions should start on a newline:

```python
>>> print(catalog)
Data Set: w5_pscNumber of dimensions: 1
Shape: 17771
Components:
 0) ID
 1) Pixel Axis 0
 2) World 0
 3) RAJ2000
 4) DEJ2000
 5) Jmag
 6) Hmag
 7) Ksmag
 8) __3.6_
 9) __4.5_
 10) __5.8_
 11) __8.0_
 12) __24_
 13) Type
 14) __4.5__-__5.8_
 15) __5.8__-__8.0_
```