### PR TITLE
Crash when pvextracting

### DIFF
--- a/glue/core/qt/roi.py
+++ b/glue/core/qt/roi.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 
-from glue.external.qt import QtCore
+from glue.external.qt.QtCore import Qt
 from glue.external.qt import QtGui, QtCore
 from glue.core import roi
 from glue.utils.qt import mpl_to_qt4_color


### PR DESCRIPTION
I tried pvextraction on a particular file (ask and I'll send a link) and it crashed with this error:

```
Traceback (most recent call last):
  File "/Users/adam/repos/glue/glue/viewers/common/qt/mpl_widget.py", line 113, in paintEvent
    self.roi_callback(self)
  File "/Users/adam/repos/glue/glue/core/qt/roi.py", line 41, in _paint_check
    self.paint(canvas)
  File "/Users/adam/repos/glue/glue/core/qt/roi.py", line 45, in paint
    self.draw_polygon(canvas, x, y)
  File "/Users/adam/repos/glue/glue/core/qt/roi.py", line 97, in draw_polygon
    p = self.get_painter(canvas)
  File "/Users/adam/repos/glue/glue/core/qt/roi.py", line 86, in get_painter
    p.setBrush(Qt.NoBrush)
NameError: name 'Qt' is not defined
QWidget: It is dangerous to leave painters active on a widget outside of the PaintEvent
QPainter::begin: A paint device can only be painted by one painter at a time.
Segmentation fault: 11
```

version is `glueviz==0.8.0.dev26152615`