### PR TITLE
Glue 0.7.1 cannot handle FITS with missing END card on Windows 7

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,8 @@ v0.7.2 (unreleased)
 
 * Make sure main window title is set. [#914]
 
+* Fix issue with FITS files that are missing an END card. [#915]
+
 v0.7.1 (2016-03-29)
 -------------------
 

--- a/glue/core/data_factories/fits.py
+++ b/glue/core/data_factories/fits.py
@@ -17,7 +17,7 @@ def is_fits(filename):
     try:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            with fits.open(filename):
+            with fits.open(filename, ignore_missing_end=True):
                 return True
     except IOError:
         return False
@@ -53,7 +53,7 @@ def fits_reader(source, auto_merge=False, exclude_exts=None, label=None):
 
     exclude_exts = exclude_exts or []
     if not isinstance(source, fits.hdu.hdulist.HDUList):
-        hdulist = fits.open(source)
+        hdulist = fits.open(source, ignore_missing_end=True)
         hdulist.verify('fix')
     else:
         hdulist = source
@@ -151,7 +151,7 @@ def is_casalike(filename, **kwargs):
 
     if not is_fits(filename):
         return False
-    with fits.open(filename) as hdulist:
+    with fits.open(filename, ignore_missing_end=True) as hdulist:
         if len(hdulist) != 1:
             return False
         if hdulist[0].header['NAXIS'] != 4:
@@ -176,7 +176,7 @@ def casalike_cube(filename, **kwargs):
     from astropy.io import fits
 
     result = Data()
-    with fits.open(filename, **kwargs) as hdulist:
+    with fits.open(filename, ignore_missing_end=True, **kwargs) as hdulist:
         array = hdulist[0].data
         header = hdulist[0].header
     result.coords = coordinates_from_header(header)

--- a/glue/core/data_factories/fits.py
+++ b/glue/core/data_factories/fits.py
@@ -176,7 +176,11 @@ def casalike_cube(filename, **kwargs):
     from astropy.io import fits
 
     result = Data()
-    with fits.open(filename, ignore_missing_end=True, **kwargs) as hdulist:
+
+    if 'ignore_missing_end' not in kwargs:
+        kwargs['ignore_missing_end'] = True
+
+    with fits.open(filename, **kwargs) as hdulist:
         array = hdulist[0].data
         header = hdulist[0].header
     result.coords = coordinates_from_header(header)


### PR DESCRIPTION
I have Glue 0.7.1 on Windows 7 (Astropy version there is 1.1.2). When I try to open test image, L1448_13CO.fits, provided by @astrofrog, I get the following traceback:

```python
Error message: Header missing END card.

Traceback (most recent call last):
  File "...\glue\dialogs\data_wizard\qt\data_wizard_dialog.py", line 36, in data_wizard
    result = gdd.load_data()
  File "...\glue\utils\qt\decorators.py", line 23, in result
    return func(*args, **kwargs)
  File "...\glue\dialogs\data_wizard\qt\data_wizard_dialog.py", line 105, in load_data
    d = load_data(path, factory=fac.function)
  File "...\glue\core\data_factories\helpers.py", line 237, in load_data
    d = as_list(factory(path, **kwargs))
  File "...\glue\core\data_factories\fits.py", line 56, in fits_reader
    hdulist = fits.open(source)
  File "...\astropy\io\fits\hdu\hdulist.py", line 138, in fitsopen
    return HDUList.fromfile(name, mode, memmap, save_backup, cache, **kwargs)
  File "...\astropy\io\fits\hdu\hdulist.py", line 280, in fromfile
    save_backup=save_backup, cache=cache, **kwargs)
  File "...\astropy\io\fits\hdu\hdulist.py", line 838, in _readfrom
    hdu = _BaseHDU.readfrom(ffo, **kwargs)
  File "...\astropy\io\fits\hdu\base.py", line 423, in readfrom
    **kwargs)
  File "...\astropy\io\fits\hdu\base.py", line 483, in _readfrom_internal
    header = Header.fromfile(data, endcard=not ignore_missing_end)
  File "...\astropy\io\fits\header.py", line 460, in fromfile
    padding)[1]
  File "...\astropy\io\fits\header.py", line 529, in _from_blocks
    raise IOError('Header missing END card.')
IOError: Header missing END card.
```

I did not see this error on Linux. And others who used the same file on Mac also did not mention seeing this error. On Windows, explicitly choosing "FITS file" from file type also did not help.

I also failed to load w5.fits, w5_psc.vot, and chandra_events.fits on Windows.