### PR TITLE
Tooltip to display full data name on hover

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@ Full changelog
 v0.8 (unreleased)
 -----------------
 
+* Add tooltip for data labels so that long labels can be more easily
+  inspected. [#912]
+
 * Added a new helper class ``AttributeLimitsHelper`` to link widgets related to
   setting limits and handle the caching of the limits as a function of
   attribute. [#872]

--- a/glue/core/qt/data_collection_model.py
+++ b/glue/core/qt/data_collection_model.py
@@ -117,6 +117,12 @@ class DataItem(Item):
         self.data.label = value
 
     @property
+    def tooltip(self):
+        # Return the label as the tooltip - this is useful if filenames are
+        # really long and don't fit in the window.
+        return self.label
+
+    @property
     def style(self):
         return self.data.style
 


### PR DESCRIPTION
![screenshot](https://cloud.githubusercontent.com/assets/2090236/14188008/d21537fe-f753-11e5-9320-d3263a7c8e8c.png)

For very long file names (JWST files will have long filenames too), it is convenient to display a tooltip to display the full name when cursor hovers over the truncated displayed name.