### PR TITLE
Glue labeled as Untitled Window on Linux, has no label on Windows 7

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,11 @@ v0.8 (unreleased)
   setting limits and handle the caching of the limits as a function of
   attribute. [#872]
 
+v0.7.2 (unreleased)
+-------------------
+
+* Make sure main window title is set. [#914]
+
 v0.7.1 (2016-03-29)
 -------------------
 

--- a/glue/app/qt/application.py
+++ b/glue/app/qt/application.py
@@ -198,6 +198,7 @@ class GlueApplication(Application, QtGui.QMainWindow):
         # in case glue was started directly by initializing this class.
         load_plugins()
 
+        self.setWindowTitle("Glue")
         self.setWindowIcon(icon)
         self.setAttribute(Qt.WA_DeleteOnClose)
         self._actions = {}


### PR DESCRIPTION
My machine was RHEL6 (64-bit). I installed Glue under Anaconda (Python 2.7, Qt4). On the task bar, Glue is labeled as "Untitled Window", as shown below:

![screenshot-1](https://cloud.githubusercontent.com/assets/2090236/14188725/0354cee8-f758-11e5-9e58-167577623325.png)

On Windows 7, it appears like this:

<img width="101" alt="untitled" src="https://cloud.githubusercontent.com/assets/2090236/14188873/85c812a4-f758-11e5-97fa-de84d3dc2f3c.png">

