### PR TITLE
Remove scrollbars from main application

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,9 @@ v0.7.3 (unreleased)
 * Ignore extra dimensions in WCS (for instance, if the data is 3D and the
   header is 4D, ignore the 4th dimension in the WCS).
 
+* Remove the scrollbars added in v0.7.1 since they cause issues on certain
+  systems. [#953]
+
 v0.7.2 (2016-04-05)
 -------------------
 

--- a/glue/app/qt/application.ui
+++ b/glue/app/qt/application.ui
@@ -31,82 +31,57 @@
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
-     <widget class="QScrollArea" name="scrollArea">
-      <property name="minimumSize">
-       <size>
-        <width>350</width>
-        <height>0</height>
-       </size>
+     <widget class="QSplitter" name="data_plot_splitter">
+      <property name="orientation">
+       <enum>Qt::Vertical</enum>
       </property>
-      <property name="frameShape">
-       <enum>QFrame::NoFrame</enum>
-      </property>
-      <property name="horizontalScrollBarPolicy">
-       <enum>Qt::ScrollBarAlwaysOff</enum>
-      </property>
-      <property name="widgetResizable">
-       <bool>true</bool>
-      </property>
-      <widget class="QSplitter" name="data_plot_splitter">
-       <property name="geometry">
-        <rect>
-         <x>0</x>
-         <y>0</y>
-         <width>350</width>
-         <height>744</height>
-        </rect>
+      <widget class="QGroupBox" name="data_layers">
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
        </property>
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
+       <property name="layoutDirection">
+        <enum>Qt::LeftToRight</enum>
        </property>
-       <widget class="QGroupBox" name="data_layers">
-        <property name="font">
-         <font>
-          <weight>75</weight>
-          <bold>true</bold>
-         </font>
-        </property>
-        <property name="layoutDirection">
-         <enum>Qt::LeftToRight</enum>
-        </property>
-        <property name="title">
-         <string>Data Collection</string>
-        </property>
-        <property name="flat">
-         <bool>false</bool>
-        </property>
-       </widget>
-       <widget class="QGroupBox" name="plot_layers">
-        <property name="font">
-         <font>
-          <weight>75</weight>
-          <bold>true</bold>
-         </font>
-        </property>
-        <property name="title">
-         <string>Plot Layers</string>
-        </property>
-        <property name="flat">
-         <bool>false</bool>
-        </property>
-       </widget>
-       <widget class="QGroupBox" name="plot_options">
-        <property name="font">
-         <font>
-          <weight>75</weight>
-          <bold>true</bold>
-         </font>
-        </property>
-        <property name="title">
-         <string>Plot Options</string>
-        </property>
-        <property name="flat">
-         <bool>false</bool>
-        </property>
-        <property name="checkable">
-         <bool>false</bool>
-        </property>
-       </widget>
+       <property name="title">
+        <string>Data Collection</string>
+       </property>
+       <property name="flat">
+        <bool>false</bool>
+       </property>
+      </widget>
+      <widget class="QGroupBox" name="plot_layers">
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="title">
+        <string>Plot Layers</string>
+       </property>
+       <property name="flat">
+        <bool>false</bool>
+       </property>
+      </widget>
+      <widget class="QGroupBox" name="plot_options">
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="title">
+        <string>Plot Options</string>
+       </property>
+       <property name="flat">
+        <bool>false</bool>
+       </property>
+       <property name="checkable">
+        <bool>false</bool>
+       </property>
       </widget>
      </widget>
      <widget class="QTabWidget" name="tabWidget">

--- a/glue/core/qt/layer_artist_model.py
+++ b/glue/core/qt/layer_artist_model.py
@@ -286,6 +286,7 @@ class LayerArtistWidget(QtGui.QWidget):
         super(LayerArtistWidget, self).__init__(parent=parent)
 
         self.layout = QtGui.QVBoxLayout()
+        self.layout.setContentsMargins(0, 0, 0, 0)
 
         self.layer_style_widget_cls = layer_style_widget_cls
 


### PR DESCRIPTION
These caused more problems than they solved, and it would be better to focus on making some of the option widgets take up less space.

For the 3D viewers, I have a PR in https://github.com/glue-viz/glue-3d-viewer/pull/120 that significantly optimizes the layout.