### PR TITLE
Fix bug which caused Component.numeric to not always work

### DIFF
--- a/glue/core/component.py
+++ b/glue/core/component.py
@@ -92,7 +92,7 @@ class Component(object):
         """
         Whether or not the datatype is numeric
         """
-        return np.can_cast(self.data[0], np.complex)
+        return np.can_cast(self.data.dtype, np.complex)
 
     @property
     def categorical(self):


### PR DESCRIPTION
I can't remember which data file triggered this, but once I figure out I'll add a regression test.