### PR TITLE
WIP: Refactor histogram viewer

### DIFF
--- a/glue/viewers/common/qt/tests/test_attribute_limits_helper.py
+++ b/glue/viewers/common/qt/tests/test_attribute_limits_helper.py
@@ -4,8 +4,9 @@ import pytest
 import numpy as np
 
 from glue.external.qt import QtGui
-from glue.core.data import Data
+from glue.core import Data, DataCollection
 from glue.core.subset import InequalitySubsetState
+from glue.core.qt.data_combo_helper import ComponentIDComboHelper
 
 from ..attribute_limits_helper import AttributeLimitsHelper
 
@@ -26,8 +27,11 @@ class TestAttributeLimitsHelper():
 
         self.log_button = QtGui.QToolButton()
         self.log_button.setCheckable(True)
-        
-        # TODO: Need to make log button checkable here for test to work
+
+        self.data = Data(x=np.linspace(-100, 100, 10000),
+                         y=np.linspace(2, 3, 10000), label='test_data')
+
+        self.data_collection = DataCollection([self.data])
 
         self.helper = AttributeLimitsHelper(self.attribute_combo,
                                             self.lower_value, self.upper_value,
@@ -35,10 +39,13 @@ class TestAttributeLimitsHelper():
                                             flip_button=self.flip_button,
                                             log_button=self.log_button)
 
-        self.data = Data(x=np.linspace(-100, 100, 10000),
-                         y=np.linspace(2, 3, 10000), label='test_data')
+        print("HERE999")
 
-        self.helper.data = self.data
+        self.component_helper = ComponentIDComboHelper(self.attribute_combo, self.data_collection)
+
+        print("SET UP CID HELPER")
+        self.component_helper.append(self.data)
+        print("APPENDED DATA")
 
         self.x_id = self.data.visible_components[0]
         self.y_id = self.data.visible_components[1]
@@ -46,19 +53,21 @@ class TestAttributeLimitsHelper():
     def test_attributes(self):
         assert self.attribute_combo.count() == 2
         assert self.attribute_combo.itemText(0) == 'x'
-        assert self.attribute_combo.itemData(0) is self.x_id
+        assert self.attribute_combo.itemData(0)[0] is self.x_id
+        assert self.attribute_combo.itemData(0)[1] is self.data
         assert self.attribute_combo.itemText(1) == 'y'
-        assert self.attribute_combo.itemData(1) is self.y_id
+        assert self.attribute_combo.itemData(1)[0] is self.y_id
+        assert self.attribute_combo.itemData(1)[1] is self.data
 
     def test_minmax(self):
         assert self.helper.vlo == -100
         assert self.helper.vhi == +100
 
     def test_change_attribute(self):
-        self.helper.attribute = self.y_id
+        self.attribute_combo.setCurrentIndex(1)
         assert self.helper.vlo == 2
         assert self.helper.vhi == 3
-        self.helper.attribute = self.x_id
+        self.attribute_combo.setCurrentIndex(0)
         assert self.helper.vlo == -100
         assert self.helper.vhi == +100
 
@@ -84,12 +93,12 @@ class TestAttributeLimitsHelper():
         # Make sure that if we change scale and change attribute, the scale
         # modes are cached on a per-attribute basis.
         self.helper.scale_mode = '99.5%'
-        self.helper.attribute = self.y_id
+        self.attribute_combo.setCurrentIndex(1)
         assert self.helper.scale_mode == 'Min/Max'
         self.helper.scale_mode = '99%'
-        self.helper.attribute = self.x_id
+        self.attribute_combo.setCurrentIndex(0)
         assert self.helper.scale_mode == '99.5%'
-        self.helper.attribute = self.y_id
+        self.attribute_combo.setCurrentIndex(1)
         assert self.helper.scale_mode == '99%'
 
     def test_flip_button(self):
@@ -100,10 +109,10 @@ class TestAttributeLimitsHelper():
         assert self.helper.vhi == -100
 
         # Make sure that values were re-cached when flipping
-        self.helper.attribute = self.y_id
+        self.attribute_combo.setCurrentIndex(1)
         assert self.helper.vlo == 2
         assert self.helper.vhi == 3
-        self.helper.attribute = self.x_id
+        self.attribute_combo.setCurrentIndex(0)
         assert self.helper.vlo == +100
         assert self.helper.vhi == -100
 
@@ -121,42 +130,11 @@ class TestAttributeLimitsHelper():
         assert self.helper.vlo == -122
         assert self.helper.vhi == 234
         assert self.helper.vlog
-        self.helper.attribute = self.y_id
+        self.attribute_combo.setCurrentIndex(1)
         assert self.helper.vlo == 2
         assert self.helper.vhi == 3
         assert not self.helper.vlog
-        self.helper.attribute = self.x_id
+        self.attribute_combo.setCurrentIndex(0)
         assert self.helper.vlo == -122
         assert self.helper.vhi == 234
         assert self.helper.vlog
-
-    def test_subset_mode(self):
-
-        with pytest.raises(ValueError) as exc:
-            self.helper.subset_mode = 'data'
-        assert exc.value.args[0] == "subset_mode should be set to None when data is not a subset"
-
-        subset_state = InequalitySubsetState(self.x_id, 10, operator.gt)
-
-        self.data.new_subset(subset_state)
-
-        subset = self.data.subsets[0]
-
-        self.helper.data = subset
-
-        with pytest.raises(ValueError) as exc:
-            self.helper.subset_mode = None
-        assert exc.value.args[0] == "subset_mode should either be 'outline', 'data' when data is a subset"
-
-        self.helper.subset_mode = 'data'
-        assert self.helper.vlo == 0
-        assert self.helper.vhi == 100
-        self.helper.vhi = 56
-
-        self.helper.subset_mode = 'outline'
-        assert self.helper.vlo == 0
-        assert self.helper.vhi == 1
-
-        self.helper.subset_mode = 'data'
-        assert self.helper.vlo == 0
-        assert self.helper.vhi == 56

--- a/glue/viewers/histogram/qt/options_widget.py
+++ b/glue/viewers/histogram/qt/options_widget.py
@@ -1,0 +1,67 @@
+import os
+
+from glue.external.qt import QtGui
+
+from glue.utils.qt.widget_properties import CurrentComboProperty, FloatLineProperty, ButtonProperty
+from glue.utils.qt import load_ui
+from glue.viewers.common.qt.attribute_limits_helper import AttributeLimitsHelper
+from glue.core.qt.data_combo_helper import ComponentIDComboHelper
+
+__all__ = ["HistogramOptionsWidget"]
+
+
+class HistogramOptionsWidget(QtGui.QWidget):
+
+    x_att = CurrentComboProperty('ui.combo_x_attribute')
+    x_log = ButtonProperty('ui.button_x_log')
+    x_min = FloatLineProperty('ui.value_x_min')
+    x_max = FloatLineProperty('ui.value_x_max')
+
+    y_normalized = ButtonProperty('ui.button_y_normalized')
+    y_cumulative = ButtonProperty('ui.button_y_cumulative')
+    y_log = ButtonProperty('ui.button_y_log')
+    y_min = FloatLineProperty('ui.value_y_min')
+    y_max = FloatLineProperty('ui.value_y_max')
+
+    hidden = FloatLineProperty('ui.checkbox_hidden')
+
+    def __init__(self, parent=None, data_collection=None):
+
+        super(HistogramOptionsWidget, self).__init__(parent=parent)
+
+        self.ui = load_ui('options_widget.ui', self,
+                          directory=os.path.dirname(__file__))
+
+        self.x_att_helper = ComponentIDComboHelper(self.ui.combo_x_attribute, data_collection)
+
+        self.x_limits_helper = AttributeLimitsHelper(self.ui.combo_x_attribute,
+                                                     self.ui.value_x_min,
+                                                     self.ui.value_x_max,
+                                                     flip_button=self.ui.button_flip_x,
+                                                     log_button=self.ui.button_x_log)
+
+    def append(self, data):
+        self.x_att_helper.append(data)
+
+    def remove(self, data):
+        self.x_att_helper.remove(data)
+
+
+if __name__ == "__main__":
+
+    from glue.external.qt import get_qapp
+    from glue.core import Data, DataCollection
+
+    data1 = Data(x=[1,2,3], y=[4,5,6], z=[7,8,9])
+    data2 = Data(a=[1,2,3], b=[4,5,6], c=[7,8,9])
+    dc = DataCollection([data1, data2])
+
+    app = get_qapp()
+
+    widget = HistogramOptionsWidget(data_collection=dc)
+    widget.append(data1)
+    widget.append(data2)
+    widget.show()
+    widget.raise_()
+
+    app.exec_()

--- a/glue/viewers/histogram/qt/options_widget.ui
+++ b/glue/viewers/histogram/qt/options_widget.ui
@@ -1,257 +1,212 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>HistogramWidget</class>
- <widget class="QWidget" name="HistogramWidget">
+ <class>Widget</class>
+ <widget class="QWidget" name="Widget">
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>240</width>
-    <height>207</height>
+    <width>322</width>
+    <height>254</height>
    </rect>
   </property>
-  <property name="focusPolicy">
-   <enum>Qt::StrongFocus</enum>
-  </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string>Viewer Options</string>
   </property>
-  <property name="styleSheet">
-   <string notr="true"/>
-  </property>
-  <layout class="QHBoxLayout" name="horizontalLayout_6">
-   <property name="margin">
-    <number>0</number>
+  <layout class="QGridLayout" name="gridLayout_5">
+   <property name="verticalSpacing">
+    <number>5</number>
    </property>
-   <item>
-    <layout class="QVBoxLayout" name="verticalLayout_5">
-     <property name="bottomMargin">
-      <number>10</number>
+   <property name="margin">
+    <number>5</number>
+   </property>
+   <item row="4" column="1" colspan="3">
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <property name="spacing">
+      <number>5</number>
      </property>
      <item>
-      <widget class="QWidget" name="option_dashboard" native="true">
-       <layout class="QVBoxLayout" name="verticalLayout_4">
-        <property name="margin">
-         <number>0</number>
-        </property>
-        <item>
-         <layout class="QVBoxLayout" name="verticalLayout_3">
-          <property name="spacing">
-           <number>3</number>
-          </property>
-          <item>
-           <layout class="QHBoxLayout" name="combo_layout">
-            <property name="spacing">
-             <number>1</number>
-            </property>
-            <item>
-             <layout class="QVBoxLayout" name="attribute_layout">
-              <property name="spacing">
-               <number>1</number>
-              </property>
-              <item>
-               <widget class="QLabel" name="label_4">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string>Attribute</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QComboBox" name="attributeCombo">
-                <property name="toolTip">
-                 <string>Select an attribute</string>
-                </property>
-                <property name="sizeAdjustPolicy">
-                 <enum>QComboBox::AdjustToMinimumContentsLength</enum>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_5">
-            <item>
-             <widget class="QDoubleSpinBox" name="binSpinBox">
-              <property name="toolTip">
-               <string>Define the histogram bin width</string>
-              </property>
-              <property name="keyboardTracking">
-               <bool>false</bool>
-              </property>
-              <property name="decimals">
-               <number>0</number>
-              </property>
-              <property name="minimum">
-               <double>1.000000000000000</double>
-              </property>
-              <property name="maximum">
-               <double>100000.000000000000000</double>
-              </property>
-              <property name="singleStep">
-               <double>3.000000000000000</double>
-              </property>
-              <property name="value">
-               <double>10.000000000000000</double>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QLabel" name="label">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>Number of bins</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_4">
-            <property name="topMargin">
-             <number>2</number>
-            </property>
-            <property name="bottomMargin">
-             <number>2</number>
-            </property>
-            <item>
-             <layout class="QHBoxLayout" name="horizontalLayout_3">
-              <item>
-               <widget class="QLabel" name="label_2">
-                <property name="text">
-                 <string>Min</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QLineEdit" name="xmin">
-                <property name="maxLength">
-                 <number>18</number>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-            <item>
-             <layout class="QHBoxLayout" name="horizontalLayout_2">
-              <item>
-               <widget class="QLabel" name="label_5">
-                <property name="text">
-                 <string>Max</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QLineEdit" name="xmax">
-                <property name="maxLength">
-                 <number>18</number>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout">
-            <item>
-             <layout class="QVBoxLayout" name="verticalLayout">
-              <item>
-               <widget class="QCheckBox" name="normalized_box">
-                <property name="text">
-                 <string>Normalized</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QCheckBox" name="autoscale_box">
-                <property name="text">
-                 <string>Autoscale y axis</string>
-                </property>
-                <property name="checked">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QCheckBox" name="cumulative_box">
-                <property name="text">
-                 <string>Cumulative</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <spacer name="verticalSpacer_2">
-                <property name="orientation">
-                 <enum>Qt::Vertical</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>20</width>
-                  <height>40</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-             </layout>
-            </item>
-            <item>
-             <layout class="QVBoxLayout" name="verticalLayout_2">
-              <item>
-               <widget class="QCheckBox" name="xlog_box">
-                <property name="text">
-                 <string>x log</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QCheckBox" name="ylog_box">
-                <property name="text">
-                 <string>y log</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <spacer name="verticalSpacer">
-                <property name="orientation">
-                 <enum>Qt::Vertical</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>20</width>
-                  <height>40</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-             </layout>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </item>
-       </layout>
+      <widget class="QToolButton" name="button_y_normalized">
+       <property name="text">
+        <string>Normalized</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
       </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="button_y_cumulative">
+       <property name="text">
+        <string>Cumulative</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="button_y_log">
+       <property name="text">
+        <string>Log</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>min/max:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="0" colspan="4">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="2" column="1" colspan="2">
+    <widget class="QSpinBox" name="spinBox"/>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>bins</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QLineEdit" name="value_x_min"/>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="x_lab">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>y axis</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1" colspan="3">
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <property name="spacing">
+      <number>5</number>
+     </property>
+     <item>
+      <widget class="QComboBox" name="combo_x_attribute"/>
+     </item>
+     <item>
+      <widget class="QToolButton" name="button_x_log">
+       <property name="text">
+        <string>Log</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
+       </property>
+       <property name="autoRepeat">
+        <bool>false</bool>
+       </property>
+       <property name="popupMode">
+        <enum>QToolButton::DelayedPopup</enum>
+       </property>
+       <property name="autoRaise">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>min/max:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="1" colspan="3">
+    <widget class="QCheckBox" name="checkbox_hidden">
+     <property name="text">
+      <string>Show hidden attributes</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="x_lab">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>x axis</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0" colspan="4">
+    <widget class="Line" name="line_2">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="3">
+    <widget class="QLineEdit" name="value_x_max"/>
+   </item>
+   <item row="1" column="2">
+    <widget class="QToolButton" name="button_flip_x">
+     <property name="font">
+      <font>
+       <pointsize>14</pointsize>
+      </font>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">padding: 0px</string>
+     </property>
+     <property name="text">
+      <string>⇄</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0" colspan="4">
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1" colspan="3">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLineEdit" name="value_y_min"/>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="value_y_max"/>
      </item>
     </layout>
    </item>
   </layout>
  </widget>
+ <layoutdefault spacing="6" margin="11"/>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
Now that there are a number of convenience classes to help deal with attributes and limits caching, I thought it would be a good time to see if the histogram viewer can be simplified. In particular, I want to investigate whether we really gain much by having a separate client class.

Before I do this, it would be good for me to review the basic design we want to follow - in particular, one of the things I learned from the 3D viewers is that code to do with internal logic relating to the options widgets should be contained in a separate class (like `HistogramOptionsWidget` here).
