### PR TITLE
Fix saving of Matplotlib colormaps to session files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,8 @@ v0.7.3 (unreleased)
 * Remove the scrollbars added in v0.7.1 since they cause issues on certain
   systems. [#953]
 
+* Fix saving of Matplotlib colormaps to session files. [#967]
+
 * Remove icons for actions that appear in contextual menus, since these
   appear too large due to a Qt bug. [#911]
 

--- a/glue/core/state.py
+++ b/glue/core/state.py
@@ -64,6 +64,8 @@ from base64 import b64encode, b64decode
 from inspect import isgeneratorfunction
 
 import numpy as np
+from matplotlib.colors import Colormap
+from matplotlib import cm
 
 from glue.external import six
 from glue import core
@@ -808,3 +810,11 @@ def _save_numpy(obj, context):
     np.save(f, obj)
     data = b64encode(f.getvalue()).decode('ascii')
     return dict(data=data)
+
+@saver(Colormap)
+def _save_cmap(cmap, context):
+    return {'cmap':cmap.name}
+
+@loader(Colormap)
+def _load_cmap(rec, context):
+    return cm.get_cmap(rec['cmap'])

--- a/glue/core/tests/test_state.py
+++ b/glue/core/tests/test_state.py
@@ -227,6 +227,12 @@ def test_polygonal_roi():
     assert r2.vx == [0, 0, 1]
     assert r2.vy == [0, 1, 0]
 
+
+def test_matplotlib_cmap():
+    from matplotlib import cm
+    assert clone(cm.gist_heat) is cm.gist_heat
+
+
 class DummyClass(object):
     pass
 


### PR DESCRIPTION
This is needed for https://github.com/glue-viz/glue-3d-viewer/pull/130