### PR TITLE
Fix icons for buttons under layer tree widget

### DIFF
--- a/glue/app/qt/layer_tree_widget.py
+++ b/glue/app/qt/layer_tree_widget.py
@@ -439,7 +439,9 @@ class LayerTreeWidget(QtGui.QMainWindow):
         self.ui.layerAddButton.clicked.connect(nonpartial(self._load_data))
         self.ui.layerRemoveButton.clicked.connect(self._actions['delete'].trigger)
         self.ui.linkButton.set_action(self._actions['link'])
+        self.ui.linkButton.setIcon(get_icon('glue_link'))
         self.ui.newSubsetButton.set_action(self._actions['new'], text=False)
+        self.ui.newSubsetButton.setIcon(get_icon('glue_subset'))
 
         rbut = self.ui.layerRemoveButton
 


### PR DESCRIPTION
This doesn't need a changelog entry since it's just a fix on top of #911