### PR TITLE
Join on multiple keys

### DIFF
--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -195,7 +195,7 @@ class Data(object):
         There are several ways to use this function, depending on how many
         components are passed to ``cid`` and ``cid_other``.
 
-        **Single component for each dataset**
+        **Joining on single components**
 
         First, one can specify a single component ID for both ``cid`` and
         ``cid_other``: this is the standard mode, and joins one component from
@@ -223,7 +223,10 @@ class Data(object):
             >>> s.to_mask()
             array([ True, False,  True,  True, False], dtype=bool)
 
-        **Multiple components**
+        **Joining on multiple components**
+
+        .. note:: This mode is currently slow, and will be optimized
+                  significantly in future.
 
         Next, one can specify several components for each dataset: in this
         case, the number of components given should match for both datasets.
@@ -255,7 +258,7 @@ class Data(object):
         and in particular, the second item (where a is 5 and b is 3) is not
         selected.
 
-        **One-to-many and many-to-one mapping**
+        **One-to-many and many-to-one joining**
 
         Finally, you can specify one component in one dataset and multiple ones
         in the other. In the case where one component is specified for this

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -313,9 +313,9 @@ class Data(object):
         """
 
         # To make things easier, we transform all component inputs to a tuple
-        if isinstance(cid, six.string_types):
+        if isinstance(cid, six.string_types) or isinstance(cid, ComponentID):
             cid = (cid,)
-        if isinstance(cid_other, six.string_types):
+        if isinstance(cid_other, six.string_types) or isinstance(cid_other, ComponentID):
             cid_other = (cid_other,)
 
         def get_component_id(data, name):

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -318,6 +318,11 @@ class Data(object):
         if isinstance(cid_other, six.string_types) or isinstance(cid_other, ComponentID):
             cid_other = (cid_other,)
 
+        if len(cid) > 1 and len(cid_other) > 1 and len(cid) != len(cid_other):
+            raise Exception("Either the number of components in the key join "
+                            "sets should match, or one of the component sets "
+                            "should contain a single component.")
+
         def get_component_id(data, name):
             cid = data.find_component_id(name)
             if cid is None:

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -173,35 +173,140 @@ class Data(object):
               cid_other='cid_like')
     def join_on_key(self, other, cid, cid_other):
         """
-        Create an *element* mapping to another dataset, by
-        joining on values of ComponentIDs in both datasets.
+        Create an *element* mapping to another dataset, by joining on values of
+        ComponentIDs in both datasets.
 
-        This join allows any subsets defined on `other` to be
-        propagated to self.
+        This join allows any subsets defined on `other` to be propagated to
+        self. The different ways to call this method are described in the
+        **Examples** section below.
 
-        :param other: :class:`~glue.core.data.Data` to join with
-        :param cid: str or :class:`glue.core.component_id.ComponentID` in this dataset to use as a key
-        :param cid_other: ComponentID in the other dataset to use as a key
+        Parameters
+        ----------
+        other : :class:`~glue.core.data.Data`
+            Data object to join with
+        cid : str or :class:`~glue.core.component_id.ComponentID` or iterable
+            Component(s) in this dataset to use as a key
+        cid_other : str or :class:`~glue.core.component_id.ComponentID` or iterable
+            Component(s) in the other dataset to use as a key
 
-        :example:
+        Examples
+        --------
 
-        >>> d1 = Data(x=[1, 2, 3, 4, 5], k1=[0, 0, 1, 1, 2], label='d1')
-        >>> d2 = Data(y=[2, 4, 5, 8, 4], k2=[1, 3, 1, 2, 3], label='d2')
-        >>> d2.join_on_key(d1, 'k2', 'k1')
+        There are several ways to use this function, depending on how many
+        components are passed to ``cid`` and ``cid_other``.
 
-        >>> s = d1.new_subset()
-        >>> s.subset_state = d1.id['x'] > 2
-        >>> s.to_mask()
-        array([False, False,  True,  True,  True], dtype=bool)
+        **Single component for each dataset**
 
-        >>> s = d2.new_subset()
-        >>> s.subset_state = d1.id['x'] > 2
-        >>> s.to_mask()
-        array([ True, False,  True,  True, False], dtype=bool)
+        First, one can specify a single component ID for both ``cid`` and
+        ``cid_other``: this is the standard mode, and joins one component from
+        one dataset to the other:
 
-        The subset state selects the last 3 items in d1. These have
-        key values k1 of 1 and 2. Thus, the selected items in d2
-        are the elements where k2 = 1 or 2.
+            >>> d1 = Data(x=[1, 2, 3, 4, 5], k1=[0, 0, 1, 1, 2], label='d1')
+            >>> d2 = Data(y=[2, 4, 5, 8, 4], k2=[1, 3, 1, 2, 3], label='d2')
+            >>> d2.join_on_key(d1, 'k2', 'k1')
+
+        Selecting all values in ``d1`` where x is greater than 2 returns
+        the last three items as expected:
+
+            >>> s = d1.new_subset()
+            >>> s.subset_state = d1.id['x'] > 2
+            >>> s.to_mask()
+            array([False, False,  True,  True,  True], dtype=bool)
+
+        The linking was done between k1 and k2, and the values of
+        k1 for the last three items are 1 and 2 - this means that the
+        first, third, and fourth item in ``d2`` will then get selected,
+        since k2 has a value of either 1 or 2 for these items.
+
+            >>> s = d2.new_subset()
+            >>> s.subset_state = d1.id['x'] > 2
+            >>> s.to_mask()
+            array([ True, False,  True,  True, False], dtype=bool)
+
+        **Multiple components**
+
+        Next, one can specify several components for each dataset: in this
+        case, the number of components given should match for both datasets.
+        This causes items in both datasets to be linked when (and only when)
+        the set of keys match between the two datasets:
+
+            >>> d1 = Data(x=[1, 2, 3, 5, 5],
+            ...           y=[0, 0, 1, 1, 2], label='d1')
+            >>> d2 = Data(a=[2, 5, 5, 8, 4],
+            ...           b=[1, 3, 2, 2, 3], label='d2')
+            >>> d2.join_on_key(d1, ('a', 'b'), ('x', 'y'))
+
+        Selecting all items where x is 5 in ``d1`` in which x is a
+        component works as expected and selects the two last items::
+
+            >>> s = d1.new_subset()
+            >>> s.subset_state = d1.id['x'] == 5
+            >>> s.to_mask()
+            array([False, False, False,  True,  True], dtype=bool)
+
+        If we apply this selection to ``d2``, only items where a is 5
+        and b is 2 will be selected:
+
+            >>> s = d2.new_subset()
+            >>> s.subset_state = d1.id['x'] == 5
+            >>> s.to_mask()
+            array([False, False,  True, False, False], dtype=bool)
+
+        and in particular, the second item (where a is 5 and b is 3) is not
+        selected.
+
+        **One-to-many and many-to-one mapping**
+
+        Finally, you can specify one component in one dataset and multiple ones
+        in the other. In the case where one component is specified for this
+        dataset and multiple ones for the other dataset, then when an item
+        is selected in the other dataset, it will cause any item in the present
+        dataset which matches any of the keys in the other data to be selected:
+
+            >>> d1 = Data(x=[1, 2, 3], label='d1')
+            >>> d2 = Data(a=[1, 1, 2],
+            ...           b=[2, 3, 3], label='d2')
+            >>> d1.join_on_key(d2, 'x', ('a', 'b'))
+
+        In this case, if we select all items in ``d2`` where a is 2, this
+        will select the third item:
+
+            >>> s = d2.new_subset()
+            >>> s.subset_state = d2.id['a'] == 2
+            >>> s.to_mask()
+            array([False, False,  True], dtype=bool)
+
+        Since we have joined the datasets using both a and b, we select
+        all items in ``d1`` where x is either the value or a or b
+        (2 or 3) which means we select the second and third item:
+
+            >>> s = d1.new_subset()
+            >>> s.subset_state = d2.id['a'] == 2
+            >>> s.to_mask()
+            array([False,  True,  True], dtype=bool)
+
+        We can also join the datasets the other way around:
+
+            >>> d1 = Data(x=[1, 2, 3], label='d1')
+            >>> d2 = Data(a=[1, 1, 2],
+            ...           b=[2, 3, 3], label='d2')
+            >>> d2.join_on_key(d1, ('a', 'b'), 'x')
+
+        In this case, selecting items in ``d1`` where x is 1 selects the
+        first item, as expected:
+
+            >>> s = d1.new_subset()
+            >>> s.subset_state = d1.id['x'] == 1
+            >>> s.to_mask()
+            array([ True, False, False], dtype=bool)
+
+        This then causes any item in ``d2`` where either a or b are 1
+        to be selected, i.e. the first two items:
+
+            >>> s = d2.new_subset()
+            >>> s.subset_state = d1.id['x'] == 1
+            >>> s.to_mask()
+            array([ True,  True, False], dtype=bool)
         """
 
         # To make things easier, we transform all component inputs to a tuple

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -203,15 +203,22 @@ class Data(object):
         key values k1 of 1 and 2. Thus, the selected items in d2
         are the elements where k2 = 1 or 2.
         """
-        _i1, _i2 = cid, cid_other
-        cid = self.find_component_id(cid)
-        cid_other = other.find_component_id(cid_other)
-        if cid is None:
-            raise ValueError("ComponentID not found in %s: %s" %
-                             (self.label, _i1))
-        if cid_other is None:
-            raise ValueError("ComponentID not found in %s: %s" %
-                             (other.label, _i2))
+
+        # To make things easier, we transform all component inputs to a tuple
+        if isinstance(cid, six.string_types):
+            cid = (cid,)
+        if isinstance(cid_other, six.string_types):
+            cid_other = (cid_other,)
+
+        def get_component_id(data, name):
+            cid = data.find_component_id(name)
+            if cid is None:
+                raise ValueError("ComponentID not found in %s: %s" %
+                                 (data.label, name))
+            return cid
+
+        cid = tuple(get_component_id(self, name) for name in cid)
+        cid_other = tuple(get_component_id(other, name) for name in cid_other)
 
         self._key_joins[other] = (cid, cid_other)
         other._key_joins[self] = (cid_other, cid)

--- a/glue/core/state.py
+++ b/glue/core/state.py
@@ -693,7 +693,9 @@ def _load_data_2(rec, context):
 @saver(Data, version=3)
 def _save_data_3(data, context):
     result = _save_data_2(data, context)
-    result['_key_joins'] = [[context.id(k), context.id(v0), context.id(v1)]
+    def save_cid_tuple(cids):
+        return tuple(context.id(cid) for cid in cids)
+    result['_key_joins'] = [[context.id(k), save_cid_tuple(v0), save_cid_tuple(v1)]
                             for k, (v0, v1) in data._key_joins.items()]
     return result
 
@@ -702,7 +704,9 @@ def _save_data_3(data, context):
 def _load_data_3(rec, context):
     result = _load_data_2(rec, context)
     yield result
-    result._key_joins = dict((context.object(k), (context.object(v0), context.object(v1)))
+    def load_cid_tuple(cids):
+        return tuple(context.object(cid) for cid in cids)
+    result._key_joins = dict((context.object(k), (load_cid_tuple(v0), load_cid_tuple(v1)))
                              for k, v0, v1 in rec['_key_joins'])
 
 

--- a/glue/core/subset.py
+++ b/glue/core/subset.py
@@ -189,8 +189,8 @@ class Subset(object):
 
             if len(cid1) == 1 and len(cid2) == 1:
 
-                key_left = self.data[cid1, view].ravel()
-                key_right = other[cid2, mask_right].ravel()
+                key_left = self.data[cid1[0], view].ravel()
+                key_right = other[cid2[0], mask_right].ravel()
                 mask = np.in1d(key_left, key_right)
 
                 return mask.reshape(self.data[cid1[0], view].shape)

--- a/glue/core/subset.py
+++ b/glue/core/subset.py
@@ -189,11 +189,11 @@ class Subset(object):
 
             if len(cid1) == 1 and len(cid2) == 1:
 
-                key_left = self.data[cid1[0], view].ravel()
-                key_right = other[cid2[0], mask_right].ravel()
-                mask = np.in1d(key_left, key_right)
+                key_left = self.data[cid1[0], view]
+                key_right = other[cid2[0], mask_right]
+                mask = np.in1d(key_left.ravel(), key_right.ravel())
 
-                return mask.reshape(self.data[cid1[0], view].shape)
+                return mask.reshape(key_left.shape)
 
             elif len(cid1) == len(cid2):
 

--- a/glue/core/subset.py
+++ b/glue/core/subset.py
@@ -238,7 +238,9 @@ class Subset(object):
 
             else:
 
-                raise Exception("Either the number of components in the key join should match, or one of them should be a scalar")
+                raise Exception("Either the number of components in the key join sets "
+                                "should match, or one of the component sets should ",
+                                "contain a single component.")
 
         raise IncompatibleAttribute
 


### PR DESCRIPTION
I realized today that we can solve the linking case described in https://github.com/glue-viz/glue/issues/958 by extending ``join_on_key`` to support linking on pairs, triplets, and n-tuples of components rather than just single components. The current PR implements a very rough (and very slow) version of that, just to test the concept. If things work well, then I can work on a way to make the calculation of the masks much faster. Here's an example in use:

We have a position-position-velocity cube and a second moment map (on the same celestial pixel scale).

```python
from glue.core import DataCollection, Data
from glue.app.qt.application import GlueApplication
from glue.core.data_factories import load_data
from glue.viewers.image.qt.viewer_widget import ImageWidget
from glue.viewers.histogram.qt.viewer_widget import HistogramWidget

data_linewidth = load_data('linewidth.fits')
data_cube = load_data('ppv_cube.fits')

dc = DataCollection([data_linewidth, data_cube])

# We can now link on pairs of components
data_linewidth.join_on_key(data_cube, ('Pixel x', 'Pixel y'), ('Pixel Axis 2', 'Pixel Axis 1'))

ga = GlueApplication(dc)

image = ga.new_data_viewer(ImageWidget)
image.add_data(data_cube)

histogram = ga.new_data_viewer(HistogramWidget)
histogram.add_data(data_linewidth)

ga.exec_()
```

Selecting in the linewidth histogram will now highlight pixels in the image.

Note that the fact the pixel axes have different naming conventions needs to be fixed (see https://github.com/glue-viz/glue/issues/959)

@ChrisBeaumont - do you have any thoughts on this approach so far?