### PR TITLE
Preventively avoid any issues with combo box contents causing layout to change

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,9 @@ v0.8 (unreleased)
 v0.7.3 (unreleased)
 -------------------
 
+* Make sure that no combo boxes get resized based on the content (unless
+  strictly needed).
+
 * Fix a bug that caused the merge window to appear multiple times, make sure
   that all components named PRIMARY get renamed after merging, and make sure
   that the merge mechanism is also triggered when opening datasets from the

--- a/glue/dialogs/common/qt/component_selector.ui
+++ b/glue/dialogs/common/qt/component_selector.ui
@@ -36,7 +36,11 @@
       </widget>
      </item>
      <item>
-      <widget class="QComboBox" name="data_selector"/>
+      <widget class="QComboBox" name="data_selector">
+       <property name="sizeAdjustPolicy">
+        <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+       </property>
+      </widget>
      </item>
      <item>
       <widget class="QLabel" name="label_2">

--- a/glue/dialogs/link_editor/qt/link_equation.ui
+++ b/glue/dialogs/link_editor/qt/link_equation.ui
@@ -50,6 +50,9 @@
        <property name="toolTip">
         <string>Select a translation function to use</string>
        </property>
+       <property name="sizeAdjustPolicy">
+        <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+       </property>
       </widget>
      </item>
      <item>

--- a/glue/dialogs/subset_facet/qt/subset_facet.ui
+++ b/glue/dialogs/subset_facet/qt/subset_facet.ui
@@ -112,7 +112,11 @@
       </widget>
      </item>
      <item>
-      <widget class="QComboBox" name="color_scale"/>
+      <widget class="QComboBox" name="color_scale">
+       <property name="sizeAdjustPolicy">
+        <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>

--- a/glue/plugins/dendro_viewer/qt/options_widget.ui
+++ b/glue/plugins/dendro_viewer/qt/options_widget.ui
@@ -35,7 +35,11 @@
         </widget>
        </item>
        <item>
-        <widget class="QComboBox" name="heightCombo"/>
+        <widget class="QComboBox" name="heightCombo">
+         <property name="sizeAdjustPolicy">
+          <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+         </property>
+        </widget>
        </item>
       </layout>
      </item>
@@ -52,7 +56,11 @@
         </widget>
        </item>
        <item>
-        <widget class="QComboBox" name="parentCombo"/>
+        <widget class="QComboBox" name="parentCombo">
+         <property name="sizeAdjustPolicy">
+          <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+         </property>
+        </widget>
        </item>
       </layout>
      </item>
@@ -69,7 +77,11 @@
         </widget>
        </item>
        <item>
-        <widget class="QComboBox" name="orderCombo"/>
+        <widget class="QComboBox" name="orderCombo">
+         <property name="sizeAdjustPolicy">
+          <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+         </property>
+        </widget>
        </item>
       </layout>
      </item>

--- a/glue/plugins/tools/spectrum_tool/qt/spectrum_fit_panel.ui
+++ b/glue/plugins/tools/spectrum_tool/qt/spectrum_fit_panel.ui
@@ -60,6 +60,9 @@
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
+         <property name="sizeAdjustPolicy">
+          <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+         </property>
         </widget>
        </item>
       </layout>
@@ -95,6 +98,9 @@
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
+         </property>
+         <property name="sizeAdjustPolicy">
+          <enum>QComboBox::AdjustToMinimumContentsLength</enum>
          </property>
         </widget>
        </item>

--- a/glue/viewers/image/qt/options_widget.ui
+++ b/glue/viewers/image/qt/options_widget.ui
@@ -106,7 +106,11 @@
          </widget>
         </item>
         <item row="2" column="1">
-         <widget class="QComboBox" name="aspectCombo"/>
+         <widget class="QComboBox" name="aspectCombo">
+          <property name="sizeAdjustPolicy">
+           <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+          </property>
+         </widget>
         </item>
        </layout>
       </item>


### PR DESCRIPTION
Counterpart to https://github.com/glue-viz/glue-3d-viewer/pull/135 in the 3D viewer, where the changes were definitely needed (in many combo boxes, the correct options were already set in the core glue package)