### PR TITLE
Fix D3PO and Plotly export in Python 3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,10 @@ v0.8 (unreleased)
   functions by default, and expressions are tested on-the-fly to check that
   there are no issues with syntax or undefined variables. [#956]
 
+* Fixed D3PO export when using Python 3. [#989]
+
+* Fixed display of certain error messages when using Python 3. [#989]
+
 v0.7.3 (2015-05-04)
 -------------------
 

--- a/glue/plugins/export_d3po.py
+++ b/glue/plugins/export_d3po.py
@@ -136,7 +136,7 @@ def can_save_d3po(application):
 
     for tab in application.viewers:
         for viewer in tab:
-            if not isinstance(viewer, DISPATCH.keys()):
+            if not isinstance(viewer, tuple(DISPATCH.keys())):
                 raise ValueError("D3PO Export only supports scatter "
                                  "and histogram plots")
     if sum(len(tab) for tab in application.viewers) == 0:
@@ -219,8 +219,8 @@ def launch(path):
 
     :param path: The TLD of the bundle
     """
-    from SocketServer import TCPServer
-    from SimpleHTTPServer import SimpleHTTPRequestHandler
+    from glue.external.six.moves.socketserver import TCPServer
+    from glue.external.six.moves.SimpleHTTPServer import SimpleHTTPRequestHandler
     from random import randrange
     from socket import error
     import webbrowser

--- a/glue/utils/qt/decorators.py
+++ b/glue/utils/qt/decorators.py
@@ -37,7 +37,7 @@ def messagebox_on_error(msg):
             try:
                 return func(*args, **kwargs)
             except Exception as e:
-                m = "%s\n%s" % (msg, e.message)
+                m = "%s\n%s" % (msg, e.args[0])
                 detail = str(traceback.format_exc())
                 qmb = QMessageBox(QMessageBox.Critical, "Error", m)
                 qmb.setDetailedText(detail)


### PR DESCRIPTION
Without these changes, D3PO and Plotly were not able to raise proper error messages in the GUI, and D3PO export was broken.