### PR TITLE
fix the d3po isinstance error

### DIFF
--- a/glue/plugins/export_d3po.py
+++ b/glue/plugins/export_d3po.py
@@ -136,7 +136,7 @@ def can_save_d3po(application):
 
     for tab in application.viewers:
         for viewer in tab:
-            if not isinstance(viewer, DISPATCH.keys()):
+            if not isinstance(viewer, (ScatterWidget, HistogramWidget)):
                 raise ValueError("D3PO Export only supports scatter "
                                  "and histogram plots")
     if sum(len(tab) for tab in application.viewers) == 0:
@@ -303,8 +303,8 @@ initialize('states.json', 'data.csv');
 """
 
 try:
-    from glue.viewers.scatter.qt import ScatterWidget
-    from glue.viewers.histogram.qt import HistogramWidget
+    from glue.viewers.scatter.qt.viewer_widget import ScatterWidget
+    from glue.viewers.histogram.qt.viewer_widget import HistogramWidget
 except ImportError:
     pass
 else:

--- a/glue/plugins/export_plotly.py
+++ b/glue/plugins/export_plotly.py
@@ -312,8 +312,8 @@ def setup():
 DISPATCH = {}
 
 try:
-    from glue.viewers.scatter.qt import ScatterWidget
-    from glue.viewers.histogram.qt import HistogramWidget
+    from glue.viewers.scatter.qt.viewer_widget import ScatterWidget
+    from glue.viewers.histogram.qt.viewer_widget import HistogramWidget
 except ImportError:
     pass
 else:


### PR DESCRIPTION
I fixed the isinstance `TypeError` when export scatter/histogram into d3po format, while got another error looks like related to astropy write file, could you help to have a look @astrofrog :)

```
Traceback (most recent call last):
  File "/Users/penny/Works/Gluedev/glue/glue/glue/utils/qt/decorators.py", line 38, in wrapper
    return func(*args, **kwargs)
  File "/Users/penny/Works/Gluedev/glue/glue/glue/app/qt/application.py", line 725, in _choose_export_session
    return saver(self, outfile)
  File "/Users/penny/Works/Gluedev/glue/glue/glue/plugins/export_d3po.py", line 193, in save_d3po
    make_data_file(data, subsets, path)
  File "/Users/penny/Works/Gluedev/glue/glue/glue/plugins/export_d3po.py", line 168, in make_data_file
    t.write(data_path, format='ascii', delimiter=',')
  File "/Users/penny/anaconda/lib/python2.7/site-packages/astropy/table/table.py", line 2278, in write
    io_registry.write(self, *args, **kwargs)
  File "/Users/penny/anaconda/lib/python2.7/site-packages/astropy/io/registry.py", line 396, in write
    writer(data, *args, **kwargs)
  File "/Users/penny/anaconda/lib/python2.7/site-packages/astropy/io/ascii/connect.py", line 29, in write_asciitable
    return write(table, filename, **kwargs)
  File "/Users/penny/anaconda/lib/python2.7/site-packages/astropy/io/ascii/ui.py", line 675, in write
    writer.write(table, output)
  File "/Users/penny/anaconda/lib/python2.7/site-packages/astropy/io/ascii/fastbasic.py", line 135, in write
    self._write(table, output, {})
  File "/Users/penny/anaconda/lib/python2.7/site-packages/astropy/io/ascii/fastbasic.py", line 149, in _write
    writer.write(output, header_output, output_types)
  File "astropy/io/ascii/cparser.pyx", line 996, in astropy.io.ascii.cparser.FastWriter.write (astropy/io/ascii/cparser.c:18623)
TypeError: unhashable type: 'list'
```