### PR TITLE
Add new ``add_data`` function to application instances

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ Full changelog
 v0.8 (unreleased)
 -----------------
 
+* Add a new method ``add_data`` to application instances. This allows for
+  example additional data to be passed to glue after being launched by
+  ``qglue``. [#993]
+
 * Add playback controls to slice widget. [#971]
 
 * Add tooltip for data labels so that long labels can be more easily

--- a/glue/core/application_base.py
+++ b/glue/core/application_base.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import traceback
-from functools import wraps, partial
+from functools import wraps
 
 from glue.core.session import Session
 from glue.core.edit_subset_mode import EditSubsetMode
@@ -152,6 +152,33 @@ class Application(HubListener):
     def load_data(self, path):
         d = load_data(path)
         self.add_datasets(self.data_collection, d)
+
+    @catch_error("Could not add data")
+    def add_data(self, *args, **kwargs):
+        """
+        Add data to the session.
+
+        Positional arguments are interpreted using the data factories, while
+        keyword arguments are interpreted using the same infrastructure as the
+        `qglue` command.
+        """
+
+        datasets = []
+
+        for path in args:
+            datasets.append(load_data(path))
+
+        links = kwargs.pop('links', None)
+
+        from glue.qglue import parse_data, parse_links
+
+        for label, data in kwargs.items():
+            datasets.extend(parse_data(data, label))
+
+        self.add_datasets(self.data_collection, datasets)
+
+        if links is not None:
+            self.data_collection.add_link(parse_links(self.data_collection, links))
 
     def report_error(self, message, detail):
         """ Report an error message to the user.

--- a/glue/qglue.py
+++ b/glue/qglue.py
@@ -133,7 +133,7 @@ except ImportError:
     pass
 
 
-def _parse_links(dc, links):
+def parse_links(dc, links):
     from glue.core.link_helpers import MultiLink
     from glue.core import ComponentLink
 
@@ -222,7 +222,7 @@ def qglue(**kwargs):
         dc.extend(parse_data(data, label))
 
     if links is not None:
-        dc.add_link(_parse_links(dc, links))
+        dc.add_link(parse_links(dc, links))
 
     with restore_io():
         ga = GlueApplication(dc)


### PR DESCRIPTION
This will make it easier to add data to a glue session from IPython/Jupyter

In the long term, we can deprecate the more limited ``load_data``

Closes https://github.com/glue-viz/glue/issues/629