### PR TITLE
More flexible spectra selection

### DIFF
--- a/glue/plugins/tools/spectrum_tool/qt/spectrum_tool.py
+++ b/glue/plugins/tools/spectrum_tool/qt/spectrum_tool.py
@@ -24,6 +24,8 @@ from glue.app.qt.mdi_area import GlueMdiSubWindow
 from glue.viewers.common.qt.mpl_widget import MplWidget
 from glue.utils import nonpartial, Pointer
 from glue.utils.qt import Worker, messagebox_on_error
+from glue.core import roi as core_roi
+from matplotlib.path import Path
 
 from .profile_viewer import ProfileViewer
 
@@ -46,35 +48,62 @@ class Extractor(object):
         yaxis = slc.index('y')
         ndim, nz = data.ndim, data.shape[zaxis]
 
-        l, r, b, t = roi.xmin, roi.xmax, roi.ymin, roi.ymax
-        shp = data.shape
-        # The 'or 0' is because Numpy in Python 3 cannot deal with 'None'
-        l, r = np.clip([l or 0, r or 0], 0, shp[xaxis])
-        b, t = np.clip([b or 0, t or 0], 0, shp[yaxis])
+        if isinstance(roi, core_roi.RectangularROI):
+            l, r, b, t = roi.xmin, roi.xmax, roi.ymin, roi.ymax
+            shp = data.shape
+            # The 'or 0' is because Numpy in Python 3 cannot deal with 'None'
+            l, r = np.clip([l or 0, r or 0], 0, shp[xaxis])
+            b, t = np.clip([b or 0, t or 0], 0, shp[yaxis])
 
-        # extract sub-slice, without changing dimension
-        slc = [slice(s, s + 1)
-               if s not in ['x', 'y'] else slice(None)
-               for s in slc]
-        slc[xaxis] = slice(l, r)
-        slc[yaxis] = slice(b, t)
-        slc[zaxis] = slice(None)
-        x = Extractor.abcissa(data, zaxis)
+            # extract sub-slice, without changing dimension
+            slc = [slice(s, s + 1)
+                   if s not in ['x', 'y'] else slice(None)
+                   for s in slc]
+            slc[xaxis] = slice(l, r)
+            slc[yaxis] = slice(b, t)
+            slc[zaxis] = slice(None)
+            x = Extractor.abcissa(data, zaxis)
 
-        data = data[attribute, tuple(slc)]
-        finite = np.isfinite(data)
+            data = data[attribute, tuple(slc)]   # attribute is Primary,
+            finite = np.isfinite(data)
 
-        assert data.ndim == ndim
+            assert data.ndim == ndim
 
-        for i in reversed(list(range(ndim))):
-            if i != zaxis:
-                data = np.nansum(data, axis=i)
-                finite = finite.sum(axis=i)
+            for i in reversed(list(range(ndim))):
+                if i != zaxis:  # index of the zaxis in dataset
+                    data = np.nansum(data, axis=i)
+                    finite = finite.sum(axis=i)
 
-        assert data.ndim == 1
-        assert data.size == nz
+            assert data.ndim == 1
+            assert data.size == nz
 
-        data = (1. * data / finite).ravel()
+            data = (1. * data / finite).ravel()
+
+        if isinstance(roi, core_roi.PolygonalROI):
+            # both circular and polygonal selection will call here
+            x = Extractor.abcissa(data, zaxis)
+            data = data[attribute]
+
+            slice_shape = []
+            for i in range(ndim):
+                if i != zaxis:
+                    slice_shape.append(data.shape[i])
+            slice_data = np.ones(slice_shape)
+            posdata = np.argwhere(slice_data)
+
+            # mask for each slice
+            mask = roi.contains(posdata[:, 0], posdata[:, 1])
+
+            return_data = []
+            for i in range(nz):
+                select_data = np.take(data, i, axis=zaxis).ravel()[mask]
+                finite = np.isfinite(select_data).sum()
+                return_data.append(1.*np.nansum(select_data)/finite)
+
+            data = np.array(return_data)
+            assert data.ndim == 1
+            assert data.size == nz
+
         return x, data
 
     @staticmethod

--- a/glue/viewers/common/qt/mouse_mode.py
+++ b/glue/viewers/common/qt/mouse_mode.py
@@ -592,9 +592,53 @@ class SpectrumExtractorMode(RoiMode):
         self.mode_id = 'Spectrum'
         self.action_text = 'Spectrum'
         self.tool_tip = 'Extract a spectrum from the selection'
-        self._roi_tool = qt_roi.QtRectangularROI(self._axes)
+
+        self._roi_tool = qt_roi.QtRectangularROI(self._axes) # default
+        self.shortcut = 'S'
+
+    def menu_actions(self):
+        result = []
+
+        a = QtGui.QAction('Rectangle', None)
+        a.triggered.connect(nonpartial(self.set_roi_tool, 'Rectangle'))
+        result.append(a)
+
+        a = QtGui.QAction('Circle', None)
+        a.triggered.connect(nonpartial(self.set_roi_tool, 'Circle'))
+        result.append(a)
+
+        a = QtGui.QAction('Polygon', None)
+        a.triggered.connect(nonpartial(self.set_roi_tool, 'Polygon'))
+        result.append(a)
+
+        for r in result:
+            if self._move_callback is not None:
+                r.triggered.connect(nonpartial(self._move_callback, self))
+
+        return result
+
+    def set_roi_tool(self, mode):
+        if mode is 'Rectangle':
+            self._roi_tool = qt_roi.QtRectangularROI(self._axes)
+
+        if mode is 'Circle':
+            self._roi_tool = qt_roi.QtCircularROI(self._axes)
+
+        if mode is 'Polygon':
+            self._roi_tool = qt_roi.QtPolygonalROI(self._axes)
+
         self._roi_tool.plot_opts.update(edgecolor='#c51b7d',
                                         facecolor=None,
                                         edgewidth=3,
                                         alpha=1.0)
-        self.shortcut = 'S'
+    # TODO: cheange the spectrum extractor solution
+    '''
+    File "/Users/penny/Works/Gluedev/glue/glue/glue/plugins/tools/spectrum_tool/qt/spectrum_tool.py", line 826, in _update_from_roi
+    x, y = Extractor.spectrum(data, att, roi, slc, zax)
+    File "/Users/penny/Works/Gluedev/glue/glue/glue/plugins/tools/spectrum_tool/qt/spectrum_tool.py", line 49, in spectrum
+    l, r, b, t = roi.xmin, roi.xmax, roi.ymin, roi.ymax
+    AttributeError: 'PolygonalROI' object has no attribute 'xmin'
+    '''
+
+
+


### PR DESCRIPTION
I am trying to implement more selection solutions for the spectrum extractor tool as shown below:

![image](https://cloud.githubusercontent.com/assets/13411839/15407748/84f6870e-1dda-11e6-87e4-e00bd290528b.png)

Now the drawing of different selection shapes works well, but there is a strange error that when I use `CircularROI` for the selection, the real ROI instance is `Polygonal ROI`, so the `if isinstance(roi, core_roi.CircularROI)` statement doesn't work, do you know how to solve this issue? @astrofrog Thanks a lot!
 