### PR TITLE
Small tweaks to how settings are read/written to disk

### DIFF
--- a/glue/_settings_helpers.py
+++ b/glue/_settings_helpers.py
@@ -13,10 +13,10 @@ def save_settings():
     settings_cfg = os.path.join(CFG_DIR, 'settings.cfg')
 
     config = configparser.ConfigParser()
-    config.add_section('settings')
+    config.add_section('main')
 
     for name, value, _ in sorted(settings):
-        config.set('settings', name, value=json.dumps(value))
+        config.set('main', name, value=json.dumps(value))
 
     if not os.path.exists(CFG_DIR):
         os.mkdir(CFG_DIR)
@@ -25,20 +25,31 @@ def save_settings():
         config.write(fout)
 
 
-def load_settings():
+def load_settings(force=False):
+    """
+    Load the settings from disk.
+
+    By default, only settings not already defined in memory are read in, but
+    by setting ``force=True``, all settings will be read in.
+    """
 
     from glue.config import settings, CFG_DIR
     settings_cfg = os.path.join(CFG_DIR, 'settings.cfg')
 
+    logger.info("Loading settings from {0}".format(settings_cfg))
+
     config = configparser.ConfigParser()
     read = config.read(settings_cfg)
 
-    if len(read) == 0 or not config.has_section('settings'):
+    if len(read) == 0 or not config.has_section('main'):
         return
 
-    for name, value in config.items('settings'):
+    for name, value in config.items('main'):
         name = name.upper()
-        if hasattr(settings, name):
-            setattr(settings, name, json.loads(value))
+        if name in settings:
+            if settings.is_default(name) or force:
+                setattr(settings, name, json.loads(value))
+            elif not settings.is_default(name):
+                logger.info("Setting {0} already initialized - skipping".format(name))
         else:
             logger.info("Unknown setting {0} - skipping".format(name))

--- a/glue/main.py
+++ b/glue/main.py
@@ -298,5 +298,11 @@ def load_plugins():
     except Exception as e:
         logger.warn("Failed to load plugin configuration")
 
+    # Reload the settings now that we have loaded plugins, since some plugins
+    # may have added some settings. Note that this will not re-read settings
+    # that were previously read.
+    from glue._settings_helpers import load_settings
+    load_settings()
+
 if __name__ == "__main__":
     sys.exit(main(sys.argv))  # prama: no cover

--- a/glue/tests/test_settings_helpers.py
+++ b/glue/tests/test_settings_helpers.py
@@ -9,6 +9,7 @@ from glue._settings_helpers import load_settings, save_settings
 def test_roundtrip(tmpdir):
 
     settings = SettingRegistry()
+
     settings.add('STRING', 'green', str)
     settings.add('INT', 3, int)
     settings.add('FLOAT', 5.5, float)
@@ -22,15 +23,37 @@ def test_roundtrip(tmpdir):
             settings.FLOAT = 3.5
             settings.LIST = ['A', 'BB', 'CCC']
 
+            settings.reset_defaults()
+
+            assert settings.STRING == 'green'
+            assert settings.INT == 3
+            assert settings.FLOAT == 5.5
+            assert settings.LIST == [1, 2, 3]
+
+            settings.STRING = 'blue'
+            settings.INT = 4
+            settings.FLOAT = 3.5
+            settings.LIST = ['A', 'BB', 'CCC']
+
             save_settings()
 
             assert os.path.exists(os.path.join(tmpdir.strpath, 'settings.cfg'))
 
-            settings.STRING = 'red'
-            settings.INT = 3
-            settings.FLOAT = 4.5
-            settings.LIST = ['DDD', 'EE', 'F']
+            settings.reset_defaults()
 
+            settings.STRING = 'red'
+            settings.INT = 5
+
+            # Loading settings will only change settings that have not been 
+            # changed from the defaults...
+            load_settings()
+
+            assert settings.STRING == 'red'
+            assert settings.INT == 5
+            assert settings.FLOAT == 3.5
+            assert settings.LIST == ['A', 'BB', 'CCC']
+
+            # ... unless the ``force=True`` option is passed
             load_settings(force=True)
 
             assert settings.STRING == 'blue'

--- a/glue/tests/test_settings_helpers.py
+++ b/glue/tests/test_settings_helpers.py
@@ -31,7 +31,7 @@ def test_roundtrip(tmpdir):
             settings.FLOAT = 4.5
             settings.LIST = ['DDD', 'EE', 'F']
 
-            load_settings()
+            load_settings(force=True)
 
             assert settings.STRING == 'blue'
             assert settings.INT == 4


### PR DESCRIPTION
Now the settings are read again once plugins have been read - but only settings that weren’t read in a previous step. Settings now have the concept of defaults, and it is possible to restore all settings to a default state.