### PR TITLE
Fixed a bug that caused add_datasets to crash

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,10 @@ v0.8.1 (unreleased)
 * Explicitly set the icon size for the slicing playback controls to avoid
   issues when using a mix of retina and non-retina displays. [#1005]
 
+* Fixed a bug that caused add_datasets to crash if ``datasets`` was a list of
+  lists of data, which is possible if a data factory returns more than one data
+  object. [#1006]
+
 v0.8 (2016-05-23)
 -----------------
 

--- a/glue/core/application_base.py
+++ b/glue/core/application_base.py
@@ -32,6 +32,16 @@ def catch_error(msg):
     return decorator
 
 
+def as_flat_data_list(data):
+    datasets = []
+    if isinstance(data, Data):
+        datasets.append(data)
+    else:
+        for d in data:
+            datasets.extend(as_flat_data_list(d))
+    return datasets
+
+
 class Application(HubListener):
 
     def __init__(self, data_collection=None, session=None):
@@ -225,7 +235,7 @@ class Application(HubListener):
         Adds datasets to the collection
         """
 
-        datasets = as_list(datasets)
+        datasets = as_flat_data_list(datasets)
         data_collection.extend(datasets)
 
         # We now check whether any of the datasets can be merged. We need to

--- a/glue/core/tests/test_application_base.py
+++ b/glue/core/tests/test_application_base.py
@@ -83,3 +83,31 @@ def test_set_data_color():
 
     assert y.style.color == 'red'
     assert y.style.alpha == 0.3
+
+
+def test_nested_data():
+
+    # Regression test that caused add_datasets to crash if datasets included
+    # lists of lists of data, which is possible if a data factory returns more
+    # than one data object.
+
+    x = Data(x=[1, 2])
+    y = Data(x=[1, 2, 3])
+    z = Data(y=[1, 2, 3, 4])
+    a = Data(y=[1, 2, 3, 4, 5])
+    b = Data(y=[1, 2, 3, 4, 5, 6])
+    c = Data(y=[1, 2, 3, 4, 5, 6, 7])
+
+    datasets = [x, [[[y, z]], a], [[[[b, c]]]]]
+
+
+    app = Application()
+
+    app.add_datasets(app.data_collection, datasets)
+
+    assert x in app.data_collection
+    assert y in app.data_collection
+    assert z in app.data_collection
+    assert a in app.data_collection
+    assert b in app.data_collection
+    assert c in app.data_collection


### PR DESCRIPTION
This happened if ``datasets`` was a list of lists of data, which is possible if a data factory returns more than one data object.