### PR TITLE
On Windows, drag and drop file onto Glue app raises error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,9 @@ v0.8.2 (unreleased)
 * Make sure histograms are updated if only the attribute changes and the
   limits and number of bins stay the same. [#1012]
 
+* Fix a bug on Windows that caused drag and dropping files onto the glue
+  application to not work. [#1007]
+
 v0.8.1 (2016-05-25)
 -------------------
 

--- a/glue/app/qt/application.py
+++ b/glue/app/qt/application.py
@@ -884,9 +884,21 @@ class GlueApplication(Application, QtGui.QMainWindow):
             event.ignore()
 
     def dropEvent(self, event):
+
         urls = event.mimeData().urls()
+
         for url in urls:
-            self.load_data(url.path())
+
+            # Get path to file
+            path = url.path()
+
+            # Workaround for a Qt bug that causes paths to start with a /
+            # on Windows: https://bugreports.qt.io/browse/QTBUG-46417
+            if sys.platform.startswith('win'):
+                if path.startswith('/') and path[2] == ':':
+                    path = path[1:]
+
+            self.load_data(path)
         event.accept()
 
     def report_error(self, message, detail):


### PR DESCRIPTION
It seems to add forward slashes into path?