### PR TITLE
Fix bug in ComponentIDComboHelper

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,9 @@ v0.8.2 (unreleased)
 
 * Fix compatibility with PyQt5. [#1015]
 
+* Fix a bug that caused ComponentIDComboHelper to not take into account the
+  numeric and categorical options in __init__. [#1014]
+
 v0.8.1 (2016-05-25)
 -------------------
 

--- a/glue/core/qt/data_combo_helper.py
+++ b/glue/core/qt/data_combo_helper.py
@@ -47,8 +47,8 @@ class ComponentIDComboHelper(HubListener):
             raise ValueError("Hub on data collection is not set")
 
         self._visible = visible
-        self._numeric = True
-        self._categorical = True
+        self._numeric = numeric
+        self._categorical = categorical
         self._component_id_combo = component_id_combo
         self._data = []
         self._data_collection = data_collection

--- a/glue/core/qt/tests/test_data_combo_helper.py
+++ b/glue/core/qt/tests/test_data_combo_helper.py
@@ -63,6 +63,34 @@ def test_component_id_combo_helper():
 
     assert _items_as_string(combo) == ""
 
+def test_component_id_combo_helper_init():
+
+    # Regression test to make sure that the numeric and categorical options
+    # in the __init__ are taken into account properly
+
+    combo = QtGui.QComboBox()
+
+    dc = DataCollection([])
+
+    data = Data(a=[1,2,3], b=['a','b','c'], label='data2')
+    dc.append(data)
+
+    helper = ComponentIDComboHelper(combo, dc)
+    helper.append(data)
+    assert _items_as_string(combo) == "a:b"
+
+    helper = ComponentIDComboHelper(combo, dc, numeric=False)
+    helper.append(data)
+    assert _items_as_string(combo) == "b"
+
+    helper = ComponentIDComboHelper(combo, dc, categorical=False)
+    helper.append(data)
+    assert _items_as_string(combo) == "a"
+
+    helper = ComponentIDComboHelper(combo, dc, numeric=False, categorical=False)
+    helper.append(data)
+    assert _items_as_string(combo) == ""
+
 
 def test_manual_data_combo_helper():
 


### PR DESCRIPTION
The numeric and categorical options were ignored in ``__init__``.

This needs a changelog entry and regression test.