### PR TITLE
Possible Bug: Multiple Custom Viewers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,10 @@ v0.9.0 (unreleased)
 v0.8.2 (unreleased)
 -------------------
 
+* Fix a bug that caused multiple custom viewer classes to not work properly
+  if the user did not override ``_custom_functions`` (which was private).
+  [#810]
+
 * Make sure histograms are updated if only the attribute changes and the
   limits and number of bins stay the same. [#1012]
 

--- a/glue/viewers/custom/qt/custom_viewer.py
+++ b/glue/viewers/custom/qt/custom_viewer.py
@@ -357,6 +357,7 @@ class CustomViewerMeta(type):
                 udfs[nm] = attrs.pop(nm)
 
         result = type.__new__(cls, name, bases, attrs)
+        result._custom_functions = {}
 
         # now wrap the custom UDFs using the descriptors
         for k, v in udfs.items():
@@ -528,8 +529,8 @@ class CustomViewer(object):
     # hold user descriptions of desired FormElements to create
     ui = {}
 
-    # map, e.g., 'plot_data' -> user defined function
-    # subclasses must override this dict!
+    # map, e.g., 'plot_data' -> user defined function - we also make sure we
+    # override this in sub-classes in CustomViewerMeta
     _custom_functions = {}
 
     def __init__(self, widget_instance):

--- a/glue/viewers/custom/qt/tests/test_custom_viewer.py
+++ b/glue/viewers/custom/qt/tests/test_custom_viewer.py
@@ -436,4 +436,29 @@ class TestSettingsOracle(object):
     def test_raises_if_overlapping_reserved_words(self):
 
         with pytest.raises(AssertionError):
-            oracle = SettingsOracle({'self': TextBoxElement('_text')})
+            SettingsOracle({'self': TextBoxElement('_text')})
+
+
+def test_two_custom_viewer_classes():
+
+    class MyWidget1(CustomViewer):
+
+        text_box1_Widget1 = '_Hello'
+
+        def setup(self, text_box1_Widget1):
+            pass
+
+    class MyWidget2(CustomViewer):
+
+        text_box1_Widget2 = '_Hello'
+        text_box2_Widget2 = '_world'
+
+        def setup(self, text_box1_Widget2, text_box2_Widget2):
+            pass
+
+    app = GlueApplication()
+    dc = app.data_collection
+    d = Data(x=[1, 2, 3], label='test')
+    dc.append(d)
+    app.new_data_viewer(MyWidget1._widget_cls)
+    app.new_data_viewer(MyWidget2._widget_cls)


### PR DESCRIPTION
Hello All,



Recently written a couple of custom viewers that work well on their own but fall over when imported in the same config. I have boiled it down to the simple setup that produces the errors. The two custom viewers below are fine on their own but cause errors when imported together.

config file:
```python

import widget1,widget2
```

widget1:
```python

from glue.qt.custom_viewer import CustomViewer
class MyWidget1(CustomViewer):  
    text_box1_Widget1 = '_Hello'
    
    def setup(self,text_box1_Widget1):
        print('MyWidget1')
        print('text_box1_Widget1: '+text_box1_Widget1)
```

widget2:

```python
from glue.qt.custom_viewer import CustomViewer
class MyWidget2(CustomViewer):    
    text_box1_Widget2 = '_Hello'
    text_box2_Widget2 = '_world'
    
    def setup(self,text_box1_Widget2,text_box2):
        print('MyWidget2')
        print('text_box1_Widget2: '+text_box1_Widget2)
        print('text_box2_Widget2: '+text_box2_Widget2)
```

They produce the following when a widget is added to the glueviz screen:

```
Traceback (most recent call last):
  File "C:\Users\ckennedy\AppData\Local\Continuum\Anaconda3\lib\site-packages\glue\qt\custom_viewer.py", line 249, in introspect_and_call
    a = [settings(item) for item in a]
  File "C:\Users\ckennedy\AppData\Local\Continuum\Anaconda3\lib\site-packages\glue\qt\custom_viewer.py", line 249, in <listcomp>
    a = [settings(item) for item in a]
  File "C:\Users\ckennedy\AppData\Local\Continuum\Anaconda3\lib\site-packages\glue\qt\custom_viewer.py", line 303, in __call__
    raise MissingSettingError(key)
glue.qt.custom_viewer.MissingSettingError: 'text_box1_Widget2'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Users\ckennedy\AppData\Local\Continuum\Anaconda3\lib\site-packages\glue\qt\widgets\glue_mdi_area.py", line 70, in mousePressEvent
    self._application.choose_new_data_viewer()
  File "C:\Users\ckennedy\AppData\Local\Continuum\Anaconda3\lib\site-packages\glue\qt\glue_application.py", line 684, in choose_new_data_viewer
    return self.do(cmd)
  File "C:\Users\ckennedy\AppData\Local\Continuum\Anaconda3\lib\site-packages\glue\core\application_base.py", line 169, in do
    self._cmds.do(command)
  File "C:\Users\ckennedy\AppData\Local\Continuum\Anaconda3\lib\site-packages\glue\core\command.py", line 125, in do
    result = cmd.do(self._session)
  File "C:\Users\ckennedy\AppData\Local\Continuum\Anaconda3\lib\site-packages\glue\core\command.py", line 215, in do
    v = session.application.new_data_viewer(self.viewer, self.data)
  File "C:\Users\ckennedy\AppData\Local\Continuum\Anaconda3\lib\site-packages\glue\qt\widgets\mpl_widget.py", line 38, in wrapper
    result = func(*args, **kwargs)
  File "C:\Users\ckennedy\AppData\Local\Continuum\Anaconda3\lib\site-packages\glue\core\application_base.py", line 72, in new_data_viewer
    c = viewer_class(self._session)
  File "C:\Users\ckennedy\AppData\Local\Continuum\Anaconda3\lib\site-packages\glue\qt\custom_viewer.py", line 880, in __init__
    coordinator=self._coordinator)
  File "C:\Users\ckennedy\AppData\Local\Continuum\Anaconda3\lib\site-packages\glue\qt\custom_viewer.py", line 837, in __init__
    self._coordinator.setup()
  File "C:\Users\ckennedy\AppData\Local\Continuum\Anaconda3\lib\site-packages\glue\qt\custom_viewer.py", line 769, in _call_udf
    result = introspect_and_call(func, settings)
  File "C:\Users\ckennedy\AppData\Local\Continuum\Anaconda3\lib\site-packages\glue\qt\custom_viewer.py", line 258, in introspect_and_call
    (missing, setting_list))
glue.qt.custom_viewer.MissingSettingError: 'This custom viewer is trying to use an unrecognized variable named text_box1_Widget2\n. Valid variable names are\n -layer\n -text_box1_Widget1\n -style'
```


 


There seems to be a conflict in the calls to 'setup'. 




Thanks,

Chris