### PR TITLE
saving scatter plots as svg

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,8 @@ v0.8.2 (unreleased)
 * Fix a bug that caused ComponentIDComboHelper to not take into account the
   numeric and categorical options in __init__. [#1014]
 
+* Fix a bug that caused saving of scatter plots to SVG files to crash. [#984]
+
 v0.8.1 (2016-05-25)
 -------------------
 

--- a/glue/external/axescache.py
+++ b/glue/external/axescache.py
@@ -135,7 +135,8 @@ class AxesCache(object):
     def draw(self, renderer, *args, **kwargs):
         if self._capture is None or not self._enabled:
             Axes.draw(self.axes, renderer, *args, **kwargs)
-            self._capture = RenderCapture(self.axes, renderer)
+            if hasattr(renderer, 'buffer_rgba'):
+                self._capture = RenderCapture(self.axes, renderer)
         else:
             self.axes.axesPatch.draw(renderer, *args, **kwargs)
             self._capture.draw(renderer, *args, **kwargs)

--- a/glue/viewers/scatter/qt/tests/test_viewer_widget.py
+++ b/glue/viewers/scatter/qt/tests/test_viewer_widget.py
@@ -320,6 +320,12 @@ class TestScatterWidget(object):
         self.widget.remove_layer(l2)
         assert self.widget.windowTitle() == n1
 
+    def test_save_svg(self, tmpdir):
+        # Regression test for a bug in AxesCache that caused SVG saving to
+        # fail (because renderer.buffer_rgba did not exist)
+        filename = tmpdir.join('test.svg').strpath
+        self.widget.client.axes.figure.savefig(filename)
+
 
 class TestDrawCount(TestScatterWidget):
 


### PR DESCRIPTION
I am able to save histograms as .svg but when trying to save scatter plots I get this error:
'MixedModeRenderer' object has no attribute 'buffer_rgba'

any ideas?
Thanks! :)
![screenshot from 2016-05-11 11-55-35](https://cloud.githubusercontent.com/assets/19298675/15169622/c5380516-176f-11e6-8b7c-a99b8b2de47b.png)
