### PR TITLE
Fix slow spectra [improved]

### DIFF
--- a/glue/core/subset.py
+++ b/glue/core/subset.py
@@ -470,12 +470,19 @@ class RoiSubsetState(SubsetState):
             x_slice = x[subset]
             y_slice = y[subset]
 
-            result = self.roi.contains(x_slice, y_slice)
+            if self.roi.defined():
+                result = self.roi.contains(x_slice, y_slice)
+            else:
+                result = np.zeros(x_slice.shape, dtype=bool)
+
             result = np.broadcast_to(result, x.shape)
 
         else:
 
-            result = self.roi.contains(x, y)
+            if self.roi.defined():
+                result = self.roi.contains(x, y)
+            else:
+                result = np.zeros(x.shape, dtype=bool)
 
         if result.shape != x.shape:
             raise ValueError("Unexpected error: boolean mask has incorrect dimensions")

--- a/glue/core/subset.py
+++ b/glue/core/subset.py
@@ -15,7 +15,7 @@ from glue.core.message import SubsetDeleteMessage, SubsetUpdateMessage
 from glue.core.decorators import memoize
 from glue.core.visual import VisualAttributes
 from glue.config import settings
-from glue.utils import view_shape
+from glue.utils import view_shape, broadcast_to
 
 
 __all__ = ['Subset', 'SubsetState', 'RoiSubsetState', 'CategoricalROISubsetState',
@@ -475,7 +475,7 @@ class RoiSubsetState(SubsetState):
             else:
                 result = np.zeros(x_slice.shape, dtype=bool)
 
-            result = np.broadcast_to(result, x.shape)
+            result = broadcast_to(result, x.shape)
 
         else:
 

--- a/glue/core/subset.py
+++ b/glue/core/subset.py
@@ -435,7 +435,6 @@ class RoiSubsetState(SubsetState):
     def attributes(self):
         return (self.xatt, self.yatt)
 
-    @memoize
     @contract(data='isinstance(Data)', view='array_view')
     def to_mask(self, data, view=None):
 
@@ -472,7 +471,7 @@ class RoiSubsetState(SubsetState):
             y_slice = y[subset]
 
             result = self.roi.contains(x_slice, y_slice)
-            result = np.broadcast_to(result, data.shape)
+            result = np.broadcast_to(result, x.shape)
 
         else:
 

--- a/glue/plugins/tools/spectrum_tool/qt/profile_viewer.py
+++ b/glue/plugins/tools/spectrum_tool/qt/profile_viewer.py
@@ -241,6 +241,11 @@ def _build_axes(figure):
     ax2 = figure.add_subplot(122)
     ax1 = figure.add_subplot(121, sharex=ax2)
 
+    ax1.xaxis.get_major_formatter().set_useOffset(False)
+    ax1.yaxis.get_major_formatter().set_useOffset(False)
+    ax2.xaxis.get_major_formatter().set_useOffset(False)
+    ax2.yaxis.get_major_formatter().set_useOffset(False)
+
     return ax1, ax2
 
 

--- a/glue/plugins/tools/spectrum_tool/qt/spectrum_tool.py
+++ b/glue/plugins/tools/spectrum_tool/qt/spectrum_tool.py
@@ -68,49 +68,51 @@ class Extractor(object):
             data = data[attribute, tuple(slc)]   # attribute is Primary,
             finite = np.isfinite(data)
 
-            assert data.ndim == ndim
-
-            for i in reversed(list(range(ndim))):
-                if i != zaxis:  # index of the zaxis in dataset
-                    data = np.nansum(data, axis=i)
-                    finite = finite.sum(axis=i)
-
-            assert data.ndim == 1
-            assert data.size == nz
-
-            data = (1. * data / finite).ravel()
-
         elif isinstance(roi, core_roi.PolygonalROI):
 
             # both circular and polygonal selection will call here
             data = data[attribute]
 
-            slice_shape = []
+            # slice_data_shape is identical with data shape for getting masked data
+            slice_data_shape = []
             for i in range(ndim):
                 if i != zaxis:
-                    slice_shape.append(data.shape[i])
-            slice_data = np.ones(slice_shape)
-            posdata = np.argwhere(slice_data)
+                    slice_data_shape.append(data.shape[i])
 
-            # mask for each slice
-            mask = roi.contains(posdata[:, 0], posdata[:, 1])
+            # slice_roi_shape is relevant with xyz_axis order for defining roi region
+            slice_roi_shape = np.ones(len(slice_data_shape))
+            slice_roi_shape[0] = data.shape[xaxis]
+            slice_roi_shape[1] = data.shape[yaxis]
+            # for 4th dim
+            for j in range(ndim):
+                if j not in [xaxis, yaxis, zaxis]:
+                    slice_roi_shape[2] = data.shape[j]
+            posdata = np.argwhere(np.ones(slice_roi_shape))
 
-            return_data = []
-            for i in range(nz):
-                select_data = np.take(data, i, axis=zaxis).ravel()[mask]
-                finite = np.isfinite(select_data).sum()
-                return_data.append(1. * np.nansum(select_data) / finite)
+            # mask for each slice and expand to all
+            mask = roi.contains(posdata[:, 0], posdata[:, 1]).reshape(slice_data_shape)
+            mask = np.expand_dims(mask, axis=zaxis).repeat(nz, zaxis)
 
-            data = np.array(return_data)
+            # make sure data.ndim == ndim
+            new_shape = np.ones(ndim)
+            new_shape[zaxis] = nz
+            new_shape[xaxis] = -1
+            data = data[mask].reshape(new_shape)  # data[mask].shape is (n, )
+            finite = np.isfinite(data)
 
-            assert data.ndim == 1
-            assert data.size == nz
+        assert data.ndim == ndim
 
-        else:
+        for i in reversed(list(range(ndim))):
+            if i != zaxis:  # index of the zaxis in dataset
+                data = np.nansum(data, axis=i)
+                finite = finite.sum(axis=i)
 
-            raise TypeError("Unexpected ROI type: {0}".format(type(roi)))
+        assert data.ndim == 1
+        assert data.size == nz
 
+        data = (1. * data / finite).ravel()
         return x, data
+
 
     @staticmethod
     def world2pixel(data, axis, value):

--- a/glue/plugins/tools/spectrum_tool/qt/tests/test_spectrum_tool.py
+++ b/glue/plugins/tools/spectrum_tool/qt/tests/test_spectrum_tool.py
@@ -93,9 +93,9 @@ class Test3DExtractor(object):
 
     def test_spectrum(self):
         roi = RectangularROI()
-        roi.update_limits(0, 0, 3, 3)
+        roi.update_limits(0.5, 1.5, 2.5, 2.5)
 
-        expected = self.x[:, :3, :3].mean(axis=1).mean(axis=1)
+        expected = self.x[:, 1:3, 2:3].mean(axis=1).mean(axis=1)
         _, actual = Extractor.spectrum(
             self.data, self.data.id['x'], roi, (0, 'x', 'y'), 0)
         np.testing.assert_array_almost_equal(expected, actual)
@@ -210,7 +210,7 @@ def test_4d_single_channel():
     zaxis = 1
     expected = x[0, :, :, :].mean(axis=1).mean(axis=1)
     roi = RectangularROI()
-    roi.update_limits(0, 0, 10, 10)
+    roi.update_limits(-0.5, -0.5, 10.5, 10.5)
 
     _, actual = Extractor.spectrum(d, d.id['x'], roi, slc, zaxis)
 

--- a/glue/utils/array.py
+++ b/glue/utils/array.py
@@ -7,7 +7,7 @@ from glue.external.six import string_types
 
 
 __all__ = ['unique', 'shape_to_string', 'view_shape', 'stack_view',
-           'coerce_numeric', 'check_sorted']
+           'coerce_numeric', 'check_sorted', 'broadcast_to']
 
 
 def unique(array):
@@ -141,3 +141,14 @@ def pretty_number(numbers):
             result = result.rstrip('0')
 
     return result
+
+
+def broadcast_to(array, shape):
+    """
+    Compatibility function - can be removed once we support only Numpy 1.10
+    and above
+    """
+    try:
+        return np.broadcast_to(array, shape)
+    except AttributeError:
+        return array * np.ones(shape)

--- a/glue/utils/array.py
+++ b/glue/utils/array.py
@@ -151,4 +151,4 @@ def broadcast_to(array, shape):
     try:
         return np.broadcast_to(array, shape)
     except AttributeError:
-        return array * np.ones(shape)
+        return array * np.ones(shape, array.dtype)


### PR DESCRIPTION
@PennyQ - this is a continuation of your work in https://github.com/glue-viz/glue/pull/1023 (I have included your commits here, squashed to one commit). Basically in https://github.com/glue-viz/glue/pull/1029 I implemented a general solution for computing a mask from a ROI in an efficient way (inspired by your changes in #1023) and so I've now updated the spectrum tool to use this rather than duplicate the masking logic. I think it should be easier to read now.