### PR TITLE
Fix a bug that caused the color counter for subsets to be reset after loading a session containing subsets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,8 @@ v0.9.0 (unreleased)
 v0.8.3 (unreleased)
 -------------------
 
-* No changes yet.
+* Fixed a bug that caused new subset colors to incorrectly start from the start
+  of the color cycle after loading a session. [#1055]
 
 v0.8.2 (2016-07-06)
 -------------------

--- a/glue/core/state.py
+++ b/glue/core/state.py
@@ -597,6 +597,13 @@ def _save_data_collection_2(dc, context):
     return result
 
 
+@saver(DataCollection, version=3)
+def _save_data_collection_3(dc, context):
+    result = _save_data_collection_2(dc, context)
+    result['subset_group_count'] = dc._sg_count
+    return result
+
+
 @loader(DataCollection)
 def _load_data_collection(rec, context):
     dc = DataCollection(list(map(context.object, rec['data'])))
@@ -612,6 +619,12 @@ def _load_data_collection_2(rec, context):
     result._subset_groups = list(map(context.object, rec['groups']))
     for grp in result.subset_groups:
         grp.register_to_hub(result.hub)
+    return result
+
+@loader(DataCollection, version=3)
+def _load_data_collection_3(rec, context):
+    result = _load_data_collection_2(rec, context)
+    result._sg_count = rec['subset_group_count']
     return result
 
 


### PR DESCRIPTION
This means that if there is one red subset in glue when saving a session, the next subset created after opening a session will be green (not red, as was previously the case).

Fixes #782