### PR TITLE
Allow world coordinates to be shown on sliders

### DIFF
--- a/glue/core/coordinates.py
+++ b/glue/core/coordinates.py
@@ -231,15 +231,20 @@ def coordinates_from_header(header):
 
     :rtype: :class:`~glue.core.coordinates.Coordinates`
     """
-    try:
-        return WCSCoordinates(header)
-    except Exception as e:
-        logging.getLogger(__name__).warn("\n\n*******************************\n"
-                                         "Encounted an error during WCS parsing. "
-                                         "Discarding world coordinates! "
-                                         "\n%s\n"
-                                         "*******************************\n\n" % e
-                                         )
+
+    # We check whether the header contains at least CRVAL1 - if not, we would
+    # end up with a default WCS that isn't quite 1 to 1 (because of a 1-pixel
+    # offset) so better use Coordinates in that case.
+    if 'CRVAL1' in header:
+        try:
+            return WCSCoordinates(header)
+        except Exception as e:
+            logging.getLogger(__name__).warn("\n\n*******************************\n"
+                                             "Encounted an error during WCS parsing. "
+                                             "Discarding world coordinates! "
+                                             "\n%s\n"
+                                             "*******************************\n\n" % e
+                                             )
     return Coordinates()
 
 

--- a/glue/core/coordinates.py
+++ b/glue/core/coordinates.py
@@ -38,15 +38,18 @@ class Coordinates(object):
 
         Notes
         -----
-        This method computes the axis values using pixel positions of zero along
-        all other axes. This will therefore only give the correct result for
-        non-dependent axes (which can be checked using the ``dependent_axes``
-        method)
+        This method computes the axis values using pixel positions at the center
+        of the data along all other axes. This will therefore only give the
+        correct result for non-dependent axes (which can be checked using the
+        ``dependent_axes`` method)
         """
-        wcs_axis = data.ndim - 1 - axis
-        pixel = [np.repeat(0, data.shape[axis])] * data.ndim
-        pixel[wcs_axis] = np.arange(data.shape[axis])
-        return self.pixel2world(*pixel)[wcs_axis]
+        pixel = []
+        for i, s in enumerate(data.shape):
+            if i == axis:
+                pixel.append(np.arange(data.shape[axis]))
+            else:
+                pixel.append(np.repeat((s - 1) / 2, data.shape[axis]))
+        return self.pixel2world(*pixel[::-1])[::-1][axis]
 
     def axis_label(self, axis):
         return "World %i" % axis

--- a/glue/core/coordinates.py
+++ b/glue/core/coordinates.py
@@ -238,7 +238,10 @@ def coordinates_from_header(header):
     # We check whether the header contains at least CRVAL1 - if not, we would
     # end up with a default WCS that isn't quite 1 to 1 (because of a 1-pixel
     # offset) so better use Coordinates in that case.
-    if 'CRVAL1' in header:
+
+    from astropy.io.fits import Header
+
+    if isinstance(header, Header) and 'CRVAL1' in header:
         try:
             return WCSCoordinates(header)
         except Exception as e:
@@ -280,17 +283,4 @@ def header_from_string(string):
     Convert a string to a FITS header
     """
     from astropy.io import fits
-    cards = []
-    for s in string.splitlines():
-        try:
-            l, r = s.split('=')
-            key = l.strip()
-            value = r.split('/')[0].strip()
-            try:
-                value = int(value)
-            except ValueError:
-                pass
-        except ValueError:
-            continue
-        cards.append(fits.Card(key, value))
-    return fits.Header(cards)
+    return fits.Header.fromstring(string, sep='\n')

--- a/glue/core/coordinates.py
+++ b/glue/core/coordinates.py
@@ -23,6 +23,31 @@ class Coordinates(object):
     def world2pixel(self, *args):
         return args
 
+    def world_axis(self, data, axis):
+        """
+        Find the world coordinates along a given dimension, and which for now we
+        center on the pixel origin.
+
+        Parameters
+        ----------
+        data : `~glue.core.data.Data`
+            The data to compute the coordinate axis for (this is used to
+            determine the size of the axis)
+        axis : int
+            The axis to compute, in Numpy axis order
+
+        Notes
+        -----
+        This method computes the axis values using pixel positions of zero along
+        all other axes. This will therefore only give the correct result for
+        non-dependent axes (which can be checked using the ``dependent_axes``
+        method)
+        """
+        wcs_axis = data.ndim - 1 - axis
+        pixel = [np.repeat(0, data.shape[axis])] * data.ndim
+        pixel[wcs_axis] = np.arange(data.shape[axis])
+        return self.pixel2world(*pixel)[wcs_axis]
+
     def axis_label(self, axis):
         return "World %i" % axis
 

--- a/glue/core/data_factories/fits.py
+++ b/glue/core/data_factories/fits.py
@@ -4,7 +4,7 @@ import warnings
 from os.path import basename
 from collections import OrderedDict
 
-from glue.core.coordinates import coordinates_from_header
+from glue.core.coordinates import coordinates_from_header, WCSCoordinates
 from glue.core.data import Component, Data
 from glue.config import data_factory
 
@@ -138,8 +138,9 @@ def is_table_hdu(hdu):
 
 
 def has_wcs(coords):
-    return any(axis['coordinate_type'] is not None
-               for axis in coords.wcs.get_axis_types())
+    return (isinstance(coords, WCSCoordinates) and
+               any(axis['coordinate_type'] is not None
+               for axis in coords.wcs.get_axis_types()))
 
 
 def is_casalike(filename, **kwargs):

--- a/glue/core/tests/test_coordinates.py
+++ b/glue/core/tests/test_coordinates.py
@@ -155,32 +155,30 @@ class TestWcsCoordinates(object):
 
 class TestCoordinatesFromHeader(object):
 
-    def test_2d(self):
+    def test_2d_nowcs(self):
         hdr = {"NAXIS": 2}
-        with patch('glue.core.coordinates.WCSCoordinates') as wcs:
-            coord = coordinates_from_header(hdr)
-            wcs.assert_called_once_with(hdr)
+        coord = coordinates_from_header(hdr)
+        assert type(coord) == Coordinates
+
+    def test_2d(self):
+        hdr = header_from_string(HDR_2D_VALID)
+        coord = coordinates_from_header(hdr)
+        assert type(coord) == WCSCoordinates
+
+    def test_3d_nowcs(self):
+        hdr = HDR_3D_VALID_NOWCS
+        coord = coordinates_from_header(hdr)
+        assert type(coord) == Coordinates
 
     def test_3d(self):
-        hdr = {"NAXIS": 3}
-        with patch('glue.core.coordinates.WCSCoordinates') as wcs:
-            coord = coordinates_from_header(hdr)
-            wcs.assert_called_once_with(hdr)
+        hdr = header_from_string(HDR_3D_VALID_WCS)
+        coord = coordinates_from_header(hdr)
+        assert type(coord) == WCSCoordinates
 
-    @requires_astropy
     def test_nod(self):
         hdr = 0
-        with patch('glue.core.coordinates.Coordinates') as wcs:
-            coord = coordinates_from_header(hdr)
-            wcs.assert_called_once_with()
-
-    def test_attribute_error(self):
-        hdr = {"NAXIS": 2}
-        with patch('glue.core.coordinates.WCSCoordinates') as wcs:
-            wcs.side_effect = AttributeError
-            coord = coordinates_from_header(hdr)
-            wcs.assert_called_once_with(hdr)
-            assert type(coord) is Coordinates
+        coord = coordinates_from_header(hdr)
+        assert type(coord) == Coordinates
 
 HDR_2D_VALID = """
 SIMPLE  =                    T / Written by IDL:  Wed Jul 27 10:01:47 2011
@@ -212,8 +210,7 @@ NAXIS2  =                  128 /
 NAXIS3  =                  128 /
 """
 
-HDR_3D_VALID_WCS = """
-SIMPLE  =                    T / Written by IDL:  Thu Jul  7 15:37:21 2011
+HDR_3D_VALID_WCS = """SIMPLE  =                    T / Written by IDL:  Thu Jul  7 15:37:21 2011
 BITPIX  =                  -32 / Number of bits per data pixel
 NAXIS   =                    3 / Number of data axes
 NAXIS1  =                   82 /

--- a/glue/core/tests/test_coordinates.py
+++ b/glue/core/tests/test_coordinates.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, print_function
 import pytest
 import numpy as np
 from mock import patch
-from numpy.testing import assert_almost_equal
+from numpy.testing import assert_allclose
 
 from glue.tests.helpers import requires_astropy
 
@@ -41,8 +41,8 @@ class TestWcsCoordinates(object):
         x, y = 250., 187.5
         result = coord.pixel2world(x, y)
         expected = 359.9832692105993601, 5.0166664867400375
-        assert_almost_equal(result[0], expected[0])
-        assert_almost_equal(result[1], expected[1])
+        assert_allclose(result[0], expected[0])
+        assert_allclose(result[1], expected[1])
 
     def test_pixel2world_different_input_types(self):
         hdr = self.default_header()
@@ -51,8 +51,8 @@ class TestWcsCoordinates(object):
         x, y = 250, 187.5
         result = coord.pixel2world(x, y)
         expected = 359.9832692105993601, 5.0166664867400375
-        assert_almost_equal(result[0], expected[0])
-        assert_almost_equal(result[1], expected[1])
+        assert_allclose(result[0], expected[0])
+        assert_allclose(result[1], expected[1])
 
     def test_pixel2world_list(self):
         hdr = self.default_header()
@@ -65,7 +65,7 @@ class TestWcsCoordinates(object):
 
         for i in range(0, 1):
             for r, e in zip(result[i], expected[i]):
-                assert_almost_equal(r, e)
+                assert_allclose(r, e)
 
     def test_pixel2world_numpy(self):
         hdr = self.default_header()
@@ -102,7 +102,7 @@ class TestWcsCoordinates(object):
         result = coord.world2pixel(x, y)
         for i in range(0, 1):
             for r, e in zip(result[i], expected[i]):
-                assert_almost_equal(r, e)
+                assert_allclose(r, e)
 
     def test_world2pixel_scalar(self):
         hdr = self.default_header()
@@ -112,8 +112,8 @@ class TestWcsCoordinates(object):
         x, y = 0, 0
 
         result = coord.world2pixel(x, y)
-        assert_almost_equal(result[0], expected[0], 3)
-        assert_almost_equal(result[1], expected[1], 3)
+        assert_allclose(result[0], expected[0], 3)
+        assert_allclose(result[1], expected[1], 3)
 
     def test_world2pixel_mismatched_input(self):
         coord = WCSCoordinates(self.default_header())
@@ -121,8 +121,8 @@ class TestWcsCoordinates(object):
         expected = coord.world2pixel(x, y[0])
 
         result = coord.world2pixel(x, y)
-        assert_almost_equal(result[0], expected[0])
-        assert_almost_equal(result[1], expected[1])
+        assert_allclose(result[0], expected[0])
+        assert_allclose(result[1], expected[1])
 
     def test_pixel2world_mismatched_input(self):
         coord = WCSCoordinates(self.default_header())
@@ -130,8 +130,8 @@ class TestWcsCoordinates(object):
         expected = coord.pixel2world(x[0], y)
 
         result = coord.pixel2world(x, y)
-        assert_almost_equal(result[0], expected[0])
-        assert_almost_equal(result[1], expected[1])
+        assert_allclose(result[0], expected[0])
+        assert_allclose(result[1], expected[1])
 
     def test_pixel2world_invalid_input(self):
         coord = WCSCoordinates(None)
@@ -151,6 +151,30 @@ class TestWcsCoordinates(object):
 
         assert coord.axis_label(0) == 'Galactic Latitude'
         assert coord.axis_label(1) == 'Galactic Longitude'
+
+
+@requires_astropy
+def test_world_axis_wcs():
+
+    from astropy.io import fits
+
+    hdr = fits.Header()
+    hdr.update('NAXIS', 2)
+    hdr.update('CRVAL1', 0)
+    hdr.update('CRVAL2', 5)
+    hdr.update('CRPIX1', 2)
+    hdr.update('CRPIX2', 1)
+    hdr.update('CTYPE1', 'XOFFSET')
+    hdr.update('CTYPE2', 'YOFFSET')
+    hdr.update('CD1_1', -2.)
+    hdr.update('CD1_2', 0.)
+    hdr.update('CD2_1', 0.)
+    hdr.update('CD2_2', 2.)
+
+    data = np.ones((3, 4))
+    coord = WCSCoordinates(hdr)
+    assert_allclose(coord.world_axis(data, 0), [5, 7, 9])
+    assert_allclose(coord.world_axis(data, 1), [2, 0, -2, -4])
 
 
 class TestCoordinatesFromHeader(object):

--- a/glue/utils/qt/widget_properties.py
+++ b/glue/utils/qt/widget_properties.py
@@ -176,6 +176,7 @@ class TextProperty(WidgetProperty):
 
     def setter(self, widget, value):
         widget.setText(value)
+        widget.editingFinished.emit()
 
 
 class ButtonProperty(WidgetProperty):

--- a/glue/utils/qt/widget_properties.py
+++ b/glue/utils/qt/widget_properties.py
@@ -176,7 +176,8 @@ class TextProperty(WidgetProperty):
 
     def setter(self, widget, value):
         widget.setText(value)
-        widget.editingFinished.emit()
+        if hasattr(widget, 'editingFinished'):
+            widget.editingFinished.emit()
 
 
 class ButtonProperty(WidgetProperty):

--- a/glue/viewers/common/qt/data_slice_widget.py
+++ b/glue/viewers/common/qt/data_slice_widget.py
@@ -21,6 +21,7 @@ from glue.icons.qt import get_icon
 class SliceWidget(QtGui.QWidget):
 
     label = TextProperty('_ui_label')
+    slider_label = TextProperty('_ui_slider.label')
     slice_center = ValueProperty('_ui_slider.slider')
     mode = CurrentComboProperty('_ui_mode')
     use_world = ButtonProperty('_ui_slider.checkbox_world')
@@ -36,7 +37,7 @@ class SliceWidget(QtGui.QWidget):
         if aggregation is not None:
             raise NotImplemented("Aggregation option not implemented")
 
-        self._world = world
+        self._world = np.asarray(world)
         self._world_warning = world_warning
 
         layout = QtGui.QVBoxLayout()
@@ -140,6 +141,7 @@ class SliceWidget(QtGui.QWidget):
         if self.use_world:
             # Don't want to assume world is sorted, pick closest value
             value = np.argmin(np.abs(self._world - float(text)))
+            self._ui_slider.label.setText(str(self._world[value]))
         else:
             value = int(text)
         self._ui_slider.slider.setValue(value)

--- a/glue/viewers/common/qt/data_slice_widget.ui
+++ b/glue/viewers/common/qt/data_slice_widget.ui
@@ -6,207 +6,258 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>291</width>
-    <height>59</height>
+    <width>240</width>
+    <height>94</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <property name="leftMargin">
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
     <number>0</number>
    </property>
-   <property name="topMargin">
+   <property name="margin">
     <number>0</number>
    </property>
-   <property name="rightMargin">
-    <number>0</number>
-   </property>
-   <property name="bottomMargin">
-    <number>5</number>
-   </property>
-   <item row="0" column="0">
-    <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
      <property name="spacing">
-      <number>0</number>
+      <number>10</number>
      </property>
      <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_2">
-       <property name="spacing">
-        <number>10</number>
+      <widget class="QSlider" name="slider">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
        </property>
-       <item>
-        <widget class="QSlider" name="slider">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-     <item>
-      <layout class="QHBoxLayout" name="horizontalLayout">
-       <property name="spacing">
-        <number>6</number>
-       </property>
-       <item>
-        <spacer name="horizontalSpacer">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="QToolButton" name="button_first">
-         <property name="toolTip">
-          <string>Go to first slice</string>
-         </property>
-         <property name="text">
-          <string>&lt;&lt;</string>
-         </property>
-         <property name="iconSize">
-          <size>
-           <width>16</width>
-           <height>16</height>
-          </size>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QToolButton" name="button_prev">
-         <property name="toolTip">
-          <string>Go to previous slice</string>
-         </property>
-         <property name="text">
-          <string>&lt;</string>
-         </property>
-         <property name="iconSize">
-          <size>
-           <width>16</width>
-           <height>16</height>
-          </size>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QToolButton" name="button_back">
-         <property name="toolTip">
-          <string>Play backwards (click multiple times to speed up)</string>
-         </property>
-         <property name="text">
-          <string>&lt;</string>
-         </property>
-         <property name="iconSize">
-          <size>
-           <width>16</width>
-           <height>16</height>
-          </size>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QToolButton" name="button_stop">
-         <property name="toolTip">
-          <string>Stop the playback</string>
-         </property>
-         <property name="text">
-          <string>▪</string>
-         </property>
-         <property name="iconSize">
-          <size>
-           <width>16</width>
-           <height>16</height>
-          </size>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QToolButton" name="button_forw">
-         <property name="toolTip">
-          <string>Play forwards (click multiple times to speed up)</string>
-         </property>
-         <property name="text">
-          <string>&gt;</string>
-         </property>
-         <property name="iconSize">
-          <size>
-           <width>16</width>
-           <height>16</height>
-          </size>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QToolButton" name="button_next">
-         <property name="toolTip">
-          <string>Go to next slice</string>
-         </property>
-         <property name="text">
-          <string>&gt;</string>
-         </property>
-         <property name="iconSize">
-          <size>
-           <width>16</width>
-           <height>16</height>
-          </size>
-         </property>
-         <property name="autoRepeat">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QToolButton" name="button_last">
-         <property name="toolTip">
-          <string>Go to last slice</string>
-         </property>
-         <property name="text">
-          <string>&gt;&gt;</string>
-         </property>
-         <property name="iconSize">
-          <size>
-           <width>16</width>
-           <height>16</height>
-          </size>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="horizontalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="QLineEdit" name="label">
-         <property name="maximumSize">
-          <size>
-           <width>40</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="maxLength">
-          <number>10</number>
-         </property>
-        </widget>
-       </item>
-      </layout>
+      </widget>
      </item>
     </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <property name="spacing">
+      <number>6</number>
+     </property>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QToolButton" name="button_first">
+       <property name="toolTip">
+        <string>Go to first slice</string>
+       </property>
+       <property name="text">
+        <string>&lt;&lt;</string>
+       </property>
+       <property name="iconSize">
+        <size>
+         <width>16</width>
+         <height>16</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="button_prev">
+       <property name="toolTip">
+        <string>Go to previous slice</string>
+       </property>
+       <property name="text">
+        <string>&lt;</string>
+       </property>
+       <property name="iconSize">
+        <size>
+         <width>16</width>
+         <height>16</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="button_back">
+       <property name="toolTip">
+        <string>Play backwards (click multiple times to speed up)</string>
+       </property>
+       <property name="text">
+        <string>&lt;</string>
+       </property>
+       <property name="iconSize">
+        <size>
+         <width>16</width>
+         <height>16</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="button_stop">
+       <property name="toolTip">
+        <string>Stop the playback</string>
+       </property>
+       <property name="text">
+        <string>▪</string>
+       </property>
+       <property name="iconSize">
+        <size>
+         <width>16</width>
+         <height>16</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="button_forw">
+       <property name="toolTip">
+        <string>Play forwards (click multiple times to speed up)</string>
+       </property>
+       <property name="text">
+        <string>&gt;</string>
+       </property>
+       <property name="iconSize">
+        <size>
+         <width>16</width>
+         <height>16</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="button_next">
+       <property name="toolTip">
+        <string>Go to next slice</string>
+       </property>
+       <property name="text">
+        <string>&gt;</string>
+       </property>
+       <property name="iconSize">
+        <size>
+         <width>16</width>
+         <height>16</height>
+        </size>
+       </property>
+       <property name="autoRepeat">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="button_last">
+       <property name="toolTip">
+        <string>Go to last slice</string>
+       </property>
+       <property name="text">
+        <string>&gt;&gt;</string>
+       </property>
+       <property name="iconSize">
+        <size>
+         <width>16</width>
+         <height>16</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="label">
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="maxLength">
+        <number>10</number>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_4">
+     <item>
+      <spacer name="horizontalSpacer_4">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="checkbox_world">
+       <property name="text">
+        <string>Show real coordinates for slices</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_3">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_warning">
+     <property name="font">
+      <font>
+       <pointsize>11</pointsize>
+      </font>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">color: rgb(255, 33, 28)</string>
+     </property>
+     <property name="text">
+      <string>Warning: real coordinates are not aligned with pixel grid, and may be approximate or incorrect</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/glue/viewers/common/qt/data_slice_widget.ui
+++ b/glue/viewers/common/qt/data_slice_widget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>240</width>
-    <height>94</height>
+    <width>245</width>
+    <height>113</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -249,7 +249,7 @@
       <string notr="true">color: rgb(255, 33, 28)</string>
      </property>
      <property name="text">
-      <string>Warning: real coordinates are not aligned with pixel grid, and may be approximate or incorrect</string>
+      <string>Warning: real coordinates are not aligned with pixel grid. The coordinate shown above is the value at the center of the slice.</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignCenter</set>

--- a/glue/viewers/common/qt/tests/test_data_slice_widget.py
+++ b/glue/viewers/common/qt/tests/test_data_slice_widget.py
@@ -37,6 +37,39 @@ class TestSliceWidget(object):
         s._ui_slider.button_prev.click()
         assert s.slice_center == 9
 
+    def test_slice_world(self):
+
+        s = SliceWidget(lo=0, hi=5, world=[1, 3, 5, 5.5, 8, 12])
+
+        # Check switching between world and pixel coordinates
+        s.slice_center = 0
+        assert s.slider_label == '1.0'
+        s.use_world = False
+        assert s.slider_label == '0'
+        s.slice_center = 3
+        assert s.slider_label == '3'
+        s.use_world = True
+        assert s.slider_label == '5.5'
+
+        # Round to nearest
+        s.slider_label = '11'
+        assert s.slice_center == 5
+        assert s.slider_label == '12.0'
+
+        # Make sure out of bound values work
+        s.slider_label = '20'
+        assert s.slice_center == 5
+        assert s.slider_label == '12.0'
+        s.slider_label = '-10'
+        assert s.slice_center == 0
+        assert s.slider_label == '1.0'
+
+        # And disable world and try and set by pixel
+        s.use_world = False
+        s.slider_label = '4'
+        assert s.slice_center == 4
+        assert s.slider_label == '4'
+
 
 class TestArraySlice(object):
 


### PR DESCRIPTION
@PennyQ - this fixes #1054

Basically, this will add a checkbox for each slider that allows the user to toggle between pixel and world coordinates:

![screen shot 2016-08-01 at 3 39 32 pm](https://cloud.githubusercontent.com/assets/314716/17297592/4515afc6-57fe-11e6-9c03-2ee34e4b45e7.png) ![screen shot 2016-08-01 at 3 39 43 pm](https://cloud.githubusercontent.com/assets/314716/17297601/50880318-57fe-11e6-96d7-09ac69e4592e.png)


If the world coordinates are not well aligned with the pixel coordinates, a warning is shown:

![screen shot 2016-08-01 at 3 39 52 pm](https://cloud.githubusercontent.com/assets/314716/17297586/3dc8e86e-57fe-11e6-8bff-cae4e458003e.png)


@PennyQ - can you test this out and let me know if it works for you?