### PR TITLE
Small improvements to ComponentIDComboHelper

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,11 @@ v0.9.0 (unreleased)
   preference pane for Plotly export has now been removed in favor of this new
   way to set the options. [#1057]
 
+* Renamed the ``ComponentIDComboHelper`` and ``ManualDataComboHelper``
+  ``append`` methods to ``append_data`` and the ``remove`` methods to
+  ``remove_data``, and added a new ``ComponentIDComboHelper.set_multiple_data``
+  method. [#1060]
+
 v0.8.3 (unreleased)
 -------------------
 

--- a/glue/core/qt/tests/test_data_combo_helper.py
+++ b/glue/core/qt/tests/test_data_combo_helper.py
@@ -25,14 +25,14 @@ def test_component_id_combo_helper():
     data1 = Data(x=[1,2,3], y=[2,3,4], label='data1')
 
     dc.append(data1)
-    helper.append(data1)
+    helper.append_data(data1)
 
     assert _items_as_string(combo) == "x:y"
 
     data2 = Data(a=[1,2,3], b=['a','b','c'], label='data2')
 
     dc.append(data2)
-    helper.append(data2)
+    helper.append_data(data2)
 
     assert _items_as_string(combo) == "data1:x:y:data2:a:b"
 
@@ -59,7 +59,7 @@ def test_component_id_combo_helper():
     # data1.id['x'].label = 'z'
     # assert _items_as_string(combo) == "z:y"
 
-    helper.remove(data1)
+    helper.remove_data(data1)
 
     assert _items_as_string(combo) == ""
 
@@ -76,19 +76,19 @@ def test_component_id_combo_helper_init():
     dc.append(data)
 
     helper = ComponentIDComboHelper(combo, dc)
-    helper.append(data)
+    helper.append_data(data)
     assert _items_as_string(combo) == "a:b"
 
     helper = ComponentIDComboHelper(combo, dc, numeric=False)
-    helper.append(data)
+    helper.append_data(data)
     assert _items_as_string(combo) == "b"
 
     helper = ComponentIDComboHelper(combo, dc, categorical=False)
-    helper.append(data)
+    helper.append_data(data)
     assert _items_as_string(combo) == "a"
 
     helper = ComponentIDComboHelper(combo, dc, numeric=False, categorical=False)
-    helper.append(data)
+    helper.append_data(data)
     assert _items_as_string(combo) == ""
 
 
@@ -106,7 +106,7 @@ def test_manual_data_combo_helper():
 
     assert _items_as_string(combo) == ""
 
-    helper.append(data1)
+    helper.append_data(data1)
 
     assert _items_as_string(combo) == "data1"
 

--- a/glue/viewers/common/qt/tests/test_attribute_limits_helper.py
+++ b/glue/viewers/common/qt/tests/test_attribute_limits_helper.py
@@ -41,7 +41,7 @@ class TestAttributeLimitsHelper():
 
         self.component_helper = ComponentIDComboHelper(self.attribute_combo, self.data_collection)
 
-        self.component_helper.append(self.data)
+        self.component_helper.append_data(self.data)
 
         self.x_id = self.data.visible_components[0]
         self.y_id = self.data.visible_components[1]


### PR DESCRIPTION
Made it possible to set the ComponentIDComboHelper to a list of Data objects rather than having to append them one by one. This avoids refreshing every time a single data object is added. Also renamed the append and remove methods to append_data and remove_data.