### PR TITLE
AppVeyor: use more recent version of conda

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,7 @@ environment:
       PYTHON_ARCH: "64" # needs to be set for CMD_IN_ENV to succeed. If a mix
                         # of 32 bit and 64 bit builds are needed, move this
                         # to the matrix section.
+      CONDA_VERSION: "4.1.11"
       CONDA_CHANNELS: "conda-forge"
       CONDA_DEPENDENCIES: "scipy cython pyqt matplotlib h5py pygments pyzmq scikit-image pandas sphinx xlrd pillow pytest mock coverage ipython ipykernel qtconsole traitlets=4.1.0 qtpy"
       PIP_DEPENDENCIES: "plotly"


### PR DESCRIPTION
Should fix the AppVeyor failures with conda-forge packages.