### PR TITLE
[WIP] Add a colorbar to image viewer

### DIFF
--- a/glue/viewers/image/layer_artist.py
+++ b/glue/viewers/image/layer_artist.py
@@ -178,12 +178,22 @@ class ImageLayerArtist(MatplotlibLayerArtist, ImageLayerBase):
         for v in views:
             image = self._extract_view(v, transpose)
             extent = get_extent(v, transpose)
-            artists.append(self._axes.imshow(image, cmap=self.cmap,
-                                             norm=self.norm,
-                                             interpolation='nearest',
-                                             origin='lower',
-                                             extent=extent, zorder=0))
+            cim = self._axes.imshow(image, cmap=self.cmap, norm=self.norm,
+                                    interpolation='nearest', origin='lower',
+                                    extent=extent, zorder=0)
+            artists.append(cim)
             self._axes.set_aspect(self.aspect, adjustable='datalim')
+
+        if hasattr(self._axes, 'colorbar'):
+            # Update existing colorbar.
+            self._axes.colorbar.update_normal(cim)
+        else:
+            # Add horizontal colorbar at the bottom.
+            self._axes.figure.subplots_adjust(bottom=0.15)
+            cbar_ax = self._axes.figure.add_axes([0.1, 0.05, 0.85, 0.05])
+            self._axes.colorbar = self._axes.figure.colorbar(
+                cim, cax=cbar_ax, orientation='horizontal')
+
         self.artists = artists
         self._sync_style()
 

--- a/glue/viewers/image/layer_artist.py
+++ b/glue/viewers/image/layer_artist.py
@@ -188,11 +188,13 @@ class ImageLayerArtist(MatplotlibLayerArtist, ImageLayerBase):
             # Update existing colorbar.
             self._axes.colorbar.update_normal(cim)
         else:
-            # Add horizontal colorbar at the bottom.
-            self._axes.figure.subplots_adjust(bottom=0.15)
-            cbar_ax = self._axes.figure.add_axes([0.1, 0.05, 0.85, 0.05])
+            # Add vertical colorbar on the right.
+            bbox = self._axes.get_position()
+            self._axes.resizer.margins = [1, 1.75, 0.5, 0.25]
+            cbar_ax = self._axes.figure.add_axes(
+                [0.9, bbox.y0, 0.025, bbox.height])
             self._axes.colorbar = self._axes.figure.colorbar(
-                cim, cax=cbar_ax, orientation='horizontal')
+                cim, ax=self._axes, cax=cbar_ax)
 
         self.artists = artists
         self._sync_style()


### PR DESCRIPTION
Fixes #1087. Colorbar values seem to update properly when I change the scaling.

Todo:
- [ ] How to implement colorbar layout properly so that the axes get repositioned without overlap when the viewer is resized?
- [ ] How to hook up colormap toolbar to change the color of the colorbar? Currently, when a different colormap is selected, the colorbar is still in black and white.

@astrofrog , I am starting to think that maybe this is not the right approach. Perhaps to properly do this, Glue needs a dedicated space for colorbar in the lower levels. My current maplotlib-fu and glue-fu are insufficient to accomplish anything more complicated than what is on this PR. As a comparison, in Ginga, colorbar is actually a separate plugin but it is just always there.

Somewhat better result with vertical colorbar:
![screenshot](https://cloud.githubusercontent.com/assets/2090236/17945283/2a9bae1e-6a11-11e6-978b-5a3c05e1a8ed.png)

However, when viewer is maximized, colorbar still "eats" into the image axis:
<img src="https://cloud.githubusercontent.com/assets/2090236/17945298/3b632d80-6a11-11e6-9ea1-3be8151d1959.png" width="80" />

Ugly attempt with horizontal colorbar:
![screenshot](https://cloud.githubusercontent.com/assets/2090236/17901683/80e4c09c-6932-11e6-890e-472dd3b4303e.png)
