### PR TITLE
Follow PEP 302 'finder' spec

### DIFF
--- a/glue/_mpl_backend.py
+++ b/glue/_mpl_backend.py
@@ -6,7 +6,7 @@ class MatplotlibBackendSetter(object):
 
     enabled = True
 
-    def find_module(self, mod_name, pth):
+    def find_module(self, mod_name, pth=None):
         if self.enabled and 'matplotlib' in mod_name:
             self.enabled = False
             set_mpl_backend()


### PR DESCRIPTION
Glue uses `sys.meta_path` defined in PEP 302 to perform some setup tasks when matplotlib is imported by user code. However, the implementation doesn't exactly follow the spec from the PEP which causes import errors in completely unrelated code.

The `find_module()` method needs to have an optional second argument, whereas it is currently mandatory. There are some code paths in Python 2.7/pkgutils (at least), which call it with a single argument and fall over.

This pull request simply changes the implementation to match the spec from PEP 302.

We are currently working around this by `import glue` after all other imports.