### PR TITLE
Properly tag dev version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ from setuptools import setup, find_packages
 from distutils.core import Command
 
 import os
+import re
 import sys
 import subprocess
 
@@ -38,7 +39,8 @@ if '.dev' in __version__:  # noqa
                 dev_value=commit_number))
 
         # We modify __version__ here too for commands such as egg_info
-        __version__ += commit_number  # noqa
+        __version__ = re.sub('\.dev[^"]*', '.dev{0}'.format(commit_number),
+                             __version__)  # noqa
 
 try:
     import pypandoc

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 from __future__ import print_function
 
 from setuptools import setup, find_packages
-from setuptools.command.test import test as TestCommand
 from distutils.core import Command
 
 import os
@@ -15,7 +14,7 @@ with open('glue/version.py') as infile:
     exec(infile.read())
 
 # If the version is not stable, we can add a git hash to the __version__
-if '.dev' in __version__:
+if '.dev' in __version__:  # noqa
 
     # Find hash for __githash__ and dev number for __version__ (can't use hash
     # as per PEP440)
@@ -24,18 +23,22 @@ if '.dev' in __version__:
     command_number = 'git rev-list --count HEAD'
 
     try:
-        commit_hash = subprocess.check_output(command_hash, shell=True).decode('ascii').strip()
-        commit_number = subprocess.check_output(command_number, shell=True).decode('ascii').strip()
+        commit_hash = subprocess.check_output(
+            command_hash, shell=True).decode('ascii').strip()
+        commit_number = subprocess.check_output(
+            command_number, shell=True).decode('ascii').strip()
     except Exception:
         pass
     else:
         # We write the git hash and value so that they gets frozen if installed
         with open(os.path.join('glue', '_githash.py'), 'w') as f:
-            f.write("__githash__ = \"{githash}\"\n".format(githash=commit_hash))
-            f.write("__dev_value__ = \"{dev_value}\"\n".format(dev_value=commit_number))
+            f.write("__githash__ = \"{githash}\"\n".format(
+                githash=commit_hash))
+            f.write("__dev_value__ = \"{dev_value}\"\n".format(
+                dev_value=commit_number))
 
         # We modify __version__ here too for commands such as egg_info
-        __version__ += commit_number
+        __version__ += commit_number  # noqa
 
 try:
     import pypandoc
@@ -118,5 +121,6 @@ setup(name='glueviz',
       packages=find_packages(),
       entry_points=entry_points,
       cmdclass=cmdclass,
-      package_data={'': ['*.png', '*.ui', '*.glu', '*.hdf5', '*.fits', '*.xlsx', '*.txt']}
+      package_data={'': ['*.png', '*.ui', '*.glu', '*.hdf5', '*.fits',
+                         '*.xlsx', '*.txt']}
       )


### PR DESCRIPTION
First commit fixes PEP8 in `setup.py`. Second commit fixes #1095.

Personally, I am not a fan of `exec()` as well but that is beyond the scope of this PR.