### PR TITLE
Implement Data.update_from_data

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,9 @@ v0.9.0 (unreleased)
 * Avoid raising a (harmless) error when selecting a region in between two
   categorical components.
 
+* Added a new Data method, ``update_from_data``, that can be used to replicate
+  components from one dataset into another. [#1112]
+
 v0.8.3 (unreleased)
 -------------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,7 +21,7 @@ v0.9.0 (unreleased)
 * Avoid raising a (harmless) error when selecting a region in between two
   categorical components.
 
-* Added a new Data method, ``update_from_data``, that can be used to replicate
+* Added a new Data method, ``update_values_from_data``, that can be used to replicate
   components from one dataset into another. [#1112]
 
 v0.8.3 (unreleased)

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -823,8 +823,10 @@ class Data(object):
     def update_from_data(self, data):
         """
         Replace numerical values in data to match values from another dataset.
+
         Drop components that aren't present in the new data. The matching is
-        done by component label.
+        done by component label, and components are resized if needed. Note
+        that the style is NOT copied.
         """
 
         old_labels = [cid.label for cid in self.components]
@@ -862,6 +864,9 @@ class Data(object):
 
         # Update data label
         self.label = data.label
+
+        # Update data coordinates
+        self.coords = data.coords
 
         # alert hub of the change
         if self.hub is not None:

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -859,6 +859,17 @@ class Data(object):
             comp_new = data.get_component(cname)
             self.add_component(comp_new, cname)
 
+        # Update data label
+        self.label = data.label
+
+        # alert hub of the change
+        if self.hub is not None:
+            msg = NumericalDataChangedMessage(self)
+            self.hub.broadcast(msg)
+
+        for subset in self.subsets:
+            clear_cache(subset.subset_state.to_mask)
+
 
 @contract(i=int, ndim=int)
 def pixel_label(i, ndim):

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -856,8 +856,9 @@ class Data(object):
 
         # Add components that didn't exist in original one
         for cname in new_labels - old_labels:
+            cid = data.find_component_id(cname)
             comp_new = data.get_component(cname)
-            self.add_component(comp_new, cname)
+            self.add_component(comp_new, cid)
 
         # Update data label
         self.label = data.label

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -820,13 +820,22 @@ class Data(object):
         for subset in self.subsets:
             clear_cache(subset.subset_state.to_mask)
 
-    def update_from_data(self, data):
+    def update_values_from_data(self, data):
         """
         Replace numerical values in data to match values from another dataset.
 
-        Drop components that aren't present in the new data. The matching is
-        done by component label, and components are resized if needed. Note
-        that the style is NOT copied.
+        Notes
+        -----
+
+        This method drops components that aren't present in the new data, and
+        adds components that are in the new data that were not in the original
+        data. The matching is done by component label, and components are
+        resized if needed. This means that for components with matching labels
+        in the original and new data, the
+        :class:`~glue.core.component_id.ComponentID` are preserved, and
+        existing plots and selections will be updated to reflect the new
+        values. Note that the coordinates are also copied, but the style is
+        **not** copied.
         """
 
         old_labels = [cid.label for cid in self.components]

--- a/glue/core/tests/test_data.py
+++ b/glue/core/tests/test_data.py
@@ -570,14 +570,14 @@ def test_data_str():
     assert str(d) == EXPECTED_STR
 
 
-def test_update_from_data():
+def test_update_values_from_data():
     d1 = Data(a=[1,2,3], b=[4,5,6], label='banana')
     d2 = Data(b=[1,2,3,4], c=[5,6,7,8], label='apple')
     d1a = d1.id['a']
     d1b = d1.id['b']
     d2b = d2.id['b']
     d2c = d2.id['c']
-    d1.update_from_data(d2)
+    d1.update_values_from_data(d2)
     assert not d1a in d1.components
     assert d1b in d1.components
     assert not d2b in d1.components
@@ -585,18 +585,18 @@ def test_update_from_data():
     assert d1.shape == (4,)
 
 
-def test_update_from_data_invalid():
+def test_update_values_from_data_invalid():
 
     d1 = Data(a=[1,2,3], label='banana')
     d1.add_component([3,4,5], 'a')
     d2 = Data(b=[1,2,3,4], c=[5,6,7,8], label='apple')
     with pytest.raises(ValueError) as exc:
-        d1.update_from_data(d2)
+        d1.update_values_from_data(d2)
     assert exc.value.args[0] == "Non-unique component labels in original data"
 
     d1 = Data(a=[1,2,3], b=[4,5,6], label='banana')
     d2 = Data(b=[1,2,3,4], label='apple')
     d2.add_component([5,6,7,8], 'b')
     with pytest.raises(ValueError) as exc:
-        d1.update_from_data(d2)
+        d1.update_values_from_data(d2)
     assert exc.value.args[0] == "Non-unique component labels in new data"

--- a/glue/core/tests/test_data.py
+++ b/glue/core/tests/test_data.py
@@ -568,3 +568,35 @@ def test_data_str():
     # Regression test for Data.__str__
     d = Data(x=[1,2,3], y=[2,3,4], label='mydata')
     assert str(d) == EXPECTED_STR
+
+
+def test_update_from_data():
+    d1 = Data(a=[1,2,3], b=[4,5,6], label='banana')
+    d2 = Data(b=[1,2,3,4], c=[5,6,7,8], label='apple')
+    d1a = d1.id['a']
+    d1b = d1.id['b']
+    d2b = d2.id['b']
+    d2c = d2.id['c']
+    d1.update_from_data(d2)
+    assert not d1a in d1.components
+    assert d1b in d1.components
+    assert not d2b in d1.components
+    assert d2c in d1.components
+    assert d1.shape == (4,)
+
+
+def test_update_from_data_invalid():
+
+    d1 = Data(a=[1,2,3], label='banana')
+    d1.add_component([3,4,5], 'a')
+    d2 = Data(b=[1,2,3,4], c=[5,6,7,8], label='apple')
+    with pytest.raises(ValueError) as exc:
+        d1.update_from_data(d2)
+    assert exc.value.args[0] == "Non-unique component labels in original data"
+
+    d1 = Data(a=[1,2,3], b=[4,5,6], label='banana')
+    d2 = Data(b=[1,2,3,4], label='apple')
+    d2.add_component([5,6,7,8], 'b')
+    with pytest.raises(ValueError) as exc:
+        d1.update_from_data(d2)
+    assert exc.value.args[0] == "Non-unique component labels in new data"


### PR DESCRIPTION
This allows a dataset to be updated to match another dataset - importantly, it preserves component IDs for components that have matching labels. This can be used for example for refreshing a dataset where the number of elements has changed.