### PR TITLE
Add regression test and changelog entry for #1101

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,9 @@ v0.8.3 (unreleased)
 * Fixed a bug that caused new subset colors to incorrectly start from the start
   of the color cycle after loading a session. [#1055]
 
+* Fixed a bug that caused the functionality to execute scripts (glue -x) to not
+  work in Python 3. [#1114]
+
 v0.8.2 (2016-07-06)
 -------------------
 

--- a/glue/tests/test_main.py
+++ b/glue/tests/test_main.py
@@ -95,8 +95,9 @@ def test_exec_real(tmpdir):
     with open(filename, 'w') as f:
         f.write('a = 1')
     with patch('glue.utils.qt.QMessageBoxPatched') as qmb:
-        main('glue -x {0}'.format(os.path.abspath(filename)).split())
-
+        with patch('sys.exit') as exit:
+            main('glue -x {0}'.format(os.path.abspath(filename)).split())
+    assert exit.called_once_with(0)
 
 @pytest.mark.parametrize(('cmd'), ['glueqt -g test.glu test.fits',
                                    'glueqt -g test.py test.fits',

--- a/glue/tests/test_main.py
+++ b/glue/tests/test_main.py
@@ -89,6 +89,7 @@ def test_auto_exec():
     check_exec('glueqt test.py', 'test.py')
 
 
+@requires_qt
 def test_exec_real(tmpdir):
     # Actually test the script execution functionlity
     filename = tmpdir.join('test.py').strpath
@@ -98,6 +99,7 @@ def test_exec_real(tmpdir):
         with patch('sys.exit') as exit:
             main('glue -x {0}'.format(os.path.abspath(filename)).split())
     assert exit.called_once_with(0)
+
 
 @pytest.mark.parametrize(('cmd'), ['glueqt -g test.glu test.fits',
                                    'glueqt -g test.py test.fits',

--- a/glue/tests/test_main.py
+++ b/glue/tests/test_main.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+import os
 import pytest
 from mock import patch
 
@@ -86,6 +87,15 @@ def test_exec():
 
 def test_auto_exec():
     check_exec('glueqt test.py', 'test.py')
+
+
+def test_exec_real(tmpdir):
+    # Actually test the script execution functionlity
+    filename = tmpdir.join('test.py').strpath
+    with open(filename, 'w') as f:
+        f.write('a = 1')
+    with patch('glue.utils.qt.QMessageBoxPatched') as qmb:
+        main('glue -x {0}'.format(os.path.abspath(filename)).split())
 
 
 @pytest.mark.parametrize(('cmd'), ['glueqt -g test.glu test.fits',


### PR DESCRIPTION
@pllim - just for info, you can actually execute any Python script (including 'hello, world!') with the ``glue -x script.py``, which dispatches to ``execute_script`` (which you fixed).