### PR TITLE
Make toolbars be initialized after DataViewer.__init__ is executed.

### DIFF
--- a/doc/customizing_guide/toolbar.rst
+++ b/doc/customizing_guide/toolbar.rst
@@ -188,6 +188,25 @@ we defined above). There are currently two main classes available for toolbars:
   This toolbar can only be used if your data viewer includes a Matplotlib canvas
   accessible at ``viewer.canvas``.
 
+Note that the toolbar is set up after ``__init__`` has run. Therefore, if you
+want to do any custom set-up to the toolbar after it has been set up, you
+should overload the ``initialize_toolbar`` method, e.g:
+
+.. code:: python
+
+    class MyViewer(DataViewer):
+
+        _toolbar_cls = BasicToolbar
+        tools = ['custom_tool']
+
+        def initialize_toolbar(self):
+            super(MyViewer, self).initialize_toolbar()
+            # custom code here
+
+In ``initialize_toolbar`` (and elsewhere in the class) you can then access the
+tool instances using ``self.toolbar.tools`` (which is a dictionary where each
+key is a ``tool_id``).
+
 Available tools
 ---------------
 

--- a/glue/plugins/dendro_viewer/qt/viewer_widget.py
+++ b/glue/plugins/dendro_viewer/qt/viewer_widget.py
@@ -49,7 +49,7 @@ class DendroWidget(DataViewer):
 
         self._connect()
 
-        self._make_toolbar()
+        self.initialize_toolbar()
         self.statusBar().setSizeGripEnabled(False)
 
     def _connect(self):
@@ -61,9 +61,9 @@ class DendroWidget(DataViewer):
         connect_current_combo(cl, 'height_attr', ui.heightCombo)
         connect_current_combo(cl, 'order_attr', ui.orderCombo)
 
-    def _make_toolbar(self):
+    def initialize_toolbar(self):
 
-        super(DendroWidget, self)._make_toolbar()
+        super(DendroWidget, self).initialize_toolbar()
 
         def on_move(mode):
             if mode._drag:

--- a/glue/plugins/ginga_viewer/qt/viewer_widget.py
+++ b/glue/plugins/ginga_viewer/qt/viewer_widget.py
@@ -85,8 +85,6 @@ class GingaWidget(ImageWidgetBase):
 
         super(GingaWidget, self).__init__(session, parent)
 
-        self._make_toolbar()
-
     def make_client(self):
         return GingaClient(self._data, self.viewer, self._layer_artist_container)
 

--- a/glue/utils/noconflict.py
+++ b/glue/utils/noconflict.py
@@ -1,0 +1,73 @@
+# Code adapted from:
+#
+# http://code.activestate.com/recipes/204197-solving-the-metaclass-conflict/
+#
+# The code at the above URL was released under the PSF license.
+
+import inspect
+import types
+
+from glue.external import six
+
+if six.PY2:
+    import __builtin__
+    CLASS_TYPE = types.ClassType
+else:
+    import builtins
+    CLASS_TYPE = type
+
+__all__ = ['classmaker']
+
+def skip_redundant(iterable, skipset=None):
+    """
+    Redundant items are repeated items or items in the original skipset.
+    """
+    if skipset is None:
+        skipset = set()
+    for item in iterable:
+        if item not in skipset:
+            skipset.add(item)
+            yield item
+
+
+def remove_redundant(metaclasses):
+    skipset = set([CLASS_TYPE])
+    for meta in metaclasses:  # determines the metaclasses to be skipped
+        skipset.update(inspect.getmro(meta)[1:])
+    return tuple(skip_redundant(metaclasses, skipset))
+
+memoized_metaclasses_map = {}
+
+
+def get_noconflict_metaclass(bases, left_metas, right_metas):
+    """
+    Not intended to be used outside of this module, unless you know
+    what you are doing.
+    """
+    # make tuple of needed metaclasses in specified priority order
+    metas = left_metas + tuple(map(type, bases)) + right_metas
+    needed_metas = remove_redundant(metas)
+
+    # return existing confict-solving meta, if any
+    if needed_metas in memoized_metaclasses_map:
+        return memoized_metaclasses_map[needed_metas]
+    # nope: compute, memoize and return needed conflict-solving meta
+    elif not needed_metas:         # wee, a trivial case, happy us
+        meta = type
+    elif len(needed_metas) == 1:  # another trivial case
+        meta = needed_metas[0]
+    # check for recursion, can happen i.e. for Zope ExtensionClasses
+    elif needed_metas == bases:
+        raise TypeError("Incompatible root metatypes", needed_metas)
+    else:  # gotta work ...
+        metaname = '_' + ''.join([m.__name__ for m in needed_metas])
+        meta = classmaker()(metaname, needed_metas, {})
+    memoized_metaclasses_map[needed_metas] = meta
+    return meta
+
+def classmaker(left_metas=(), right_metas=()):
+    def make_class(name, bases, adict):
+        metaclass = get_noconflict_metaclass(
+            bases, left_metas, right_metas)
+        return metaclass(name, bases, adict)
+    return make_class

--- a/glue/viewers/common/qt/tests/test_toolbar.py
+++ b/glue/viewers/common/qt/tests/test_toolbar.py
@@ -46,10 +46,9 @@ class ExampleViewer(DataViewer):
         self._axes = self.central_widget.canvas.fig.add_subplot(111)
         self._axes.plot([1, 2, 3])[0]
         self.setCentralWidget(self.central_widget)
-        self._make_toolbar()
 
-    def _make_toolbar(self):
-        super(ExampleViewer, self)._make_toolbar()
+    def initialize_toolbar(self):
+        super(ExampleViewer, self).initialize_toolbar()
         self.mode = MouseModeTest(self, release_callback=self.callback)
         self.toolbar.add_tool(self.mode)
 
@@ -132,7 +131,6 @@ class ExampleViewer2(DataViewer):
 
     def __init__(self, session, parent=None):
         super(ExampleViewer2, self).__init__(session, parent=parent)
-        self._make_toolbar()
 
 
 def test_duplicate_shortcut():

--- a/glue/viewers/custom/qt/custom_viewer.py
+++ b/glue/viewers/custom/qt/custom_viewer.py
@@ -884,7 +884,6 @@ class CustomWidgetBase(DataViewer):
                                    layer_artist_container=self._layer_artist_container,
                                    coordinator=self._coordinator)
 
-        self._make_toolbar()
         self.statusBar().setSizeGripEnabled(False)
         self._update_artists = []
         self.settings_changed()

--- a/glue/viewers/histogram/qt/viewer_widget.py
+++ b/glue/viewers/histogram/qt/viewer_widget.py
@@ -62,7 +62,6 @@ class HistogramWidget(DataViewer):
                                       self.central_widget.canvas.fig,
                                       layer_artist_container=self._layer_artist_container)
         self._init_limits()
-        self._make_toolbar()
         self._connect()
         # maps _hash(componentID) -> componentID
         self._component_hashes = {}

--- a/glue/viewers/image/qt/viewer_widget.py
+++ b/glue/viewers/image/qt/viewer_widget.py
@@ -363,10 +363,6 @@ class ImageWidget(ImageWidgetBase):
     tools = ['select:rectangle', 'select:circle', 'select:polygon',
              'image:contrast', 'image:colormap']
 
-    def __init__(self, session, parent=None):
-        super(ImageWidget, self).__init__(session, parent=parent)
-        self._make_toolbar()
-
     def make_client(self):
         return MplImageClient(self._data,
                               self.central_widget.canvas.fig,
@@ -375,9 +371,9 @@ class ImageWidget(ImageWidgetBase):
     def make_central_widget(self):
         return MplWidget()
 
-    def _make_toolbar(self):
+    def initialize_toolbar(self):
 
-        super(ImageWidget, self)._make_toolbar()
+        super(ImageWidget, self).initialize_toolbar()
 
         # connect viewport update buttons to client commands to
         # allow resampling
@@ -441,7 +437,7 @@ class StandaloneImageWidget(QtWidgets.QMainWindow):
         self._im = None
         self._norm = DS9Normalize()
 
-        self._make_toolbar()
+        self.initialize_toolbar()
 
         if image is not None:
             self.set_image(image=image, wcs=wcs, **kwargs)
@@ -519,7 +515,7 @@ class StandaloneImageWidget(QtWidgets.QMainWindow):
         self._im.set_norm(self._norm)
         self._redraw()
 
-    def _make_toolbar(self):
+    def initialize_toolbar(self):
 
         # TODO: remove once Python 2 is no longer supported - see below for
         #       simpler code.

--- a/glue/viewers/scatter/qt/viewer_widget.py
+++ b/glue/viewers/scatter/qt/viewer_widget.py
@@ -71,10 +71,12 @@ class ScatterWidget(DataViewer):
 
         self._connect()
         self.unique_fields = set()
-        self._make_toolbar()
-        cache_axes(self.client.axes, self.toolbar)
         self.statusBar().setSizeGripEnabled(False)
         self.setFocusPolicy(Qt.StrongFocus)
+
+    def initialize_toolbar(self):
+        super(ScatterWidget, self).initialize_toolbar()
+        cache_axes(self.client.axes, self.toolbar)
 
     def _tweak_geometry(self):
         self.central_widget.resize(600, 400)

--- a/glue/viewers/table/qt/viewer_widget.py
+++ b/glue/viewers/table/qt/viewer_widget.py
@@ -11,6 +11,7 @@ from glue.core.edit_subset_mode import EditSubsetMode
 from glue.core import message as msg
 from glue.utils.qt import load_ui
 from glue.viewers.common.qt.data_viewer import DataViewer
+from glue.viewers.common.qt.toolbar import BasicToolbar
 
 
 class DataTableModel(QtCore.QAbstractTableModel):
@@ -79,6 +80,9 @@ class DataTableModel(QtCore.QAbstractTableModel):
 class TableWidget(DataViewer):
 
     LABEL = "Table Viewer"
+
+    _toolbar_cls = BasicToolbar
+    tools = []
 
     def __init__(self, session, parent=None, widget=None):
 


### PR DESCRIPTION
This uses a metaclass for DataViewer, which in turn needs the noconflict module which defines a class maker that avoids issues due to the fact that DataViewer has multiple inheritance, and one of the classes is from Qt.

Fixes #1119