### PR TITLE
Renamed --no-fullscreen option to --no-maximized

### DIFF
--- a/glue/main.py
+++ b/glue/main.py
@@ -58,7 +58,7 @@ def parse(argv):
                       help='use CONFIG as configuration file')
     parser.add_option('-v', '--verbose', action='store_true',
                       help="Increase the vebosity level", default=False)
-    parser.add_option('--no-fullscreen', action='store_true', dest='nofs',
+    parser.add_option('--no-maximized', action='store_true', dest='nomax',
                       help="Do not start Glue maximized", default=False)
 
     err_msg = verify(parser, argv)
@@ -209,7 +209,7 @@ def main(argv=sys.argv):
 
     # Global keywords for Glue startup.
     kwargs = {'config': opt.config,
-              'maximized': not opt.nofs}
+              'maximized': not opt.nomax}
 
     if opt.test:
         return run_tests()


### PR DESCRIPTION
This is a follow-up on #1093, as decided in [this comment](https://github.com/glue-viz/glue/pull/1093#issuecomment-245729622). This renames `--no-fullscreen` option to `--no-maximized`, which is more accurate.