### PR TITLE
Scatter layer editor in image viewer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -120,7 +120,7 @@ before_install:
   # package with a version of 5.x rather than a pyqt5 package, so we explicitly
   # request pyqt=4 for PyQt4.
   - if [[ $QT_PKG == pyside ]]; then export CONDA_DEPENDENCIES="pyside "$CONDA_DEPENDENCIES; fi
-  - if [[ $QT_PKG == pyqt ]]; then export CONDA_DEPENDENCIES="pyqt=4 "$CONDA_DEPENDENCIES; fi
+  - if [[ $QT_PKG == pyqt ]]; then export CONDA_DEPENDENCIES="pyqt=4.11.3 "$CONDA_DEPENDENCIES; fi
   - if [[ $QT_PKG == pyqt5 ]]; then export CONDA_DEPENDENCIES="pyqt5 "$CONDA_DEPENDENCIES; fi
 
   # Special cases depending on IPython version

--- a/.travis.yml
+++ b/.travis.yml
@@ -120,7 +120,7 @@ before_install:
   # package with a version of 5.x rather than a pyqt5 package, so we explicitly
   # request pyqt=4 for PyQt4.
   - if [[ $QT_PKG == pyside ]]; then export CONDA_DEPENDENCIES="pyside "$CONDA_DEPENDENCIES; fi
-  - if [[ $QT_PKG == pyqt ]]; then export CONDA_DEPENDENCIES="pyqt=4.11.3 "$CONDA_DEPENDENCIES; fi
+  - if [[ $QT_PKG == pyqt ]]; then export CONDA_DEPENDENCIES="pyqt<=4.11.3 "$CONDA_DEPENDENCIES; fi
   - if [[ $QT_PKG == pyqt5 ]]; then export CONDA_DEPENDENCIES="pyqt5 "$CONDA_DEPENDENCIES; fi
 
   # Special cases depending on IPython version

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,10 @@ v0.9.0 (unreleased)
 -----------------
 
 * Make sure that the scatter layer artist style editor is shown when overplotting
-  a scatter plot on top of an image.
+  a scatter plot on top of an image. [#1134]
+
+* Data viewers can now make layer_style_widget_cls a dictionary in cases
+  where multiple layer artist types are supported. [#1134]
 
 * Fix compatibility of test suite with pytest 3.x. [#1116]
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@ Full changelog
 v0.9.0 (unreleased)
 -----------------
 
+* Make sure that the scatter layer artist style editor is shown when overplotting
+  a scatter plot on top of an image.
+
 * Fix compatibility of test suite with pytest 3.x. [#1116]
 
 * Updated bundled version of WCSAxes to v0.9.

--- a/glue/core/qt/layer_artist_model.py
+++ b/glue/core/qt/layer_artist_model.py
@@ -303,6 +303,9 @@ class LayerArtistWidget(QtWidgets.QWidget):
 
         self.layout_style_widgets = {}
 
+        self.empty = QtWidgets.QWidget()
+        self.layer_options_layout.addWidget(self.empty)
+
     def on_artist_add(self, layer_artists):
 
         if self.layer_style_widget_cls is None:
@@ -310,7 +313,15 @@ class LayerArtistWidget(QtWidgets.QWidget):
 
         for layer_artist in layer_artists:
             if layer_artist not in self.layout_style_widgets:
-                self.layout_style_widgets[layer_artist] = self.layer_style_widget_cls(layer_artist)
+                if isinstance(self.layer_style_widget_cls, dict):
+                    layer_artist_cls = layer_artist.__class__
+                    if layer_artist_cls in self.layer_style_widget_cls:
+                        layer_style_widget_cls = self.layer_style_widget_cls[layer_artist_cls]
+                    else:
+                        return
+                else:
+                    layer_style_widget_cls = self.layer_style_widget_cls
+                self.layout_style_widgets[layer_artist] = layer_style_widget_cls(layer_artist)
                 self.layer_options_layout.addWidget(self.layout_style_widgets[layer_artist])
 
     def on_selection_change(self, layer_artist):
@@ -319,10 +330,9 @@ class LayerArtistWidget(QtWidgets.QWidget):
             return
 
         if layer_artist in self.layout_style_widgets:
-            self.layer_options_layout.setEnabled(True)
             self.layer_options_layout.setCurrentWidget(self.layout_style_widgets[layer_artist])
         else:
-            self.layer_options_layout.setEnabled(False)
+            self.layer_options_layout.setCurrentWidget(self.empty)
 
 
 

--- a/glue/core/tests/test_coordinates.py
+++ b/glue/core/tests/test_coordinates.py
@@ -21,17 +21,17 @@ class TestWcsCoordinates(object):
     def default_header(self):
         from astropy.io import fits
         hdr = fits.Header()
-        hdr.update('NAXIS', 2)
-        hdr.update('CRVAL1', 0)
-        hdr.update('CRVAL2', 5)
-        hdr.update('CRPIX1', 250)
-        hdr.update('CRPIX2', 187.5)
-        hdr.update('CTYPE1', 'GLON-TAN')
-        hdr.update('CTYPE2', 'GLAT-TAN')
-        hdr.update('CD1_1', -0.0166666666667)
-        hdr.update('CD1_2', 0.)
-        hdr.update('CD2_1', 0.)
-        hdr.update('CD2_2', 0.01666666666667)
+        hdr['NAXIS'] = 2
+        hdr['CRVAL1'] = 0
+        hdr['CRVAL2'] = 5
+        hdr['CRPIX1'] = 250
+        hdr['CRPIX2'] = 187.5
+        hdr['CTYPE1'] = 'GLON-TAN'
+        hdr['CTYPE2'] = 'GLAT-TAN'
+        hdr['CD1_1'] = -0.0166666666667
+        hdr['CD1_2'] = 0.
+        hdr['CD2_1'] = 0.
+        hdr['CD2_2'] = 0.01666666666667
         return hdr
 
     def test_pixel2world_scalar(self):
@@ -159,17 +159,17 @@ def test_world_axis_wcs():
     from astropy.io import fits
 
     hdr = fits.Header()
-    hdr.update('NAXIS', 2)
-    hdr.update('CRVAL1', 0)
-    hdr.update('CRVAL2', 5)
-    hdr.update('CRPIX1', 2)
-    hdr.update('CRPIX2', 1)
-    hdr.update('CTYPE1', 'XOFFSET')
-    hdr.update('CTYPE2', 'YOFFSET')
-    hdr.update('CD1_1', -2.)
-    hdr.update('CD1_2', 0.)
-    hdr.update('CD2_1', 0.)
-    hdr.update('CD2_2', 2.)
+    hdr['NAXIS'] = 2
+    hdr['CRVAL1'] = 0
+    hdr['CRVAL2'] = 5
+    hdr['CRPIX1'] = 2
+    hdr['CRPIX2'] = 1
+    hdr['CTYPE1'] = 'XOFFSET'
+    hdr['CTYPE2'] = 'YOFFSET'
+    hdr['CD1_1'] = -2.
+    hdr['CD1_2'] = 0.
+    hdr['CD2_1'] = 0.
+    hdr['CD2_2'] = 2.
 
     data = np.ones((3, 4))
     coord = WCSCoordinates(hdr)

--- a/glue/viewers/histogram/qt/viewer_widget.py
+++ b/glue/viewers/histogram/qt/viewer_widget.py
@@ -15,8 +15,7 @@ from glue.utils.qt.widget_properties import (connect_int_spin, ButtonProperty,
 from glue.viewers.common.qt.data_viewer import DataViewer
 from glue.viewers.common.qt.mpl_widget import MplWidget, defer_draw
 from glue.viewers.histogram.qt.layer_style_widget import HistogramLayerStyleWidget
-from glue.utils.array import pretty_number
-
+from glue.viewers.histogram.layer_artist import HistogramLayerArtist
 
 __all__ = ['HistogramWidget']
 
@@ -44,7 +43,7 @@ class HistogramWidget(DataViewer):
     xlog = ButtonProperty('ui.xlog_box', 'Log-scale the x axis?')
     ylog = ButtonProperty('ui.ylog_box', 'Log-scale the y axis?')
 
-    _layer_style_widget_cls = HistogramLayerStyleWidget
+    _layer_style_widget_cls = {HistogramLayerArtist: HistogramLayerStyleWidget}
 
     _toolbar_cls = MatplotlibViewerToolbar
     tools = ['select:xrange']

--- a/glue/viewers/image/qt/viewer_widget.py
+++ b/glue/viewers/image/qt/viewer_widget.py
@@ -21,6 +21,8 @@ from glue.viewers.common.qt.mpl_widget import MplWidget, defer_draw
 from glue.utils import nonpartial, Pointer
 from glue.utils.qt import cmap2pixmap, update_combobox, load_ui
 from glue.viewers.common.qt.tool import Tool
+from glue.viewers.scatter.layer_artist import ScatterLayerArtist
+from glue.viewers.scatter.qt.layer_style_widget import ScatterLayerStyleWidget
 
 # We do the following import to register the custom Qt Widget there
 from glue.viewers.image.qt.rgb_edit import RGBEdit  # pylint: disable=W0611
@@ -51,6 +53,8 @@ class ImageWidgetBase(DataViewer):
     rgb_mode = ButtonProperty('ui.rgb',
                               'RGB Mode?')
     rgb_viz = Pointer('ui.rgb_options.rgb_visible')
+
+    _layer_style_widget_cls = {ScatterLayerArtist: ScatterLayerStyleWidget}
 
     def __init__(self, session, parent=None):
         super(ImageWidgetBase, self).__init__(session, parent)

--- a/glue/viewers/scatter/qt/layer_style_widget.py
+++ b/glue/viewers/scatter/qt/layer_style_widget.py
@@ -32,7 +32,7 @@ class ScatterLayerStyleWidget(QtWidgets.QWidget):
         # Set initial values
         self.symbol = self.layer.style.marker
         self.size = self.layer.style.markersize
-        self.ui.label_color.setColor(self.layer.style.color)        
+        self.ui.label_color.setColor(self.layer.style.color)
         self.alpha = self.layer.style.alpha
 
     def _connect_global(self):

--- a/glue/viewers/scatter/qt/viewer_widget.py
+++ b/glue/viewers/scatter/qt/viewer_widget.py
@@ -13,6 +13,7 @@ from glue.utils.qt import load_ui
 from glue.viewers.common.qt.data_viewer import DataViewer
 from glue.viewers.common.qt.mpl_widget import MplWidget, defer_draw
 from glue.viewers.scatter.qt.layer_style_widget import ScatterLayerStyleWidget
+from glue.viewers.scatter.layer_artist import ScatterLayerArtist
 from glue.utils import nonpartial, cache_axes
 from glue.utils.qt.widget_properties import (ButtonProperty, FloatLineProperty,
                                              CurrentComboProperty,
@@ -47,7 +48,7 @@ class ScatterWidget(DataViewer):
     yatt = CurrentComboProperty('ui.yAxisComboBox',
                                 'Attribute to plot on y axis')
 
-    _layer_style_widget_cls = ScatterLayerStyleWidget
+    _layer_style_widget_cls = {ScatterLayerArtist: ScatterLayerStyleWidget}
 
     _toolbar_cls = MatplotlibViewerToolbar
     tools = ['select:rectangle', 'select:xrange', 'select:yrange', 'select:circle', 'select:polygon']


### PR DESCRIPTION
Make sure that the scatter layer artist style editor is shown when overplotting a scatter plot on top of an image, and allow _layer_style_widget_cls to be a dictionary