### PR TITLE
Put table column unit on second line in header

### DIFF
--- a/glue/viewers/table/qt/viewer_widget.py
+++ b/glue/viewers/table/qt/viewer_widget.py
@@ -66,7 +66,7 @@ class DataTableModel(QtCore.QAbstractTableModel):
             column_name = self.columns[section].label
             units = self._data.get_component(self.columns[section]).units
             if units != '':
-                column_name += " [{0}]".format(units)
+                column_name += "\n{0}".format(units)
             return column_name
         elif orientation == Qt.Vertical:
             return str(self.order[section])


### PR DESCRIPTION
Follow up to #1135 . This moves the unit *below* the column name in the header row. Otherwise, I'll need to stretch out the column to see the units.