### PR TITLE
Implement InequalitySubsetState for categorical components

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,9 @@ v0.9.1 (2016-11-01)
 * Fixed plotting of fit on spectrum to make sure that the two are properly
   aligned. [#1158]
 
+* Made it possible to now create InequalitySubsetStates for
+  categorical components using e.g. d.id['a'] == 'string'. [#1153]
+
 * Fixed a bug that caused selections to not propagate properly between
   linked images and cubes. [#1144]
 

--- a/glue/core/component_id.py
+++ b/glue/core/component_id.py
@@ -1,17 +1,28 @@
 from __future__ import absolute_import, division, print_function
 
 import operator
-
-import numpy as np
+import numbers
 
 from glue.external import six
 from glue.core.component_link import BinaryComponentLink
 from glue.core.subset import InequalitySubsetState
 
 
-__all__ = ['PixelComponentID', 'ComponentID', 'PixelComponentID', 'ComponentIDDict']
+__all__ = ['PixelComponentID', 'ComponentID', 'PixelComponentID', 'ComponentIDDict', 'ComponentIDList']
 
 # access to ComponentIDs via .item[name]
+
+class ComponentIDList(list):
+
+    def __contains__(self, cid):
+        if isinstance(cid, six.string_types):
+            for c in self:
+                if cid == c.label:
+                    return True
+            else:
+                return False
+        else:
+            return list.__contains__(self, cid)
 
 
 class ComponentIDDict(object):
@@ -70,7 +81,7 @@ class ComponentID(object):
         return str(self._label)
 
     def __eq__(self, other):
-        if np.issubsctype(type(other), np.number):
+        if isinstance(other, (numbers.Number, six.string_types)):
             return InequalitySubsetState(self, other, operator.eq)
         return other is self
 
@@ -79,7 +90,7 @@ class ComponentID(object):
         __hash__ = object.__hash__
 
     def __ne__(self, other):
-        if np.issubsctype(type(other), np.number):
+        if isinstance(other, (numbers.Number, six.string_types)):
             return InequalitySubsetState(self, other, operator.ne)
         return other is not self
 

--- a/glue/core/component_link.py
+++ b/glue/core/component_link.py
@@ -86,7 +86,7 @@ class ComponentLink(object):
         self.hidden = False  # show in widgets?
         self.identity = self._using is identity
 
-        if type(comp_from) is not list:
+        if not isinstance(comp_from, list):
             raise TypeError("comp_from must be a list: %s" % type(comp_from))
 
         if not all(isinstance(f, ComponentID) for f in self._from):

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -15,6 +15,7 @@ from glue.core.decorators import clear_cache
 from glue.core.util import split_component_view
 from glue.core.hub import Hub
 from glue.core.subset import Subset, SubsetState
+from glue.core.component_id import ComponentIDList
 from glue.core.component_link import ComponentLink, CoordinateComponentLink
 from glue.core.exceptions import IncompatibleAttribute
 from glue.core.visual import VisualAttributes
@@ -76,8 +77,8 @@ class Data(object):
 
         # Components
         self._components = OrderedDict()
-        self._pixel_component_ids = []
-        self._world_component_ids = []
+        self._pixel_component_ids = ComponentIDList()
+        self._world_component_ids = ComponentIDList()
 
         self.id = ComponentIDDict(self)
 
@@ -333,11 +334,14 @@ class Data(object):
                             "should contain a single component.")
 
         def get_component_id(data, name):
-            cid = data.find_component_id(name)
-            if cid is None:
-                raise ValueError("ComponentID not found in %s: %s" %
-                                 (data.label, name))
-            return cid
+            if isinstance(name, ComponentID):
+                return name
+            else:
+                cid = data.find_component_id(name)
+                if cid is None:
+                    raise ValueError("ComponentID not found in %s: %s" %
+                                     (data.label, name))
+                return cid
 
         cid = tuple(get_component_id(self, name) for name in cid)
         cid_other = tuple(get_component_id(other, name) for name in cid_other)
@@ -572,7 +576,7 @@ class Data(object):
         """
         Equivalent to :attr:`Data.components`
         """
-        return list(self._components.keys())
+        return ComponentIDList(self._components.keys())
 
     @contract(subset='isinstance(Subset)|None',
               color='color|None',

--- a/glue/core/layer_artist.py
+++ b/glue/core/layer_artist.py
@@ -113,6 +113,7 @@ class LayerArtistBase(PropertySetMixin):
         """
         if len(attributes) == 0:
             self.disable('')
+            return
 
         msg = ('Layer depends on attributes that '
                'cannot be derived for %s:\n -%s' %

--- a/glue/core/subset.py
+++ b/glue/core/subset.py
@@ -938,8 +938,8 @@ class InequalitySubsetState(SubsetState):
             raise TypeError("Input must be ComponentID or NumberType or string: %s"
                             % type(left))
 
-        if not isinstance(left, (ComponentID, numbers.Number,
-                                 ComponentLink, six.string_types)):
+        if not isinstance(right, (ComponentID, numbers.Number,
+                                  ComponentLink, six.string_types)):
             raise TypeError("Input must be ComponentID or NumberType or string: %s"
                             % type(right))
         self._left = left

--- a/glue/core/subset.py
+++ b/glue/core/subset.py
@@ -965,7 +965,7 @@ class InequalitySubsetState(SubsetState):
         # if x is a Numpy array, x[None] has one more dimension than x. For
         # now we just fix this for the scope of this method.
         if view is None:
-            view = ...
+            view = Ellipsis
 
         if isinstance(self._left, (numbers.Number, six.string_types)):
             left = self._left

--- a/glue/core/tests/test_data.py
+++ b/glue/core/tests/test_data.py
@@ -372,7 +372,7 @@ class TestROICreation(object):
         d = Data(x=['a', 'b', 'c'], y=[1, 2, 3])
         comp = d.get_component(d.id['x'])
         roi = CategoricalROI(['b', 'c'])
-        s = comp.subset_from_roi('x', roi)
+        s = comp.subset_from_roi(d.id['x'], roi)
         assert isinstance(s, CategoricalROISubsetState)
         np.testing.assert_array_equal((s.roi.contains(['a', 'b', 'c'], None)),
                                       [False, True, True])
@@ -389,7 +389,7 @@ class TestROICreation(object):
         x_comp = d.get_component(d.id['x'])
         y_comp = d.get_component(d.id['y'])
         roi = PolygonalROI([0, 0, 2, 2], [0, 2, 2, 0])
-        s = x_comp.subset_from_roi('x', roi, other_comp=y_comp, other_att='y')
+        s = x_comp.subset_from_roi(d.id['x'], roi, other_comp=y_comp, other_att=d.id['y'])
         assert isinstance(s, RoiSubsetState)
         np.testing.assert_array_equal(s.to_mask(d), [True, True, False, False])
 

--- a/glue/core/tests/test_subset.py
+++ b/glue/core/tests/test_subset.py
@@ -534,6 +534,7 @@ def test_inequality_state_str():
     x = d.id['x']
     y = d.id['y']
 
+    assert str(x == 'a') == '(x == a)'
     assert str(x > 3) == '(x > 3)'
     assert str(x < 2) == '(x < 2)'
     assert str(x < y) == '(x < y)'
@@ -624,3 +625,9 @@ def test_save_element_subset_state():
     state1 = ElementSubsetState(indices=[1, 3, 4])
     state2 = clone(state1)
     assert state2._indices == [1, 3, 4]
+
+
+def test_inequality_subset_state_string():
+    d = Data(x=['a', 'b', 'c', 'b'])
+    state = d.id['x'] == 'b'
+    np.testing.assert_equal(state.to_mask(d), np.array([False, True, False, True]))


### PR DESCRIPTION
This makes it possible to create InequalitySubsetStates for categorical components using e.g. `d.id['a'] == 'string'`
