### PR TITLE
Add a .meta attribute to Data objects

### DIFF
--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -81,6 +81,9 @@ class Data(object):
 
         self.id = ComponentIDDict(self)
 
+        # Metadata
+        self.meta = OrderedDict()
+
         # Subsets of the data
         self._subsets = []
 

--- a/glue/core/data_factories/astropy_table.py
+++ b/glue/core/data_factories/astropy_table.py
@@ -65,6 +65,8 @@ def astropy_tabular_data(*args, **kwargs):
 
     table = astropy_table_read(*args, **kwargs)
 
+    result.meta = table.meta
+
     # Loop through columns and make component list
     for column_name in table.columns:
         c = table[column_name]


### PR DESCRIPTION
For Issue #1147 

Give the `Data` object an `OrderedDict` of metadata.
`astropy_tabular_data()` passes the `Table` metadata to the `Data` object.