### PR TITLE
Plotting of spectrum fit is offset from data

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,9 @@ v0.10.0 (unreleased)
 v0.9.1 (unreleased)
 -------------------
 
+* Fixed plotting of fit on spectrum to make sure that the two are properly
+  aligned. [#1158]
+
 * Fixed a bug that caused selections to not propagate properly between
   linked images and cubes.
 

--- a/glue/plugins/tools/spectrum_tool/qt/profile_viewer.py
+++ b/glue/plugins/tools/spectrum_tool/qt/profile_viewer.py
@@ -333,7 +333,7 @@ class ProfileViewer(object):
         if self._artist is not None:
             self._artist.remove()
 
-        kwargs.setdefault('drawstyle', 'steps-post')
+        kwargs.setdefault('drawstyle', 'steps-mid')
 
         self._artist = self.axes.plot(x, y, **kwargs)[0]
         self._relayout()

--- a/glue/plugins/tools/spectrum_tool/qt/spectrum_tool.py
+++ b/glue/plugins/tools/spectrum_tool/qt/spectrum_tool.py
@@ -656,6 +656,9 @@ class SpectrumMainWindow(QtWidgets.QMainWindow):
         if isinstance(layer, Subset):
             self.subset_dropped.emit(layer)
 
+    def set_status(self, message):
+        sb = self.statusBar()
+        sb.showMessage(message)
 
 @viewer_tool
 class SpectrumExtractorMode(RoiMode):


### PR DESCRIPTION
<img width="857" alt="screen shot 2016-10-31 at 17 14 20" src="https://cloud.githubusercontent.com/assets/314716/19863788/836feb2a-9f8d-11e6-90ab-6d96bc0073db.png">

Probably a steps-mid vs steps-pre issue in Matplotlib plotting.