### PR TITLE
Make it possible to define a default index for DataComboHelper 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,12 @@ v0.10.0 (unreleased)
 - Removed ginga plugin from core package and moved it to a separate repository
   at https://github.com/ejeschke/glue-ginga.
 
+- Make it possible to define a default index for DataComboHelper - this makes
+  it possible for viewers to have three DataComboHelper and ensure that they
+  default to different attributes. [#1163]
+
+- Deal properly with adding Subset objects to DataComboHelper. [#1163]
+
 - Added the ability to export data and subset from the data collection view via
   contextual menus. It was previously possible to export only the mask itself,
   and only to FITS files, but the framework for exporting data/subsets has now

--- a/glue/core/qt/data_combo_helper.py
+++ b/glue/core/qt/data_combo_helper.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from glue.core import Data, DataCollection
+from glue.core import Data, DataCollection, Subset
 from qtpy import QtGui, QtWidgets
 from qtpy.QtCore import Qt
 from glue.core.hub import HubListener
@@ -14,6 +14,7 @@ from glue.utils.qt.widget_properties import CurrentComboDataProperty
 
 __all__ = ['ComponentIDComboHelper', 'ManualDataComboHelper',
            'DataCollectionComboHelper']
+
 
 class ComponentIDComboHelper(HubListener):
     """
@@ -39,7 +40,7 @@ class ComponentIDComboHelper(HubListener):
     """
 
     def __init__(self, component_id_combo, data_collection, visible=True,
-                 numeric=True, categorical=True):
+                 numeric=True, categorical=True, default_index=0):
 
         super(ComponentIDComboHelper, self).__init__()
 
@@ -53,6 +54,7 @@ class ComponentIDComboHelper(HubListener):
         self._data = []
         self._data_collection = data_collection
         self.hub = data_collection.hub
+        self.default_index = default_index
 
     def clear(self):
         self._data.clear()
@@ -87,6 +89,9 @@ class ComponentIDComboHelper(HubListener):
 
     def append_data(self, data):
 
+        if isinstance(data, Subset):
+            data = data.data
+
         if self.hub is None:
             if data.hub is None:
                 raise ValueError("Hub is not set on Data object")
@@ -95,9 +100,9 @@ class ComponentIDComboHelper(HubListener):
         elif data.hub is not self.hub:
             raise ValueError("Data Hub is different from current hub")
 
-        self._data.append(data)
-
-        self.refresh()
+        if data not in self._data:
+            self._data.append(data)
+            self.refresh()
 
     def remove_data(self, data):
         self._data.remove(data)
@@ -154,7 +159,7 @@ class ComponentIDComboHelper(HubListener):
 
             label_data.extend([(cid.label, (cid, data)) for cid in component_ids])
 
-        update_combobox(self._component_id_combo, label_data)
+        update_combobox(self._component_id_combo, label_data, default_index=self.default_index)
 
         # Disable header rows
         model = self._component_id_combo.model()

--- a/glue/utils/qt/helpers.py
+++ b/glue/utils/qt/helpers.py
@@ -11,7 +11,7 @@ from glue.utils.qt import get_text
 __all__ = ['update_combobox', 'GlueTabBar', 'load_ui', 'process_dialog']
 
 
-def update_combobox(combo, labeldata):
+def update_combobox(combo, labeldata, default_index=0):
     """
     Redefine the items in a QComboBox
 
@@ -48,12 +48,14 @@ def update_combobox(combo, labeldata):
         current = None
 
     combo.clear()
-    index = 0
+    index = None
     for i, (label, data) in enumerate(labeldata):
         combo.addItem(label, userData=data)
-        if data is current:
+        if data is current or data == current:
             index = i
     combo.blockSignals(False)
+    if index is None:
+        index = min(default_index, combo.count() - 1)
     combo.setCurrentIndex(index)
 
     # We need to force emit this, otherwise if the index happens to be the


### PR DESCRIPTION
This makes it possible for viewers to have three DataComboHelper and ensure that they default to different attributes. Also deal properly with adding Subset objects to DataComboHelper.