### PR TITLE
Add a hub message for when Glue application is closed

### DIFF
--- a/glue/app/qt/application.py
+++ b/glue/app/qt/application.py
@@ -11,6 +11,7 @@ from qtpy import QtCore, QtWidgets, QtGui, compat
 from qtpy.QtCore import Qt
 
 from glue.core.application_base import Application
+from glue.core.message import ApplicationClosedMessage
 from glue.core import command, Data
 from glue import env
 from glue.main import load_plugins
@@ -908,6 +909,11 @@ class GlueApplication(Application, QtWidgets.QMainWindow):
                     path = path[1:]
 
             self.load_data(path)
+        event.accept()
+
+    def closeEvent(self, event):
+        """Emit a message to hub before closing."""
+        self._hub.broadcast(ApplicationClosedMessage(None))
         event.accept()
 
     def report_error(self, message, detail):

--- a/glue/core/message.py
+++ b/glue/core/message.py
@@ -10,7 +10,7 @@ __all__ = ['Message', 'ErrorMessage', 'SubsetMessage', 'SubsetCreateMessage',
            'DataAddComponentMessage', 'DataUpdateMessage',
            'DataCollectionMessage', 'DataCollectionActiveChange',
            'DataCollectionActiveDataChange', 'DataCollectionAddMessage',
-           'DataCollectionDeleteMessage']
+           'DataCollectionDeleteMessage', 'ApplicationClosedMessage']
 
 
 class Message(object):
@@ -191,3 +191,8 @@ class SettingsChangeMessage(Message):
     def __init__(self, sender, settings, tag=None):
         super(SettingsChangeMessage, self).__init__(sender=sender, tag=tag)
         self.settings = settings
+
+
+class ApplicationClosedMessage(Message):
+    """A general message issued when Glue application is closed."""
+    pass


### PR DESCRIPTION
Add a hub message for when Glue application is closed. This is useful for external GUI like Ginga that calls Glue. Closes #1167. Also see ejeschke/glue-ginga#10.