### PR TITLE
Significant performance improvements for WCS linking with cubes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,8 @@ v0.9.2 (unreleased)
   The original behavior of keeping the coordinate information from the first
   dataset has been restored. [#1186]
 
+* Fix signficant performance bottlenecks with WCS coordinate conversions. [#1185]
+
 v0.9.1 (2016-11-01)
 -------------------
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -72,10 +72,6 @@ To install or update glue on the command-line, simply do::
 
     conda install -c conda-forge glueviz
 
-.. note:: There is currently a known issue when running Anaconda's Qt on
-          certain Linux distributions (including Kubuntu). See
-          `Issue with PyQt4 from conda`_ for more details.
-
 Installing with pip
 -------------------
 

--- a/glue/core/component.py
+++ b/glue/core/component.py
@@ -289,7 +289,7 @@ class CoordinateComponent(Component):
                     pix_coords.append(0)
             pix_coords = np.meshgrid(*pix_coords, indexing='ij', copy=False)
 
-            world_coords = self._data.coords.pixel2world_indiv(*pix_coords[::-1],
+            world_coords = self._data.coords.pixel2world_single_axis(*pix_coords[::-1],
                                                                axis=self._data.ndim - 1 - self.axis)
 
             world_coords = np.broadcast_to(world_coords, self._data.shape)

--- a/glue/core/component.py
+++ b/glue/core/component.py
@@ -9,7 +9,6 @@ import pandas as pd
 
 from glue.core.subset import (RoiSubsetState, RangeSubsetState,
                               CategoricalROISubsetState, AndState,
-                              MultiRangeSubsetState,
                               CategoricalMultiRangeSubsetState,
                               CategoricalROISubsetState2D)
 from glue.core.roi import (PolygonalROI, CategoricalROI, RangeROI, XRangeROI,
@@ -108,7 +107,7 @@ class Component(object):
         return False
 
     def __str__(self):
-        return "Component with shape %s" % shape_to_string(self.shape)
+        return "%s with shape %s" % (self.__class__.__name__, shape_to_string(self.shape))
 
     def jitter(self, method=None):
         raise NotImplementedError
@@ -257,7 +256,6 @@ class DerivedComponent(Component):
 
 
 class CoordinateComponent(Component):
-
     """
     Components associated with pixel or world coordinates
 
@@ -275,16 +273,44 @@ class CoordinateComponent(Component):
         return self._calculate()
 
     def _calculate(self, view=None):
-        slices = [slice(0, s, 1) for s in self.shape]
-        grids = np.broadcast_arrays(*np.ogrid[slices])
-        if view is not None:
-            grids = [g[view] for g in grids]
 
         if self.world:
-            world = self._data.coords.pixel2world(*grids[::-1])[::-1]
-            return world[self.axis]
+
+            # This can be a bottleneck if we aren't careful, so we need to make
+            # sure that if not all dimensions depend on each other, we use smart
+            # broadcasting
+
+            pix_coords = []
+            dep_coords = self._data.coords.dependent_axes(self.axis)
+            for i in range(self._data.ndim):
+                if i in dep_coords:
+                    pix_coords.append(np.arange(self._data.shape[i]))
+                else:
+                    pix_coords.append(0)
+            pix_coords = np.meshgrid(*pix_coords, indexing='ij', copy=False)
+
+            world_coords = self._data.coords.pixel2world_indiv(*pix_coords[::-1],
+                                                               axis=self._data.ndim - 1 - self.axis)
+
+            world_coords = np.broadcast_to(world_coords, self._data.shape)
+
+            if view is None:
+                view = Ellipsis
+
+            # FIXME: this is inefficient if view is only a small fraction of the
+            # whole array, and should be optimized.
+
+            return world_coords[view]
+
         else:
+
+            slices = [slice(0, s, 1) for s in self.shape]
+            grids = np.broadcast_arrays(*np.ogrid[slices])
+            if view is not None:
+                grids = [g[view] for g in grids]
             return grids[self.axis]
+
+
 
     @property
     def shape(self):

--- a/glue/core/component.py
+++ b/glue/core/component.py
@@ -15,7 +15,7 @@ from glue.core.roi import (PolygonalROI, CategoricalROI, RangeROI, XRangeROI,
                            YRangeROI, RectangularROI)
 from glue.core.util import row_lookup
 from glue.utils import (unique, shape_to_string, coerce_numeric, check_sorted,
-                        polygon_line_intersections)
+                        polygon_line_intersections, broadcast_to)
 
 
 __all__ = ['Component', 'DerivedComponent',
@@ -292,7 +292,7 @@ class CoordinateComponent(Component):
             world_coords = self._data.coords.pixel2world_single_axis(*pix_coords[::-1],
                                                                axis=self._data.ndim - 1 - self.axis)
 
-            world_coords = np.broadcast_to(world_coords, self._data.shape)
+            world_coords = broadcast_to(world_coords, self._data.shape)
 
             if view is None:
                 view = Ellipsis

--- a/glue/core/component_link.py
+++ b/glue/core/component_link.py
@@ -271,7 +271,8 @@ class CoordinateComponentLink(ComponentLink):
         self.hidden = True
 
     def using(self, *args):
-        attr = 'pixel2world' if self.pixel2world else 'world2pixel'
+
+        attr = 'pixel2world_indiv' if self.pixel2world else 'world2pixel_indiv'
         func = getattr(self.coords, attr)
 
         args2 = [None] * self.ndim
@@ -282,7 +283,7 @@ class CoordinateComponentLink(ComponentLink):
                 args2[i] = np.zeros_like(args[0])
         args2 = tuple(args2)
 
-        return func(*args2[::-1])[::-1][self.index]
+        return func(*args2[::-1], axis=self.ndim - 1 - self.index)
 
     def __str__(self):
         rep = 'pix2world' if self.pixel2world else 'world2pix'

--- a/glue/core/component_link.py
+++ b/glue/core/component_link.py
@@ -272,7 +272,7 @@ class CoordinateComponentLink(ComponentLink):
 
     def using(self, *args):
 
-        attr = 'pixel2world_indiv' if self.pixel2world else 'world2pixel_indiv'
+        attr = 'pixel2world_single_axis' if self.pixel2world else 'world2pixel_single_axis'
         func = getattr(self.coords, attr)
 
         args2 = [None] * self.ndim

--- a/glue/core/coordinates.py
+++ b/glue/core/coordinates.py
@@ -4,7 +4,7 @@ import logging
 
 import numpy as np
 
-from glue.utils import unbroadcast
+from glue.utils import unbroadcast, broadcast_to
 
 
 __all__ = ['Coordinates', 'WCSCoordinates']
@@ -93,7 +93,7 @@ class Coordinates(object):
 
         result = self.pixel2world(*pixel)
 
-        return np.broadcast_to(result[axis], original_shape)
+        return broadcast_to(result[axis], original_shape)
 
     def world2pixel_single_axis(self, *world, **kwargs):
         """
@@ -135,7 +135,7 @@ class Coordinates(object):
 
         result = self.world2pixel(*world)
 
-        return np.broadcast_to(result[axis], original_shape)
+        return broadcast_to(result[axis], original_shape)
 
     def world_axis(self, data, axis):
         """

--- a/glue/core/coordinates.py
+++ b/glue/core/coordinates.py
@@ -51,7 +51,9 @@ class Coordinates(object):
         """
         return args
 
-    def pixel2world_single_axis(self, *pixel, axis=None):
+    # PY3: pixel2world_single_axis(self, *pixel, axis=None)
+
+    def pixel2world_single_axis(self, *pixel, **kwargs):
         """
         Convert pixel to world coordinates, preserving input type/shape.
 
@@ -73,6 +75,9 @@ class Coordinates(object):
             The world coordinates for the requested axis
         """
 
+        # PY3: the following is needed for Python 2
+        axis = kwargs.get('axis', None)
+
         if axis is None:
             raise ValueError("axis needs to be set")
 
@@ -90,7 +95,7 @@ class Coordinates(object):
 
         return np.broadcast_to(result[axis], original_shape)
 
-    def world2pixel_single_axis(self, *world, axis=None):
+    def world2pixel_single_axis(self, *world, **kwargs):
         """
         Convert world to pixel coordinates, preserving input type/shape.
 
@@ -111,6 +116,9 @@ class Coordinates(object):
         pixel : `numpy.ndarray`
             The pixel coordinates for the requested axis
         """
+
+        # PY3: the following is needed for Python 2
+        axis = kwargs.get('axis', None)
 
         if axis is None:
             raise ValueError("axis needs to be set")
@@ -275,11 +283,13 @@ class WCSCoordinates(Coordinates):
             naxis = None
         self._wcs = WCS(self._header, naxis=naxis)
 
-    def pixel2world(self, *pixel, axis=None):
-        return self._wcs.wcs_pix2world(*pixel, 0)
+    def pixel2world(self, *pixel):
+        # PY3: can just do pix2world(*pixel, 0)
+        return self._wcs.wcs_pix2world(*(tuple(pixel) + (0,)))
 
-    def world2pixel(self, *world, axis=None):
-        return self._wcs.wcs_world2pix(*world, 0)
+    def world2pixel(self, *world):
+        # PY3: can just do world2pix(*world, 0)
+        return self._wcs.wcs_world2pix(*(tuple(world) + (0,)))
 
     def axis_label(self, axis):
         header = self._header

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -533,12 +533,12 @@ class Data(object):
 
         def make_toworld_func(i):
             def pix2world(*args):
-                return self.coords.pixel2world_indiv(*args[::-1], axis=self.ndim - 1 - i)
+                return self.coords.pixel2world_single_axis(*args[::-1], axis=self.ndim - 1 - i)
             return pix2world
 
         def make_topixel_func(i):
             def world2pix(*args):
-                return self.coords.world2pixel_indiv(*args[::-1], axis=self.ndim - 1 - i)
+                return self.coords.world2pixel_single_axis(*args[::-1], axis=self.ndim - 1 - i)
             return world2pix
 
         result = []

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -533,12 +533,12 @@ class Data(object):
 
         def make_toworld_func(i):
             def pix2world(*args):
-                return self.coords.pixel2world(*args[::-1])[::-1][i]
+                return self.coords.pixel2world_indiv(*args[::-1], axis=self.ndim - 1 - i)
             return pix2world
 
         def make_topixel_func(i):
             def world2pix(*args):
-                return self.coords.world2pixel(*args[::-1])[::-1][i]
+                return self.coords.world2pixel_indiv(*args[::-1], axis=self.ndim - 1 - i)
             return world2pix
 
         result = []
@@ -737,6 +737,7 @@ class Data(object):
 
         :returns: :class:`~numpy.ndarray`
         """
+
         key, view = split_component_view(key)
         if isinstance(key, six.string_types):
             _k = key
@@ -753,6 +754,7 @@ class Data(object):
             raise IncompatibleAttribute(key)
 
         shp = view_shape(self.shape, view)
+
         if view is not None:
             result = comp[view]
         else:

--- a/glue/core/roi.py
+++ b/glue/core/roi.py
@@ -516,10 +516,7 @@ class PolygonalROI(VertexROIBase):
         if not isinstance(y, np.ndarray):
             y = np.asarray(y)
 
-        result = points_inside_poly(x.flat, y.flat, self.vx, self.vy)
-        good = np.isfinite(x.flat) & np.isfinite(y.flat)
-        result[~good] = False
-        result.shape = x.shape
+        result = points_inside_poly(x, y, self.vx, self.vy)
         return result
 
     def move_to(self, xdelta, ydelta):

--- a/glue/core/tests/test_component.py
+++ b/glue/core/tests/test_component.py
@@ -13,6 +13,7 @@ from glue.external import six
 from glue import core
 from glue.tests.helpers import requires_astropy
 
+from ..coordinates import Coordinates
 from ..component import (Component, DerivedComponent, CoordinateComponent,
                          CategoricalComponent)
 from ..component_id import ComponentID
@@ -203,10 +204,14 @@ class TestCategoricalComponent(object):
 class TestCoordinateComponent(object):
 
     def setup_method(self, method):
-        class TestCoords(object):
+
+        class TestCoords(Coordinates):
 
             def pixel2world(self, *args):
                 return [a * (i + 1) for i, a in enumerate(args)]
+
+            def dependent_axes(self, axis):
+                return (axis,)
 
         data = core.Data()
         data.add_component(Component(np.zeros((3, 3, 3))), 'test')

--- a/glue/core/tests/test_pandas.py
+++ b/glue/core/tests/test_pandas.py
@@ -6,8 +6,7 @@ from mock import MagicMock
 from pandas.util.testing import (assert_series_equal,
                                  assert_frame_equal)
 
-from ..component import (Component, DerivedComponent, CoordinateComponent,
-                         CategoricalComponent)
+from ..component import Component, DerivedComponent, CategoricalComponent
 from ..data import Data
 
 
@@ -59,10 +58,11 @@ class TestPandasConversion(object):
             'n': [4, 5, 6, 7],
             'c': ['a', 'b', 'c', 'd'],
             'd': np.arange(4),
-            'Pixel Axis 0 [x]': np.arange(4),
-            'World 0': np.arange(4)
+            'Pixel Axis 0 [x]': np.ogrid[0:4],
+            'World 0': np.arange(4, dtype=np.int64)
         })
         out_frame = d.to_dataframe()
+
         assert_frame_equal(out_frame, frame)
         assert list(out_frame.columns) == order
 

--- a/glue/utils/array.py
+++ b/glue/utils/array.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import, division, print_function
 
 import numpy as np
+from numpy.lib.stride_tricks import as_strided
+
 import pandas as pd
 
 from glue.external.six import string_types
@@ -11,15 +13,19 @@ __all__ = ['unique', 'shape_to_string', 'view_shape', 'stack_view',
 
 
 def unbroadcast(array):
+    """
+    Given an array, return a new array that is the smallest subset of the
+    original array that can be re-broadcasted back to the original array.
+
+    See http://stackoverflow.com/questions/40845769/un-broadcasting-numpy-arrays
+    for more details.
+    """
+
     if array.ndim == 0:
         return array
-    slices = []
-    for i in range(array.ndim):
-        if array.strides[i] == 0:
-            slices.append(slice(0, 1))
-        else:
-            slices.append(slice(None))
-    return array[slices]
+
+    new_shape = np.where(np.array(array.strides) == 0, 1, array.shape)
+    return as_strided(array, shape=new_shape)
 
 
 def unique(array):

--- a/glue/utils/array.py
+++ b/glue/utils/array.py
@@ -169,4 +169,4 @@ def broadcast_to(array, shape):
     try:
         return np.broadcast_to(array, shape)
     except AttributeError:
-        return array * np.ones(shape, array.dtype)
+        return np.broadcast_arrays(array, np.ones(shape, array.dtype))[0]

--- a/glue/utils/array.py
+++ b/glue/utils/array.py
@@ -7,7 +7,17 @@ from glue.external.six import string_types
 
 
 __all__ = ['unique', 'shape_to_string', 'view_shape', 'stack_view',
-           'coerce_numeric', 'check_sorted', 'broadcast_to']
+           'coerce_numeric', 'check_sorted', 'broadcast_to', 'unbroadcast']
+
+
+def unbroadcast(array):
+    slices = []
+    for i in range(array.ndim):
+        if array.strides[i] == 0:
+            slices.append(slice(0, 1))
+        else:
+            slices.append(slice(None))
+    return array[slices]
 
 
 def unique(array):

--- a/glue/utils/array.py
+++ b/glue/utils/array.py
@@ -11,6 +11,8 @@ __all__ = ['unique', 'shape_to_string', 'view_shape', 'stack_view',
 
 
 def unbroadcast(array):
+    if array.ndim == 0:
+        return array
     slices = []
     for i in range(array.ndim):
         if array.strides[i] == 0:

--- a/glue/utils/geometry.py
+++ b/glue/utils/geometry.py
@@ -2,10 +2,23 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 
+from glue.utils import unbroadcast
+
 __all__ = ['points_inside_poly', 'polygon_line_intersections']
 
 
 def points_inside_poly(x, y, vx, vy):
+
+    original_shape = x.shape
+
+    x = unbroadcast(x)
+    y = unbroadcast(y)
+    x, y = np.broadcast_arrays(x, y)
+
+    reduced_shape = x.shape
+
+    x = x.flat
+    y = y.flat
 
     from matplotlib.path import Path
     p = Path(np.column_stack((vx, vy)))
@@ -23,6 +36,12 @@ def points_inside_poly(x, y, vx, vy):
     coords = np.column_stack((x, y))
 
     inside[keep] = p.contains_points(coords).astype(bool)
+
+    good = np.isfinite(x) & np.isfinite(y)
+    inside[~good] = False
+
+    inside = inside.reshape(reduced_shape)
+    inside = np.broadcast_to(inside, original_shape)
 
     return inside
 

--- a/glue/utils/geometry.py
+++ b/glue/utils/geometry.py
@@ -38,7 +38,7 @@ def points_inside_poly(x, y, vx, vy):
     inside[keep] = p.contains_points(coords).astype(bool)
 
     good = np.isfinite(x) & np.isfinite(y)
-    inside[~good] = False
+    inside[keep][~good] = False
 
     inside = inside.reshape(reduced_shape)
     inside = np.broadcast_to(inside, original_shape)

--- a/glue/utils/geometry.py
+++ b/glue/utils/geometry.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 
-from glue.utils import unbroadcast
+from glue.utils import unbroadcast, broadcast_to
 
 __all__ = ['points_inside_poly', 'polygon_line_intersections']
 
@@ -41,7 +41,7 @@ def points_inside_poly(x, y, vx, vy):
     inside[keep][~good] = False
 
     inside = inside.reshape(reduced_shape)
-    inside = np.broadcast_to(inside, original_shape)
+    inside = broadcast_to(inside, original_shape)
 
     return inside
 

--- a/glue/utils/tests/test_array.py
+++ b/glue/utils/tests/test_array.py
@@ -5,8 +5,8 @@ import numpy as np
 
 from glue.external.six import string_types, PY2
 
-from ..array import (view_shape, coerce_numeric, stack_view, unique,
-                     shape_to_string, check_sorted, pretty_number)
+from ..array import (view_shape, coerce_numeric, stack_view, unique, broadcast_to,
+                     shape_to_string, check_sorted, pretty_number, unbroadcast)
 
 
 @pytest.mark.parametrize(('before', 'ref_after', 'ref_indices'),
@@ -104,3 +104,13 @@ class TestPrettyNumber(object):
     def test_list(self):
         assert pretty_number([1, 2, 3.3, 1e5]) == ['1', '2', '3.3',
                                                    '1.000e+05']
+
+
+def test_unbroadcast():
+
+    x = np.array([1, 2, 3])
+    y = broadcast_to(x, (2, 4, 3))
+
+    z = unbroadcast(y)
+    assert z.shape == (1, 1, 3)
+    np.testing.assert_allclose(z[0, 0], x)


### PR DESCRIPTION
This includes a number of general performance improvements mainly related to avoiding repeating calculations in broadcasted arrays. The most immediate application is when linking e.g. a spectral cube and an image, selections in the image now propagate very fast to cubes.