### PR TITLE
Fix error when changing the contrast radio button the RGB image viewer mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,8 +18,8 @@ v0.9.2 (unreleased)
 
 * Fix significant performance bottlenecks with WCS coordinate conversions. [#1185]
 
-* Fix error when changing the contrast radio button the RGB image viewer mode.
-  [#1187]
+* Fix error when changing the contrast radio button the RGB image viewer mode,
+  and also fix bugs with setting the range of values manually. [#1187]
 
 v0.9.1 (2016-11-01)
 -------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,10 @@ v0.9.2 (unreleased)
   The original behavior of keeping the coordinate information from the first
   dataset has been restored. [#1186]
 
-* Fix signficant performance bottlenecks with WCS coordinate conversions. [#1185]
+* Fix significant performance bottlenecks with WCS coordinate conversions. [#1185]
+
+* Fix error when changing the contrast radio button the RGB image viewer mode.
+  [#1187]
 
 v0.9.1 (2016-11-01)
 -------------------

--- a/glue/viewers/common/qt/toolbar.py
+++ b/glue/viewers/common/qt/toolbar.py
@@ -66,7 +66,7 @@ class BasicToolbar(QtWidgets.QToolBar):
             self.activate_tool(new_tool)
             if isinstance(new_tool, CheckableTool):
                 button = self.actions[new_tool.tool_id]
-                if button.isChecked():
+                if not button.isChecked():
                     button.blockSignals(True)
                     button.setChecked(True)
                     button.blockSignals(False)

--- a/glue/viewers/image/ds9norm.py
+++ b/glue/viewers/image/ds9norm.py
@@ -123,6 +123,8 @@ class DS9Normalize(Normalize, object):
         self.contrast = 1.0
         self.clip_lo = 5.
         self.clip_hi = 95.
+        self.clip_vmin = None
+        self.clip_vmax = None
 
     @property
     def stretch(self):
@@ -136,17 +138,30 @@ class DS9Normalize(Normalize, object):
         self._stretch = value
 
     def update_clip(self, image):
+        if self.clip_lo is None or self.clip_hi is None:
+            return
         vmin, vmax = fast_limits(image, self.clip_lo, self.clip_hi)
-        self.vmin = vmin
-        self.vmax = vmax
+        self.clip_vmin = vmin
+        self.clip_vmax = vmax
 
     def __call__(self, value, clip=False):
+
         # XXX ignore clip
 
-        self.autoscale_None(value)  # set vmin, vmax if unset
-        inverted = self.vmax <= self.vmin
+        # Note, 'self.vmin or self.clip_vmin' doesn't work because self.vmin
+        # can be 0 which causes vmin to then be None.
+        vmin = self.clip_vmin if self.vmin is None else self.vmin
+        vmax = self.clip_vmax if self.vmax is None else self.vmax
 
-        hi, lo = max(self.vmin, self.vmax), min(self.vmin, self.vmax)
+        # For the corner case where vmin/vmax aren't defined yet
+        if vmin is None:
+            vmin = np.min(value)
+        if vmax is None:
+            vmax = np.max(value)
+
+        inverted = vmax <= vmin
+
+        hi, lo = max(vmin, vmax), min(vmin, vmax)
 
         warp = warpers[self.stretch]
         result = warp(value, lo, hi, self.bias, self.contrast)
@@ -157,6 +172,47 @@ class DS9Normalize(Normalize, object):
         result = np.ma.MaskedArray(result, copy=False)
 
         return result
+
+    # We need to make sure that when we set vmin/vmax manually that always
+    # takes precedence over the automatically determined values. We use the
+    # following properties to make sure only one of vmin/vmax or clip_lo/clip_hi
+    # is defined at any one time.
+
+    @property
+    def vmin(self):
+        return self._vmin
+
+    @vmin.setter
+    def vmin(self, value):
+        self._vmin = value
+        self._clip_lo = None
+
+    @property
+    def vmax(self):
+        return self._vmax
+
+    @vmax.setter
+    def vmax(self, value):
+        self._vmax = value
+        self._clip_hi = None
+
+    @property
+    def clip_lo(self):
+        return self._clip_lo
+
+    @clip_lo.setter
+    def clip_lo(self, value):
+        self._clip_lo = value
+        self._vmin = None
+
+    @property
+    def clip_hi(self):
+        return self._clip_hi
+
+    @clip_hi.setter
+    def clip_hi(self, value):
+        self._clip_hi = value
+        self._vmax = None
 
     def __gluestate__(self, context):
         return dict(vmin=self.vmin, vmax=self.vmax, clip_lo=self.clip_lo,

--- a/glue/viewers/image/ds9norm.py
+++ b/glue/viewers/image/ds9norm.py
@@ -137,6 +137,11 @@ class DS9Normalize(Normalize, object):
                              (value, warpers.keys()))
         self._stretch = value
 
+    def autoscale_None(self, *args, **kwargs):
+        # We have to override the Matplotlib autoscale_None method to make sure
+        # that the limits don't get changed non-deterministically.
+        pass
+
     def update_clip(self, image):
         if self.clip_lo is None or self.clip_hi is None:
             return

--- a/glue/viewers/image/qt/viewer_widget.py
+++ b/glue/viewers/image/qt/viewer_widget.py
@@ -407,9 +407,12 @@ class ImageWidget(ImageWidgetBase):
         g = QtCore.QRect(20, self.central_widget.geometry().height() - h, w, h)
         self.label_widget.setGeometry(g)
 
+    def _set_contrast_mode(self):
+        self.toolbar.active_tool = self.toolbar.tools['image:contrast']
+
     def _connect(self):
         super(ImageWidget, self)._connect()
-        self.ui.rgb_options.current_changed.connect(lambda: self._toolbars[0].set_mode(self._contrast))
+        self.ui.rgb_options.current_changed.connect(nonpartial(self._set_contrast_mode))
         self.central_widget.canvas.resize_end.connect(self.client.check_update)
 
     def set_cmap(self, cmap):


### PR DESCRIPTION
Fixes error that look like:

```
Traceback (most recent call last):
  File "/Users/tom/miniconda3/envs/dev/lib/python3.5/site-packages/glue/viewers/image/qt/viewer_widget.py", line 412, in <lambda>
    self.ui.rgb_options.current_changed.connect(lambda: self._toolbars[0].set_mode(self._contrast))
AttributeError: 'MatplotlibViewerToolbar' object has no attribute 'set_mode'
```