### PR TITLE
Fix Data.coords assignment in merge

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,8 @@ v0.9.2 (unreleased)
 * Fix error when changing the contrast radio button the RGB image viewer mode,
   and also fix bugs with setting the range of values manually. [#1187]
 
+* Fix a bug that caused coordinate axis labels to be lost during merging. [#1195]
+
 v0.9.1 (2016-11-01)
 -------------------
 

--- a/glue/core/data_collection.py
+++ b/glue/core/data_collection.py
@@ -234,15 +234,19 @@ class DataCollection(HubListener):
             if d.shape != shp:
                 raise ValueError("All arguments must have the same shape")
 
-
         label = kwargs.get('label', data[0].label)
 
         master = Data(label=label)
         self.append(master)
 
+        master.coords = data[0].coords
+
         for d in data:
+
             skip = d.pixel_component_ids + d.world_component_ids
+
             for c in d.components:
+
                 if c in skip:
                     continue
 
@@ -263,9 +267,8 @@ class DataCollection(HubListener):
                 lbl = disambiguate(lbl, taken)
                 c._label = lbl
                 master.add_component(d.get_component(c), c)
-            self.remove(d)
 
-        master.coords = data[0].coords
+            self.remove(d)
 
         return self
 

--- a/glue/core/tests/test_data_collection.py
+++ b/glue/core/tests/test_data_collection.py
@@ -330,3 +330,23 @@ class TestDataCollection(object):
         dc.merge(x, y)
 
         assert dc[0].coords is x.coords
+
+    def test_merge_coordinates_preserve_labels(self):
+
+        # Regression test to make sure that axis labels are preserved after
+        # merging.
+
+        x = Data(x=[1, 2, 3])
+        y = Data(y=[2, 3, 4])
+        dc = DataCollection([x, y])
+
+        class CustomCoordinates(Coordinates):
+            def axis_label(self, axis):
+                return 'Custom {0}'.format(axis)
+
+        x.coords = CustomCoordinates()
+        y.coords = CustomCoordinates()
+
+        dc.merge(x, y)
+
+        assert sorted(cid.label for cid in dc[0].world_component_ids) == ['Custom 0']


### PR DESCRIPTION
This will solve the issue of the coordinate names being lost during a merge.