### PR TITLE
Properly deal with reassignment of Data.coords

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,9 @@ v0.13.3 (unreleased)
 * Fixed a bug related to callback functions when restoring sessions.
   [#1695]
 
+* Fixed a bug that meant that setting Data.coords after adding
+  components didn't work as expected. [#1196]
+
 * Fixed a Qt-related segmentation fault that occurred during the
   testing process and may also affect users. [#1703]
 

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -124,9 +124,10 @@ class Data(object):
 
     @coords.setter
     def coords(self, value):
-        self._coords = value
-        if len(self.components) > 0:
-            self._update_world_components(self.ndim)
+        if (hasattr(self, '_coords') and self._coords != value) or not hasattr(self, '_coords'):
+            self._coords = value
+            if len(self.components) > 0:
+                self._update_world_components(self.ndim)
 
     @property
     def subsets(self):

--- a/glue/core/tests/test_data.py
+++ b/glue/core/tests/test_data.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, division, print_function
 
 import pytest
 import numpy as np
+from numpy.testing import assert_equal
 from mock import MagicMock
 
 from glue.external import six
@@ -785,3 +786,34 @@ def test_clone_meta():
     assert data2.meta['a'] == 1
     assert data2.meta['b'] == 'test'
     assert 'c' not in data2.meta
+
+
+def test_update_coords():
+
+    # Make sure that when overriding coords, the world coordinate components
+    # are updated.
+
+    data = Data(x=[1, 2, 3])
+
+    assert len(data.components) == 3
+
+    assert_equal(data[data.world_component_ids[0]], [0, 1, 2])
+
+    class CustomCoordinates(Coordinates):
+
+        def axis_label(self, axis):
+            return 'Custom {0}'.format(axis)
+
+        def world2pixel(self, *world):
+            return tuple([0.4 * w for w in world])
+
+        def pixel2world(self, *pixel):
+            return tuple([2.5 * p for p in pixel])
+
+    data.coords = CustomCoordinates()
+
+    assert len(data.components) == 3
+
+    assert_equal(data[data.world_component_ids[0]], [0, 2.5, 5])
+
+    assert sorted(cid.label for cid in data.world_component_ids) == ['Custom 0']

--- a/glue/viewers/matplotlib/qt/tests/test_data_viewer.py
+++ b/glue/viewers/matplotlib/qt/tests/test_data_viewer.py
@@ -534,6 +534,7 @@ class BaseTestMatplotlibDataViewer(object):
         self.viewer.add_data(self.data)
         assert self.draw_count == 1
         data = Data(label=self.data.label)
+        data.coords = self.data.coords
         for cid in self.data.visible_components:
             data.add_component(self.data[cid] * 2, cid.label)
         self.data.update_values_from_data(data)


### PR DESCRIPTION
Re-compute world components if ``Data.coords`` is changed.

This will need to be rebased after https://github.com/glue-viz/glue/pull/1195 is merged and also will have some failures we need to investigate after https://github.com/glue-viz/glue/pull/1189 is merged.