### PR TITLE
Improve behavior when hiding layers in the RGB image viewer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,9 @@ v0.10.0 (unreleased)
   and only to FITS files, but the framework for exporting data/subsets has now
   been generalied.
 
+- When hiding layers in the RGB image viewer, make sure the current layer changes
+  to be a visible one if possible.
+
 v0.9.2 (unreleased)
 -------------------
 

--- a/glue/viewers/image/qt/tests/test_rgb_edit.py
+++ b/glue/viewers/image/qt/tests/test_rgb_edit.py
@@ -29,3 +29,81 @@ class TestRGBEdit(object):
         for color in ['red', 'green', 'blue']:
             self.w.current[color].click()
             assert self.artist.contrast_layer == color
+
+    def test_disable_current(self):
+
+        # If the current layer is set to not be visible, the current layer
+        # needs to automatically change.
+
+        self.w.current['red'].click()
+        self.w.vis['red'].click()
+
+        assert not self.w.current['red'].isEnabled()
+        assert self.w.current['green'].isEnabled()
+        assert self.w.current['blue'].isEnabled()
+
+        assert not self.w.current['red'].isChecked()
+        assert self.w.current['green'].isChecked()
+        assert not self.w.current['blue'].isChecked()
+
+        assert self.w.rgb_visible == (False, True, True)
+
+        self.w.vis['red'].click()
+
+        assert self.w.current['red'].isEnabled()
+        assert self.w.current['green'].isEnabled()
+        assert self.w.current['blue'].isEnabled()
+
+        assert not self.w.current['red'].isChecked()
+        assert self.w.current['green'].isChecked()
+        assert not self.w.current['blue'].isChecked()
+
+        assert self.w.rgb_visible == (True, True, True)
+
+        self.w.vis['blue'].click()
+
+        assert self.w.current['red'].isEnabled()
+        assert self.w.current['green'].isEnabled()
+        assert not self.w.current['blue'].isEnabled()
+
+        assert not self.w.current['red'].isChecked()
+        assert self.w.current['green'].isChecked()
+        assert not self.w.current['blue'].isChecked()
+
+        assert self.w.rgb_visible == (True, True, False)
+
+        self.w.vis['green'].click()
+
+        assert self.w.current['red'].isEnabled()
+        assert not self.w.current['green'].isEnabled()
+        assert not self.w.current['blue'].isEnabled()
+
+        assert self.w.current['red'].isChecked()
+        assert not self.w.current['green'].isChecked()
+        assert not self.w.current['blue'].isChecked()
+
+        assert self.w.rgb_visible == (True, False, False)
+
+        self.w.vis['red'].click()
+
+        assert not self.w.current['red'].isEnabled()
+        assert not self.w.current['green'].isEnabled()
+        assert not self.w.current['blue'].isEnabled()
+
+        assert self.w.current['red'].isChecked()
+        assert not self.w.current['green'].isChecked()
+        assert not self.w.current['blue'].isChecked()
+
+        assert self.w.rgb_visible == (False, False, False)
+
+        self.w.vis['green'].click()
+
+        assert not self.w.current['red'].isEnabled()
+        assert self.w.current['green'].isEnabled()
+        assert not self.w.current['blue'].isEnabled()
+
+        assert not self.w.current['red'].isChecked()
+        assert self.w.current['green'].isChecked()
+        assert not self.w.current['blue'].isChecked()
+
+        assert self.w.rgb_visible == (False, True, False)


### PR DESCRIPTION
When hiding layers in the RGB image viewer, make sure the current layer changes to be a visible one if possible and that the radio button for the current layer is disabled for that layer.
