### PR TITLE
Fix six import of input

### DIFF
--- a/glue/config_gen.py
+++ b/glue/config_gen.py
@@ -10,7 +10,7 @@ import sys
 from shutil import copyfile
 
 import glue
-from glue.external.six import input
+from glue.external.six.moves import input
 
 
 def get_clobber():


### PR DESCRIPTION
This fixes the following:
```
$ glue-config
Traceback (most recent call last):
  File "/Users/eisenham/anaconda3/envs/da_jwst/bin/glue-config", line 11, in <module>
    load_entry_point('glueviz==0.10.0.dev3235', 'console_scripts', 'glue-config')()
  File "/Users/eisenham/anaconda3/envs/da_jwst/lib/python3.5/site-packages/setuptools-27.2.0-py3.5.egg/pkg_resources/__init__.py", line 565, in load_entry_point
  File "/Users/eisenham/anaconda3/envs/da_jwst/lib/python3.5/site-packages/setuptools-27.2.0-py3.5.egg/pkg_resources/__init__.py", line 2598, in load_entry_point
  File "/Users/eisenham/anaconda3/envs/da_jwst/lib/python3.5/site-packages/setuptools-27.2.0-py3.5.egg/pkg_resources/__init__.py", line 2258, in load
  File "/Users/eisenham/anaconda3/envs/da_jwst/lib/python3.5/site-packages/setuptools-27.2.0-py3.5.egg/pkg_resources/__init__.py", line 2264, in resolve
  File "/Users/eisenham/anaconda3/envs/da_jwst/lib/python3.5/site-packages/glueviz-0.10.0.dev3235-py3.5.egg/glue/config_gen.py", line 13, in <module>
    from glue.external.six import input
ImportError: cannot import name 'input'
```