### PR TITLE
Added a decorator to avoid circular calling of class methods

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,9 @@ v0.10.0 (unreleased)
   Finally, ``ComponentID`` objects now hold a reference to the first parent data
   they are used in. [#1189]
 
+- Added a decorator that can be used to avoid circular calling of methods (can
+  occur when dealing with callbacks).
+
 v0.9.2 (unreleased)
 -------------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,7 +22,7 @@ v0.10.0 (unreleased)
   they are used in. [#1189]
 
 - Added a decorator that can be used to avoid circular calling of methods (can
-  occur when dealing with callbacks).
+  occur when dealing with callbacks). [#1207]
 
 v0.9.2 (unreleased)
 -------------------

--- a/glue/utils/decorators.py
+++ b/glue/utils/decorators.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import traceback
 
-__all__ = ['die_on_error']
+__all__ = ['die_on_error', 'avoid_circular']
 
 
 def die_on_error(msg):
@@ -23,3 +23,14 @@ def die_on_error(msg):
                 print('=' * 72)
         return wrapper
     return decorator
+
+
+def avoid_circular(meth):
+    def wrapper(self, *args, **kwargs):
+        if not hasattr(self, '_active_callback') or not self._active_callback:
+            self._active_callback = True
+            try:
+                return meth(self, *args, **kwargs)
+            finally:
+                self._active_callback = False
+    return wrapper

--- a/glue/utils/decorators.py
+++ b/glue/utils/decorators.py
@@ -27,10 +27,10 @@ def die_on_error(msg):
 
 def avoid_circular(meth):
     def wrapper(self, *args, **kwargs):
-        if not hasattr(self, '_active_callback') or not self._active_callback:
-            self._active_callback = True
+        if not hasattr(self, '_in_avoid_circular') or not self._in_avoid_circular:
+            self._in_avoid_circular = True
             try:
                 return meth(self, *args, **kwargs)
             finally:
-                self._active_callback = False
+                self._in_avoid_circular = False
     return wrapper

--- a/glue/utils/tests/test_decorator.py
+++ b/glue/utils/tests/test_decorator.py
@@ -1,0 +1,19 @@
+from ..decorators import avoid_circular
+
+
+def test_avoid_circular():
+
+    class CircularCall(object):
+
+        @avoid_circular
+        def a(self):
+            self.b()
+
+        @avoid_circular
+        def b(self):
+            self.a()
+
+    c = CircularCall()
+
+    # Without avoid_circular, the following causes a recursion error
+    c.a()


### PR DESCRIPTION
This is needed in PRs to refactor the viewers, but just thought I'd break it off as a separate PR.