### PR TITLE
Add properties to Subset that are the same as for Data (and other small fixes)

### DIFF
--- a/glue/_settings_helpers.py
+++ b/glue/_settings_helpers.py
@@ -16,7 +16,7 @@ def save_settings():
     config.add_section('main')
 
     for name, value, _ in sorted(settings):
-        config.set('main', name, value=json.dumps(value))
+        config.set('main', name, value=json.dumps(value, sort_keys=True))
 
     if not os.path.exists(CFG_DIR):
         os.mkdir(CFG_DIR)

--- a/glue/core/qt/data_combo_helper.py
+++ b/glue/core/qt/data_combo_helper.py
@@ -87,7 +87,7 @@ class ComponentIDComboHelper(HubListener):
         self._categorical = value
         self.refresh()
 
-    def append_data(self, data):
+    def append_data(self, data, refresh=True):
 
         if isinstance(data, Subset):
             data = data.data
@@ -102,7 +102,8 @@ class ComponentIDComboHelper(HubListener):
 
         if data not in self._data:
             self._data.append(data)
-            self.refresh()
+            if refresh:
+                self.refresh()
 
     def remove_data(self, data):
         self._data.remove(data)
@@ -121,7 +122,8 @@ class ComponentIDComboHelper(HubListener):
             self._data.clear()
         except AttributeError:  # PY2
             self._data[:] = []
-        self._data.extend(datasets)
+        for data in datasets:
+            self.append_data(data, refresh=False)
         self.refresh()
 
     @property

--- a/glue/core/state.py
+++ b/glue/core/state.py
@@ -371,12 +371,13 @@ class GlueSerializer(object):
 
     def dumps(self, indent=None):
         result = self.dumpo()
-        return json.dumps(result, indent=indent, default=self.json_default)
+        return json.dumps(result, default=self.json_default,
+                          indent=indent, sort_keys=True)
 
     def dump(self, outfile, indent=None):
         result = self.dumpo()
         return json.dump(result, outfile, default=self.json_default,
-                         indent=indent)
+                         indent=indent, sort_keys=True)
 
 
 class GlueUnSerializer(object):

--- a/glue/core/state.py
+++ b/glue/core/state.py
@@ -480,12 +480,14 @@ loader = GlueUnSerializer.unserializes
 
 @saver(dict)
 def _save_dict(state, context):
-    return dict(contents=json.dumps(state))
+    return dict(contents=dict((context.id(key), context.id(value))
+                for key, value in state.items()))
 
 
 @loader(dict)
 def _load_dict(rec, context):
-    return json.loads(rec['contents'])
+    return dict((context.object(key), context.object(value))
+                for key, value in rec['contents'].items())
 
 
 @saver(CompositeSubsetState)

--- a/glue/core/subset.py
+++ b/glue/core/subset.py
@@ -426,6 +426,44 @@ class Subset(object):
     if PY3:
         __hash__ = object.__hash__
 
+    # Provide convenient access to Data methods/properties that make sense
+    # here too.
+
+    def component_ids(self):
+        return self.data.component_ids()
+
+    @property
+    def components(self):
+        return self.data.components
+
+    @property
+    def derived_components(self):
+        return self.data.derived_components
+
+    @property
+    def primary_components(self):
+        return self.data.primary_components
+
+    @property
+    def visible_components(self):
+        return self.data.visible_components
+
+    @property
+    def pixel_component_ids(self):
+        return self.data.pixel_component_ids
+
+    @property
+    def world_component_ids(self):
+        return self.data.world_component_ids
+
+    @property
+    def ndim(self):
+        return self.data.ndim
+
+    @property
+    def shape(self):
+        return self.data.shape
+
 
 class SubsetState(object):
 

--- a/glue/core/subset.py
+++ b/glue/core/subset.py
@@ -464,6 +464,10 @@ class Subset(object):
     def shape(self):
         return self.data.shape
 
+    @property
+    def hub(self):
+        return self.data.hub
+
 
 class SubsetState(object):
 

--- a/glue/core/tests/test_state_objects.py
+++ b/glue/core/tests/test_state_objects.py
@@ -57,7 +57,7 @@ class TestStateAttributeLimitsHelper():
             comp = CallbackProperty()
             lower = CallbackProperty()
             upper = CallbackProperty()
-            log = CallbackProperty()
+            log = CallbackProperty(False)
             scale = CallbackProperty(100)
 
         self.state = SimpleState()

--- a/glue/core/tests/test_subset.py
+++ b/glue/core/tests/test_subset.py
@@ -631,3 +631,21 @@ def test_inequality_subset_state_string():
     d = Data(x=['a', 'b', 'c', 'b'])
     state = d.id['x'] == 'b'
     np.testing.assert_equal(state.to_mask(d), np.array([False, True, False, True]))
+
+
+def test_inherited_properties():
+
+    d = Data(x=np.random.random((3, 2, 4)).astype(np.float32))
+    sub = d.new_subset()
+    sub.subset_state = d.id['x'] > 0.5
+
+    assert sub.component_ids() == d.component_ids()
+    assert sub.components == d.components
+    assert sub.derived_components == d.derived_components
+    assert sub.primary_components == d.primary_components
+    assert sub.visible_components == d.visible_components
+    assert sub.pixel_component_ids == d.pixel_component_ids
+    assert sub.world_component_ids == d.world_component_ids
+
+    assert sub.ndim == 3
+    assert sub.shape == (3, 2, 4)

--- a/glue/core/tests/test_subset.py
+++ b/glue/core/tests/test_subset.py
@@ -649,3 +649,5 @@ def test_inherited_properties():
 
     assert sub.ndim == 3
     assert sub.shape == (3, 2, 4)
+
+    assert sub.hub is d.hub

--- a/glue/plugins/export_d3po.py
+++ b/glue/plugins/export_d3po.py
@@ -203,7 +203,7 @@ def save_d3po(application, path):
 
     state_path = os.path.join(path, 'states.json')
     with open(state_path, 'w') as outfile:
-        json.dump(result, outfile, indent=2)
+        json.dump(result, outfile, indent=2, sort_keys=True)
 
     # index.html
     html_path = os.path.join(path, 'index.html')

--- a/glue/plugins/exporters/plotly/qt/tests/test_exporter.py
+++ b/glue/plugins/exporters/plotly/qt/tests/test_exporter.py
@@ -45,7 +45,7 @@ def make_credentials_file(path, username='', api_key=''):
     credentials['proxy_password'] = ''
     credentials['stream_ids'] = []
     with open(path, 'w') as f:
-        json.dump(credentials, f)
+        json.dump(credentials, f, sort_keys=True)
     plotly.files.FILE_CONTENT[path] = credentials
 
 


### PR DESCRIPTION
This makes it so that e.g. Subset.visible_components works and just mirrors the Data object. This avoids things like:

```python
if isinstance(data, Subset):
    components = data.data.visible_components
else:
    components = data.visible_components
```

This also includes bug fixes for State-related functionality (since all these changes were made as part of the refactoring of the 3D viewers)