### PR TITLE
Fix lookup_class to make sure it works properly on Python 2 and 3 when builtins are used

### DIFF
--- a/glue/utils/misc.py
+++ b/glue/utils/misc.py
@@ -4,6 +4,7 @@ import string
 from functools import partial
 from contextlib import contextmanager
 
+from glue.external.six import PY2
 from glue.external.six.moves import reduce
 
 
@@ -68,11 +69,19 @@ def lookup_class(ref):
     ref : str
         The module string
     """
+
+    if PY2 and ref.startswith('builtins'):
+        ref = '.'.join(['__builtin__'] + ref.split('.')[1:])
+    elif not PY2 and ref.startswith('__builtin__'):
+        ref = '.'.join(['builtins'] + ref.split('.')[1:])
+
     mod = ref.rsplit('.', 1)[0]
+
     try:
         result = __import__(mod)
     except ImportError:
         raise ValueError("Module '{0}' not found".format(mod))
+
     try:
         for attr in ref.split('.')[1:]:
             result = getattr(result, attr)

--- a/glue/utils/tests/test_misc.py
+++ b/glue/utils/tests/test_misc.py
@@ -77,15 +77,21 @@ def test_nonpartial():
 
 def test_lookup_class():
 
-    lookup_class('glue.utils.misc.DeferredMethod') is DeferredMethod
+    assert lookup_class('glue.utils.misc.DeferredMethod') is DeferredMethod
 
     with pytest.raises(ValueError) as exc:
-        lookup_class('gluh.utils.misc.DeferredMethod') is None
+        assert lookup_class('gluh.utils.misc.DeferredMethod') is None
     assert exc.value.args[0] == "Module 'gluh.utils.misc' not found"
 
     with pytest.raises(ValueError) as exc:
-        lookup_class('glue.utils.misc.DeferredMethods') is None
+        assert lookup_class('glue.utils.misc.DeferredMethods') is None
     assert exc.value.args[0] == "Object 'glue.utils.misc.DeferredMethods' not found"
+
+
+def test_lookup_class_builtins():
+
+    assert lookup_class('__builtin__.dict') is dict
+    assert lookup_class('builtins.dict') is dict
 
 
 def test_as_list():


### PR DESCRIPTION
This is needed in case session files include e.g. dict objects (which they start to include with the refactored 3D viewers)