### PR TITLE
Try and remove conda-forge from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,6 @@ env:
     - PYTHON_VERSION=2.7
     - PYTHON_VERSION=3.6
   global:
-    - CONDA_CHANNELS='conda-forge'
-    - CONDA_CHANNEL_PRIORITY=True
     - MATPLOTLIB_VERSION=1.5
     - NUMPY_VERSION=1.11
     - ASTROPY_VERSION=1.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
     - IPYTHON_VERSION=5
     - PYTEST_ARGS="--cov glue -vs"
     - NO_CFG_FILES=false
-    - QT_PKG=pyqt
+    - QT_PKG=pyqt5
     - SETUP_XVFB=True
     # Note that we need to specify requests 2.9 because of a bug in the version check in linkchecker, and we can't use conda since requests 2.9 won't exist for e.g. Python 3.6
     - CONDA_DEPENDENCIES="nomkl pip dill ipython matplotlib scipy cython h5py pygments pyzmq scikit-image pandas sphinx xlrd pillow pytest mock coverage pyyaml sphinx_rtd_theme qtpy traitlets ipykernel qtconsole"
@@ -52,11 +52,6 @@ matrix:
           env: PYTHON_VERSION=3.6
                NUMPY_VERSION=dev
 
-        # PyQt5
-        - os: linux
-          env: PYTHON_VERSION=2.7
-               QT_PKG=pyqt5
-
         # The following configuration tests that glue functions with minimal
         # dependencies. The --no-deps is to prevent scipy from getting
         # installed as a pandas dependency.
@@ -79,18 +74,24 @@ matrix:
 
         - os: linux
           env: PYTHON_VERSION=2.7
+               QT_PKG=pyqt
+
+        - os: linux
+          env: PYTHON_VERSION=2.7
                ASTROPY_VERSION=1.0
                MATPLOTLIB_VERSION=1.4
                NUMPY_VERSION=1.9
                IPYTHON_VERSION=4
                PANDAS_VERSION=0.14
                SETUPTOOLS=1.0
+               QT_PKG=pyqt
 
         - os: linux
           env: PYTHON_VERSION=2.7
                ASTROPY_VERSION=1.1
                MATPLOTLIB_VERSION=1.5
                NUMPY_VERSION=1.10
+               QT_PKG=pyqt
 
         # Test with PySide, but due to segmentation faults, mark as an
         # allowed failure.

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ matrix:
         - os: linux
           env: PYTHON_VERSION=3.6
                PYTEST_ARGS="--cov glue"
-               CONDA_DEPENDENCIES="pytz pyparsing cycler python-dateutil freetype libpng sip qt pip setuptools pandas mock pbr six funcsigs matplotlib qtpy"
+               CONDA_DEPENDENCIES="pytz pyparsing cycler python-dateutil freetype libpng sip qt pip setuptools pandas mock pbr six matplotlib qtpy"
                CONDA_DEPENDENCIES_FLAGS='--no-deps'
                PIP_DEPENDENCIES="pytest-cov coveralls"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -120,7 +120,7 @@ before_install:
   # package with a version of 5.x rather than a pyqt5 package, so we explicitly
   # request pyqt=4 for PyQt4.
   - if [[ $QT_PKG == pyside ]]; then export CONDA_DEPENDENCIES="pyside "$CONDA_DEPENDENCIES; fi
-  - if [[ $QT_PKG == pyqt ]]; then export CONDA_DEPENDENCIES="pyqt=4 icu=56 "$CONDA_DEPENDENCIES; fi
+  - if [[ $QT_PKG == pyqt ]]; then export CONDA_DEPENDENCIES="pyqt=4 "$CONDA_DEPENDENCIES; fi
   - if [[ $QT_PKG == pyqt5 ]]; then export CONDA_DEPENDENCIES="pyqt=5 "$CONDA_DEPENDENCIES; fi
 
   # Documentation dependencies

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ environment:
       PYTHON_ARCH: "64" # needs to be set for CMD_IN_ENV to succeed. If a mix
                         # of 32 bit and 64 bit builds are needed, move this
                         # to the matrix section.
-      CONDA_DEPENDENCIES: "scipy cython pyqt=4 matplotlib h5py pygments pyzmq scikit-image pandas sphinx xlrd pillow pytest mock coverage ipython ipykernel qtconsole traitlets qtpy"
+      CONDA_DEPENDENCIES: "scipy cython pyqt matplotlib h5py pygments pyzmq scikit-image pandas sphinx xlrd pillow pytest mock coverage ipython ipykernel qtconsole traitlets qtpy"
       PIP_DEPENDENCIES: "plotly"
 
   matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,8 +10,6 @@ environment:
       PYTHON_ARCH: "64" # needs to be set for CMD_IN_ENV to succeed. If a mix
                         # of 32 bit and 64 bit builds are needed, move this
                         # to the matrix section.
-      CONDA_CHANNELS: "conda-forge"
-      CONDA_CHANNEL_PRIORITY: "True"
       CONDA_DEPENDENCIES: "scipy cython pyqt=4 matplotlib h5py pygments pyzmq scikit-image pandas sphinx xlrd pillow pytest mock coverage ipython ipykernel qtconsole traitlets qtpy"
       PIP_DEPENDENCIES: "plotly"
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -38,7 +38,7 @@ with warnings.catch_warnings():
     sip.setapi('QTextStream', 2)
     sip.setapi('QTime', 2)
     sip.setapi('QUrl', 2)
-    import PyQt4
+    import PyQt5
     import matplotlib.pyplot as plt
 
 # Add any Sphinx extension module names here, as strings. They can be extensions

--- a/glue/viewers/image/qt/tests/test_viewer_widget.py
+++ b/glue/viewers/image/qt/tests/test_viewer_widget.py
@@ -204,7 +204,7 @@ class TestImageWidget(_TestImageWidgetBase):
         for artist in client.artists:
             assert artist.aspect == 'auto'
 
-    @pytest.mark.skipif("CI and not TRAVIS_LINUX")
+    @pytest.mark.skipif("CI")
     def test_resize(self):
 
         # Regression test for a bug that caused images to not be shown at


### PR DESCRIPTION
I want to check if we still need to use conda-forge for Travis and AppVeyor. Using both defaults and conda-forge can lead to fun times, and it'd be nice if we didn't have to mix channels. We may have everything we need in defaults now?