### PR TITLE
Fix font sizes across platforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -185,6 +185,13 @@ install:
 
 script:
 
+  # In the following, we make sure there are no font sizes hard-coded in *.ui files.
+  # We do this because the default application font size may change on different
+  # platforms, but the sizes in ui files are absolute, which can lead to mismatched
+  # font sizes.
+  - find glue -name "*.ui" -exec grep "pointsize" {} \; >& font.log
+  - test ! -s font.log
+
   - if [[ $QT_PKG == False ]]; then glue --version; fi
 
   - python setup.py test -a "$PYTEST_ARGS";

--- a/glue/app/qt/layer_tree_widget.ui
+++ b/glue/app/qt/layer_tree_widget.ui
@@ -10,11 +10,6 @@
     <height>282</height>
    </rect>
   </property>
-  <property name="font">
-   <font>
-    <pointsize>13</pointsize>
-   </font>
-  </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
@@ -54,11 +49,6 @@
        </property>
        <item>
         <widget class="QPushButton" name="layerAddButton">
-         <property name="font">
-          <font>
-           <pointsize>11</pointsize>
-          </font>
-         </property>
          <property name="text">
           <string/>
          </property>
@@ -72,11 +62,6 @@
        </item>
        <item>
         <widget class="GlueActionButton" name="newSubsetButton">
-         <property name="font">
-          <font>
-           <pointsize>11</pointsize>
-          </font>
-         </property>
          <property name="text">
           <string/>
          </property>
@@ -93,11 +78,6 @@
          <property name="enabled">
           <bool>false</bool>
          </property>
-         <property name="font">
-          <font>
-           <pointsize>11</pointsize>
-          </font>
-         </property>
          <property name="text">
           <string/>
          </property>
@@ -111,11 +91,6 @@
        </item>
        <item>
         <widget class="GlueActionButton" name="linkButton">
-         <property name="font">
-          <font>
-           <pointsize>11</pointsize>
-          </font>
-         </property>
          <property name="text">
           <string/>
          </property>

--- a/glue/app/qt/mdi_area.py
+++ b/glue/app/qt/mdi_area.py
@@ -78,7 +78,7 @@ class GlueMdiArea(QtWidgets.QMdiArea):
         painter = QtGui.QPainter(self.viewport())
         painter.setPen(QtGui.QColor(210, 210, 210))
         font = painter.font()
-        font.setPointSize(48)
+        font.setPointSize(font.pointSize() * 4)
         font.setWeight(font.Black)
         painter.setFont(font)
         rect = self.contentsRect()

--- a/glue/app/qt/plugin_manager.ui
+++ b/glue/app/qt/plugin_manager.ui
@@ -20,25 +20,6 @@
    <item>
     <layout class="QVBoxLayout" name="verticalLayout">
      <item>
-      <widget class="QLabel" name="label_2">
-       <property name="font">
-        <font>
-         <weight>75</weight>
-         <bold>true</bold>
-        </font>
-       </property>
-       <property name="text">
-        <string>Plugin Manager</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_8"/>
-     </item>
-     <item>
       <widget class="QLabel" name="label_3">
        <property name="text">
         <string>Select plugins to enable them, de-select to disable</string>

--- a/glue/app/qt/plugin_manager.ui
+++ b/glue/app/qt/plugin_manager.ui
@@ -23,7 +23,6 @@
       <widget class="QLabel" name="label_2">
        <property name="font">
         <font>
-         <pointsize>18</pointsize>
          <weight>75</weight>
          <bold>true</bold>
         </font>

--- a/glue/app/qt/versions.ui
+++ b/glue/app/qt/versions.ui
@@ -20,22 +20,6 @@
    <item>
     <layout class="QVBoxLayout" name="verticalLayout">
      <item>
-      <widget class="QLabel" name="label_2">
-       <property name="font">
-        <font>
-         <weight>75</weight>
-         <bold>true</bold>
-        </font>
-       </property>
-       <property name="text">
-        <string>Version information</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
       <widget class="QTreeWidget" name="version_tree">
        <property name="alternatingRowColors">
         <bool>true</bool>

--- a/glue/app/qt/versions.ui
+++ b/glue/app/qt/versions.ui
@@ -23,7 +23,6 @@
       <widget class="QLabel" name="label_2">
        <property name="font">
         <font>
-         <pointsize>18</pointsize>
          <weight>75</weight>
          <bold>true</bold>
         </font>

--- a/glue/dialogs/custom_component/qt/widget.ui
+++ b/glue/dialogs/custom_component/qt/widget.ui
@@ -24,7 +24,6 @@
      </property>
      <property name="font">
       <font>
-       <pointsize>15</pointsize>
        <weight>75</weight>
        <bold>true</bold>
       </font>
@@ -145,11 +144,6 @@ p, li { white-space: pre-wrap; }
    </item>
    <item>
     <widget class="QLabel" name="label_5">
-     <property name="font">
-      <font>
-       <pointsize>12</pointsize>
-      </font>
-     </property>
      <property name="text">
       <string>In the box below, you can compose mathematical expressions that include components from the list above (you can drag and drop components into the field below or type them and use tab-completion).</string>
      </property>
@@ -173,11 +167,6 @@ p, li { white-space: pre-wrap; }
    </item>
    <item>
     <widget class="QLabel" name="label_6">
-     <property name="font">
-      <font>
-       <pointsize>12</pointsize>
-      </font>
-     </property>
      <property name="text">
       <string>Note: Make sure you include spaces around the component names. If a component name turns red, the syntax is invalid. You can use any variable defined inside your config.py file, as well as numpy.&lt;function&gt;, np.&lt;function&gt;, and math.&lt;function&gt; (e.g. np.log10 or math.sqrt).</string>
      </property>

--- a/glue/dialogs/custom_component/qt/widget.ui
+++ b/glue/dialogs/custom_component/qt/widget.ui
@@ -11,31 +11,9 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string>Define new component</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_5" stretch="0,5,0,0,0,1">
-   <item>
-    <widget class="QLabel" name="label_3">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Define new component</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignCenter</set>
-     </property>
-    </widget>
-   </item>
+  <layout class="QVBoxLayout" name="verticalLayout_5" stretch="5,0,0,0,1">
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,1">
      <item>

--- a/glue/dialogs/link_editor/qt/link_equation.py
+++ b/glue/dialogs/link_editor/qt/link_equation.py
@@ -160,15 +160,24 @@ class LinkEquation(QtWidgets.QWidget):
             type(self.function).__name__ == 'LinkFunction'
 
     def _init_widgets(self):
+
         layout = QtWidgets.QVBoxLayout()
         layout.setSpacing(1)
         self._ui.input_canvas.setLayout(layout)
+
         layout = QtWidgets.QVBoxLayout()
         layout.setContentsMargins(1, 0, 1, 1)
         self._ui.output_canvas.setLayout(layout)
+
         layout.addWidget(self._output_widget)
-        spacer = QtWidgets.QSpacerItem(5, 5, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding)
+        spacer = QtWidgets.QSpacerItem(5, 5,
+                                       QtWidgets.QSizePolicy.Minimum,
+                                       QtWidgets.QSizePolicy.Expanding)
         layout.addItem(spacer)
+
+        font = self._ui.info.font()
+        font.setPointSize(font.pointSize() * 1.4)
+        self._ui.info.setFont(font)
 
     @property
     def signature(self):

--- a/glue/dialogs/link_editor/qt/link_equation.ui
+++ b/glue/dialogs/link_editor/qt/link_equation.ui
@@ -89,12 +89,6 @@
      </item>
      <item>
       <widget class="QLabel" name="info">
-       <property name="font">
-        <font>
-         <pointsize>18</pointsize>
-         <kerning>true</kerning>
-        </font>
-       </property>
        <property name="text">
         <string>result = f(x, y)</string>
        </property>
@@ -107,8 +101,6 @@
       <widget class="QLabel" name="help_txt">
        <property name="font">
         <font>
-         <family>Helvetica</family>
-         <pointsize>12</pointsize>
          <italic>true</italic>
         </font>
        </property>
@@ -129,7 +121,6 @@
         <widget class="QLabel" name="input_label">
          <property name="font">
           <font>
-           <pointsize>14</pointsize>
            <weight>75</weight>
            <bold>true</bold>
           </font>
@@ -166,7 +157,6 @@
         <widget class="QLabel" name="output_label">
          <property name="font">
           <font>
-           <pointsize>14</pointsize>
            <weight>75</weight>
            <bold>true</bold>
           </font>

--- a/glue/plugins/exporters/plotly/qt/exporter.ui
+++ b/glue/plugins/exporters/plotly/qt/exporter.ui
@@ -15,22 +15,6 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QLabel" name="label_10">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Export to Plotly</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item>
     <widget class="QLabel" name="label_6">
      <property name="text">
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p style=&quot;line-height:16px&quot;&gt;The default is to export plots to Plotly using secret URLs and using your local plotly settings (~/.plotly/.credentals) if present, and the glue account if not.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>

--- a/glue/plugins/exporters/plotly/qt/exporter.ui
+++ b/glue/plugins/exporters/plotly/qt/exporter.ui
@@ -18,7 +18,6 @@
     <widget class="QLabel" name="label_10">
      <property name="font">
       <font>
-       <pointsize>18</pointsize>
        <weight>75</weight>
        <bold>true</bold>
       </font>

--- a/glue/viewers/common/qt/data_slice_widget.py
+++ b/glue/viewers/common/qt/data_slice_widget.py
@@ -67,6 +67,10 @@ class SliceWidget(QtWidgets.QWidget):
                          directory=os.path.dirname(__file__))
         self._ui_slider = slider
 
+        font = slider.label_warning.font()
+        font.setPointSize(font.pointSize() * 0.75)
+        slider.label_warning.setFont(font)
+
         slider.button_first.setStyleSheet('border: 0px')
         slider.button_first.setIcon(get_icon('playback_first'))
         slider.button_prev.setStyleSheet('border: 0px')

--- a/glue/viewers/common/qt/data_slice_widget.ui
+++ b/glue/viewers/common/qt/data_slice_widget.ui
@@ -247,11 +247,6 @@
    </item>
    <item>
     <widget class="QLabel" name="label_warning">
-     <property name="font">
-      <font>
-       <pointsize>11</pointsize>
-      </font>
-     </property>
      <property name="styleSheet">
       <string notr="true">color: rgb(255, 33, 28)</string>
      </property>


### PR DESCRIPTION
On Linux and Windows, font sizes were sometimes mismatched - this is because the default system font size changes depending on the platform/screen size/resolution. The best solution is therefore to not hard-code any font sizes in the ui files but instead to set font sizes in relative terms in the actual Python code.

Before this can be merged, I need to fix the font size for the dialogs (where this has been removed here) and then also add a command to Travis to make sure there are no font sizes hard-coded in ui files.