### PR TITLE
Remove 'sep' from separator, since the word 'sep' shows up on Linux

### DIFF
--- a/glue/app/qt/layer_tree_widget.py
+++ b/glue/app/qt/layer_tree_widget.py
@@ -505,9 +505,9 @@ class LayerTreeWidget(QtWidgets.QMainWindow):
         self._actions['maskify'] = MaskifySubsetAction(self)
 
         # new component definer
-        separator = QtWidgets.QAction("sep", tree)
-        separator.setSeparator(True)
-        tree.addAction(separator)
+        sep = QtWidgets.QAction("", tree)
+        sep.setSeparator(True)
+        tree.addAction(sep)
 
         a = action("Define new component", self,
                  tip="Define a new component using python expressions")


### PR DESCRIPTION
One finds a lot of things when using glue on a different platform...