### PR TITLE
Fix component order

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -54,6 +54,11 @@ v0.9.2 (unreleased)
   The original behavior of keeping the coordinate information from the first
   dataset has been restored. [#1186]
 
+* Fix Data.update_values_from_data to make sure that original component order
+  is preserved.
+
+* Fix Data.components to return original component order, not alphabetical order.
+
 * Fix significant performance bottlenecks with WCS coordinate conversions. [#1185]
 
 * Fix error when changing the contrast radio button the RGB image viewer mode,

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -55,9 +55,10 @@ v0.9.2 (unreleased)
   dataset has been restored. [#1186]
 
 * Fix Data.update_values_from_data to make sure that original component order
-  is preserved.
+  is preserved. [#1238]
 
 * Fix Data.components to return original component order, not alphabetical order.
+  [#1238]
 
 * Fix significant performance bottlenecks with WCS coordinate conversions. [#1185]
 

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -901,7 +901,6 @@ class Data(object):
         # the order of the components, and sets don't preserve order.
         for cid in self.components:
             cname = cid.label
-            print('loop1', cname, cname in old_labels & new_labels)
             if cname in old_labels & new_labels:
                 comp_old = self.get_component(cname)
                 comp_new = data.get_component(cname)
@@ -911,7 +910,6 @@ class Data(object):
         # and preserve the order of components as much as possible.
         for cid in data.components:
             cname = cid.label
-            print('loop2', cname, cname in new_labels - old_labels)
             if cname in new_labels - old_labels:
                 cid = data.find_component_id(cname)
                 comp_new = data.get_component(cname)

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -462,7 +462,7 @@ class Data(object):
 
         :rtype: list
         """
-        return sorted(self._components.keys(), key=lambda x: x.label)
+        return list(self._components.keys())
 
     @property
     def visible_components(self):
@@ -896,17 +896,26 @@ class Data(object):
         # Update shape
         self._shape = data._shape
 
-        # Update components that exist in both
-        for cname in old_labels & new_labels:
-            comp_old = self.get_component(cname)
-            comp_new = data.get_component(cname)
-            comp_old._data = comp_new._data
+        # Update components that exist in both. Note that we can't just loop
+        # over old_labels & new_labels since we need to make sure we preserve
+        # the order of the components, and sets don't preserve order.
+        for cid in self.components:
+            cname = cid.label
+            print('loop1', cname, cname in old_labels & new_labels)
+            if cname in old_labels & new_labels:
+                comp_old = self.get_component(cname)
+                comp_new = data.get_component(cname)
+                comp_old._data = comp_new._data
 
-        # Add components that didn't exist in original one
-        for cname in new_labels - old_labels:
-            cid = data.find_component_id(cname)
-            comp_new = data.get_component(cname)
-            self.add_component(comp_new, cid)
+        # Add components that didn't exist in original one. As above, we try
+        # and preserve the order of components as much as possible.
+        for cid in data.components:
+            cname = cid.label
+            print('loop2', cname, cname in new_labels - old_labels)
+            if cname in new_labels - old_labels:
+                cid = data.find_component_id(cname)
+                comp_new = data.get_component(cname)
+                self.add_component(comp_new, cid)
 
         # Update data label
         self.label = data.label

--- a/glue/core/qt/tests/test_data_combo_helper.py
+++ b/glue/core/qt/tests/test_data_combo_helper.py
@@ -22,14 +22,14 @@ def test_component_id_combo_helper():
 
     assert _items_as_string(combo) == ""
 
-    data1 = Data(x=[1,2,3], y=[2,3,4], label='data1')
+    data1 = Data(x=[1, 2, 3], y=[2, 3, 4], label='data1')
 
     dc.append(data1)
     helper.append_data(data1)
 
     assert _items_as_string(combo) == "x:y"
 
-    data2 = Data(a=[1,2,3], b=['a','b','c'], label='data2')
+    data2 = Data(a=[1, 2, 3], b=['a', 'b', 'c'], label='data2')
 
     dc.append(data2)
     helper.append_data(data2)
@@ -48,7 +48,7 @@ def test_component_id_combo_helper():
     helper.numeric = True
 
     helper.visible = False
-    assert _items_as_string(combo) == "data1:Pixel Axis 0 [x]:World 0:x:y:data2:Pixel Axis 0 [x]:World 0:a:b"
+    assert _items_as_string(combo) == "data1:x:Pixel Axis 0 [x]:World 0:y:data2:a:Pixel Axis 0 [x]:World 0:b"
     helper.visible = True
 
     dc.remove(data2)

--- a/glue/core/state.py
+++ b/glue/core/state.py
@@ -670,9 +670,7 @@ def _load_data(rec, context):
 
     comps = [list(map(context.object, [cid, comp]))
              for cid, comp in rec['components']]
-    comps = sorted(comps,
-                   key=lambda x: isinstance(x[1], (DerivedComponent,
-                                                   CoordinateComponent)))
+
     for cid, comp in comps:
         if isinstance(comp, CoordinateComponent):
             comp._data = result

--- a/glue/core/tests/test_data.py
+++ b/glue/core/tests/test_data.py
@@ -622,11 +622,7 @@ def test_update_values_from_data_order():
     d2['j'] = [0, 1, 2]
     d2['a'] = [4, 4, 4]
 
-    print(d1.components)
-    print(d2.components)
-
     d2.update_values_from_data(d1)
-
 
     assert d2.visible_components == [d2.id['j'], d2.id['a'], d1.id['c'],
                                      d1.id['b'], d1.id['f']]

--- a/glue/core/tests/test_data.py
+++ b/glue/core/tests/test_data.py
@@ -565,39 +565,68 @@ Hidden components:
  1) World 0
 """.strip()
 
+
 def test_data_str():
     # Regression test for Data.__str__
-    d = Data(x=[1,2,3], y=[2,3,4], label='mydata')
+    d = Data(x=[1, 2, 3], y=[2, 3, 4], label='mydata')
     assert str(d) == EXPECTED_STR
 
 
 def test_update_values_from_data():
-    d1 = Data(a=[1,2,3], b=[4,5,6], label='banana')
-    d2 = Data(b=[1,2,3,4], c=[5,6,7,8], label='apple')
+    d1 = Data(a=[1, 2, 3], b=[4, 5, 6], label='banana')
+    d2 = Data(b=[1, 2, 3, 4], c=[5, 6, 7, 8], label='apple')
     d1a = d1.id['a']
     d1b = d1.id['b']
     d2b = d2.id['b']
     d2c = d2.id['c']
     d1.update_values_from_data(d2)
-    assert not d1a in d1.components
+    assert d1a not in d1.components
     assert d1b in d1.components
-    assert not d2b in d1.components
+    assert d2b not in d1.components
     assert d2c in d1.components
     assert d1.shape == (4,)
 
 
 def test_update_values_from_data_invalid():
 
-    d1 = Data(a=[1,2,3], label='banana')
-    d1.add_component([3,4,5], 'a')
-    d2 = Data(b=[1,2,3,4], c=[5,6,7,8], label='apple')
+    d1 = Data(a=[1, 2, 3], label='banana')
+    d1.add_component([3, 4, 5], 'a')
+    d2 = Data(b=[1, 2, 3, 4], c=[5, 6, 7, 8], label='apple')
     with pytest.raises(ValueError) as exc:
         d1.update_values_from_data(d2)
     assert exc.value.args[0] == "Non-unique component labels in original data"
 
-    d1 = Data(a=[1,2,3], b=[4,5,6], label='banana')
-    d2 = Data(b=[1,2,3,4], label='apple')
-    d2.add_component([5,6,7,8], 'b')
+    d1 = Data(a=[1, 2, 3], b=[4, 5, 6], label='banana')
+    d2 = Data(b=[1, 2, 3, 4], label='apple')
+    d2.add_component([5, 6, 7, 8], 'b')
     with pytest.raises(ValueError) as exc:
         d1.update_values_from_data(d2)
     assert exc.value.args[0] == "Non-unique component labels in new data"
+
+
+def test_update_values_from_data_order():
+
+    # Make sure that the order of components is preserved when calling
+    # Data.update_values_from_data. The final order should be first
+    # components that existed before, followed by new components
+
+    d1 = Data()
+    d1['c'] = [1, 2, 3]
+    d1['b'] = [2, 3, 4]
+    d1['j'] = [0, 1, 2]
+    d1['a'] = [4, 4, 4]
+    d1['f'] = [4, 5, 6]
+
+    d2 = Data()
+    d2['h'] = [4, 4, 4]
+    d2['j'] = [0, 1, 2]
+    d2['a'] = [4, 4, 4]
+
+    print(d1.components)
+    print(d2.components)
+
+    d2.update_values_from_data(d1)
+
+
+    assert d2.visible_components == [d2.id['j'], d2.id['a'], d1.id['c'],
+                                     d1.id['b'], d1.id['f']]

--- a/glue/core/tests/test_pandas.py
+++ b/glue/core/tests/test_pandas.py
@@ -60,13 +60,12 @@ class TestPandasConversion(object):
         else:
             world_0_dtype = np.int64
 
-        frame = pd.DataFrame({
-            'n': np.array([4, 5, 6, 7]),
-            'c': ['a', 'b', 'c', 'd'],
-            'd': np.arange(4),
-            'Pixel Axis 0 [x]': np.ogrid[0:4],
-            'World 0': np.arange(4).astype(world_0_dtype)
-        })
+        frame = pd.DataFrame()
+        frame['n'] = np.array([4, 5, 6, 7])
+        frame['Pixel Axis 0 [x]'] = np.ogrid[0:4]
+        frame['World 0'] = np.arange(4).astype(world_0_dtype)
+        frame['c'] = ['a', 'b', 'c', 'd']
+        frame['d'] = np.arange(4)
         out_frame = d.to_dataframe()
 
         assert_frame_equal(out_frame, frame)

--- a/glue/plugins/dendro_viewer/client.py
+++ b/glue/plugins/dendro_viewer/client.py
@@ -40,9 +40,11 @@ class DendroClient(GenericMplClient):
         add_callback(self, 'parent_attr', nonpartial(self._relayout))
 
     def _default_attributes(self):
+
         assert self.display_data is not None
 
-        fallback = self.display_data.components[0]
+        fallback = self.display_data.pixel_component_ids[0]
+
         with delay_callback(self, 'height_attr', 'parent_attr',
                             'order_attr'):
 


### PR DESCRIPTION
Make sure that the order of components is preserved when using ``Data.update_values_from_data``, and make ``Data.components`` order be the original component order, not alphabetical

Fixes https://github.com/glue-viz/glue/issues/1206