### PR TITLE
Improve naming of components during merging of datasets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,8 @@ v0.13.3 (unreleased)
 * Fixed a bug that caused scatter plots to not revert to fixed color
   mode after being in linear color mode. [#1705]
 
+* Improved naming of components when merging datasets. [#1249]
+
 v0.13.2 (2018-05-01)
 --------------------
 
@@ -402,8 +404,6 @@ v0.11.0 (2017-08-22)
   lists, and instead refresh whenever a message is sent from the hub
   (which results in immediate changes rather than waiting up to a
    second for things to change). [#1343]
-
-* Improved naming of components when merging datasets. [#1249]
 
 * Made it possible to delay callbacks from the Hub using the
   ``Hub.delay_callbacks`` context manager. Also fixed the Hub so that

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -403,6 +403,8 @@ v0.11.0 (2017-08-22)
   (which results in immediate changes rather than waiting up to a
    second for things to change). [#1343]
 
+* Improved naming of components when merging datasets. [#1249]
+
 * Made it possible to delay callbacks from the Hub using the
   ``Hub.delay_callbacks`` context manager. Also fixed the Hub so that
   it uses weak references to classes and methods wherever possible. [#1339]

--- a/glue/app/qt/application.py
+++ b/glue/app/qt/application.py
@@ -1306,7 +1306,7 @@ class GlueApplication(Application, QtWidgets.QMainWindow):
             self.tab_bar.setTabText(index, value)
 
     @staticmethod
-    def _choose_merge(data, others):
+    def _choose_merge(data, others, suggested_label):
 
         w = load_ui('merge.ui', None, directory=os.path.dirname(__file__))
         w.button_yes.clicked.connect(w.accept)
@@ -1328,8 +1328,7 @@ class GlueApplication(Application, QtWidgets.QMainWindow):
                     others[0], others[i] = others[i], others[0]
                     break
 
-        label = others[0].label
-        w.merged_label.setText(label)
+        w.merged_label.setText(suggested_label)
 
         entries = [QtWidgets.QListWidgetItem(other.label) for other in others]
         for e in entries:

--- a/glue/core/application_base.py
+++ b/glue/core/application_base.py
@@ -312,10 +312,12 @@ class Application(HubListener):
             if not other or skip_merge:
                 continue
 
+            suggested_label = data_collection.suggest_merge_label(data, *other)
+
             if auto_merge:
-                merges, label = [data] + other, data.label
+                merges, label = [data] + other, suggested_label
             else:
-                merges, label = cls._choose_merge(data, other)
+                merges, label = cls._choose_merge(data, other, suggested_label)
 
             if merges:
                 data_collection.merge(*merges, label=label)
@@ -324,7 +326,7 @@ class Application(HubListener):
             suggested.extend(other)
 
     @staticmethod
-    def _choose_merge(data, other):
+    def _choose_merge(data, other, suggested_label):
         """
         Present an interface to the user for approving or rejecting
         a proposed data merger. Returns a list of datasets from other

--- a/glue/core/data_collection.py
+++ b/glue/core/data_collection.py
@@ -12,7 +12,7 @@ from glue.core.data import Data
 from glue.core.hub import Hub, HubListener
 from glue.core.coordinates import WCSCoordinates
 from glue.config import settings
-from glue.utils import as_list
+from glue.utils import as_list, common_prefix
 
 
 __all__ = ['DataCollection']
@@ -240,6 +240,31 @@ class DataCollection(HubListener):
         for s in subset_grp.subsets:
             s.delete()
         subset_grp.unregister(self.hub)
+
+    def suggest_merge_label(self, *data):
+        """
+        Determine what merge label to suggest given datasets
+        """
+
+        # Find longest common prefix for data
+        suggestion = common_prefix([d.label for d in data])
+
+        if len(suggestion) < 3:
+            suggestion = 'Merged data'
+
+        # Now check if the suggestion already exists, and if so add a suffix
+        labels = self.labels
+        if suggestion in labels:
+            suffix = 2
+            while "{0} [{1}]".format(suggestion, suffix) in labels:
+                suffix += 1
+            suggestion = "{0} [{1}]".format(suggestion, suffix)
+
+        return suggestion
+
+    @property
+    def labels(self):
+        return [d.label for d in self]
 
     def merge(self, *data, **kwargs):
         """

--- a/glue/core/data_collection.py
+++ b/glue/core/data_collection.py
@@ -275,21 +275,15 @@ class DataCollection(HubListener):
                 master.coords = d.coords
                 break
 
-        ambiguous = []
-
         # Find ambiguous components (ones which have labels in more than one
         # dataset
+
         from collections import Counter
-        clabel_count = Counter([c.label for c in d.components for d in data])
+        clabel_count = Counter([c.label for d in data for c in d.visible_components])
 
         for d in data:
 
-            skip = d.pixel_component_ids + d.world_component_ids
-
             for c in d.components:
-
-                if c in skip:
-                    continue
 
                 if c in master.components:  # already present (via a link)
                     continue

--- a/glue/core/data_collection.py
+++ b/glue/core/data_collection.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, division, print_function
 
 from contextlib import contextmanager
 
-from glue.core.util import disambiguate
 from glue.core.message import (DataCollectionAddMessage,
                                DataCollectionDeleteMessage,
                                ComponentsChangedMessage)

--- a/glue/core/data_collection.py
+++ b/glue/core/data_collection.py
@@ -275,6 +275,13 @@ class DataCollection(HubListener):
                 master.coords = d.coords
                 break
 
+        ambiguous = []
+
+        # Find ambiguous components (ones which have labels in more than one
+        # dataset
+        from collections import Counter
+        clabel_count = Counter([c.label for c in d.components for d in data])
+
         for d in data:
 
             skip = d.pixel_component_ids + d.world_component_ids
@@ -287,18 +294,11 @@ class DataCollection(HubListener):
                 if c in master.components:  # already present (via a link)
                     continue
 
-                taken = [_.label for _ in master.components]
                 lbl = c.label
 
-                # Special-case 'PRIMARY', rename to data label
-                if lbl == 'PRIMARY':
-                    lbl = d.label
+                if clabel_count[lbl] > 1:
+                    lbl = lbl + " [{0}]".format(d.label)
 
-                # First-pass disambiguation, try component_data
-                if lbl in taken:
-                    lbl = '%s_%s' % (lbl, d.label)
-
-                lbl = disambiguate(lbl, taken)
                 c._label = lbl
                 c.parent = master
                 master.add_component(d.get_component(c), c)

--- a/glue/core/data_factories/fits.py
+++ b/glue/core/data_factories/fits.py
@@ -80,11 +80,11 @@ def fits_reader(source, auto_merge=False, exclude_exts=None, label=None):
             label_base = basename(hdulist_name)
 
     # Create a new image Data.
-    def new_data():
-        label = '{0}[{1}]'.format(
-            label_base,
-            hdu_name
-        )
+    def new_data(suffix=True):
+        if suffix:
+            label = '{0}[{1}]'.format(label_base, hdu_name)
+        else:
+            label = label_base
         data = Data(label=label)
         data.coords = coords
 
@@ -115,12 +115,12 @@ def fits_reader(source, auto_merge=False, exclude_exts=None, label=None):
                 shape = hdu.data.shape
                 coords = coordinates_from_header(hdu.header)
                 if not auto_merge or has_wcs(coords):
-                    data = new_data()
+                    data = new_data(suffix=len(hdulist) > 1)
                 else:
                     try:
                         data = groups[extension_by_shape[shape]]
                     except KeyError:
-                        data = new_data()
+                        data = new_data(suffix=len(hdulist) > 1)
                 data.add_component(component=hdu.data,
                                    label=hdu_name)
             elif is_table_hdu(hdu):

--- a/glue/core/tests/test_data_collection.py
+++ b/glue/core/tests/test_data_collection.py
@@ -491,3 +491,16 @@ class TestDataCollection(object):
         assert len(messages) == 3
         assert messages[1].data is data1
         assert messages[2].data is data2
+
+    def test_merge_duplicate(self):
+
+        x = Data(x=[1, 2, 3], label='d1')
+        y = Data(x=[2, 3, 4], label='d2')
+        z = Data(y=[2, 3, 4], label='d3')
+        dc = DataCollection([x, y])
+
+        dc.merge(x, y, z)
+
+        assert dc[0].main_components[0].label == 'x [d1]'
+        assert dc[0].main_components[1].label == 'x [d2]'
+        assert dc[0].main_components[2].label == 'y'

--- a/glue/core/tests/test_data_collection.py
+++ b/glue/core/tests/test_data_collection.py
@@ -497,10 +497,32 @@ class TestDataCollection(object):
         x = Data(x=[1, 2, 3], label='d1')
         y = Data(x=[2, 3, 4], label='d2')
         z = Data(y=[2, 3, 4], label='d3')
-        dc = DataCollection([x, y])
+        dc = DataCollection([x, y, z])
 
         dc.merge(x, y, z)
 
         assert dc[0].main_components[0].label == 'x [d1]'
         assert dc[0].main_components[1].label == 'x [d2]'
         assert dc[0].main_components[2].label == 'y'
+
+    def test_suggest_merge_label(self):
+
+        x = Data(x=[1, 2, 3], label='abc_1')
+        y = Data(x=[2, 3, 4], label='abc_2')
+        z = Data(y=[2, 3, 4], label='abc_3')
+        w = Data(y=[2, 3, 4], label='banana')
+        dc = DataCollection([x, y, z])
+
+        assert dc.suggest_merge_label(x, y) == 'abc'
+        assert dc.suggest_merge_label(x, y, z) == 'abc'
+        assert dc.suggest_merge_label(x, y, z, w) == 'Merged data'
+
+        u = Data(y=[2, 3, 4], label='abc')
+        dc.append(u)
+
+        assert dc.suggest_merge_label(x, y) == 'abc [2]'
+
+        v = Data(y=[2, 3, 4], label='Merged data')
+        dc.append(v)
+
+        assert dc.suggest_merge_label(x, w) == 'Merged data [2]'

--- a/glue/tests/test_qglue.py
+++ b/glue/tests/test_qglue.py
@@ -113,7 +113,7 @@ class TestQGlue(object):
         with patch('glue.app.qt.GlueApplication') as ga:
             qglue(data1=self.hdulist).data_collection
             dc = ga.call_args[0][0]
-        self.check_setup(dc, {'data1[PRIMARY]': ['PRIMARY']})
+        self.check_setup(dc, {'data1': ['PRIMARY']})
 
     def test_glue_data(self):
         d = Data(x=[1, 2, 3])

--- a/glue/utils/misc.py
+++ b/glue/utils/misc.py
@@ -10,7 +10,7 @@ from glue.external.six.moves import reduce
 
 __all__ = ['DeferredMethod', 'nonpartial', 'lookup_class', 'as_variable_name',
            'as_list', 'file_format', 'CallbackMixin', 'PropertySetMixin',
-           'Pointer']
+           'Pointer', 'common_prefix']
 
 
 class DeferredMethod(object):
@@ -178,6 +178,23 @@ class PropertySetMixin(object):
             if k not in value:
                 continue
             setattr(self, k, value[k])
+
+
+def common_prefix(strings, exclude_punctuation=True):
+    """
+    Given a list of strings, find the longest prefix common to all of them
+    """
+    if len(strings) > 0:
+        for i in range(len(strings[0]), 0, -1):
+            if exclude_punctuation and strings[0][i - 1] in string.punctuation:
+                continue
+            for st in strings[1:]:
+                if st[:i] != strings[0][:i]:
+                    break
+            else:
+                return strings[0][:i]
+    return ''
+
 
 
 class Pointer(object):

--- a/glue/utils/misc.py
+++ b/glue/utils/misc.py
@@ -196,7 +196,6 @@ def common_prefix(strings, exclude_punctuation=True):
     return ''
 
 
-
 class Pointer(object):
 
     def __init__(self, key):

--- a/glue/utils/tests/test_misc.py
+++ b/glue/utils/tests/test_misc.py
@@ -2,7 +2,8 @@ from __future__ import absolute_import, division, print_function
 
 import pytest
 
-from ..misc import as_variable_name, file_format, DeferredMethod, nonpartial, lookup_class, as_list
+from ..misc import (as_variable_name, file_format, DeferredMethod, nonpartial,
+                    lookup_class, as_list, common_prefix)
 
 
 INPUT_EXPECTED = [('x', 'x'),
@@ -96,5 +97,13 @@ def test_as_list():
     as_list(1) == [1]
     as_list([2, 3]) == [2, 3]
 
+
+def test_common_prefix():
+    assert common_prefix(['abc', 'ab', 'abcd']) == 'ab'
+    assert common_prefix(['aaabbc', 'aabc', 'aaba']) == 'aa'
+    assert common_prefix(['aaabbc', 'baabbc', 'caabbc']) == ''
+    assert common_prefix(['abc1', 'abc2', 'abc3']) == 'abc'
+    assert common_prefix(['abc_1', 'abc_2', 'abc_3']) == 'abc'
+    assert common_prefix(['abc_1', 'abc_2', 'abc_3'], exclude_punctuation=False) == 'abc_'
 
 # TODO: add test for PropertySetMixin


### PR DESCRIPTION
Prior to this, one of the components would have a name that didn't indicate which data it came from in ambiguous cases.