### PR TITLE
Remove unnecessary install dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,6 @@ install_requires = ['numpy>=1.9',
                     'ipykernel',
                     'qtconsole',
                     'dill>=0.2',
-                    'glue-vispy-viewers>=0.7',
                     'xlrd>=1.0',
                     'h5py>=2.4']
 


### PR DESCRIPTION
Hello.  Would it be possible to remove the "install_requires" dependency on `glue-vispy-viewers`? It appears to not be a hard build, install, or runtime dependency for glue and the reference to `glue-vispy-viewers` here necessitates some gymnastics in packaging other glue plugins in astroconda, for instance.