### PR TITLE
Hide Matplotlib warnings related to equal min/max limits

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@ v0.10.2 (unreleased)
 
 * Fixed a deprecation warning for pandas >= 0.19. [#1263]
 
+* Hide common Matplotlib warnings when min/max along an axis are equal. [#1268]
+
 v0.10.1 (2017-03-16)
 --------------------
 

--- a/glue/viewers/common/qt/mpl_widget.py
+++ b/glue/viewers/common/qt/mpl_widget.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, division, print_function
 
 from functools import wraps
 
+import warnings
 import matplotlib
 from matplotlib.figure import Figure
 
@@ -22,6 +23,11 @@ else:
     except ImportError:  # mpl < 1.4
         from matplotlib.backends.backend_qt4agg import FigureManagerQTAgg as FigureManager
     from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas
+
+# We want to ignore warnings about left==right and bottom==top since these are
+# not critical and the default behavior makes sense.
+warnings.filterwarnings('ignore', '.*Attempting to set identical left==right', UserWarning)
+warnings.filterwarnings('ignore', '.*Attempting to set identical bottom==top', UserWarning)
 
 
 def defer_draw(func):


### PR DESCRIPTION
Fixes #1265 