### PR TITLE
Fixed a bug that caused Data.find_component_id to return incorrect results

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,9 @@ v0.11.0 (unreleased)
 v0.10.2 (unreleased)
 --------------------
 
+* Fixed a bug that caused Data.find_component_id to return incorrect results
+  when string components were present in the data. [#1269]
+
 * Fixed a bug that caused errors to appear in the console log after a
   table viewer was closed. [#1267]
 

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -528,9 +528,18 @@ class Data(object):
             label in the primary and one in the derived components, the primary
             one takes precedence.
         """
+
         for cid_set in (self.primary_components, self.derived_components):
-            result = [cid for cid in cid_set if
-                      cid.label == label or cid is label]
+
+            result = []
+            for cid in cid_set:
+                if isinstance(label, ComponentID):
+                    if cid is label:
+                        result.append(cid)
+                else:
+                    if cid.label == label:
+                        result.append(cid)
+
             if len(result) == 1:
                 return result[0]
             elif len(result) > 1:

--- a/glue/core/tests/test_data.py
+++ b/glue/core/tests/test_data.py
@@ -626,3 +626,16 @@ def test_update_values_from_data_order():
 
     assert d2.visible_components == [d2.id['j'], d2.id['a'], d1.id['c'],
                                      d1.id['b'], d1.id['f']]
+
+
+def test_find_component_id_with_cid():
+
+    # Regression test for a bug that caused Data.find_component_id to return
+    # True erroneously when passing a component ID.
+
+    d1 = Data()
+    d1['a'] = ['a', 'b', 'c']
+    d1['b'] = [1, 2, 3]
+
+    assert d1.find_component_id(d1.id['a']) is d1.id['a']
+    assert d1.find_component_id(d1.id['b']) is d1.id['b']


### PR DESCRIPTION
… when string components were present in the data (due to recent changes that mean that using == with categorical components returns a SubsetState)