### PR TITLE
Fix how we deal with component IDs for linked components

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,9 @@ v0.11.0 (unreleased)
 v0.10.2 (unreleased)
 --------------------
 
+* Fixed a bug that caused components that were linked to then disappear from
+  drop-down lists of available components in new viewers. [#1270]
+
 * Fixed a bug that caused Data.find_component_id to return incorrect results
   when string components were present in the data. [#1269]
 

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -391,7 +391,8 @@ class Data(object):
 
         if isinstance(label, ComponentID):
             component_id = label
-            component_id.parent = self
+            if component_id.parent is None:
+                component_id.parent = self
         else:
             component_id = ComponentID(label, hidden=hidden, parent=self)
 
@@ -471,7 +472,7 @@ class Data(object):
         :rtype: list
         """
         return [cid for cid, comp in self._components.items()
-                if not cid.hidden and not comp.hidden]
+                if not cid.hidden and not comp.hidden and cid.parent is self]
 
     @property
     def coordinate_components(self):
@@ -931,7 +932,7 @@ class Data(object):
             if cname in new_labels - old_labels:
                 cid = data.find_component_id(cname)
                 comp_new = data.get_component(cname)
-                self.add_component(comp_new, cid)
+                self.add_component(comp_new, cid.label)
 
         # Update data label
         self.label = data.label

--- a/glue/core/link_manager.py
+++ b/glue/core/link_manager.py
@@ -196,9 +196,6 @@ class LinkManager(object):
         for cid, link in six.iteritems(links):
             d = DerivedComponent(data, link)
             if cid not in data.components:
-                # Need to hide component since we don't want to show components
-                # that are auto-generated in datasets by default.
-                cid.hidden = True
                 data.add_component(d, cid)
 
     @property


### PR DESCRIPTION
Previously, when linking two components, we added the component ID of the linked component in each dataset to the other dataset, and set .hidden to True. However since the component ID was shared, this also hid the component ID in the original data. Instead, we now don't hide the component IDs, but instead treat component IDs where .parent is not the dataset being looked at to be effectively hidden.

Fixes https://github.com/glue-viz/glue/issues/1257