### PR TITLE
Fixed saving/restoring of session files with table viewers that have no subsets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,9 @@ v0.10.2 (unreleased)
 
 * Hide common Matplotlib warnings when min/max along an axis are equal. [#1268]
 
+* Fixed a bug that caused sessions with table viewers that had no subsets
+  to not be restored correctly. [#1271]
+
 v0.10.1 (2017-03-16)
 --------------------
 

--- a/glue/viewers/table/qt/tests/test_viewer_widget.py
+++ b/glue/viewers/table/qt/tests/test_viewer_widget.py
@@ -265,3 +265,33 @@ def test_table_widget(tmpdir):
     colors = ['#aa0000', '#380088', '#aa0000', "#aa0000", "#bababa"]
 
     check_values_and_color(model2, data, colors)
+
+
+def test_table_widget_session_no_subset(tmpdir):
+
+    # Regression test for a bug that caused table viewers with no subsets to
+    # not be restored correctly and instead raise an exception.
+
+    app = get_qapp()
+
+    d = Data(a=[1, 2, 3, 4, 5],
+             b=[3.2, 1.2, 4.5, 3.3, 2.2],
+             c=['e', 'b', 'c', 'a', 'f'], label='test')
+
+    dc = DataCollection([d])
+
+    gapp = GlueApplication(dc)
+
+    widget = gapp.new_data_viewer(TableWidget)
+    widget.add_data(d)
+
+    session_file = tmpdir.join('table.glu').strpath
+
+    gapp.save_session(session_file)
+
+    gapp2 = GlueApplication.restore_session(session_file)
+    gapp2.show()
+
+    d = gapp2.data_collection[0]
+
+    widget2 = gapp2.viewers[0][0]

--- a/glue/viewers/table/qt/viewer_widget.py
+++ b/glue/viewers/table/qt/viewer_widget.py
@@ -97,6 +97,8 @@ class DataTableModel(QtCore.QAbstractTableModel):
             # Find all subsets that this index is part of
             colors = []
             for layer_artist in self._table_viewer.layers[::-1]:
+                if isinstance(layer_artist.layer, Data):
+                    continue
                 if layer_artist.visible:
                     subset = layer_artist.layer
                     try:
@@ -256,12 +258,12 @@ class TableWidget(DataViewer):
 
     def _sync_layers(self):
 
-        # For now we don't show the data in the list because it always has to
-        # be shown
-
         for layer_artist in self.layers:
-            if layer_artist.layer not in self.data.subsets:
+            if layer_artist.layer is not self.data and layer_artist.layer not in self.data.subsets:
                 self._layer_artist_container.remove(layer_artist)
+
+        if self.data not in self._layer_artist_container:
+            self._layer_artist_container.append(TableLayerArtist(self.data, self))
 
         for subset in self.data.subsets:
             if subset not in self._layer_artist_container:
@@ -298,6 +300,9 @@ class TableWidget(DataViewer):
             c = lookup_class_with_patches(layer.pop('_type'))
             props = dict((k, context.object(v)) for k, v in layer.items())
             layer = props['layer']
-            self.add_data(layer.data)
+            if isinstance(layer, Data):
+                self.add_data(layer)
+            else:
+                self.add_data(layer.data)
             break
         self._sync_layers()


### PR DESCRIPTION
The issue was that since we weren't showing the data in the list of layers, table viewers could end up without any layers.

Fixes https://github.com/glue-viz/glue/issues/1253