### PR TITLE
Fixes related to ComponentID.parent

### DIFF
--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -744,7 +744,10 @@ class Data(object):
             else:
                 s += "Main "
             s += "components:\n"
-            components = [c for c in self.components if c.hidden == hidden]
+            if hidden:
+                components = [c for c in self.components if c not in self.visible_components]
+            else:
+                components = [c for c in self.visible_components]
             for i, cid in enumerate(components):
                 if cid.hidden != hidden:
                     continue

--- a/glue/core/state.py
+++ b/glue/core/state.py
@@ -762,12 +762,12 @@ def _load_component_id(rec, context):
 
 
 @saver(PixelComponentID)
-def _save_component_id(cid, context):
+def _save_pixel_component_id(cid, context):
     return dict(axis=cid.axis, label=cid.label, hidden=cid.hidden)
 
 
 @loader(PixelComponentID)
-def _load_component_id(rec, context):
+def _load_pixel_component_id(rec, context):
     if 'axis' in rec:
         axis = rec['axis']
     else:  # backward-compatibility

--- a/glue/core/tests/test_joins.py
+++ b/glue/core/tests/test_joins.py
@@ -113,8 +113,8 @@ class TestSubsets(object):
         assert exc.value.args[0] == 'ComponentID not found in y: bad_key'
 
     def test_clone(self):
-        x = Data(id=[0, 1, 2])
-        y = Data(id=[0, 1, 2], x=[1, 2, 3])
+        x = Data(id=[0, 1, 2], label='data_x')
+        y = Data(id=[0, 1, 2], x=[1, 2, 3], label='data_y')
         x.join_on_key(y, 'id', 'id')
 
         dc = DataCollection([x, y])


### PR DESCRIPTION
There is an issue with restored ComponentIDs having an incorrect .parent - I've included a regression test to demonstrate the issue. While trying to fix this I'm running into issues with the join_on_key stuff, so I need to sit down and figure this all out at the same time.