### PR TITLE
Made file extension check case insensitive.

### DIFF
--- a/glue/core/data_factories/helpers.py
+++ b/glue/core/data_factories/helpers.py
@@ -76,7 +76,7 @@ def has_extension(exts):
     """
 
     def tester(x, **kwargs):
-        return _extension(x) in set(exts.split())
+        return _extension(x).lower() in set(exts.lower().split())
     return tester
 
 


### PR DESCRIPTION
Hello!

I was playing around with glue today, and noticed that it would not load some of my .PNG files. I realized this was because glue technically only accepts ".png" files, not ".PNG" files. This probably isn't a problem for most PNG files out there, but I think Windows (my laptop) randomly prefers to save into ".PNG" format by default, which can be a pain for using glue. This problem might be a little confusing on Windows too, as Windows is case insensitive (unlike Linux) for file extensions.

To fix it, I just made the extension checker function in Glue convert both sides of the equality to lowercase. That way, ".PNG" and any other capital extension would be converted to ".png" before it was checked against a valid list of extensions. As far as I know, this shouldn't break anything else unless there are filetypes out there that are different depending on their casing...

Another option would just to be to add more acceptable extensions on a case by case basis, e.g. ['png', 'PNG', 'jpg', 'JPG', ...] but this seems easier.

The error that pops up when trying to open a ".PNG" file is pasted below:
```

Error message: u"Don't know how to open file: C:/Users/abeers/Pictures/ModelScreenshot.PNG"

Traceback (most recent call last):
  File "c:\users\abeers\documents\github\personal_repos\glue\glue\dialogs\data_wizard\qt\data_wizard_dialog.py", line 38, in data_wizard
    result = gdd.load_data()
  File "c:\users\abeers\documents\github\personal_repos\glue\glue\dialogs\data_wizard\qt\data_wizard_dialog.py", line 109, in load_data
    d = load_data(path, factory=fac.function)
  File "c:\users\abeers\documents\github\personal_repos\glue\glue\core\data_factories\helpers.py", line 237, in load_data
    d = as_list(factory(path, **kwargs))
  File "c:\users\abeers\documents\github\personal_repos\glue\glue\core\data_factories\helpers.py", line 329, in auto_data
    raise KeyError("Don't know how to open file: %s" % filename)
KeyError: u"Don't know how to open file: C:/Users/abeers/Pictures/ModelScreenshot.PNG"
```


Some quick test code to test the difference is pasted below:

```
from glue.core.data_factories.helpers import auto_data

auto_data('C:/Users/abeers/Pictures/ModelScreenshot.PNG')
auto_data('C:/Users/abeers/Pictures/ModelScreenshot.png')
```


