### PR TITLE
Generate names for mpl colormaps and register all of them

### DIFF
--- a/glue/config.py
+++ b/glue/config.py
@@ -386,7 +386,7 @@ class ColormapRegistry(Registry):
             # Change suffix of the reversed colormaps
             mpl_cmap_name = re.sub(r'_r$', ' (reversed)', mpl_cmap_name)
 
-            for abbr, colname in colmapper.iteritems():
+            for (abbr, colname) in colmapper.items():
                 # First check that the colname is not in the cmap name:
                 # Skips cmaps like "Oranges" and "Purples" so that
                 # the abbreviations "Or" and "Pu" do not get replaced


### PR DESCRIPTION
Addressing issue #738.

This adds *all* of the matplotlib colormaps to the registry. This may not have been the desired outcome! The colormap selection is now pretty crowded, but maybe that's OK? 

![screenshot from 2017-05-21 01-23-22](https://cloud.githubusercontent.com/assets/13138905/26281545/3948a7c4-3dc8-11e7-9d8c-2f2c87777be7.png)

Would it be better for the colormaps to be ordered in some way?