### PR TITLE
Make it possible to initialize ComponentIDComboHelper with single dataset

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -216,7 +216,7 @@ script:
   - if [ $DOC_TRIGGER ]; then cat doc/warnings.log; fi
   # make sure stderr was empty, i.e. no warnings
   - if [ $DOC_TRIGGER ]; then test ! -s doc/warnings.log; fi
-  - if [ $DOC_TRIGGER ]; then linkchecker --ignore-url=".*fontawesome_webfont.*" doc/_build/html; fi
+  - if [ $DOC_TRIGGER ]; then linkchecker --ignore-url=".*fontawesome.*" doc/_build/html; fi
 
 after_success:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@ Full changelog
 v0.11.0 (unreleased)
 --------------------
 
+* Updated ComponentIDComboHelper so that it can work with single datasets
+  that aren't necessarily attached to a DataCollection.
+
 * Updated bundled version of echo to include fixes to avoid circular
   references, which in turn caused some callback functions to not be
   cleaned up. [#1281]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@ v0.11.0 (unreleased)
 --------------------
 
 * Updated ComponentIDComboHelper so that it can work with single datasets
-  that aren't necessarily attached to a DataCollection.
+  that aren't necessarily attached to a DataCollection. [#1296]
 
 * Updated bundled version of echo to include fixes to avoid circular
   references, which in turn caused some callback functions to not be

--- a/glue/core/qt/data_combo_helper.py
+++ b/glue/core/qt/data_combo_helper.py
@@ -54,8 +54,10 @@ class ComponentIDComboHelper(HubListener):
         self._component_id_combo = component_id_combo
 
         if data is None:
+            self._manual_data = False
             self._data = []
         else:
+            self._manual_data = True
             self._data = [data]
 
         self._data_collection = data_collection
@@ -103,6 +105,10 @@ class ComponentIDComboHelper(HubListener):
 
     def append_data(self, data, refresh=True):
 
+        if self._manual_data:
+            raise Exception("Cannot change data in ComponentIDComboHelper "
+                            "initialized from a single dataset")
+
         if isinstance(data, Subset):
             data = data.data
 
@@ -120,6 +126,11 @@ class ComponentIDComboHelper(HubListener):
                 self.refresh()
 
     def remove_data(self, data):
+
+        if self._manual_data:
+            raise Exception("Cannot change data in ComponentIDComboHelper "
+                            "initialized from a single dataset")
+
         if data in self._data:
             self._data.remove(data)
             self.refresh()
@@ -133,6 +144,11 @@ class ComponentIDComboHelper(HubListener):
         datasets : list
             The list of :class:`~glue.core.data.Data` objects to add
         """
+
+        if self._manual_data:
+            raise Exception("Cannot change data in ComponentIDComboHelper "
+                            "initialized from a single dataset")
+
         try:
             self._data.clear()
         except AttributeError:  # PY2

--- a/glue/core/qt/tests/test_data_combo_helper.py
+++ b/glue/core/qt/tests/test_data_combo_helper.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+import pytest
 from mock import MagicMock
 
 from glue.core import Data, DataCollection
@@ -61,6 +62,54 @@ def test_component_id_combo_helper():
     helper.remove_data(data1)
 
     assert combo_as_string(combo) == ""
+
+
+
+def test_component_id_combo_helper_nocollection():
+
+    # Make sure that we can use use ComponentIDComboHelper without any
+    # data collection.
+
+    combo = QtWidgets.QComboBox()
+
+    data = Data(x=[1, 2, 3], y=[2, 3, 4], z=['a','b','c'], label='data1')
+
+    helper = ComponentIDComboHelper(combo, data=data)
+
+    assert combo_as_string(combo) == "x:y:z"
+
+    helper.categorical = False
+
+    assert combo_as_string(combo) == "x:y"
+
+    helper.numeric = False
+
+    assert combo_as_string(combo) == ""
+
+    helper.categorical = True
+
+    assert combo_as_string(combo) == "z"
+
+    helper.numeric = True
+
+    assert combo_as_string(combo) == "x:y:z"
+
+    data2 = Data(a=[1, 2, 3], b=['a', 'b', 'c'], label='data2')
+
+    with pytest.raises(Exception) as exc:
+        helper.append_data(data2)
+    assert exc.value.args[0] == ("Cannot change data in ComponentIDComboHelper "
+                                 "initialized from a single dataset")
+
+    with pytest.raises(Exception) as exc:
+        helper.remove_data(data2)
+    assert exc.value.args[0] == ("Cannot change data in ComponentIDComboHelper "
+                                 "initialized from a single dataset")
+
+    with pytest.raises(Exception) as exc:
+        helper.set_multiple_data([data2])
+    assert exc.value.args[0] == ("Cannot change data in ComponentIDComboHelper "
+                                 "initialized from a single dataset")
 
 
 def test_component_id_combo_helper_init():


### PR DESCRIPTION
This makes it possible to not have to give a DataCollection to ComponentIDComboHelper