### PR TITLE
Unstructuredarrayfix

### DIFF
--- a/glue/core/data_factories/npy.py
+++ b/glue/core/data_factories/npy.py
@@ -4,7 +4,7 @@ from glue.core.data import Data, Component
 from glue.config import data_factory
 from glue.core.data_factories.helpers import has_extension
 
-__all__ = ['is_npy', 'npy_reader', 'is_npz', 'npz_reader']
+__all__ = ['is_npy', 'npy_reader', 'is_npz', 'npz_reader', 'from_unstructured_array']
 
 # TODO: implement support for regular arrays, e.g., not just structured arrays?
 

--- a/glue/core/data_factories/tests/test_numpy.py
+++ b/glue/core/data_factories/tests/test_numpy.py
@@ -20,6 +20,31 @@ def test_npy_load(tmpdir):
         assert_array_equal(data['ra'], data2['ra'])
         assert_array_equal(data['dec'], data2['dec'])
 
+def test_unstruc_npy_load(tmpdir):
+    data = np.array([[152.2352, -21.513], [21.412, 35.1341]], dtype='f8')
+
+    with open(tmpdir.join('test.npy').strpath, 'wb') as f:
+        np.save(f, data)
+        f.seek(0)
+
+        data2 = df.load_data(f.name)
+        assert_array_equal(data, data2['array'])
+
+def test_unstruc_npz_load(tmpdir):
+    data1 = np.array([[152.2352, -21.513], [21.412, 35.1341]], dtype='f8')
+    data2 = np.array([[15.2352, -2.513], [2.412, 3.1341]], dtype='f8')
+
+    with open(tmpdir.join('test.npz').strpath, 'wb') as f:
+        np.savez(f, data1=data1, data2=data2)
+        f.seek(0)
+
+        data_loaded = df.load_data(f.name)
+        arr = data_loaded[0]
+        assert_array_equal(data1, arr['array'])
+
+        arr = data_loaded[1]
+        assert_array_equal(data2, arr['array'])
+
 def test_npz_load(tmpdir):
     data1 = np.array([("a",152.2352,-21.513), ("b",21.412,35.1341)],
                      dtype=[('name','|S1'),('ra','f8'),('dec','f8')])


### PR DESCRIPTION
Upon finding I couldn't import numpy arrays automatically as seen here: #1307 
I set out to do as @astrofrog suggested and automatically convert an unstructured array to a structured array with a single field name of 'array'.

this includes test functions for unstructured arrays which are essentially copies of the already existing test_npy/npz_load functions

this is my first pull request so let me know what I'm missing, etc

thanks!
