### PR TITLE
Fix issues related to subset mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,12 @@ v0.11.0 (unreleased)
   both in terms of number of lines and in terms of the number of
   connections/callbacks that need to be set up manually. [#1278, #1289]
 
+* Updated EditSubsetMode so that Data objects no longer have an edit_subset
+  attribute - instead, the current list of subsets being edited is kept in
+  EditSubsetMode itself. We also update the subset state only once on each
+  subset group, rather than once per dataset, which avoids doing the same
+  update to each dataset multiple times. [#1338]
+
 v0.10.5 (unreleased)
 --------------------
 

--- a/glue/app/qt/layer_tree_widget.py
+++ b/glue/app/qt/layer_tree_widget.py
@@ -10,7 +10,7 @@ import os
 from qtpy import QtCore, QtWidgets, QtGui
 from qtpy.QtCore import Qt
 
-from glue.core.edit_subset_mode import AndMode, OrMode, XorMode, AndNotMode
+from glue.core.edit_subset_mode import AndMode, OrMode, XorMode, AndNotMode, EditSubsetMode
 from glue.config import single_subset_action
 from glue import core
 from glue.dialogs.link_editor.qt import LinkEditor
@@ -472,13 +472,8 @@ class LayerTreeWidget(QtWidgets.QMainWindow):
 
     def _update_editable_subset(self):
         """Update edit subsets to match current selection"""
-        layers = self.selected_layers()
-        layers.extend(s for l in layers
-                      if isinstance(l, core.SubsetGroup)
-                      for s in l.subsets)
-
-        for data in self.data_collection:
-            data.edit_subset = [s for s in data.subsets if s in layers]
+        mode = EditSubsetMode()
+        mode.edit_subset = [s for s in self.selected_layers() if isinstance(s, core.SubsetGroup)]
 
     def _create_component(self):
         dialog = CustomComponentWidget(self.data_collection)

--- a/glue/app/qt/tests/test_layer_tree_widget.py
+++ b/glue/app/qt/tests/test_layer_tree_widget.py
@@ -9,6 +9,7 @@ from qtpy.QtTest import QTest
 from qtpy import QtWidgets
 from glue import core
 from glue.tests import example_data
+from glue.core.edit_subset_mode import EditSubsetMode
 
 from ..layer_tree_widget import (LayerTreeWidget, Clipboard, PlotAction)
 
@@ -195,25 +196,26 @@ class TestLayerTree(object):
         assert sub.subset_state is not dummy_state
 
     def test_single_selection_updates_editable(self):
+        mode = EditSubsetMode()
         self.widget.bind_selection_to_edit_subset()
-        layer = self.add_layer()
+        self.add_layer()
         grp1 = self.collect.new_subset_group()
         grp2 = self.collect.new_subset_group()
-        assert layer.edit_subset[0].group is not grp1
+        assert mode.edit_subset[0] is not grp1
         self.select_layers(grp1)
-        assert layer.edit_subset[0].group is grp1
+        assert mode.edit_subset[0] is grp1
 
     def test_multi_selection_updates_editable(self):
         """Selection disables edit_subset for all other data"""
+        mode = EditSubsetMode()
         self.widget.bind_selection_to_edit_subset()
-        layer = self.add_layer()
-        layer2 = self.add_layer()
+        self.add_layer()
+        self.add_layer()
         grps = [self.collect.new_subset_group() for _ in range(3)]
         self.select_layers(*grps[:2])
-        selected = [s.group for s in layer.edit_subset + layer2.edit_subset]
-        assert grps[0] in selected
-        assert grps[1] in selected
-        assert grps[2] not in selected
+        assert grps[0] in mode.edit_subset
+        assert grps[1] in mode.edit_subset
+        assert grps[2] not in mode.edit_subset
 
     def test_selection_updates_on_data_add(self):
         layer = self.add_layer()

--- a/glue/conftest.py
+++ b/glue/conftest.py
@@ -3,11 +3,18 @@ from __future__ import absolute_import, division, print_function
 import os
 
 from glue.config import CFG_DIR as CFG_DIR_ORIG
+from glue.core.edit_subset_mode import EditSubsetMode, ReplaceMode
 
 
 def pytest_addoption(parser):
     parser.addoption("--no-optional-skip", action="store_true",
                      help="don't skip any tests with optional dependencies")
+
+
+def pytest_runtest_setup(item):
+    mode = EditSubsetMode()
+    mode.mode = ReplaceMode
+    mode.edit_subset = []
 
 
 def pytest_configure(config):

--- a/glue/core/edit_subset_mode.py
+++ b/glue/core/edit_subset_mode.py
@@ -38,7 +38,7 @@ class EditSubsetMode(object):
         :param edit_subset: The current edit_subset
         :param new_state: The new SubsetState
         """
-        if self.edit_subset == []:
+        if not self.edit_subset:
             if self.data_collection is None:
                 raise RuntimeError("Must set data_collection before "
                                    "calling update")

--- a/glue/core/tests/test_edit_subset_mode.py
+++ b/glue/core/tests/test_edit_subset_mode.py
@@ -2,16 +2,13 @@
 
 from __future__ import absolute_import, division, print_function
 
-import itertools
-
-import pytest
 import numpy as np
 
 from ..data import Component, Data
 from ..data_collection import DataCollection
 from ..edit_subset_mode import (EditSubsetMode, ReplaceMode, OrMode, AndMode,
                                 XorMode, AndNotMode)
-from ..subset import ElementSubsetState, SubsetState
+from ..subset import ElementSubsetState
 
 
 class TestEditSubsetMode(object):
@@ -27,19 +24,19 @@ class TestEditSubsetMode(object):
         state1 = ElementSubsetState(ind1)
         state2 = ElementSubsetState(ind2)
 
-        data.edit_subset = data.new_subset()
+        self.edit_mode = EditSubsetMode()
+        self.edit_mode.edit_subset = data.new_subset()
+        self.edit_mode.edit_subset.subset_state = state1
 
-        data.edit_subset.subset_state = state1
         self.data = data
         self.cid = cid
         self.state1 = state1
         self.state2 = state2
 
     def check_mode(self, mode, expected):
-        edit_mode = EditSubsetMode()
-        edit_mode.mode = mode
-        edit_mode.update(self.data, self.state2)
-        np.testing.assert_array_equal(self.data.edit_subset.to_mask(),
+        self.edit_mode.mode = mode
+        self.edit_mode.update(self.data, self.state2)
+        np.testing.assert_array_equal(self.edit_mode.edit_subset.to_mask(),
                                       expected)
 
     def test_replace(self):
@@ -59,113 +56,36 @@ class TestEditSubsetMode(object):
 
     def test_combine_maps_over_multiselection(self):
         """If data has many edit subsets, act on all of them"""
-        mode = EditSubsetMode()
-        mode.mode = ReplaceMode
+
+        self.edit_mode.mode = ReplaceMode
+
         for i in range(5):
             self.data.new_subset()
+        self.edit_mode.edit_subset = list(self.data.subsets)
 
-        self.data.edit_subset = list(self.data.subsets)
-
-        mode.update(self.data, self.state2)
+        self.edit_mode.update(self.data, self.state2)
         expected = np.array([False, True, True])
         for s in self.data.subsets:
             np.testing.assert_array_equal(s.to_mask(), expected)
 
     def test_combine_with_collection(self):
         """A data collection input works on each data object"""
-        mode = EditSubsetMode()
-        mode.mode = ReplaceMode
+
+        self.edit_mode.mode = ReplaceMode
 
         for i in range(5):
             self.data.new_subset()
-        self.data.edit_subset = list(self.data.subsets)
+        self.edit_mode.edit_subset = list(self.data.subsets)
 
         dc = DataCollection([self.data])
 
-        mode.update(dc, self.state2)
+        self.edit_mode.update(dc, self.state2)
         expected = np.array([False, True, True])
         for s in self.data.subsets:
             np.testing.assert_array_equal(s.to_mask(), expected)
 
     def test_combines_make_copy(self):
-        mode = EditSubsetMode()
-        mode.mode = ReplaceMode
-        self.data.edit_subset = self.data.new_subset()
-        mode.update(self.data, self.state2)
-        assert self.data.edit_subset.subset_state is not self.state2
-
-
-# Tests for multiselection logic
-combs = list(itertools.product([True, False], [True, False],
-                               [True, False], [True, False]))
-
-
-@pytest.mark.parametrize(("emp", "loc", "glob", "foc"), combs)
-def test_multiselect(emp, loc, glob, foc):
-    """Test logic of when subsets should be updated/added, given
-    the state of all editable subsets in a data collection.
-
-    We consider four variables. The first data set in the collection
-    is tested, and considired the 'local' data
-    :param emp: Is the local set empty (i.e. no subsets)?
-    :param loc: Are any of the local subsets editable?
-    :param glob: Are any non-local subsets editable?
-    :param foc: Does the local dataset have focus?
-    """
-    if emp and loc:  # can't be empty with selections
-        return
-    dc, state = setup_multi(emp, loc, glob, foc)
-    did_add, did_apply = apply(dc, state, foc)
-    assert did_add == should_add(emp, loc, glob, foc)
-    assert did_apply == should_apply(emp, loc, glob, foc)
-
-
-def setup_multi(empty, local_select, global_select, focus):
-    d1 = Data()
-    d2 = Data()
-    dc = DataCollection([d1, d2])
-    EditSubsetMode().data_collection = dc
-
-    d2.new_subset()
-    if not empty:
-        d1.new_subset()
-    if (not empty) and local_select:
-        d1.edit_subset = d1.subsets[0]
-
-    if global_select:
-        d2.edit_subset = d2.subsets[0]
-
-    state = SubsetState()
-    return dc, state
-
-
-def should_add(emp, loc, glob, foc):
-    return foc and not (loc or glob)
-
-
-def should_apply(emp, loc, glob, foc):
-    return loc and not emp
-
-
-def apply(dc, state, focus=False):
-    """Update data collection, return did_add, did_apply for
-    first data object"""
-
-    ct = len(dc[0].subsets)
-
-    sub = dc[0].edit_subset
-    if isinstance(sub, list):
-        sub = None if len(sub) == 0 else sub[0]
-
-    old_state = None
-    if sub is not None:
-        old_state = sub.subset_state
-
-    mode = EditSubsetMode()
-    mode.mode = ReplaceMode
-    mode.update(dc, state, dc[0] if focus else None)
-
-    print(len(dc[0].subsets))
-    did_add = len(dc[0].subsets) > ct
-    did_apply = sub is not None and sub.subset_state is not old_state
-    return did_add, did_apply
+        self.edit_mode.mode = ReplaceMode
+        self.edit_mode.edit_subset = self.data.new_subset()
+        self.edit_mode.update(self.data, self.state2)
+        assert self.edit_mode.edit_subset.subset_state is not self.state2

--- a/glue/viewers/histogram/layer_artist.py
+++ b/glue/viewers/histogram/layer_artist.py
@@ -110,7 +110,7 @@ class HistogramLayerArtist(MatplotlibLayerArtist):
         else:
             self.state._y_max *= 1.2
 
-        largest_y_max = max(layer._y_max for layer in self._viewer_state.layers)
+        largest_y_max = max(getattr(layer, '_y_max', 0) for layer in self._viewer_state.layers)
         if largest_y_max != self._viewer_state.y_max:
             self._viewer_state.y_max = largest_y_max
 

--- a/glue/viewers/histogram/qt/data_viewer.py
+++ b/glue/viewers/histogram/qt/data_viewer.py
@@ -80,18 +80,13 @@ class HistogramViewer(MatplotlibDataViewer):
 
         roi_new = RangeROI(min=lo, max=hi, orientation='x')
 
-        for layer_artist in self._layer_artist_container:
+        x_comp = self.state.x_att.parent.get_component(self.state.x_att)
 
-            if not isinstance(layer_artist.layer, Data):
-                continue
+        subset_state = x_comp.subset_from_roi(self.state.x_att, roi_new,
+                                              coord='x')
 
-            x_comp = layer_artist.layer.get_component(self.state.x_att)
-
-            subset_state = x_comp.subset_from_roi(self.state.x_att, roi_new,
-                                                  coord='x')
-
-            mode = EditSubsetMode()
-            mode.update(self._data, subset_state, focus_data=layer_artist.layer)
+        mode = EditSubsetMode()
+        mode.update(self._data, subset_state)
 
     @staticmethod
     def update_viewer_state(rec, context):

--- a/glue/viewers/histogram/qt/tests/test_viewer_widget.py
+++ b/glue/viewers/histogram/qt/tests/test_viewer_widget.py
@@ -12,7 +12,7 @@ from numpy.testing import assert_equal, assert_allclose
 from glue.core.message import SubsetUpdateMessage
 from glue.core import HubListener, Data
 from glue.core.roi import XRangeROI
-from glue.core.subset import RangeSubsetState
+from glue.core.subset import RangeSubsetState, CategoricalROISubsetState
 from glue import core
 from glue.core.component_id import ComponentID
 from glue.core.tests.util import simple_session

--- a/glue/viewers/histogram/qt/tests/test_viewer_widget.py
+++ b/glue/viewers/histogram/qt/tests/test_viewer_widget.py
@@ -3,20 +3,23 @@
 from __future__ import absolute_import, division, print_function
 
 import os
+from collections import Counter
 
 import pytest
 
 from numpy.testing import assert_equal, assert_allclose
 
-from glue.core import Data
+from glue.core.message import SubsetUpdateMessage
+from glue.core import HubListener, Data
 from glue.core.roi import XRangeROI
-from glue.core.subset import RangeSubsetState, CategoricalROISubsetState
+from glue.core.subset import RangeSubsetState
 from glue import core
 from glue.core.component_id import ComponentID
 from glue.core.tests.util import simple_session
 from glue.utils.qt import combo_as_string
 from glue.viewers.matplotlib.qt.tests.test_data_viewer import BaseTestMatplotlibDataViewer
 from glue.core.state import GlueUnSerializer
+from glue.app.qt.layer_tree_widget import LayerTreeWidget
 
 from ..data_viewer import HistogramViewer
 
@@ -495,3 +498,49 @@ class TestHistogramViewer(object):
         assert viewer4.state.layers[1].visible
         assert viewer4.state.cumulative
         assert not viewer4.state.normalize
+
+    def test_apply_roi_single(self):
+
+        # Regression test for a bug that caused mode.update to be called
+        # multiple times and resulted in all other viewers receiving many
+        # messages regarding subset updates (this occurred when multiple)
+        # datasets were present.
+
+        layer_tree = LayerTreeWidget()
+        layer_tree.set_checkable(False)
+        layer_tree.setup(self.data_collection)
+        layer_tree.bind_selection_to_edit_subset()
+
+        class Client(HubListener):
+
+            def __init__(self, *args, **kwargs):
+                super(Client, self).__init__(*args, **kwargs)
+                self.count = Counter()
+
+            def ping(self, message):
+                self.count[message.sender] += 1
+
+            def register_to_hub(self, hub):
+                hub.subscribe(self, SubsetUpdateMessage, handler=self.ping)
+
+        d1 = Data(a=[1, 2, 3], label='d1')
+        d2 = Data(b=[1, 2, 3], label='d2')
+        d3 = Data(c=[1, 2, 3], label='d3')
+        d4 = Data(d=[1, 2, 3], label='d4')
+
+        self.data_collection.append(d1)
+        self.data_collection.append(d2)
+        self.data_collection.append(d3)
+        self.data_collection.append(d4)
+
+        client = Client()
+        client.register_to_hub(self.hub)
+
+        self.viewer.add_data(d1)
+        self.viewer.add_data(d3)
+
+        roi = XRangeROI(2.5, 3.5)
+        self.viewer.apply_roi(roi)
+
+        for subset in client.count:
+            assert client.count[subset] == 1

--- a/glue/viewers/image/layer_artist.py
+++ b/glue/viewers/image/layer_artist.py
@@ -46,7 +46,11 @@ class ImageLayerArtist(MatplotlibLayerArtist):
 
     def get_image_data(self):
 
+        # FIXME: we should disable the layer if the image cannot be shown
+        # on the same grid as the reference data.
+
         try:
+            # FIXME: is the following slow? Should slide at same time?
             image = self.layer[self.state.attribute]
         except (IncompatibleAttribute, IndexError):
             # The following includes a call to self.clear()

--- a/glue/viewers/image/layer_artist.py
+++ b/glue/viewers/image/layer_artist.py
@@ -181,7 +181,15 @@ class ImageSubsetLayerArtist(MatplotlibLayerArtist):
         return mask
 
     def _update_image_data(self):
-        data = self._get_image_data()
+
+        try:
+            data = self._get_image_data()
+        except IncompatibleAttribute:
+            self.disable_invalid_attributes(self.state.attribute)
+            data = np.zeros(self.layer.shape)
+        else:
+            self._enabled = True
+
         self.mpl_image.set_data(data)
         self.mpl_image.set_extent([-0.5, data.shape[1] - 0.5, -0.5, data.shape[0] - 0.5])
         self.redraw()

--- a/glue/viewers/image/qt/data_viewer.py
+++ b/glue/viewers/image/qt/data_viewer.py
@@ -127,21 +127,16 @@ class ImageViewer(MatplotlibDataViewer):
 
         # TODO Does subset get applied to all data or just visible data?
 
-        for layer_artist in self._layer_artist_container:
+        x_comp = self.state.x_att.parent.get_component(self.state.x_att)
+        y_comp = self.state.y_att.parent.get_component(self.state.y_att)
 
-            if not isinstance(layer_artist.layer, Data):
-                continue
+        subset_state = x_comp.subset_from_roi(self.state.x_att, roi,
+                                              other_comp=y_comp,
+                                              other_att=self.state.y_att,
+                                              coord='x')
 
-            x_comp = layer_artist.layer.get_component(self.state.x_att)
-            y_comp = layer_artist.layer.get_component(self.state.y_att)
-
-            subset_state = x_comp.subset_from_roi(self.state.x_att, roi,
-                                                  other_comp=y_comp,
-                                                  other_att=self.state.y_att,
-                                                  coord='x')
-
-            mode = EditSubsetMode()
-            mode.update(self._data, subset_state, focus_data=layer_artist.layer)
+        mode = EditSubsetMode()
+        mode.update(self._data, subset_state)
 
     def _scatter_artist(self, axes, state, layer=None):
         if len(self._layer_artist_container) == 0:

--- a/glue/viewers/image/qt/standalone_image_viewer.py
+++ b/glue/viewers/image/qt/standalone_image_viewer.py
@@ -20,7 +20,7 @@ class StandaloneImageViewer(QtWidgets.QMainWindow):
     """
     window_closed = QtCore.Signal()
     _toolbar_cls = MatplotlibViewerToolbar
-    tools = ['image:contrast_bias', 'image:colormap']
+    tools = ['image:contrast', 'image:colormap']
 
     def __init__(self, image=None, wcs=None, parent=None, **kwargs):
         """

--- a/glue/viewers/image/qt/tests/test_viewer_widget.py
+++ b/glue/viewers/image/qt/tests/test_viewer_widget.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import, division, print_function
 
 import os
+from collections import Counter
 
 import pytest
 
@@ -11,16 +12,18 @@ from astropy.wcs import WCS
 import numpy as np
 from numpy.testing import assert_allclose
 
-from glue.core import Data
 from glue.core.coordinates import Coordinates, WCSCoordinates
-from glue.core.roi import RectangularROI
+from glue.core.message import SubsetUpdateMessage
+from glue.core import HubListener, Data
+from glue.core.roi import XRangeROI, RectangularROI
 from glue.core.subset import RoiSubsetState
 from glue.core.tests.util import simple_session
 from glue.utils.qt import combo_as_string
 from glue.viewers.matplotlib.qt.tests.test_data_viewer import BaseTestMatplotlibDataViewer
 from glue.core.state import GlueUnSerializer
-from glue.viewers.image.state import ImageLayerState, ImageSubsetLayerState
+from glue.app.qt.layer_tree_widget import LayerTreeWidget
 from glue.viewers.scatter.state import ScatterLayerState
+from glue.viewers.image.state import ImageLayerState, ImageSubsetLayerState
 
 from ..data_viewer import ImageViewer
 
@@ -249,6 +252,52 @@ class TestImageViewer(object):
         self.data_collection.append(hypercube2)
 
         self.viewer.add_data(hypercube2)
+
+    def test_apply_roi_single(self):
+
+        # Regression test for a bug that caused mode.update to be called
+        # multiple times and resulted in all other viewers receiving many
+        # messages regarding subset updates (this occurred when multiple)
+        # datasets were present.
+
+        layer_tree = LayerTreeWidget()
+        layer_tree.set_checkable(False)
+        layer_tree.setup(self.data_collection)
+        layer_tree.bind_selection_to_edit_subset()
+
+        class Client(HubListener):
+
+            def __init__(self, *args, **kwargs):
+                super(Client, self).__init__(*args, **kwargs)
+                self.count = Counter()
+
+            def ping(self, message):
+                self.count[message.sender] += 1
+
+            def register_to_hub(self, hub):
+                hub.subscribe(self, SubsetUpdateMessage, handler=self.ping)
+
+        d1 = Data(a=[[1, 2], [3, 4]], label='d1')
+        d2 = Data(b=[[1, 2], [3, 4]], label='d2')
+        d3 = Data(c=[[1, 2], [3, 4]], label='d3')
+        d4 = Data(d=[[1, 2], [3, 4]], label='d4')
+
+        self.data_collection.append(d1)
+        self.data_collection.append(d2)
+        self.data_collection.append(d3)
+        self.data_collection.append(d4)
+
+        client = Client()
+        client.register_to_hub(self.hub)
+
+        self.viewer.add_data(d1)
+        self.viewer.add_data(d3)
+
+        roi = XRangeROI(2.5, 3.5)
+        self.viewer.apply_roi(roi)
+
+        for subset in client.count:
+            assert client.count[subset] == 1
 
 
 class TestSessions(object):

--- a/glue/viewers/scatter/qt/data_viewer.py
+++ b/glue/viewers/scatter/qt/data_viewer.py
@@ -71,23 +71,16 @@ class ScatterViewer(MatplotlibDataViewer):
         # cmd = command.ApplyROI(client=self.client, roi=roi)
         # self._session.command_stack.do(cmd)
 
-        # TODO Does subset get applied to all data or just visible data?
+        x_comp = self.state.x_att.parent.get_component(self.state.x_att)
+        y_comp = self.state.y_att.parent.get_component(self.state.y_att)
 
-        for layer_artist in self._layer_artist_container:
+        subset_state = x_comp.subset_from_roi(self.state.x_att, roi,
+                                              other_comp=y_comp,
+                                              other_att=self.state.y_att,
+                                              coord='x')
 
-            if not isinstance(layer_artist.layer, Data):
-                continue
-
-            x_comp = layer_artist.layer.get_component(self.state.x_att)
-            y_comp = layer_artist.layer.get_component(self.state.y_att)
-
-            subset_state = x_comp.subset_from_roi(self.state.x_att, roi,
-                                                  other_comp=y_comp,
-                                                  other_att=self.state.y_att,
-                                                  coord='x')
-
-            mode = EditSubsetMode()
-            mode.update(self._data, subset_state, focus_data=layer_artist.layer)
+        mode = EditSubsetMode()
+        mode.update(self._data, subset_state)
 
     @staticmethod
     def update_viewer_state(rec, context):

--- a/glue/viewers/scatter/qt/tests/test_viewer_widget.py
+++ b/glue/viewers/scatter/qt/tests/test_viewer_widget.py
@@ -3,13 +3,15 @@
 from __future__ import absolute_import, division, print_function
 
 import os
+from collections import Counter
 
 import pytest
 
 from numpy.testing import assert_allclose
 
-from glue.core import Data
-from glue.core.roi import RectangularROI
+from glue.core.message import SubsetUpdateMessage
+from glue.core import HubListener, Data
+from glue.core.roi import XRangeROI, RectangularROI
 from glue.core.subset import RoiSubsetState, AndState
 from glue import core
 from glue.core.component_id import ComponentID
@@ -17,6 +19,7 @@ from glue.core.tests.util import simple_session
 from glue.utils.qt import combo_as_string
 from glue.viewers.matplotlib.qt.tests.test_data_viewer import BaseTestMatplotlibDataViewer
 from glue.core.state import GlueUnSerializer
+from glue.app.qt.layer_tree_widget import LayerTreeWidget
 
 from ..data_viewer import ScatterViewer
 
@@ -302,3 +305,51 @@ class TestScatterViewer(object):
         assert viewer_state.y_max == 8
 
         assert len(self.viewer.layers[0].mpl_artists) == 1
+
+    def test_apply_roi_single(self):
+
+        # Regression test for a bug that caused mode.update to be called
+        # multiple times and resulted in all other viewers receiving many
+        # messages regarding subset updates (this occurred when multiple)
+        # datasets were present.
+
+        layer_tree = LayerTreeWidget()
+        layer_tree.set_checkable(False)
+        layer_tree.setup(self.data_collection)
+        layer_tree.bind_selection_to_edit_subset()
+
+        class Client(HubListener):
+
+            def __init__(self, *args, **kwargs):
+                super(Client, self).__init__(*args, **kwargs)
+                self.count = Counter()
+
+            def ping(self, message):
+                self.count[message.sender] += 1
+
+            def register_to_hub(self, hub):
+                hub.subscribe(self, SubsetUpdateMessage, handler=self.ping)
+
+        self.data_collection.remove(self.data)
+        self.data_collection.remove(self.data_2d)
+
+        d1 = Data(a=[1, 2, 3], label='d1')
+        d2 = Data(b=[1, 2, 3], label='d2')
+        d3 = Data(c=[1, 2, 3], label='d3')
+        d4 = Data(d=[1, 2, 3], label='d4')
+
+        self.data_collection.append(d1)
+        self.data_collection.append(d2)
+        self.data_collection.append(d3)
+        self.data_collection.append(d4)
+
+        client = Client()
+        client.register_to_hub(self.hub)
+
+        self.viewer.add_data(d1)
+
+        roi = XRangeROI(2.5, 3.5)
+        self.viewer.apply_roi(roi)
+
+        for subset in client.count:
+            assert client.count[subset] == 1

--- a/glue/viewers/scatter/qt/tests/test_viewer_widget.py
+++ b/glue/viewers/scatter/qt/tests/test_viewer_widget.py
@@ -330,13 +330,10 @@ class TestScatterViewer(object):
             def register_to_hub(self, hub):
                 hub.subscribe(self, SubsetUpdateMessage, handler=self.ping)
 
-        self.data_collection.remove(self.data)
-        self.data_collection.remove(self.data_2d)
-
-        d1 = Data(a=[1, 2, 3], label='d1')
-        d2 = Data(b=[1, 2, 3], label='d2')
-        d3 = Data(c=[1, 2, 3], label='d3')
-        d4 = Data(d=[1, 2, 3], label='d4')
+        d1 = Data(a=[1, 2, 3], label='d3')
+        d2 = Data(b=[1, 2, 3], label='d4')
+        d3 = Data(c=[1, 2, 3], label='d5')
+        d4 = Data(d=[1, 2, 3], label='d6')
 
         self.data_collection.append(d1)
         self.data_collection.append(d2)
@@ -347,6 +344,7 @@ class TestScatterViewer(object):
         client.register_to_hub(self.hub)
 
         self.viewer.add_data(d1)
+        self.viewer.add_data(d3)
 
         roi = XRangeROI(2.5, 3.5)
         self.viewer.apply_roi(roi)

--- a/glue/viewers/table/qt/tests/test_viewer_widget.py
+++ b/glue/viewers/table/qt/tests/test_viewer_widget.py
@@ -6,7 +6,7 @@ import numpy as np
 from qtpy import QtCore, QtGui
 from glue.utils.qt import get_qapp
 from qtpy.QtCore import Qt
-from glue.core import Data, DataCollection, Session
+from glue.core import Data, DataCollection
 from glue.utils.qt import qt4_to_mpl_color
 from glue.app.qt import GlueApplication
 
@@ -194,8 +194,7 @@ def test_table_widget(tmpdir):
     # We specify that we are editing the second subset, and use a 'not' logical
     # operation to remove the currently selected line from the second subset.
 
-    d.edit_subset = [d.subsets[1]]
-
+    subset_mode.edit_subset = [d.subsets[1]]
     subset_mode.mode = AndNotMode
 
     press_key(Qt.Key_Enter)
@@ -215,7 +214,7 @@ def test_table_widget(tmpdir):
 
     subset_mode.mode = OrMode
 
-    d.edit_subset = [d.subsets[0]]
+    subset_mode.edit_subset = [d.subsets[0]]
 
     press_key(Qt.Key_Enter)
 
@@ -229,7 +228,7 @@ def test_table_widget(tmpdir):
 
     subset_mode.mode = ReplaceMode
 
-    d.edit_subset = None
+    subset_mode.edit_subset = None
 
     press_key(Qt.Key_Enter)
 


### PR DESCRIPTION
This fixes several issues related to subset modes:

* Currently, when multiple datasets were present, when updating a subset state each subset was updated multiple times which lead to slower performance
* The new image, histogram and scatter viewers updated the subset state multiple times for the whole data collection.