### PR TITLE
Remove the ability to create new viewer from right-clicking on canvas

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,7 +44,7 @@ v0.11.0 (unreleased)
 
 * Remove the ability to create a new viewer by right-clicking on the canvas,
   since this causes confusion when trying to control-click to paste in the
-  IPython terminal.
+  IPython terminal. [#1342]
 
 v0.10.5 (unreleased)
 --------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,6 +42,10 @@ v0.11.0 (unreleased)
   subset group, rather than once per dataset, which avoids doing the same
   update to each dataset multiple times. [#1338]
 
+* Remove the ability to create a new viewer by right-clicking on the canvas,
+  since this causes confusion when trying to control-click to paste in the
+  IPython terminal.
+
 v0.10.5 (unreleased)
 --------------------
 

--- a/glue/app/qt/mdi_area.py
+++ b/glue/app/qt/mdi_area.py
@@ -62,12 +62,6 @@ class GlueMdiArea(QtWidgets.QMdiArea):
 
         event.accept()
 
-    def mousePressEvent(self, event):
-        """Right mouse press in the MDI area opens a new data viewer"""
-        if event.button() != Qt.RightButton:
-            return
-        self._application.choose_new_data_viewer()
-
     def close(self):
         self.closeAllSubWindows()
         super(GlueMdiArea, self).close()


### PR DESCRIPTION
This causes confusion when trying to control-click to paste into the IPython terminal