### PR TITLE
Get rid of QTimers for updating the data collection and layer artist lists

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@ Full changelog
 v0.11.0 (unreleased)
 --------------------
 
+* Get rid of QTimers for updating the data collection and layer artist
+  lists, and instead refresh whenever a message is sent from the hub
+  (which results in immediate changes rather than waiting up to a
+   second for things to change). [#1343]
+
 * Made it possible to delay callbacks from the Hub using the
   ``Hub.delay_callbacks`` context manager. Also fixed the Hub so that
   it uses weak references to classes and methods wherever possible. [#1339]

--- a/glue/core/qt/tests/test_layer_artist_model.py
+++ b/glue/core/qt/tests/test_layer_artist_model.py
@@ -4,7 +4,7 @@ from mock import MagicMock
 
 from qtpy.QtCore import Qt
 from qtpy import PYQT5
-from glue.core import Data
+from glue.core import Data, Hub
 from glue.core.layer_artist import MatplotlibLayerArtist as _LayerArtist
 
 from ..layer_artist_model import LayerArtistModel, LayerArtistView
@@ -217,7 +217,8 @@ class TestLayerArtistView(object):
 
     def setup_method(self, method):
         self.model, self.artists = setup_model(2)
-        self.view = LayerArtistView()
+        self.hub = Hub()
+        self.view = LayerArtistView(hub=self.hub)
         self.view.setModel(self.model)
 
     def test_current_row(self):

--- a/glue/viewers/common/qt/data_viewer.py
+++ b/glue/viewers/common/qt/data_viewer.py
@@ -62,7 +62,8 @@ class DataViewer(ViewerBase, QtWidgets.QMainWindow):
         QtWidgets.QMainWindow.__init__(self, parent)
         ViewerBase.__init__(self, session)
         self.setWindowIcon(get_qapp().windowIcon())
-        self._view = LayerArtistWidget(layer_style_widget_cls=self._layer_style_widget_cls)
+        self._view = LayerArtistWidget(layer_style_widget_cls=self._layer_style_widget_cls,
+                                       hub=session.hub)
         self._view.layer_list.setModel(self._layer_artist_container.model)
         self._tb_vis = {}  # store whether toolbars are enabled
         self.setAttribute(Qt.WA_DeleteOnClose)


### PR DESCRIPTION
Instead refresh whenever a message is sent from the hub (which results in immediate changes rather than waiting up to a second for things to change).