### PR TITLE
Implement a new way to deal with combo boxes

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -342,7 +342,8 @@ nitpick_ignore = [('py:class', 'object'), ('py:class', 'str'),
                   ('py:mod', 'glue.viewers.common'),
                   ('py:mod', 'glue.viewers.common.qt.mouse_mode'),
                   ('py:mod', 'glue.dialogs.custom_component'),
-                  ('py:class', 'glue.external.echo.core.HasCallbackProperties')
+                  ('py:class', 'glue.external.echo.core.HasCallbackProperties'),
+                  ('py:class', 'glue.external.echo.core.CallbackProperty')
               ]
 
 # coax Sphinx into treating descriptors as attributes

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -343,7 +343,8 @@ nitpick_ignore = [('py:class', 'object'), ('py:class', 'str'),
                   ('py:mod', 'glue.viewers.common.qt.mouse_mode'),
                   ('py:mod', 'glue.dialogs.custom_component'),
                   ('py:class', 'glue.external.echo.core.HasCallbackProperties'),
-                  ('py:class', 'glue.external.echo.core.CallbackProperty')
+                  ('py:class', 'glue.external.echo.core.CallbackProperty'),
+                  ('py:class', 'glue.external.echo.core.SelectionCallbackProperty')
               ]
 
 # coax Sphinx into treating descriptors as attributes

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -344,7 +344,7 @@ nitpick_ignore = [('py:class', 'object'), ('py:class', 'str'),
                   ('py:mod', 'glue.dialogs.custom_component'),
                   ('py:class', 'glue.external.echo.core.HasCallbackProperties'),
                   ('py:class', 'glue.external.echo.core.CallbackProperty'),
-                  ('py:class', 'glue.external.echo.core.SelectionCallbackProperty')
+                  ('py:class', 'glue.external.echo.selection.SelectionCallbackProperty')
               ]
 
 # coax Sphinx into treating descriptors as attributes

--- a/glue/app/qt/terminal.py
+++ b/glue/app/qt/terminal.py
@@ -226,7 +226,7 @@ def glue_terminal(**kwargs):
     # TODO: if glue is launched from a qtconsole or a notebook, we should in
     # principle be able to use the connected_console function above, but this
     # doesn't behave quite right and requires further investigation.
-    
+
     # Note however that if we do this, then we need to avoid polluting the
     # namespace of the original IPython console, as described in this issue:
     # https://github.com/glue-viz/glue/issues/1209

--- a/glue/app/qt/tests/test_terminal.py
+++ b/glue/app/qt/tests/test_terminal.py
@@ -1,15 +1,21 @@
 from __future__ import absolute_import, division, print_function
 
+import os
+
+import pytest
 from mock import MagicMock, patch
 
 from glue.tests.helpers import requires_ipython, IPYTHON_INSTALLED
 
+
+CIRCLECI = os.environ.get('CIRCLECI', 'false') == 'true'
 
 if IPYTHON_INSTALLED:
     from ..terminal import glue_terminal
 
 
 @requires_ipython
+@pytest.mark.skipif(CIRCLECI, reason='IPython terminal tests tend to hang on CircleCI')
 class TestTerminal(object):
     def test_mpl_non_interactive(self):
         """IPython v0.12 sometimes turns on mpl interactive. Ensure

--- a/glue/core/data_combo_helper.py
+++ b/glue/core/data_combo_helper.py
@@ -1,4 +1,5 @@
-# Non-Qt-specific versions of the combo helpers
+# Combo helpers independent of GUI framework - these operate on
+# SelectionCallbackProperty objects.
 
 from __future__ import absolute_import, division, print_function
 
@@ -18,6 +19,19 @@ __all__ = ['ComponentIDComboHelper', 'ManualDataComboHelper',
 
 
 class ComboHelper(HubListener):
+    """
+    Base class for any combo helper represented by a SelectionCallbackProperty.
+
+    This stores the state and selection property and exposes the ``state``,
+    ``selection`` and ``choices`` properties.
+
+    Parameters
+    ----------
+    state : :class:`~glue.core.state_objects.State`
+        The state to which the selection property belongs
+    selection_property : :class:`~glue.external.echo.core.SelectionCallbackProperty`
+        The selection property representing the combo.
+    """
 
     def __init__(self, state, selection_property):
 
@@ -26,10 +40,16 @@ class ComboHelper(HubListener):
 
     @property
     def state(self):
+        """
+        The state to which the selection property belongs.
+        """
         return self._state()
 
     @property
     def selection(self):
+        """
+        The current selected value.
+        """
         return getattr(self.state, self.selection_property)
 
     @selection.setter
@@ -38,6 +58,9 @@ class ComboHelper(HubListener):
 
     @property
     def choices(self):
+        """
+        The current valid choices for the combo.
+        """
         prop = getattr(type(self.state), self.selection_property)
         return prop.get_choices(self.state)
 
@@ -49,20 +72,23 @@ class ComboHelper(HubListener):
 
 class ComponentIDComboHelper(ComboHelper):
     """
-    The purpose of this class is to set up a combo showing componentIDs for
-    one or more datasets, and to update these componentIDs if needed, for
-    example if new components are added to a dataset, or if componentIDs are
-    renamed.
+    The purpose of this class is to set up a combo (represented by a
+    SelectionCallbackProperty) showing componentIDs for one or more datasets, and to
+    update these componentIDs if needed, for example if new components are added
+    to a dataset, or if componentIDs are renamed. This is a GUI
+    framework-independent implementation.
 
     Parameters
     ----------
-    component_id_combo : Qt combo widget
-        The Qt widget for the component ID combo box
-    data_collection : :class:`~glue.core.DataCollection`
+    state : :class:`~glue.core.state_objects.State`
+        The state to which the selection property belongs
+    selection_property : :class:`~glue.external.echo.core.SelectionCallbackProperty`
+        The selection property representing the combo.
+    data_collection : :class:`~glue.core.DataCollection`, optional
         The data collection to which the datasets belong - if specified,
         this is used to remove datasets from the combo when they are removed
         from the data collection.
-    data : :class:`~glue.core.Data`
+    data : :class:`~glue.core.Data`, optional
         If specified, set up the combo for this dataset only and don't allow
         datasets to be added/removed
     visible : bool, optional
@@ -276,8 +302,10 @@ class BaseDataComboHelper(ComboHelper):
 
     Parameters
     ----------
-    data_combo : Qt combo widget
-        The Qt widget for the data combo box
+    state : :class:`~glue.core.state_objects.State`
+        The state to which the selection property belongs
+    selection_property : :class:`~glue.external.echo.core.SelectionCallbackProperty`
+        The selection property representing the combo.
     """
 
     def __init__(self, state, selection_property):
@@ -328,8 +356,10 @@ class ManualDataComboHelper(BaseDataComboHelper):
 
     Parameters
     ----------
-    data_combo : Qt combo widget
-        The Qt widget for the data combo box
+    state : :class:`~glue.core.state_objects.State`
+        The state to which the selection property belongs
+    selection_property : :class:`~glue.external.echo.core.SelectionCallbackProperty`
+        The selection property representing the combo.
     data_collection : :class:`~glue.core.DataCollection`
         The data collection to which the datasets belong - this is needed
         because if a dataset is removed from the data collection, we want to
@@ -400,8 +430,10 @@ class DataCollectionComboHelper(BaseDataComboHelper):
 
     Parameters
     ----------
-    data_combo : Qt combo widget
-        The Qt widget for the data combo box
+    state : :class:`~glue.core.state_objects.State`
+        The state to which the selection property belongs
+    selection_property : :class:`~glue.external.echo.core.SelectionCallbackProperty`
+        The selection property representing the combo.
     data_collection : :class:`~glue.core.DataCollection`
         The data collection with which to stay in sync
     """

--- a/glue/core/glue_pickle.py
+++ b/glue/core/glue_pickle.py
@@ -3,8 +3,7 @@ from __future__ import absolute_import, division, print_function
 from glue.logger import logger
 
 try:
-    from dill import dumps, loads
+    from dill import dumps, loads  # noqa
 except ImportError:
     logger.info("Dill library not installed. Falling back to cPickle")
-
-from glue.external.six.moves.cPickle import dumps, loads
+    from glue.external.six.moves.cPickle import dumps, loads  # noqa

--- a/glue/core/qt/data_combo_helper.py
+++ b/glue/core/qt/data_combo_helper.py
@@ -19,17 +19,25 @@ __all__ = ['ComponentIDComboHelper', 'ManualDataComboHelper',
 
 class QtComboHelper(object):
 
-    def __init__(self, combo, state, selection_property, choices_property):
+    def __init__(self, combo, state, selection_property):
         self.combo = combo
         self.state = state
         self.selection_property = selection_property
-        self.choices_property = choices_property
         self.state.add_callback(selection_property, self._selection_changed)
         self.state.add_callback(selection_property, self._choices_changed)
 
+    @property
+    def selection(self):
+        return getattr(self.state, self.selection_property)
+
+    @property
+    def choices(self):
+        prop = getattr(type(self.state), self.selection_property)
+        return prop.get_choices(self.state)
+
     def _choices_changed(self, *args):
 
-        choices = getattr(self.state, self.choices_property)
+        choices = self.choices
 
         self.combo.blockSignals(True)
 
@@ -58,7 +66,7 @@ class QtComboHelper(object):
         self.combo.currentIndexChanged.emit(index)
 
     def _selection_changed(self, *args):
-        index = self.combo.findData(getattr(self.state, self.selection_property))
+        index = self.combo.findData(self.selection)
         if self.combo.currentIndex() != index:
             self.combo.setCurrentIndex(index)
 

--- a/glue/core/qt/data_combo_helper.py
+++ b/glue/core/qt/data_combo_helper.py
@@ -12,63 +12,10 @@ from glue.core.message import (ComponentsChangedMessage,
 from glue.utils import nonpartial
 from glue.utils.qt import update_combobox
 from glue.utils.qt.widget_properties import CurrentComboDataProperty
+from glue.external.echo.qt.connect import _find_combo_data
 
 __all__ = ['ComponentIDComboHelper', 'ManualDataComboHelper',
            'DataCollectionComboHelper']
-
-
-class QtComboHelper(object):
-
-    def __init__(self, combo, state, selection_property):
-        self.combo = combo
-        self.state = state
-        self.selection_property = selection_property
-        self.state.add_callback(selection_property, self._selection_changed)
-        self.state.add_callback(selection_property, self._choices_changed)
-
-    @property
-    def selection(self):
-        return getattr(self.state, self.selection_property)
-
-    @property
-    def choices(self):
-        prop = getattr(type(self.state), self.selection_property)
-        return prop.get_choices(self.state)
-
-    def _choices_changed(self, *args):
-
-        choices = self.choices
-
-        self.combo.blockSignals(True)
-
-        self.combo.clear()
-
-        if len(choices) == 0:
-            return
-
-        combo_model = self.combo.model()
-
-        for index, (label, data) in enumerate(choices):
-
-            self.combo.addItem(label, userData=data)
-
-            # We interpret None data as being disabled rows (used for headers)
-            if data is None:
-                item = combo_model.item(index)
-                palette = self.combo.palette()
-                item.setFlags(item.flags() & ~(Qt.ItemIsSelectable | Qt.ItemIsEnabled))
-                item.setData(palette.color(QtGui.QPalette.Disabled, QtGui.QPalette.Text))
-
-        self._selection_changed()
-
-        self.combo.blockSignals(False)
-
-        self.combo.currentIndexChanged.emit(index)
-
-    def _selection_changed(self, *args):
-        index = self.combo.findData(self.selection)
-        if self.combo.currentIndex() != index:
-            self.combo.setCurrentIndex(index)
 
 
 class ComponentIDComboHelper(HubListener):

--- a/glue/core/qt/tests/test_data_collection_model.py
+++ b/glue/core/qt/tests/test_data_collection_model.py
@@ -33,11 +33,11 @@ class TestDataCollectionModel(object):
         model = self.make_model(1, 5)
         assert model.rowCount(model.subsets_index()) == 5
 
-    def test_row_count_single_subset(self):
+    def test_row_count_single_subset1(self):
         model = self.make_model(2, 1)
         assert model.rowCount(model.subsets_index(0)) == 2
 
-    def test_row_count_single_subset(self):
+    def test_row_count_single_subset2(self):
         model = self.make_model(2, 1)
         s = model.subsets_index(0)
 

--- a/glue/core/state_objects.py
+++ b/glue/core/state_objects.py
@@ -76,7 +76,7 @@ class State(HasCallbackProperties):
         """
         properties = {}
         for name in dir(self):
-            if self.is_callback_property(name):
+            if self.is_callback_property(name) and not name.startswith('_'):
                 properties[name] = getattr(self, name)
         return properties
 

--- a/glue/core/state_objects.py
+++ b/glue/core/state_objects.py
@@ -10,7 +10,7 @@ from glue.external.echo import (delay_callback, CallbackProperty,
                                 HasCallbackProperties, CallbackList)
 from glue.core.state import saver, loader
 
-__all__ = ['State', 'StateAttributeCacheHelper', 'SelectionCallbackProperty',
+__all__ = ['State', 'StateAttributeCacheHelper',
            'StateAttributeLimitsHelper', 'StateAttributeSingleValueHelper']
 
 
@@ -22,42 +22,6 @@ def _save_callback_list(items, context):
 @loader(CallbackList)
 def _load_callback_list(rec, context):
     return [context.object(obj) for obj in rec['values']]
-
-
-class SelectionCallbackProperty(CallbackProperty):
-
-    def __init__(self, default_index=0, **kwargs):
-        super(SelectionCallbackProperty, self).__init__(**kwargs)
-        self.default_index = default_index
-        self._choices = WeakKeyDictionary()
-
-    def get_choices(self, instance):
-        return self._choices[instance]
-
-    def set_choices(self, instance, choices):
-        self._choices[instance] = choices
-        self._choices_updated(instance, choices)
-
-    def _choices_updated(self, instance, choices):
-
-        if not choices:
-            self.__set__(instance, None)
-            return
-
-        selection = self.__get__(instance)
-
-        # TODO: try and generalize this selection to choices relation
-        if selection in set(x[1] for x in choices):
-            return
-
-        if self.default_index < 0:
-            index = len(choices) + self.default_index
-        else:
-            index = self.default_index
-
-        index = min(index, len(choices) - 1)
-
-        self.__set__(instance, choices[index][1])
 
 
 class State(HasCallbackProperties):

--- a/glue/core/state_objects.py
+++ b/glue/core/state_objects.py
@@ -76,7 +76,7 @@ class State(HasCallbackProperties):
         """
         properties = {}
         for name in dir(self):
-            if self.is_callback_property(name) and not name.startswith('_'):
+            if self.is_callback_property(name):
                 properties[name] = getattr(self, name)
         return properties
 

--- a/glue/core/state_objects.py
+++ b/glue/core/state_objects.py
@@ -10,7 +10,7 @@ from glue.external.echo import (delay_callback, CallbackProperty,
                                 HasCallbackProperties, CallbackList)
 from glue.core.state import saver, loader
 
-__all__ = ['State', 'StateAttributeCacheHelper',
+__all__ = ['State', 'StateAttributeCacheHelper', 'SelectionCallbackProperty',
            'StateAttributeLimitsHelper', 'StateAttributeSingleValueHelper']
 
 

--- a/glue/core/state_objects.py
+++ b/glue/core/state_objects.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
 from collections import defaultdict
-from weakref import WeakKeyDictionary
 
 import numpy as np
 
@@ -217,7 +216,7 @@ class StateAttributeCacheHelper(object):
             raise AttributeError(attribute)
 
     def __setattr__(self, attribute, value):
-        if attribute.startswith('_') or not attribute in self._attribute_lookup:
+        if attribute.startswith('_') or attribute not in self._attribute_lookup:
             return object.__setattr__(self, attribute, value)
         else:
             return setattr(self._state, self._attribute_lookup[attribute], value)
@@ -292,7 +291,6 @@ class StateAttributeLimitsHelper(StateAttributeCacheHelper):
                 # Otherwise, we force the recalculation or the fetching from
                 # cache of the limits based on the current attribute
                 self._update_attribute()
-
 
     def update_values(self, use_default_modifiers=False, **properties):
 

--- a/glue/core/tests/test_data_combo_helper.py
+++ b/glue/core/tests/test_data_combo_helper.py
@@ -1,0 +1,238 @@
+from __future__ import absolute_import, division, print_function
+
+import pytest
+from mock import MagicMock
+
+from glue.core import Data, DataCollection
+from glue.core.component_id import ComponentID
+from glue.utils.qt import combo_as_string
+from glue.external.echo.core import SelectionCallbackProperty
+from glue.core.state_objects import State
+
+from ..data_combo_helper import (ComponentIDComboHelper, ManualDataComboHelper,
+                                 DataCollectionComboHelper)
+
+def selection_choices(state, property):
+    items = [x[0] for x in getattr(type(state), property).get_choices(state)]
+    return ":".join(items)
+
+
+
+class ExampleState(State):
+    combo = SelectionCallbackProperty()
+
+
+def test_component_id_combo_helper():
+
+    state = ExampleState()
+
+    dc = DataCollection([])
+
+    helper = ComponentIDComboHelper(state, 'combo', dc)
+
+    assert selection_choices(state, 'combo') == ""
+
+    data1 = Data(x=[1, 2, 3], y=[2, 3, 4], label='data1')
+
+    dc.append(data1)
+    helper.append_data(data1)
+
+    assert selection_choices(state, 'combo') == "x:y"
+
+    data2 = Data(a=[1, 2, 3], b=['a', 'b', 'c'], label='data2')
+
+    dc.append(data2)
+    helper.append_data(data2)
+
+    assert selection_choices(state, 'combo') == "data1:x:y:data2:a:b"
+
+    helper.categorical = False
+
+    assert selection_choices(state, 'combo') == "data1:x:y:data2:a"
+
+    helper.numeric = False
+
+    assert selection_choices(state, 'combo') == "data1:data2"
+
+    helper.categorical = True
+    helper.numeric = True
+
+    helper.visible = False
+    assert selection_choices(state, 'combo') == "data1:x:Pixel Axis 0 [x]:World 0:y:data2:a:Pixel Axis 0 [x]:World 0:b"
+    helper.visible = True
+
+    dc.remove(data2)
+
+    assert selection_choices(state, 'combo') == "x:y"
+
+    # TODO: check that renaming a component updates the combo
+    # data1.id['x'].label = 'z'
+    # assert selection_choices(state, 'combo') == "z:y"
+
+    helper.remove_data(data1)
+
+    assert selection_choices(state, 'combo') == ""
+
+
+
+def test_component_id_combo_helper_nocollection():
+
+    # Make sure that we can use use ComponentIDComboHelper without any
+    # data collection.
+
+    state = ExampleState()
+
+    data = Data(x=[1, 2, 3], y=[2, 3, 4], z=['a', 'b', 'c'], label='data1')
+
+    helper = ComponentIDComboHelper(state, 'combo', data=data)
+
+    assert selection_choices(state, 'combo') == "x:y:z"
+
+    helper.categorical = False
+
+    assert selection_choices(state, 'combo') == "x:y"
+
+    helper.numeric = False
+
+    assert selection_choices(state, 'combo') == ""
+
+    helper.categorical = True
+
+    assert selection_choices(state, 'combo') == "z"
+
+    helper.numeric = True
+
+    assert selection_choices(state, 'combo') == "x:y:z"
+
+    data2 = Data(a=[1, 2, 3], b=['a', 'b', 'c'], label='data2')
+
+    with pytest.raises(Exception) as exc:
+        helper.append_data(data2)
+    assert exc.value.args[0] == ("Cannot change data in ComponentIDComboHelper "
+                                 "initialized from a single dataset")
+
+    with pytest.raises(Exception) as exc:
+        helper.remove_data(data2)
+    assert exc.value.args[0] == ("Cannot change data in ComponentIDComboHelper "
+                                 "initialized from a single dataset")
+
+    with pytest.raises(Exception) as exc:
+        helper.set_multiple_data([data2])
+    assert exc.value.args[0] == ("Cannot change data in ComponentIDComboHelper "
+                                 "initialized from a single dataset")
+
+
+def test_component_id_combo_helper_init():
+
+    # Regression test to make sure that the numeric and categorical options
+    # in the __init__ are taken into account properly
+
+    state = ExampleState()
+
+    dc = DataCollection([])
+
+    data = Data(a=[1, 2, 3], b=['a', 'b', 'c'], label='data2')
+    dc.append(data)
+
+    helper = ComponentIDComboHelper(state, 'combo', dc)
+    helper.append_data(data)
+    assert selection_choices(state, 'combo') == "a:b"
+
+    helper = ComponentIDComboHelper(state, 'combo', dc, numeric=False)
+    helper.append_data(data)
+    assert selection_choices(state, 'combo') == "b"
+
+    helper = ComponentIDComboHelper(state, 'combo', dc, categorical=False)
+    helper.append_data(data)
+    assert selection_choices(state, 'combo') == "a"
+
+    helper = ComponentIDComboHelper(state, 'combo', dc, numeric=False, categorical=False)
+    helper.append_data(data)
+    assert selection_choices(state, 'combo') == ""
+
+
+def test_component_id_combo_helper_replaced():
+
+    # Make sure that when components are replaced, the equivalent combo index
+    # remains selected and an event is broadcast so that any attached callback
+    # properties can be sure to pull the latest text/userData.
+
+    callback = MagicMock()
+
+    state = ExampleState()
+    state.add_callback('combo', callback)
+
+    dc = DataCollection([])
+
+    helper = ComponentIDComboHelper(state, 'combo', dc)
+
+    assert selection_choices(state, 'combo') == ""
+
+    data1 = Data(x=[1, 2, 3], y=[2, 3, 4], label='data1')
+
+    callback.reset_mock()
+
+    dc.append(data1)
+    helper.append_data(data1)
+
+    callback.assert_called_once_with(0)
+    callback.reset_mock()
+
+    assert selection_choices(state, 'combo') == "x:y"
+
+    new_id = ComponentID(label='new')
+
+    data1.update_id(data1.id['x'], new_id)
+
+    callback.assert_called_once_with(0)
+    callback.reset_mock()
+
+    assert selection_choices(state, 'combo') == "new:y"
+
+
+def test_manual_data_combo_helper():
+
+    state = ExampleState()
+
+    dc = DataCollection([])
+
+    helper = ManualDataComboHelper(state, 'combo', dc)
+
+    data1 = Data(x=[1, 2, 3], y=[2, 3, 4], label='data1')
+
+    dc.append(data1)
+
+    assert selection_choices(state, 'combo') == ""
+
+    helper.append_data(data1)
+
+    assert selection_choices(state, 'combo') == "data1"
+
+    data1.label = 'mydata1'
+    assert selection_choices(state, 'combo') == "mydata1"
+
+    dc.remove(data1)
+
+    assert selection_choices(state, 'combo') == ""
+
+
+def test_data_collection_combo_helper():
+
+    state = ExampleState()
+
+    dc = DataCollection([])
+
+    helper = DataCollectionComboHelper(state, 'combo', dc)
+
+    data1 = Data(x=[1, 2, 3], y=[2, 3, 4], label='data1')
+
+    dc.append(data1)
+
+    assert selection_choices(state, 'combo') == "data1"
+
+    data1.label = 'mydata1'
+    assert selection_choices(state, 'combo') == "mydata1"
+
+    dc.remove(data1)
+
+    assert selection_choices(state, 'combo') == ""

--- a/glue/core/tests/test_data_combo_helper.py
+++ b/glue/core/tests/test_data_combo_helper.py
@@ -13,7 +13,7 @@ from ..data_combo_helper import (ComponentIDComboHelper, ManualDataComboHelper,
 
 
 def selection_choices(state, property):
-    items = [x[0] for x in getattr(type(state), property).get_choices(state)]
+    items = getattr(type(state), property).get_choice_labels(state)
     return ":".join(items)
 
 

--- a/glue/core/tests/test_data_combo_helper.py
+++ b/glue/core/tests/test_data_combo_helper.py
@@ -5,7 +5,7 @@ from mock import MagicMock
 
 from glue.core import Data, DataCollection
 from glue.core.component_id import ComponentID
-from glue.external.echo.core import SelectionCallbackProperty
+from glue.external.echo.selection import SelectionCallbackProperty
 from glue.core.state_objects import State
 
 from ..data_combo_helper import (ComponentIDComboHelper, ManualDataComboHelper,

--- a/glue/external/echo/qt/autoconnect.py
+++ b/glue/external/echo/qt/autoconnect.py
@@ -21,7 +21,7 @@ HANDLERS['text'] = connect_text
 HANDLERS['combodata'] = connect_combo_data
 HANDLERS['combotext'] = connect_combo_text
 HANDLERS['button'] = connect_button
-HANDLERS['combodatasel'] = connect_combo_selection
+HANDLERS['combosel'] = connect_combo_selection
 
 
 def autoconnect_callbacks_to_qt(instance, widget, connect_kwargs={}):

--- a/glue/viewers/histogram/qt/data_viewer.py
+++ b/glue/viewers/histogram/qt/data_viewer.py
@@ -32,8 +32,8 @@ class HistogramViewer(MatplotlibDataViewer):
 
     tools = ['select:xrange']
 
-    def __init__(self, session, parent=None):
-        super(HistogramViewer, self).__init__(session, parent)
+    def __init__(self, session, parent=None, state=None):
+        super(HistogramViewer, self).__init__(session, parent, state=state)
         self.state.add_callback('x_att', nonpartial(self._update_axes))
         self.state.add_callback('x_log', nonpartial(self._update_axes))
         self.state.add_callback('normalize', nonpartial(self._update_axes))

--- a/glue/viewers/histogram/qt/options_widget.py
+++ b/glue/viewers/histogram/qt/options_widget.py
@@ -24,10 +24,6 @@ class HistogramOptionsWidget(QtWidgets.QWidget):
 
         autoconnect_callbacks_to_qt(viewer_state, self.ui)
 
-        viewer_state.add_callback('layers', self._update_combo_data)
-
-        self.x_att_helper = ComponentIDComboHelper(self.ui.combodata_x_att,
-                                                  session.data_collection)
 
         self.viewer_state = viewer_state
 
@@ -39,9 +35,3 @@ class HistogramOptionsWidget(QtWidgets.QWidget):
         self.ui.bool_x_log.setEnabled(log_enabled)
         if not log_enabled:
             self.ui.bool_x_log.setChecked(False)
-
-    def _update_combo_data(self, *args):
-        # TODO: what about if only subset and not data is present?
-        layers = [layer_state.layer for layer_state in self.viewer_state.layers
-                  if isinstance(layer_state.layer, Data)]
-        self.x_att_helper.set_multiple_data(layers)

--- a/glue/viewers/histogram/qt/options_widget.ui
+++ b/glue/viewers/histogram/qt/options_widget.ui
@@ -162,7 +162,7 @@
     <widget class="QLineEdit" name="valuetext_x_min"/>
    </item>
    <item row="0" column="3" colspan="4">
-    <widget class="QComboBox" name="combodatasel_x_att">
+    <widget class="QComboBox" name="combosel_x_att">
      <property name="sizeAdjustPolicy">
       <enum>QComboBox::AdjustToMinimumContentsLength</enum>
      </property>

--- a/glue/viewers/histogram/qt/options_widget.ui
+++ b/glue/viewers/histogram/qt/options_widget.ui
@@ -162,7 +162,7 @@
     <widget class="QLineEdit" name="valuetext_x_min"/>
    </item>
    <item row="0" column="3" colspan="4">
-    <widget class="QComboBox" name="combodata_x_att">
+    <widget class="QComboBox" name="combodatasel_x_att">
      <property name="sizeAdjustPolicy">
       <enum>QComboBox::AdjustToMinimumContentsLength</enum>
      </property>

--- a/glue/viewers/histogram/qt/tests/test_viewer_widget.py
+++ b/glue/viewers/histogram/qt/tests/test_viewer_widget.py
@@ -59,7 +59,7 @@ class TestHistogramViewer(object):
         # Check defaults when we add data
         self.viewer.add_data(self.data)
 
-        assert combo_as_string(self.viewer.options_widget().ui.combodatasel_x_att) == 'x:y'
+        assert combo_as_string(self.viewer.options_widget().ui.combosel_x_att) == 'x:y'
 
         assert viewer_state.x_att is self.data.id['x']
         assert viewer_state.x_min == -1.1
@@ -114,9 +114,9 @@ class TestHistogramViewer(object):
 
     def test_remove_data(self):
         self.viewer.add_data(self.data)
-        assert combo_as_string(self.viewer.options_widget().ui.combodatasel_x_att) == 'x:y'
+        assert combo_as_string(self.viewer.options_widget().ui.combosel_x_att) == 'x:y'
         self.data_collection.remove(self.data)
-        assert combo_as_string(self.viewer.options_widget().ui.combodatasel_x_att) == ''
+        assert combo_as_string(self.viewer.options_widget().ui.combosel_x_att) == ''
 
     def test_update_component_updates_title(self):
         self.viewer.add_data(self.data)
@@ -128,7 +128,7 @@ class TestHistogramViewer(object):
         self.viewer.add_data(self.data)
         self.data.add_component([3, 4, 1, 2], 'z')
         assert self.viewer.state.x_att is self.data.id['x']
-        assert combo_as_string(self.viewer.options_widget().ui.combodatasel_x_att) == 'x:y:z'
+        assert combo_as_string(self.viewer.options_widget().ui.combosel_x_att) == 'x:y:z'
 
     def test_nonnumeric_first_component(self):
         # regression test for #208. Shouldn't complain if
@@ -402,7 +402,7 @@ class TestHistogramViewer(object):
         test = ComponentID('test')
         self.data.update_id(self.viewer.state.x_att, test)
         assert self.viewer.state.x_att is test
-        assert combo_as_string(self.viewer.options_widget().ui.combodatasel_x_att) == 'test:y'
+        assert combo_as_string(self.viewer.options_widget().ui.combosel_x_att) == 'test:y'
 
     def test_nbin_override_persists_over_numerical_attribute_change(self):
 

--- a/glue/viewers/histogram/qt/tests/test_viewer_widget.py
+++ b/glue/viewers/histogram/qt/tests/test_viewer_widget.py
@@ -59,7 +59,7 @@ class TestHistogramViewer(object):
         # Check defaults when we add data
         self.viewer.add_data(self.data)
 
-        assert combo_as_string(self.viewer.options_widget().ui.combodata_x_att) == 'x:y'
+        assert combo_as_string(self.viewer.options_widget().ui.combodatasel_x_att) == 'x:y'
 
         assert viewer_state.x_att is self.data.id['x']
         assert viewer_state.x_min == -1.1
@@ -114,9 +114,9 @@ class TestHistogramViewer(object):
 
     def test_remove_data(self):
         self.viewer.add_data(self.data)
-        assert combo_as_string(self.viewer.options_widget().ui.combodata_x_att) == 'x:y'
+        assert combo_as_string(self.viewer.options_widget().ui.combodatasel_x_att) == 'x:y'
         self.data_collection.remove(self.data)
-        assert combo_as_string(self.viewer.options_widget().ui.combodata_x_att) == ''
+        assert combo_as_string(self.viewer.options_widget().ui.combodatasel_x_att) == ''
 
     def test_update_component_updates_title(self):
         self.viewer.add_data(self.data)
@@ -128,7 +128,7 @@ class TestHistogramViewer(object):
         self.viewer.add_data(self.data)
         self.data.add_component([3, 4, 1, 2], 'z')
         assert self.viewer.state.x_att is self.data.id['x']
-        assert combo_as_string(self.viewer.options_widget().ui.combodata_x_att) == 'x:y:z'
+        assert combo_as_string(self.viewer.options_widget().ui.combodatasel_x_att) == 'x:y:z'
 
     def test_nonnumeric_first_component(self):
         # regression test for #208. Shouldn't complain if
@@ -402,7 +402,7 @@ class TestHistogramViewer(object):
         test = ComponentID('test')
         self.data.update_id(self.viewer.state.x_att, test)
         assert self.viewer.state.x_att is test
-        assert combo_as_string(self.viewer.options_widget().ui.combodata_x_att) == 'test:y'
+        assert combo_as_string(self.viewer.options_widget().ui.combodatasel_x_att) == 'test:y'
 
     def test_nbin_override_persists_over_numerical_attribute_change(self):
 

--- a/glue/viewers/histogram/tests/test_layer_artist.py
+++ b/glue/viewers/histogram/tests/test_layer_artist.py
@@ -29,7 +29,7 @@ class TestHistogramLayerArtist(object):
 
         ax = plt.subplot(1, 1, 1)
 
-        self.data = Data(x=[1, 2, 3])
+        self.data = Data(x=[1, 2, 3], y=[2, 3, 4])
         self.subset = self.data.new_subset()
         self.subset.subset_state = self.data.id['x'] > 1
 
@@ -40,6 +40,7 @@ class TestHistogramLayerArtist(object):
 
         self.artist = HistogramLayerArtist(ax, self.viewer_state, layer=self.subset)
         self.layer_state = self.artist.state
+        self.viewer_state.layers.append(self.layer_state)
 
         self.call_counter = CallCounter()
         sys.setprofile(self.call_counter)
@@ -53,7 +54,7 @@ class TestHistogramLayerArtist(object):
         assert self.call_counter['_scale_histogram'] == 0
 
         # attribute
-        self.viewer_state.x_att = self.data.id['x']
+        self.viewer_state.x_att = self.data.id['y']
         assert self.call_counter['_calculate_histogram'] == 1
         assert self.call_counter['_scale_histogram'] == 1
 

--- a/glue/viewers/image/compat.py
+++ b/glue/viewers/image/compat.py
@@ -61,10 +61,10 @@ def update_image_viewer_state(rec, context):
         viewer_state['y_att'] = str(uuid.uuid4())
         context.register_object(viewer_state['y_att'], data.pixel_component_ids[y_index])
 
-        viewer_state['x_min'] = 0
-        viewer_state['x_max'] = data.shape[0]
-        viewer_state['y_min'] = 0
-        viewer_state['y_max'] = data.shape[1]
+        viewer_state['x_min'] = -0.5
+        viewer_state['x_max'] = data.shape[1] - 0.5
+        viewer_state['y_min'] = -0.5
+        viewer_state['y_max'] = data.shape[0] - 0.5
 
         # Slicing with cubes
         viewer_state['slices'] = [s if np.isreal(s) else 0 for s in properties['slice']]

--- a/glue/viewers/image/layer_artist.py
+++ b/glue/viewers/image/layer_artist.py
@@ -139,6 +139,7 @@ class ImageLayerArtist(BaseImageLayerArtist):
             self._enabled = True
 
         slices, transpose = self._viewer_state.numpy_slice_and_transpose
+
         image = image[slices]
         if transpose:
             image = image.transpose()
@@ -171,6 +172,7 @@ class ImageLayerArtist(BaseImageLayerArtist):
 
         self.redraw()
 
+    @defer_draw
     def _update_image(self, force=False, **kwargs):
 
         if self.state.attribute is None or self.state.layer is None:

--- a/glue/viewers/image/qt/data_viewer.py
+++ b/glue/viewers/image/qt/data_viewer.py
@@ -54,8 +54,8 @@ class ImageViewer(MatplotlibDataViewer):
              'select:yrange', 'select:circle',
              'select:polygon', 'image:contrast_bias']
 
-    def __init__(self, session, parent=None):
-        super(ImageViewer, self).__init__(session, parent=parent, wcs=True)
+    def __init__(self, session, parent=None, state=None):
+        super(ImageViewer, self).__init__(session, parent=parent, wcs=True, state=state)
         self.axes.set_adjustable('datalim')
         self.state.add_callback('aspect', self._set_aspect)
         self.state.add_callback('x_att', self._set_wcs)

--- a/glue/viewers/image/qt/data_viewer.py
+++ b/glue/viewers/image/qt/data_viewer.py
@@ -62,6 +62,7 @@ class ImageViewer(MatplotlibDataViewer):
         self.state.add_callback('y_att', self._set_wcs)
         self.state.add_callback('slices', self._set_wcs)
         self.state.add_callback('reference_data', self._set_wcs)
+        self.state.add_callback('reference_data', self._set_aspect)
         self.axes._composite = CompositeArray()
         self.axes._composite_image = imshow(self.axes, self.axes._composite,
                                             origin='lower', interpolation='nearest')
@@ -87,7 +88,6 @@ class ImageViewer(MatplotlibDataViewer):
             self._set_wcs()
             self._set_aspect()
         return result
-
 
     @defer_draw
     def _set_aspect(self, *args):

--- a/glue/viewers/image/qt/options_widget.py
+++ b/glue/viewers/image/qt/options_widget.py
@@ -4,11 +4,9 @@ import os
 
 from qtpy import QtWidgets
 
-from glue.core.data import Data
-from glue.external.echo import delay_callback
 from glue.external.echo.qt import autoconnect_callbacks_to_qt
 from glue.utils.qt import load_ui
-from glue.core.qt.data_combo_helper import ComponentIDComboHelper, ManualDataComboHelper
+from glue.core.qt.data_combo_helper import QtComboHelper
 from glue.viewers.image.qt.slice_widget import MultiSliceWidgetHelper
 
 __all__ = ['ImageOptionsWidget']
@@ -23,9 +21,6 @@ class ImageOptionsWidget(QtWidgets.QWidget):
         self.ui = load_ui('options_widget.ui', self,
                           directory=os.path.dirname(__file__))
 
-        viewer_state.add_callback('layers', self._update_combo_ref_data, priority=1500)
-        viewer_state.add_callback('reference_data', self._update_combo_att)
-
         self.ui.combodata_aspect.addItem("Square Pixels", userData='equal')
         self.ui.combodata_aspect.addItem("Automatic", userData='auto')
         self.ui.combodata_aspect.setCurrentIndex(0)
@@ -35,38 +30,17 @@ class ImageOptionsWidget(QtWidgets.QWidget):
 
         autoconnect_callbacks_to_qt(viewer_state, self.ui)
 
-        self.ref_data_helper = ManualDataComboHelper(self.ui.combodata_reference_data,
-                                                     session.data_collection)
-
-        self.x_att_helper = ComponentIDComboHelper(self.ui.combodata_x_att_world,
-                                                   session.data_collection,
-                                                   numeric=False, categorical=False,
-                                                   visible=False, world_coord=True,
-                                                   default_index=-1)
-
-        self.y_att_helper = ComponentIDComboHelper(self.ui.combodata_y_att_world,
-                                                   session.data_collection,
-                                                   numeric=False, categorical=False,
-                                                   visible=False, world_coord=True,
-                                                   default_index=-2)
+        self.ref_data_helper = QtComboHelper(self.ui.combonew_reference_data,
+                                             viewer_state, 'reference_data',
+                                             '_reference_data_choices')
+        self.x_att_world_helper = QtComboHelper(self.ui.combonew_x_att_world,
+                                                viewer_state, 'x_att_world',
+                                                '_x_att_world_choices')
+        self.y_att_world_helper = QtComboHelper(self.ui.combonew_y_att_world,
+                                                viewer_state, 'y_att_world',
+                                                '_y_att_world_choices')
 
         self.viewer_state = viewer_state
 
         self.slice_helper = MultiSliceWidgetHelper(viewer_state=self.viewer_state,
                                                    widget=self.ui.slice_tab)
-
-    def _update_combo_ref_data(self, *args):
-        datasets = []
-        for layer in self.viewer_state.layers:
-            if isinstance(layer.layer, Data):
-                if layer.layer not in datasets:
-                    datasets.append(layer.layer)
-            else:
-                if layer.layer.data not in datasets:
-                    datasets.append(layer.layer.data)
-        self.ref_data_helper.set_multiple_data(datasets)
-
-    def _update_combo_att(self, *args):
-        with delay_callback(self.viewer_state, 'x_att_world', 'y_att_world'):
-            self.x_att_helper.set_multiple_data([self.viewer_state.reference_data])
-            self.y_att_helper.set_multiple_data([self.viewer_state.reference_data])

--- a/glue/viewers/image/qt/options_widget.py
+++ b/glue/viewers/image/qt/options_widget.py
@@ -6,7 +6,6 @@ from qtpy import QtWidgets
 
 from glue.external.echo.qt import autoconnect_callbacks_to_qt
 from glue.utils.qt import load_ui
-from glue.core.qt.data_combo_helper import QtComboHelper
 from glue.viewers.image.qt.slice_widget import MultiSliceWidgetHelper
 
 __all__ = ['ImageOptionsWidget']
@@ -29,13 +28,6 @@ class ImageOptionsWidget(QtWidgets.QWidget):
         self.ui.combotext_color_mode.addItem("One color per layer")
 
         autoconnect_callbacks_to_qt(viewer_state, self.ui)
-
-        self.ref_data_helper = QtComboHelper(self.ui.combonew_reference_data,
-                                             viewer_state, 'reference_data')
-        self.x_att_world_helper = QtComboHelper(self.ui.combonew_x_att_world,
-                                                viewer_state, 'x_att_world')
-        self.y_att_world_helper = QtComboHelper(self.ui.combonew_y_att_world,
-                                                viewer_state, 'y_att_world')
 
         self.viewer_state = viewer_state
 

--- a/glue/viewers/image/qt/options_widget.py
+++ b/glue/viewers/image/qt/options_widget.py
@@ -31,14 +31,11 @@ class ImageOptionsWidget(QtWidgets.QWidget):
         autoconnect_callbacks_to_qt(viewer_state, self.ui)
 
         self.ref_data_helper = QtComboHelper(self.ui.combonew_reference_data,
-                                             viewer_state, 'reference_data',
-                                             '_reference_data_choices')
+                                             viewer_state, 'reference_data')
         self.x_att_world_helper = QtComboHelper(self.ui.combonew_x_att_world,
-                                                viewer_state, 'x_att_world',
-                                                '_x_att_world_choices')
+                                                viewer_state, 'x_att_world')
         self.y_att_world_helper = QtComboHelper(self.ui.combonew_y_att_world,
-                                                viewer_state, 'y_att_world',
-                                                '_y_att_world_choices')
+                                                viewer_state, 'y_att_world')
 
         self.viewer_state = viewer_state
 

--- a/glue/viewers/image/qt/options_widget.ui
+++ b/glue/viewers/image/qt/options_widget.ui
@@ -21,7 +21,7 @@
     <number>5</number>
    </property>
    <item row="1" column="0">
-    <widget class="QComboBox" name="combodatasel_reference_data"/>
+    <widget class="QComboBox" name="combosel_reference_data"/>
    </item>
    <item row="0" column="0">
     <widget class="QLabel" name="label_4">
@@ -118,14 +118,14 @@
         <widget class="QComboBox" name="combodata_aspect"/>
        </item>
        <item row="0" column="2" colspan="3">
-        <widget class="QComboBox" name="combodatasel_x_att_world">
+        <widget class="QComboBox" name="combosel_x_att_world">
          <property name="sizeAdjustPolicy">
           <enum>QComboBox::AdjustToMinimumContentsLength</enum>
          </property>
         </widget>
        </item>
        <item row="2" column="2" colspan="3">
-        <widget class="QComboBox" name="combodatasel_y_att_world">
+        <widget class="QComboBox" name="combosel_y_att_world">
          <property name="sizeAdjustPolicy">
           <enum>QComboBox::AdjustToMinimumContentsLength</enum>
          </property>

--- a/glue/viewers/image/qt/options_widget.ui
+++ b/glue/viewers/image/qt/options_widget.ui
@@ -21,7 +21,7 @@
     <number>5</number>
    </property>
    <item row="1" column="0">
-    <widget class="QComboBox" name="combonew_reference_data"/>
+    <widget class="QComboBox" name="combodatasel_reference_data"/>
    </item>
    <item row="0" column="0">
     <widget class="QLabel" name="label_4">
@@ -118,14 +118,14 @@
         <widget class="QComboBox" name="combodata_aspect"/>
        </item>
        <item row="0" column="2" colspan="3">
-        <widget class="QComboBox" name="combonew_x_att_world">
+        <widget class="QComboBox" name="combodatasel_x_att_world">
          <property name="sizeAdjustPolicy">
           <enum>QComboBox::AdjustToMinimumContentsLength</enum>
          </property>
         </widget>
        </item>
        <item row="2" column="2" colspan="3">
-        <widget class="QComboBox" name="combonew_y_att_world">
+        <widget class="QComboBox" name="combodatasel_y_att_world">
          <property name="sizeAdjustPolicy">
           <enum>QComboBox::AdjustToMinimumContentsLength</enum>
          </property>

--- a/glue/viewers/image/qt/options_widget.ui
+++ b/glue/viewers/image/qt/options_widget.ui
@@ -21,7 +21,7 @@
     <number>5</number>
    </property>
    <item row="1" column="0">
-    <widget class="QComboBox" name="combodata_reference_data"/>
+    <widget class="QComboBox" name="combonew_reference_data"/>
    </item>
    <item row="0" column="0">
     <widget class="QLabel" name="label_4">
@@ -118,14 +118,14 @@
         <widget class="QComboBox" name="combodata_aspect"/>
        </item>
        <item row="0" column="2" colspan="3">
-        <widget class="QComboBox" name="combodata_x_att_world">
+        <widget class="QComboBox" name="combonew_x_att_world">
          <property name="sizeAdjustPolicy">
           <enum>QComboBox::AdjustToMinimumContentsLength</enum>
          </property>
         </widget>
        </item>
        <item row="2" column="2" colspan="3">
-        <widget class="QComboBox" name="combodata_y_att_world">
+        <widget class="QComboBox" name="combonew_y_att_world">
          <property name="sizeAdjustPolicy">
           <enum>QComboBox::AdjustToMinimumContentsLength</enum>
          </property>

--- a/glue/viewers/image/qt/tests/test_viewer_widget.py
+++ b/glue/viewers/image/qt/tests/test_viewer_widget.py
@@ -104,8 +104,8 @@ class TestImageViewer(object):
 
         self.viewer.add_data(self.image1)
 
-        assert combo_as_string(self.options_widget.ui.combodatasel_x_att_world) == 'World 0:World 1'
-        assert combo_as_string(self.options_widget.ui.combodatasel_y_att_world) == 'World 0:World 1'
+        assert combo_as_string(self.options_widget.ui.combosel_x_att_world) == 'World 0:World 1'
+        assert combo_as_string(self.options_widget.ui.combosel_y_att_world) == 'World 0:World 1'
 
         assert self.viewer.axes.get_xlabel() == 'World 1'
         assert self.viewer.state.x_att_world is self.image1.id['World 1']
@@ -132,8 +132,8 @@ class TestImageViewer(object):
 
         self.viewer.add_data(self.image2)
 
-        assert combo_as_string(self.options_widget.ui.combodatasel_x_att_world) == 'Banana:Apple'
-        assert combo_as_string(self.options_widget.ui.combodatasel_x_att_world) == 'Banana:Apple'
+        assert combo_as_string(self.options_widget.ui.combosel_x_att_world) == 'Banana:Apple'
+        assert combo_as_string(self.options_widget.ui.combosel_x_att_world) == 'Banana:Apple'
 
         assert self.viewer.axes.get_xlabel() == 'Apple'
         assert self.viewer.state.x_att_world is self.image2.id['Apple']
@@ -239,8 +239,8 @@ class TestImageViewer(object):
 
         self.viewer.add_data(self.hypercube)
 
-        assert combo_as_string(self.options_widget.ui.combodatasel_x_att_world) == 'World 0:World 1:World 2:World 3'
-        assert combo_as_string(self.options_widget.ui.combodatasel_x_att_world) == 'World 0:World 1:World 2:World 3'
+        assert combo_as_string(self.options_widget.ui.combosel_x_att_world) == 'World 0:World 1:World 2:World 3'
+        assert combo_as_string(self.options_widget.ui.combosel_x_att_world) == 'World 0:World 1:World 2:World 3'
 
         assert self.viewer.axes.get_xlabel() == 'World 3'
         assert self.viewer.state.x_att_world is self.hypercube.id['World 3']

--- a/glue/viewers/image/qt/tests/test_viewer_widget.py
+++ b/glue/viewers/image/qt/tests/test_viewer_widget.py
@@ -104,8 +104,8 @@ class TestImageViewer(object):
 
         self.viewer.add_data(self.image1)
 
-        assert combo_as_string(self.options_widget.ui.combonew_x_att_world) == 'World 0:World 1'
-        assert combo_as_string(self.options_widget.ui.combonew_y_att_world) == 'World 0:World 1'
+        assert combo_as_string(self.options_widget.ui.combodatasel_x_att_world) == 'World 0:World 1'
+        assert combo_as_string(self.options_widget.ui.combodatasel_y_att_world) == 'World 0:World 1'
 
         assert self.viewer.axes.get_xlabel() == 'World 1'
         assert self.viewer.state.x_att_world is self.image1.id['World 1']
@@ -132,8 +132,8 @@ class TestImageViewer(object):
 
         self.viewer.add_data(self.image2)
 
-        assert combo_as_string(self.options_widget.ui.combonew_x_att_world) == 'Banana:Apple'
-        assert combo_as_string(self.options_widget.ui.combonew_x_att_world) == 'Banana:Apple'
+        assert combo_as_string(self.options_widget.ui.combodatasel_x_att_world) == 'Banana:Apple'
+        assert combo_as_string(self.options_widget.ui.combodatasel_x_att_world) == 'Banana:Apple'
 
         assert self.viewer.axes.get_xlabel() == 'Apple'
         assert self.viewer.state.x_att_world is self.image2.id['Apple']
@@ -239,8 +239,8 @@ class TestImageViewer(object):
 
         self.viewer.add_data(self.hypercube)
 
-        assert combo_as_string(self.options_widget.ui.combonew_x_att_world) == 'World 0:World 1:World 2:World 3'
-        assert combo_as_string(self.options_widget.ui.combonew_x_att_world) == 'World 0:World 1:World 2:World 3'
+        assert combo_as_string(self.options_widget.ui.combodatasel_x_att_world) == 'World 0:World 1:World 2:World 3'
+        assert combo_as_string(self.options_widget.ui.combodatasel_x_att_world) == 'World 0:World 1:World 2:World 3'
 
         assert self.viewer.axes.get_xlabel() == 'World 3'
         assert self.viewer.state.x_att_world is self.hypercube.id['World 3']

--- a/glue/viewers/image/qt/tests/test_viewer_widget.py
+++ b/glue/viewers/image/qt/tests/test_viewer_widget.py
@@ -487,16 +487,10 @@ class TestSessions(object):
         assert viewer1.state.x_att_world is dc[0].id['World 1']
         assert viewer1.state.y_att_world is dc[0].id['World 0']
 
-        if protocol == 0:
-            assert viewer1.state.x_min < 0.
-            assert viewer1.state.x_max > 1.5
-            assert_allclose(viewer1.state.y_min, 0)
-            assert_allclose(viewer1.state.y_max, 2)
-        else:
-            assert viewer1.state.x_min < -0.5
-            assert viewer1.state.x_max > 1.5
-            assert viewer1.state.y_min <= -0.5
-            assert viewer1.state.y_max >= 1.5
+        assert viewer1.state.x_min < -0.5
+        assert viewer1.state.x_max > 1.5
+        assert viewer1.state.y_min <= -0.5
+        assert viewer1.state.y_max >= 1.5
 
         layer_state = viewer1.state.layers[0]
         assert isinstance(layer_state, ImageLayerState)
@@ -521,16 +515,10 @@ class TestSessions(object):
         assert viewer2.state.x_att_world is dc[0].id['World 1']
         assert viewer2.state.y_att_world is dc[0].id['World 0']
 
-        if protocol == 0:
-            assert viewer2.state.x_min < 0.
-            assert viewer2.state.x_max > 1.5
-            assert_allclose(viewer2.state.y_min, 0)
-            assert_allclose(viewer2.state.y_max, 2)
-        else:
-            assert viewer2.state.x_min < -0.5
-            assert viewer2.state.x_max > 1.5
-            assert viewer2.state.y_min <= -0.5
-            assert viewer2.state.y_max >= 1.5
+        assert viewer2.state.x_min < -0.5
+        assert viewer2.state.x_max > 1.5
+        assert viewer2.state.y_min <= -0.5
+        assert viewer2.state.y_max >= 1.5
 
         layer_state = viewer2.state.layers[0]
         assert layer_state.visible
@@ -548,16 +536,10 @@ class TestSessions(object):
         assert viewer3.state.x_att_world is dc[0].id['World 1']
         assert viewer3.state.y_att_world is dc[0].id['World 0']
 
-        if protocol == 0:
-            assert viewer3.state.x_min < 0.0
-            assert viewer3.state.x_max > 1.5
-            assert_allclose(viewer3.state.y_min, 0)
-            assert_allclose(viewer3.state.y_max, 2)
-        else:
-            assert viewer3.state.x_min < -0.5
-            assert viewer3.state.x_max > 1.5
-            assert viewer3.state.y_min <= -0.5
-            assert viewer3.state.y_max >= 1.5
+        assert viewer3.state.x_min < -0.5
+        assert viewer3.state.x_max > 1.5
+        assert viewer3.state.y_min <= -0.5
+        assert viewer3.state.y_max >= 1.5
 
         layer_state = viewer3.state.layers[0]
         assert layer_state.visible

--- a/glue/viewers/image/qt/tests/test_viewer_widget.py
+++ b/glue/viewers/image/qt/tests/test_viewer_widget.py
@@ -415,9 +415,6 @@ class TestImageViewer(object):
     @pytest.mark.parametrize('wcs', [False, True])
     def test_change_reference_data_dimensionality(self, capsys, wcs):
 
-        if wcs:
-            pytest.xfail()
-
         # Regression test for a bug that caused an exception when changing
         # the dimensionality of the reference data
 

--- a/glue/viewers/image/qt/tests/test_viewer_widget.py
+++ b/glue/viewers/image/qt/tests/test_viewer_widget.py
@@ -104,8 +104,8 @@ class TestImageViewer(object):
 
         self.viewer.add_data(self.image1)
 
-        assert combo_as_string(self.options_widget.ui.combodata_x_att_world) == 'World 0:World 1'
-        assert combo_as_string(self.options_widget.ui.combodata_x_att_world) == 'World 0:World 1'
+        assert combo_as_string(self.options_widget.ui.combonew_x_att_world) == 'World 0:World 1'
+        assert combo_as_string(self.options_widget.ui.combonew_x_att_world) == 'World 0:World 1'
 
         assert self.viewer.axes.get_xlabel() == 'World 1'
         assert self.viewer.state.x_att_world is self.image1.id['World 1']
@@ -132,8 +132,8 @@ class TestImageViewer(object):
 
         self.viewer.add_data(self.image2)
 
-        assert combo_as_string(self.options_widget.ui.combodata_x_att_world) == 'Banana:Apple'
-        assert combo_as_string(self.options_widget.ui.combodata_x_att_world) == 'Banana:Apple'
+        assert combo_as_string(self.options_widget.ui.combonew_x_att_world) == 'Banana:Apple'
+        assert combo_as_string(self.options_widget.ui.combonew_x_att_world) == 'Banana:Apple'
 
         assert self.viewer.axes.get_xlabel() == 'Apple'
         assert self.viewer.state.x_att_world is self.image2.id['Apple']
@@ -239,8 +239,8 @@ class TestImageViewer(object):
 
         self.viewer.add_data(self.hypercube)
 
-        assert combo_as_string(self.options_widget.ui.combodata_x_att_world) == 'World 0:World 1:World 2:World 3'
-        assert combo_as_string(self.options_widget.ui.combodata_x_att_world) == 'World 0:World 1:World 2:World 3'
+        assert combo_as_string(self.options_widget.ui.combonew_x_att_world) == 'World 0:World 1:World 2:World 3'
+        assert combo_as_string(self.options_widget.ui.combonew_x_att_world) == 'World 0:World 1:World 2:World 3'
 
         assert self.viewer.axes.get_xlabel() == 'World 3'
         assert self.viewer.state.x_att_world is self.hypercube.id['World 3']

--- a/glue/viewers/image/qt/tests/test_viewer_widget.py
+++ b/glue/viewers/image/qt/tests/test_viewer_widget.py
@@ -105,7 +105,7 @@ class TestImageViewer(object):
         self.viewer.add_data(self.image1)
 
         assert combo_as_string(self.options_widget.ui.combonew_x_att_world) == 'World 0:World 1'
-        assert combo_as_string(self.options_widget.ui.combonew_x_att_world) == 'World 0:World 1'
+        assert combo_as_string(self.options_widget.ui.combonew_y_att_world) == 'World 0:World 1'
 
         assert self.viewer.axes.get_xlabel() == 'World 1'
         assert self.viewer.state.x_att_world is self.image1.id['World 1']

--- a/glue/viewers/image/state.py
+++ b/glue/viewers/image/state.py
@@ -45,11 +45,11 @@ class ImageViewerState(MatplotlibDataViewerState):
 
         self.limits_cache = {}
 
-        self.x_att_helper = StateAttributeLimitsHelper(self, attribute='x_att',
+        self.x_lim_helper = StateAttributeLimitsHelper(self, attribute='x_att',
                                                        lower='x_min', upper='x_max',
                                                        limits_cache=self.limits_cache)
 
-        self.y_att_helper = StateAttributeLimitsHelper(self, attribute='y_att',
+        self.y_lim_helper = StateAttributeLimitsHelper(self, attribute='y_att',
                                                        lower='y_min', upper='y_max',
                                                        limits_cache=self.limits_cache)
 
@@ -216,13 +216,13 @@ class ImageViewerState(MatplotlibDataViewerState):
         """
         Flip the x_min/x_max limits.
         """
-        self.x_att_helper.flip_limits()
+        self.x_lim_helper.flip_limits()
 
     def flip_y(self):
         """
         Flip the y_min/y_max limits.
         """
-        self.y_att_helper.flip_limits()
+        self.y_lim_helper.flip_limits()
 
 
 class ImageLayerState(MatplotlibLayerState):

--- a/glue/viewers/image/state.py
+++ b/glue/viewers/image/state.py
@@ -41,7 +41,7 @@ class ImageViewerState(MatplotlibDataViewerState):
 
     def __init__(self, **kwargs):
 
-        super(ImageViewerState, self).__init__(**kwargs)
+        super(ImageViewerState, self).__init__()
 
         self.limits_cache = {}
 
@@ -75,6 +75,8 @@ class ImageViewerState(MatplotlibDataViewerState):
         self.add_callback('x_att_world', self._on_xatt_world_change, priority=1000)
         self.add_callback('y_att_world', self._on_yatt_world_change, priority=1000)
 
+        self.update_from_dict(kwargs)
+
     def _reference_data_changed(self, *args):
         with delay_callback(self, 'x_att_world', 'y_att_world', 'slices'):
             self._update_combo_att()
@@ -103,7 +105,6 @@ class ImageViewerState(MatplotlibDataViewerState):
             else:
                 self.xw_att_helper.set_multiple_data([self.reference_data])
                 self.yw_att_helper.set_multiple_data([self.reference_data])
-
 
     def _update_priority(self, name):
         if name == 'layers':

--- a/glue/viewers/image/state.py
+++ b/glue/viewers/image/state.py
@@ -8,6 +8,7 @@ from glue.viewers.matplotlib.state import (MatplotlibDataViewerState,
 from glue.core.state_objects import StateAttributeLimitsHelper
 from glue.utils import defer_draw
 from glue.external.echo import delay_callback
+from glue.core.data_combo_helper import ManualDataComboHelper, ComponentIDComboHelper
 
 __all__ = ['ImageViewerState', 'ImageLayerState', 'ImageSubsetLayerState']
 
@@ -16,6 +17,10 @@ class ImageViewerState(MatplotlibDataViewerState):
     """
     A state class that includes all the attributes for an image viewer.
     """
+
+    _x_att_world_choices = DDCProperty()
+    _y_att_world_choices = DDCProperty()
+    _reference_data_choices = DDCProperty()
 
     x_att = DDCProperty(docstring='The component ID giving the pixel component '
                                   'shown on the x axis')
@@ -51,8 +56,23 @@ class ImageViewerState(MatplotlibDataViewerState):
                                                        lower='y_min', upper='y_max',
                                                        limits_cache=self.limits_cache)
 
-        self.add_callback('reference_data', self._set_default_slices)
-        self.add_callback('layers', self._set_reference_data)
+        self.ref_data_helper = ManualDataComboHelper(self, 'reference_data',
+                                                     '_reference_data_choices')
+
+        self.xw_att_helper = ComponentIDComboHelper(self, 'x_att_world',
+                                                    '_x_att_world_choices',
+                                                    numeric=False, categorical=False,
+                                                    visible=False, world_coord=True,
+                                                    default_index=-1)
+
+        self.yw_att_helper = ComponentIDComboHelper(self, 'y_att_world',
+                                                    '_y_att_world_choices',
+                                                    numeric=False, categorical=False,
+                                                    visible=False, world_coord=True,
+                                                    default_index=-2)
+
+        self.add_callback('reference_data', self._reference_data_changed)
+        self.add_callback('layers', self._layers_changed)
 
         self.add_callback('x_att', self._on_xatt_change, priority=500)
         self.add_callback('y_att', self._on_yatt_change, priority=500)
@@ -62,6 +82,36 @@ class ImageViewerState(MatplotlibDataViewerState):
 
         self.add_callback('x_att_world', self._on_xatt_world_change, priority=1000)
         self.add_callback('y_att_world', self._on_yatt_world_change, priority=1000)
+
+    def _reference_data_changed(self, *args):
+        with delay_callback(self, 'x_att_world', 'y_att_world', 'slices'):
+            self._update_combo_att()
+            self._set_default_slices()
+
+    def _layers_changed(self, *args):
+        self._update_combo_ref_data()
+        self._set_reference_data()
+
+    def _update_combo_ref_data(self, *args):
+        datasets = []
+        for layer in self.layers:
+            if isinstance(layer.layer, Data):
+                if layer.layer not in datasets:
+                    datasets.append(layer.layer)
+            else:
+                if layer.layer.data not in datasets:
+                    datasets.append(layer.layer.data)
+        self.ref_data_helper.set_multiple_data(datasets)
+
+    def _update_combo_att(self, *args):
+        with delay_callback(self, 'x_att_world', 'y_att_world'):
+            if self.reference_data is None:
+                self.xw_att_helper.set_multiple_data([])
+                self.yw_att_helper.set_multiple_data([])
+            else:
+                self.xw_att_helper.set_multiple_data([self.reference_data])
+                self.yw_att_helper.set_multiple_data([self.reference_data])
+
 
     def _update_priority(self, name):
         if name == 'layers':
@@ -98,7 +148,7 @@ class ImageViewerState(MatplotlibDataViewerState):
 
     @defer_draw
     def _on_xatt_world_change(self, *args):
-        if self.x_att_world == self.y_att_world:
+        if self.x_att_world is not None and self.x_att_world == self.y_att_world:
             world_ids = self.reference_data.world_component_ids
             if self.x_att_world == world_ids[-1]:
                 self.y_att_world = world_ids[-2]
@@ -107,7 +157,7 @@ class ImageViewerState(MatplotlibDataViewerState):
 
     @defer_draw
     def _on_yatt_world_change(self, *args):
-        if self.y_att_world == self.x_att_world:
+        if self.y_att_world is not None and self.y_att_world == self.x_att_world:
             world_ids = self.reference_data.world_component_ids
             if self.y_att_world == world_ids[-1]:
                 self.x_att_world = world_ids[-2]

--- a/glue/viewers/image/tests/test_state.py
+++ b/glue/viewers/image/tests/test_state.py
@@ -1,18 +1,22 @@
 from glue.core import Data
 
-from ..state import ImageViewerState
+from ..state import ImageViewerState, ImageLayerState
+
 
 class TestImageViewerState(object):
 
     def setup_method(self, method):
         self.state = ImageViewerState()
         self.data = Data(label='data', x=[[1, 2], [3, 4]], y=[[5, 6], [7, 8]])
+        self.layer_state = ImageLayerState(layer=self.data)
+        self.state.layers.append(self.layer_state)
 
     def test_pixel_world_linking(self):
 
         w1, w2 = self.data.world_component_ids
         p1, p2 = self.data.pixel_component_ids
 
+        # TODO: following should raise explicit error that has to be in layers
         self.state.reference_data = self.data
 
         # Setting world components should set the pixel ones

--- a/glue/viewers/matplotlib/qt/data_viewer.py
+++ b/glue/viewers/matplotlib/qt/data_viewer.py
@@ -25,7 +25,7 @@ class MatplotlibDataViewer(DataViewer):
 
     allow_duplicate_data = False
 
-    def __init__(self, session, parent=None, wcs=None):
+    def __init__(self, session, parent=None, wcs=None, state=None):
 
         super(MatplotlibDataViewer, self).__init__(session, parent)
 
@@ -40,7 +40,7 @@ class MatplotlibDataViewer(DataViewer):
 
         # Set up the state which will contain everything needed to represent
         # the current state of the viewer
-        self.state = self._state_cls()
+        self.state = state or self._state_cls()
         self.state.data_collection = session.data_collection
 
         # Set up the options widget, which will include options that control the
@@ -260,14 +260,14 @@ class MatplotlibDataViewer(DataViewer):
             cls.update_viewer_state(rec, context)
 
         session = context.object(rec['session'])
-        viewer = cls(session)
+
+        viewer_state = cls._state_cls.__setgluestate__(rec['state'], context)
+
+        viewer = cls(session, state=viewer_state)
         viewer.register_to_hub(session.hub)
         viewer.viewer_size = rec['size']
         x, y = rec['pos']
         viewer.move(x=x, y=y)
-
-        viewer_state = cls._state_cls.__setgluestate__(rec['state'], context)
-        viewer.state.update_from_state(viewer_state)
 
         # Restore layer artists
         for l in rec['layers']:

--- a/glue/viewers/matplotlib/state.py
+++ b/glue/viewers/matplotlib/state.py
@@ -1,8 +1,9 @@
 from __future__ import absolute_import, division, print_function
 
-from glue.external.echo import CallbackProperty, ListCallbackProperty, keep_in_sync
+from glue.external.echo import (CallbackProperty, ListCallbackProperty,
+                                SelectionCallbackProperty, keep_in_sync)
 
-from glue.core.state_objects import State, SelectionCallbackProperty
+from glue.core.state_objects import State
 
 from glue.utils import defer_draw
 

--- a/glue/viewers/matplotlib/state.py
+++ b/glue/viewers/matplotlib/state.py
@@ -2,11 +2,12 @@ from __future__ import absolute_import, division, print_function
 
 from glue.external.echo import CallbackProperty, ListCallbackProperty, keep_in_sync
 
-from glue.core.state_objects import State
+from glue.core.state_objects import State, SelectionCallbackProperty
 
 from glue.utils import defer_draw
 
-__all__ = ['MatplotlibDataViewerState', 'MatplotlibLayerState']
+__all__ = ['DeferredDrawSelectionCallbackProperty', 'DeferredDrawCallbackProperty',
+           'MatplotlibDataViewerState', 'MatplotlibLayerState']
 
 
 class DeferredDrawCallbackProperty(CallbackProperty):
@@ -18,6 +19,17 @@ class DeferredDrawCallbackProperty(CallbackProperty):
     @defer_draw
     def notify(self, *args, **kwargs):
         super(DeferredDrawCallbackProperty, self).notify(*args, **kwargs)
+
+
+class DeferredDrawSelectionCallbackProperty(SelectionCallbackProperty):
+    """
+    A callback property where drawing is deferred until
+    after notify has called all callback functions.
+    """
+
+    @defer_draw
+    def notify(self, *args, **kwargs):
+        super(DeferredDrawSelectionCallbackProperty, self).notify(*args, **kwargs)
 
 
 class MatplotlibDataViewerState(State):

--- a/glue/viewers/scatter/layer_artist.py
+++ b/glue/viewers/scatter/layer_artist.py
@@ -35,6 +35,9 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
 
     def _update_scatter_data(self):
 
+        if len(self.mpl_artists) == 0:
+            return
+
         try:
             x = self.layer[self._viewer_state.x_att].ravel()
         except (IncompatibleAttribute, IndexError):

--- a/glue/viewers/scatter/qt/data_viewer.py
+++ b/glue/viewers/scatter/qt/data_viewer.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function
 from glue.utils import nonpartial
 from glue.viewers.matplotlib.qt.toolbar import MatplotlibViewerToolbar
 from glue.core.edit_subset_mode import EditSubsetMode
-from glue.core import Data
 from glue.core.util import update_ticks
 from glue.utils import defer_draw
 
@@ -31,8 +30,8 @@ class ScatterViewer(MatplotlibDataViewer):
              'select:yrange', 'select:circle',
              'select:polygon']
 
-    def __init__(self, session, parent=None):
-        super(ScatterViewer, self).__init__(session, parent)
+    def __init__(self, session, parent=None, state=None):
+        super(ScatterViewer, self).__init__(session, parent, state=state)
         self.state.add_callback('x_att', nonpartial(self._update_axes))
         self.state.add_callback('y_att', nonpartial(self._update_axes))
         self.state.add_callback('x_log', nonpartial(self._update_axes))

--- a/glue/viewers/scatter/qt/options_widget.py
+++ b/glue/viewers/scatter/qt/options_widget.py
@@ -23,34 +23,7 @@ class ScatterOptionsWidget(QtWidgets.QWidget):
 
         autoconnect_callbacks_to_qt(viewer_state, self.ui)
 
-        viewer_state.add_callback('layers', self._update_combo_data)
-
-        self.x_att_helper = ComponentIDComboHelper(self.ui.combodata_x_att,
-                                                   session.data_collection,
-                                                   default_index=0)
-
-        self.y_att_helper = ComponentIDComboHelper(self.ui.combodata_y_att,
-                                                   session.data_collection,
-                                                   default_index=1)
-
         self.viewer_state = viewer_state
 
     def reset_limits(self):
         self.viewer_state.reset_limits()
-
-    def _update_combo_data(self, *args):
-
-        layers = []
-
-        for layer_state in self.viewer_state.layers:
-            if isinstance(layer_state.layer, Data):
-                if layer_state.layer not in layers:
-                    layers.append(layer_state.layer)
-
-        for layer_state in self.viewer_state.layers:
-            if isinstance(layer_state.layer, Subset) and layer_state.layer.data not in layers:
-                if layer_state.layer not in layers:
-                    layers.append(layer_state.layer)
-
-        self.x_att_helper.set_multiple_data(layers)
-        self.y_att_helper.set_multiple_data(layers)

--- a/glue/viewers/scatter/qt/options_widget.ui
+++ b/glue/viewers/scatter/qt/options_widget.ui
@@ -27,7 +27,7 @@
     <widget class="QLineEdit" name="valuetext_x_min"/>
    </item>
    <item row="0" column="3" colspan="4">
-    <widget class="QComboBox" name="combodata_x_att">
+    <widget class="QComboBox" name="combodatasel_x_att">
      <property name="sizeAdjustPolicy">
       <enum>QComboBox::AdjustToMinimumContentsLength</enum>
      </property>
@@ -90,7 +90,7 @@
     </widget>
    </item>
    <item row="2" column="3" colspan="4">
-    <widget class="QComboBox" name="combodata_y_att">
+    <widget class="QComboBox" name="combodatasel_y_att">
      <property name="sizeAdjustPolicy">
       <enum>QComboBox::AdjustToMinimumContentsLength</enum>
      </property>

--- a/glue/viewers/scatter/qt/options_widget.ui
+++ b/glue/viewers/scatter/qt/options_widget.ui
@@ -27,7 +27,7 @@
     <widget class="QLineEdit" name="valuetext_x_min"/>
    </item>
    <item row="0" column="3" colspan="4">
-    <widget class="QComboBox" name="combodatasel_x_att">
+    <widget class="QComboBox" name="combosel_x_att">
      <property name="sizeAdjustPolicy">
       <enum>QComboBox::AdjustToMinimumContentsLength</enum>
      </property>
@@ -90,7 +90,7 @@
     </widget>
    </item>
    <item row="2" column="3" colspan="4">
-    <widget class="QComboBox" name="combodatasel_y_att">
+    <widget class="QComboBox" name="combosel_y_att">
      <property name="sizeAdjustPolicy">
       <enum>QComboBox::AdjustToMinimumContentsLength</enum>
      </property>

--- a/glue/viewers/scatter/qt/tests/test_viewer_widget.py
+++ b/glue/viewers/scatter/qt/tests/test_viewer_widget.py
@@ -62,8 +62,8 @@ class TestScatterViewer(object):
         # Check defaults when we add data
         self.viewer.add_data(self.data)
 
-        assert combo_as_string(self.viewer.options_widget().ui.combodata_x_att) == 'x:y:z'
-        assert combo_as_string(self.viewer.options_widget().ui.combodata_y_att) == 'x:y:z'
+        assert combo_as_string(self.viewer.options_widget().ui.combodatasel_x_att) == 'x:y:z'
+        assert combo_as_string(self.viewer.options_widget().ui.combodatasel_y_att) == 'x:y:z'
 
         assert viewer_state.x_att is self.data.id['x']
         assert viewer_state.x_min == -1.1
@@ -117,11 +117,11 @@ class TestScatterViewer(object):
 
     def test_remove_data(self):
         self.viewer.add_data(self.data)
-        assert combo_as_string(self.viewer.options_widget().ui.combodata_x_att) == 'x:y:z'
-        assert combo_as_string(self.viewer.options_widget().ui.combodata_y_att) == 'x:y:z'
+        assert combo_as_string(self.viewer.options_widget().ui.combodatasel_x_att) == 'x:y:z'
+        assert combo_as_string(self.viewer.options_widget().ui.combodatasel_y_att) == 'x:y:z'
         self.data_collection.remove(self.data)
-        assert combo_as_string(self.viewer.options_widget().ui.combodata_x_att) == ''
-        assert combo_as_string(self.viewer.options_widget().ui.combodata_y_att) == ''
+        assert combo_as_string(self.viewer.options_widget().ui.combodatasel_x_att) == ''
+        assert combo_as_string(self.viewer.options_widget().ui.combodatasel_y_att) == ''
 
     def test_update_component_updates_title(self):
         self.viewer.add_data(self.data)
@@ -134,8 +134,8 @@ class TestScatterViewer(object):
         self.data.add_component([3, 4, 1, 2], 'a')
         assert self.viewer.state.x_att is self.data.id['x']
         assert self.viewer.state.y_att is self.data.id['y']
-        assert combo_as_string(self.viewer.options_widget().ui.combodata_x_att) == 'x:y:z:a'
-        assert combo_as_string(self.viewer.options_widget().ui.combodata_y_att) == 'x:y:z:a'
+        assert combo_as_string(self.viewer.options_widget().ui.combodatasel_x_att) == 'x:y:z:a'
+        assert combo_as_string(self.viewer.options_widget().ui.combodatasel_y_att) == 'x:y:z:a'
 
     def test_nonnumeric_first_component(self):
         # regression test for #208. Shouldn't complain if
@@ -221,7 +221,7 @@ class TestScatterViewer(object):
         test = ComponentID('test')
         self.data.update_id(self.viewer.state.x_att, test)
         assert self.viewer.state.x_att is test
-        assert combo_as_string(self.viewer.options_widget().ui.combodata_x_att) == 'test:y:z'
+        assert combo_as_string(self.viewer.options_widget().ui.combodatasel_x_att) == 'test:y:z'
 
     @pytest.mark.parametrize('protocol', [0, 1])
     def test_session_back_compat(self, protocol):

--- a/glue/viewers/scatter/qt/tests/test_viewer_widget.py
+++ b/glue/viewers/scatter/qt/tests/test_viewer_widget.py
@@ -62,8 +62,8 @@ class TestScatterViewer(object):
         # Check defaults when we add data
         self.viewer.add_data(self.data)
 
-        assert combo_as_string(self.viewer.options_widget().ui.combodatasel_x_att) == 'x:y:z'
-        assert combo_as_string(self.viewer.options_widget().ui.combodatasel_y_att) == 'x:y:z'
+        assert combo_as_string(self.viewer.options_widget().ui.combosel_x_att) == 'x:y:z'
+        assert combo_as_string(self.viewer.options_widget().ui.combosel_y_att) == 'x:y:z'
 
         assert viewer_state.x_att is self.data.id['x']
         assert viewer_state.x_min == -1.1
@@ -117,11 +117,11 @@ class TestScatterViewer(object):
 
     def test_remove_data(self):
         self.viewer.add_data(self.data)
-        assert combo_as_string(self.viewer.options_widget().ui.combodatasel_x_att) == 'x:y:z'
-        assert combo_as_string(self.viewer.options_widget().ui.combodatasel_y_att) == 'x:y:z'
+        assert combo_as_string(self.viewer.options_widget().ui.combosel_x_att) == 'x:y:z'
+        assert combo_as_string(self.viewer.options_widget().ui.combosel_y_att) == 'x:y:z'
         self.data_collection.remove(self.data)
-        assert combo_as_string(self.viewer.options_widget().ui.combodatasel_x_att) == ''
-        assert combo_as_string(self.viewer.options_widget().ui.combodatasel_y_att) == ''
+        assert combo_as_string(self.viewer.options_widget().ui.combosel_x_att) == ''
+        assert combo_as_string(self.viewer.options_widget().ui.combosel_y_att) == ''
 
     def test_update_component_updates_title(self):
         self.viewer.add_data(self.data)
@@ -134,8 +134,8 @@ class TestScatterViewer(object):
         self.data.add_component([3, 4, 1, 2], 'a')
         assert self.viewer.state.x_att is self.data.id['x']
         assert self.viewer.state.y_att is self.data.id['y']
-        assert combo_as_string(self.viewer.options_widget().ui.combodatasel_x_att) == 'x:y:z:a'
-        assert combo_as_string(self.viewer.options_widget().ui.combodatasel_y_att) == 'x:y:z:a'
+        assert combo_as_string(self.viewer.options_widget().ui.combosel_x_att) == 'x:y:z:a'
+        assert combo_as_string(self.viewer.options_widget().ui.combosel_y_att) == 'x:y:z:a'
 
     def test_nonnumeric_first_component(self):
         # regression test for #208. Shouldn't complain if
@@ -221,7 +221,7 @@ class TestScatterViewer(object):
         test = ComponentID('test')
         self.data.update_id(self.viewer.state.x_att, test)
         assert self.viewer.state.x_att is test
-        assert combo_as_string(self.viewer.options_widget().ui.combodatasel_x_att) == 'test:y:z'
+        assert combo_as_string(self.viewer.options_widget().ui.combosel_x_att) == 'test:y:z'
 
     @pytest.mark.parametrize('protocol', [0, 1])
     def test_session_back_compat(self, protocol):


### PR DESCRIPTION
The choices are defined in the State, not in the Qt code, moving a reasonable fraction of code to non-Qt-specific code. Just a WIP for now while exploring this.

Things that are missing:

* [x] New combo helpers don't have access to hub currently (get from first dataset passed in append_data)
* [x] Extend to all viewers
* [x] Find a better way than having two callback properties
* [x] Move logic up to 'echo' level
* [x] Update docstrings
* [x] Add tests of new non-Qt-specific functionality
* [x] Port changes to echo

Fixes #1345 
