### PR TITLE
Miscellaneous improvements

### DIFF
--- a/glue/app/qt/application.py
+++ b/glue/app/qt/application.py
@@ -226,6 +226,8 @@ class GlueApplication(Application, QtWidgets.QMainWindow):
         self._ui.data_layers.setLayout(self._vb)
         self._layer_widget = lw
 
+        self._ui.layout_top.setSpacing(0)
+
         # log window + status light
         self._log = GlueLogger(button_console=self._ui.button_console)
         self._log.window().setWindowTitle("Console Log")
@@ -236,8 +238,11 @@ class GlueApplication(Application, QtWidgets.QMainWindow):
         """Maximize window by default."""
         if maximized:
             self.setWindowState(Qt.WindowMaximized)
-        self._ui.main_splitter.setSizes([100, 800])
-        self._ui.data_plot_splitter.setSizes([100, 150, 250])
+        self._ui.main_splitter.setStretchFactor(0, 0)
+        self._ui.main_splitter.setStretchFactor(1, 1)
+        self._ui.data_plot_splitter.setStretchFactor(0, 0.25)
+        self._ui.data_plot_splitter.setStretchFactor(1, 0.5)
+        self._ui.data_plot_splitter.setStretchFactor(2, 0.25)
 
     @property
     def tab_widget(self):
@@ -371,7 +376,9 @@ class GlueApplication(Application, QtWidgets.QMainWindow):
                 widget.setLayout(layout)
             while layout.count():
                 layout.takeAt(0).widget().hide()
-            widget.setTitle(title)
+
+        self._ui.plot_options_label.setText("Plot Options")
+        self._ui.plot_layers_label.setText("Plot Layers")
 
     def _update_plot_dashboard(self, sub_window):
         self._clear_dashboard()
@@ -392,11 +399,11 @@ class GlueApplication(Application, QtWidgets.QMainWindow):
         options_widget.show()
 
         if title:
-            self._ui.plot_options.setTitle("Plot Options - %s" % title)
-            self._ui.plot_layers.setTitle("Plot Layers - %s" % title)
+            self._ui.plot_options_label.setText("Plot Options - %s" % title)
+            self._ui.plot_layers_label.setText("Plot Layers - %s" % title)
         else:
-            self._ui.plot_options.setTitle("Plot Options")
-            self._ui.plot_layers.setTitle("Plot Layers")
+            self._ui.plot_options_label.setText("Plot Options")
+            self._ui.plot_layers_label.setText("Plot Layers")
 
         self._update_focus_decoration()
 

--- a/glue/app/qt/application.py
+++ b/glue/app/qt/application.py
@@ -74,41 +74,21 @@ def _fix_ipython_pylab():
         pass
 
 
-def status_pixmap(attention=False):
-    """
-    A small icon to grab attention
-
-    :param attention: If True, return attention-grabbing pixmap
-    """
-    color = Qt.red if attention else Qt.lightGray
-
-    pm = QtGui.QPixmap(15, 15)
-    p = QtGui.QPainter(pm)
-    b = QtGui.QBrush(color)
-    p.fillRect(-1, -1, 20, 20, b)
-    return pm
-
-
-class ClickableLabel(QtWidgets.QLabel):
-
-    """
-    A QtWidgets.QLabel you can click on to generate events
-    """
-
-    clicked = QtCore.Signal()
-
-    def mousePressEvent(self, event):
-        self.clicked.emit()
-
-
 class GlueLogger(QtWidgets.QWidget):
 
     """
     A window to display error messages
     """
 
-    def __init__(self, parent=None):
+    def __init__(self, button_console, parent=None):
+
         super(GlueLogger, self).__init__(parent)
+
+        self.button_console = button_console
+        self.button_stylesheet = button_console.styleSheet()
+
+        self.button_console.clicked.connect(self._show)
+
         self._text = QtWidgets.QTextEdit()
         self._text.setTextInteractionFlags(Qt.TextSelectableByMouse)
 
@@ -120,12 +100,6 @@ class GlueLogger(QtWidgets.QWidget):
 
         self.stderr = sys.stderr
         sys.stderr = self
-
-        self._status = ClickableLabel()
-        self._status.setToolTip("View Errors and Warnings")
-        self._status.clicked.connect(self._show)
-        self._status.setPixmap(status_pixmap())
-        self._status.setContentsMargins(0, 0, 0, 0)
 
         l = QtWidgets.QVBoxLayout()
         h = QtWidgets.QHBoxLayout()
@@ -141,12 +115,11 @@ class GlueLogger(QtWidgets.QWidget):
 
         self.setLayout(l)
 
-    @property
-    def status_light(self):
-        """
-        The icon representing the status of the log
-        """
-        return self._status
+    def _set_console_button(self, attention):
+        if attention:
+            self.button_console.setStyleSheet('background: red;')
+        else:
+            self.button_console.setStyleSheet(self.button_stylesheet)
 
     def write(self, message):
         """
@@ -155,7 +128,7 @@ class GlueLogger(QtWidgets.QWidget):
         self.stderr.write(message)
         self._text.moveCursor(QtGui.QTextCursor.End)
         self._text.insertPlainText(message)
-        self._status.setPixmap(status_pixmap(attention=True))
+        self._set_console_button(attention=True)
 
     def flush(self):
         """
@@ -175,7 +148,7 @@ class GlueLogger(QtWidgets.QWidget):
         Erase the log
         """
         self._text.setText('')
-        self._status.setPixmap(status_pixmap(attention=False))
+        self._set_console_button(attention=False)
         self.close()
 
     def _show(self):
@@ -254,12 +227,10 @@ class GlueApplication(Application, QtWidgets.QMainWindow):
         self._layer_widget = lw
 
         # log window + status light
-        self._log = GlueLogger()
+        self._log = GlueLogger(button_console=self._ui.button_console)
         self._log.window().setWindowTitle("Console Log")
         self._log.resize(550, 550)
-        self.statusBar().addPermanentWidget(self._log.status_light)
-        self.statusBar().setContentsMargins(2, 0, 20, 2)
-        self.statusBar().setSizeGripEnabled(False)
+        self._log.hide()
 
     def _tweak_geometry(self, maximized=True):
         """Maximize window by default."""
@@ -499,9 +470,9 @@ class GlueApplication(Application, QtWidgets.QMainWindow):
         menu = QtWidgets.QMenu(mbar)
         menu.setTitle("&Toolbars")
         tbar = EditSubsetModeToolBar()
+        tbar.setStyle(QtWidgets.QStyleFactory.create("windows"));
         self._mode_toolbar = tbar
-        self.addToolBar(tbar)
-        tbar.hide()
+        self._ui.layout_top.insertWidget(0, tbar)
         a = QtWidgets.QAction("Selection Mode &Toolbar", menu)
         a.setCheckable(True)
         a.toggled.connect(tbar.setVisible)

--- a/glue/app/qt/application.ui
+++ b/glue/app/qt/application.ui
@@ -84,43 +84,82 @@
        </property>
       </widget>
      </widget>
-     <widget class="QTabWidget" name="tabWidget">
-      <property name="enabled">
-       <bool>true</bool>
-      </property>
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">
-        <horstretch>1</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>400</width>
-        <height>0</height>
-       </size>
-      </property>
-      <property name="tabShape">
-       <enum>QTabWidget::Rounded</enum>
-      </property>
-      <property name="currentIndex">
-       <number>-1</number>
-      </property>
-      <property name="elideMode">
-       <enum>Qt::ElideRight</enum>
-      </property>
-      <property name="usesScrollButtons">
-       <bool>false</bool>
-      </property>
-      <property name="documentMode">
-       <bool>false</bool>
-      </property>
-      <property name="tabsClosable">
-       <bool>false</bool>
-      </property>
-      <property name="movable">
-       <bool>true</bool>
-      </property>
+     <widget class="QWidget" name="verticalLayoutWidget">
+      <layout class="QVBoxLayout" name="layout_right">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <layout class="QHBoxLayout" name="layout_top">
+         <item>
+          <spacer name="horizontalSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QToolButton" name="button_console">
+           <property name="toolTip">
+            <string>View Errors and Warnings</string>
+           </property>
+           <property name="text">
+            <string>View Console</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QTabWidget" name="tabWidget">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">
+           <horstretch>1</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>400</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="tabShape">
+          <enum>QTabWidget::Rounded</enum>
+         </property>
+         <property name="currentIndex">
+          <number>-1</number>
+         </property>
+         <property name="elideMode">
+          <enum>Qt::ElideRight</enum>
+         </property>
+         <property name="usesScrollButtons">
+          <bool>false</bool>
+         </property>
+         <property name="documentMode">
+          <bool>false</bool>
+         </property>
+         <property name="tabsClosable">
+          <bool>false</bool>
+         </property>
+         <property name="movable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </widget>
     </widget>
    </item>

--- a/glue/app/qt/application.ui
+++ b/glue/app/qt/application.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1116</width>
-    <height>749</height>
+    <width>1024</width>
+    <height>557</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -35,57 +35,120 @@
       <property name="orientation">
        <enum>Qt::Vertical</enum>
       </property>
-      <widget class="QGroupBox" name="data_layers">
-       <property name="font">
-        <font>
-         <weight>75</weight>
-         <bold>true</bold>
-        </font>
-       </property>
-       <property name="layoutDirection">
-        <enum>Qt::LeftToRight</enum>
-       </property>
-       <property name="title">
-        <string>Data Collection</string>
-       </property>
-       <property name="flat">
-        <bool>false</bool>
-       </property>
+      <widget class="QWidget" name="data_layers_container">
+       <layout class="QVBoxLayout" name="data_layers_layout">
+        <property name="spacing">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QLabel" name="data_layers_label">
+          <property name="font">
+           <font>
+            <weight>75</weight>
+            <bold>true</bold>
+           </font>
+          </property>
+          <property name="text">
+           <string>Data Collection</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="data_layers">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="layoutDirection">
+           <enum>Qt::LeftToRight</enum>
+          </property>
+          <property name="flat">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </widget>
-      <widget class="QGroupBox" name="plot_layers">
-       <property name="font">
-        <font>
-         <weight>75</weight>
-         <bold>true</bold>
-        </font>
-       </property>
-       <property name="title">
-        <string>Plot Layers</string>
-       </property>
-       <property name="flat">
-        <bool>false</bool>
-       </property>
+      <widget class="QWidget" name="plot_layers_container">
+       <layout class="QVBoxLayout" name="plot_layers_layout">
+        <property name="spacing">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QLabel" name="plot_layers_label">
+          <property name="font">
+           <font>
+            <weight>75</weight>
+            <bold>true</bold>
+           </font>
+          </property>
+          <property name="text">
+           <string>Plot Layers</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="plot_layers">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="layoutDirection">
+           <enum>Qt::LeftToRight</enum>
+          </property>
+          <property name="flat">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </widget>
-      <widget class="QGroupBox" name="plot_options">
-       <property name="font">
-        <font>
-         <weight>75</weight>
-         <bold>true</bold>
-        </font>
-       </property>
-       <property name="title">
-        <string>Plot Options</string>
-       </property>
-       <property name="flat">
-        <bool>false</bool>
-       </property>
-       <property name="checkable">
-        <bool>false</bool>
-       </property>
+      <widget class="QWidget" name="plot_options_container">
+       <layout class="QVBoxLayout" name="plot_options_layout">
+        <property name="spacing">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QLabel" name="plot_options_label">
+          <property name="font">
+           <font>
+            <weight>75</weight>
+            <bold>true</bold>
+           </font>
+          </property>
+          <property name="text">
+           <string>Plot Options</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="plot_options">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="layoutDirection">
+           <enum>Qt::LeftToRight</enum>
+          </property>
+          <property name="flat">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </widget>
      </widget>
      <widget class="QWidget" name="verticalLayoutWidget">
       <layout class="QVBoxLayout" name="layout_right">
+       <property name="spacing">
+        <number>0</number>
+       </property>
        <property name="leftMargin">
         <number>0</number>
        </property>
@@ -102,7 +165,7 @@
            <property name="sizeHint" stdset="0">
             <size>
              <width>40</width>
-             <height>20</height>
+             <height>2</height>
             </size>
            </property>
           </spacer>

--- a/glue/app/qt/edit_subset_mode_toolbar.py
+++ b/glue/app/qt/edit_subset_mode_toolbar.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from qtpy import QtWidgets
+from qtpy import QtCore, QtWidgets
 from glue.core.edit_subset_mode import (EditSubsetMode, OrMode, AndNotMode,
                                         AndMode, XorMode, ReplaceMode)
 from glue.app.qt.actions import action
@@ -16,6 +16,8 @@ class EditSubsetModeToolBar(QtWidgets.QToolBar):
 
     def __init__(self, title="Subset Update Mode", parent=None):
         super(EditSubsetModeToolBar, self).__init__(title, parent)
+        self.addWidget(QtWidgets.QLabel("Selection Mode:"))
+        self.setIconSize(QtCore.QSize(20, 20))
         self._group = QtWidgets.QActionGroup(self)
         self._modes = {}
         self._add_actions()

--- a/glue/core/data_factories/__init__.py
+++ b/glue/core/data_factories/__init__.py
@@ -1,15 +1,15 @@
 from __future__ import absolute_import, division, print_function
 
-from .astropy_table import *
-from .dendrogram import *
-from .excel import *
-from .fits import *
-from .hdf5 import *
-from .helpers import *
-from .image import *
-from .npy import *
-from .pandas import *
-from .tables import *
+from .astropy_table import *  # noqa
+from .dendrogram import *  # noqa
+from .excel import *  # noqa
+from .fits import *  # noqa
+from .hdf5 import *  # noqa
+from .helpers import *  # noqa
+from .image import *  # noqa
+from .npy import *  # noqa
+from .pandas import *  # noqa
+from .tables import *  # noqa
 
 
 # from .deprecated import *

--- a/glue/core/qt/layer_artist_model.py
+++ b/glue/core/qt/layer_artist_model.py
@@ -24,6 +24,7 @@ from glue.utils.qt import PythonListModel, PyMimeData
 from glue.core.hub import HubListener
 from glue.core.message import Message
 
+
 class LayerArtistModel(PythonListModel):
 
     """A Qt model to manage a list of LayerArtists. Multiple
@@ -187,6 +188,7 @@ class LayerArtistView(QtWidgets.QListView, HubListener):
         self.setContextMenuPolicy(Qt.ActionsContextMenu)
         self.setEditTriggers(self.NoEditTriggers)
 
+        self.setMinimumSize(200, 50)
         self._actions = {}
         self._create_actions()
 

--- a/glue/core/qt/layer_artist_model.py
+++ b/glue/core/qt/layer_artist_model.py
@@ -187,7 +187,6 @@ class LayerArtistView(QtWidgets.QListView, HubListener):
         self.setContextMenuPolicy(Qt.ActionsContextMenu)
         self.setEditTriggers(self.NoEditTriggers)
 
-        self._set_palette()
         self._actions = {}
         self._create_actions()
 
@@ -240,13 +239,6 @@ class LayerArtistView(QtWidgets.QListView, HubListener):
         if len(rows) != 1:
             return
         return rows[0].row()
-
-    def _set_palette(self):
-        p = self.palette()
-        c = QtGui.QColor(240, 240, 240)
-        p.setColor(QtGui.QPalette.Highlight, c)
-        p.setColor(QtGui.QPalette.HighlightedText, QtGui.QColor(Qt.black))
-        self.setPalette(p)
 
     def _update_actions(self):
         pass
@@ -332,9 +324,6 @@ class LayerArtistWidget(QtWidgets.QWidget):
                 self.layer_options_layout.addWidget(self.layout_style_widgets[layer_artist])
 
     def on_selection_change(self, layer_artist):
-
-        if layer_artist is None:
-            return
 
         if layer_artist in self.layout_style_widgets:
             self.layer_options_layout.setCurrentWidget(self.layout_style_widgets[layer_artist])

--- a/glue/dialogs/common/qt/component_selector.ui
+++ b/glue/dialogs/common/qt/component_selector.ui
@@ -58,11 +58,7 @@
      <item>
       <widget class="GlueMimeListWidget" name="component_selector">
        <property name="toolTip">
-        <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Lucida Grande'; font-size:12pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The Component IDs associated with this data set&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>The Component IDs associated with this data set</string>
        </property>
       </widget>
      </item>

--- a/glue/dialogs/custom_component/qt/widget.ui
+++ b/glue/dialogs/custom_component/qt/widget.ui
@@ -43,11 +43,7 @@
        <item>
         <widget class="QListWidget" name="component_list">
          <property name="toolTip">
-          <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Lucida Grande'; font-size:12pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Available components to reference when defining a new component&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>Available components to reference when defining a new component</string>
          </property>
          <property name="defaultDropAction">
           <enum>Qt::IgnoreAction</enum>
@@ -108,11 +104,7 @@ p, li { white-space: pre-wrap; }
        <item>
         <widget class="QListWidget" name="data_list">
          <property name="toolTip">
-          <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Lucida Grande'; font-size:12pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Select one or more data sets to add the new component to&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>Select one or more data sets to add the new component to</string>
          </property>
         </widget>
        </item>

--- a/glue/io/formats/tests/__init__.py
+++ b/glue/io/formats/tests/__init__.py
@@ -1,1 +1,0 @@
-# Common tests for all formats

--- a/glue/plugins/tools/spectrum_tool/qt/spectrum_tool.py
+++ b/glue/plugins/tools/spectrum_tool/qt/spectrum_tool.py
@@ -687,6 +687,11 @@ class SpectrumExtractorMode(RoiMode):
         self._release_callback = self._tool._update_profile
         self._move_callback = self._tool._move_profile
         self._roi_callback = None
+        self.viewer.state.add_callback('reference_data', self._on_reference_data_change)
+
+    def _on_reference_data_change(self, reference_data):
+        if reference_data is not None:
+            self.enabled = reference_data.ndim == 3
 
     def menu_actions(self):
 

--- a/glue/plugins/tools/spectrum_tool/qt/spectrum_tool.py
+++ b/glue/plugins/tools/spectrum_tool/qt/spectrum_tool.py
@@ -25,7 +25,6 @@ from glue.app.qt.mdi_area import GlueMdiSubWindow
 from glue.viewers.matplotlib.qt.widget import MplWidget
 from glue.utils import nonpartial, Pointer
 from glue.utils.qt import Worker, messagebox_on_error
-from glue.core import roi as core_roi
 from glue.core.subset import RoiSubsetState
 from glue.core.qt import roi as qt_roi
 from .profile_viewer import ProfileViewer

--- a/glue/tests/test_main.py
+++ b/glue/tests/test_main.py
@@ -7,8 +7,7 @@ from mock import patch
 from glue.tests.helpers import requires_qt
 
 from ..core import Data
-from ..main import (die_on_error, restore_session, load_data_files,
-                    main, start_glue)
+from ..main import die_on_error, load_data_files, main, start_glue
 
 
 @requires_qt

--- a/glue/utils/qt/app.py
+++ b/glue/utils/qt/app.py
@@ -13,6 +13,10 @@ def get_qapp(icon_path=None):
         qapp.setQuitOnLastWindowClosed(True)
         if icon_path is not None:
             qapp.setWindowIcon(QtGui.QIcon(icon_path))
+        font = qapp.font()
+        font.setPointSize(font.pointSize() - 2)
+        qapp.setFont(font)
+
 
     # Make sure we use high resolution icons with PyQt5 for HDPI
     # displays. TODO: check impact on non-HDPI displays.

--- a/glue/utils/qt/mixins.py
+++ b/glue/utils/qt/mixins.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-from qtpy import QtWidgets
 from glue.utils.qt.mime import PyMimeData
 
 __all__ = ['GlueItemWidget']

--- a/glue/utils/qt/tests/test_colors.py
+++ b/glue/utils/qt/tests/test_colors.py
@@ -5,8 +5,8 @@ from mock import MagicMock
 from glue.external.echo import CallbackProperty
 from qtpy import QtGui
 
-from ..helpers import process_dialog
 from ..colors import qt4_to_mpl_color, QColorBox, connect_color, QColormapCombo
+
 
 def test_colors():
     assert qt4_to_mpl_color(QtGui.QColor(255, 0, 0)) == '#ff0000'

--- a/glue/utils/qt/tests/test_mime.py
+++ b/glue/utils/qt/tests/test_mime.py
@@ -1,10 +1,10 @@
 from __future__ import absolute_import, division, print_function
 
-import pytest
-
-from qtpy.QtTest import QTest
-from qtpy.QtCore import Qt
-from qtpy import QtWidgets
+# import pytest
+#
+# from qtpy.QtTest import QTest
+# from qtpy.QtCore import Qt
+# from qtpy import QtWidgets
 
 from .. import mime
 

--- a/glue/utils/qt/widget_properties.py
+++ b/glue/utils/qt/widget_properties.py
@@ -30,7 +30,7 @@ from glue.external.echo.qt import (connect_checkable_button as connect_bool_butt
                                    connect_combo_data as connect_current_combo,
                                    connect_combo_text as connect_current_combo_text,
                                    connect_float_text as connect_float_edit,
-                                   connect_value, connect_text)
+                                   connect_value, connect_text)  # noqa
 
 connect_int_spin = connect_value
 

--- a/glue/utils/tests/test_array.py
+++ b/glue/utils/tests/test_array.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 import pytest
 import numpy as np
 
-from glue.external.six import string_types, PY2
+from glue.external.six import string_types, PY2  # noqa
 
 from ..array import (view_shape, coerce_numeric, stack_view, unique, broadcast_to,
                      shape_to_string, check_sorted, pretty_number, unbroadcast)

--- a/glue/utils/tests/test_geometry.py
+++ b/glue/utils/tests/test_geometry.py
@@ -1,4 +1,4 @@
-from ..geometry import polygon_line_intersections, points_inside_poly
+from ..geometry import polygon_line_intersections
 
 
 def test_square_nonclosed():

--- a/glue/viewers/common/qt/attribute_limits_helper.py
+++ b/glue/viewers/common/qt/attribute_limits_helper.py
@@ -1,3 +1,5 @@
+# DEPREACTED
+
 import numpy as np
 
 from qtpy import QtWidgets

--- a/glue/viewers/common/qt/data_slice_widget.ui
+++ b/glue/viewers/common/qt/data_slice_widget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>310</width>
-    <height>107</height>
+    <width>291</width>
+    <height>90</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,22 +17,65 @@
    <property name="spacing">
     <number>0</number>
    </property>
-   <property name="leftMargin">
-    <number>0</number>
-   </property>
-   <property name="topMargin">
-    <number>0</number>
-   </property>
-   <property name="rightMargin">
-    <number>0</number>
-   </property>
-   <property name="bottomMargin">
+   <property name="margin">
     <number>0</number>
    </property>
    <item>
-    <widget class="QLabel" name="text_label">
+    <layout class="QHBoxLayout" name="horizontalLayout_4">
+     <item>
+      <widget class="QLabel" name="text_label">
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>Main label</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_4">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="bool_use_world">
+       <property name="text">
+        <string>Show real coordinates</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QLabel" name="text_warning">
+     <property name="styleSheet">
+      <string notr="true">color: rgb(255, 33, 28)</string>
+     </property>
      <property name="text">
-      <string>Main label</string>
+      <string>Warning: real coordinates are not aligned with pixel grid. The coordinate shown above is the value at the center of the slice.</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
      </property>
     </widget>
    </item>
@@ -53,7 +96,7 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <property name="spacing">
-      <number>6</number>
+      <number>2</number>
      </property>
      <item>
       <spacer name="horizontalSpacer">
@@ -217,65 +260,6 @@
       </widget>
      </item>
     </layout>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_4">
-     <item>
-      <spacer name="horizontalSpacer_4">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="bool_use_world">
-       <property name="text">
-        <string>Show real coordinates for slices</string>
-       </property>
-       <property name="checkable">
-        <bool>true</bool>
-       </property>
-       <property name="checked">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_3">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <widget class="QLabel" name="text_warning">
-     <property name="styleSheet">
-      <string notr="true">color: rgb(255, 33, 28)</string>
-     </property>
-     <property name="text">
-      <string>Warning: real coordinates are not aligned with pixel grid. The coordinate shown above is the value at the center of the slice.</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignCenter</set>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-    </widget>
    </item>
   </layout>
  </widget>

--- a/glue/viewers/common/qt/data_viewer.py
+++ b/glue/viewers/common/qt/data_viewer.py
@@ -205,9 +205,9 @@ class DataViewer(ViewerBase, QtWidgets.QMainWindow):
         if self._warn_close and (not os.environ.get('GLUE_TESTING')) and self.isVisible():
             buttons = QtWidgets.QMessageBox.Ok | QtWidgets.QMessageBox.Cancel
             dialog = QtWidgets.QMessageBox.warning(self, "Confirm Close",
-                                               "Do you want to close this window?",
-                                               buttons=buttons,
-                                               defaultButton=QtWidgets.QMessageBox.Cancel)
+                                                   "Do you want to close this window?",
+                                                   buttons=buttons,
+                                                   defaultButton=QtWidgets.QMessageBox.Cancel)
             return dialog == QtWidgets.QMessageBox.Ok
         return True
 
@@ -223,8 +223,8 @@ class DataViewer(ViewerBase, QtWidgets.QMainWindow):
             cancel = QtWidgets.QMessageBox.Cancel
             buttons = ok | cancel
             result = QtWidgets.QMessageBox.question(self, title, warn_msg,
-                                                buttons=buttons,
-                                                defaultButton=cancel)
+                                                    buttons=buttons,
+                                                    defaultButton=cancel)
             return result == ok
 
     def layer_view(self):

--- a/glue/viewers/common/qt/mouse_mode.py
+++ b/glue/viewers/common/qt/mouse_mode.py
@@ -20,7 +20,6 @@ from __future__ import absolute_import, division, print_function
 import os
 
 from qtpy import QtGui, QtWidgets
-from glue.core.callback_property import CallbackProperty
 from glue.core import roi
 from glue.core.qt import roi as qt_roi
 from glue.utils.qt import get_qapp

--- a/glue/viewers/common/qt/tests/test_attribute_limits_helper.py
+++ b/glue/viewers/common/qt/tests/test_attribute_limits_helper.py
@@ -1,11 +1,7 @@
-import operator
-
-import pytest
 import numpy as np
 
 from qtpy import QtWidgets
 from glue.core import Data, DataCollection
-from glue.core.subset import InequalitySubsetState
 from glue.core.qt.data_combo_helper import ComponentIDComboHelper
 
 from ..attribute_limits_helper import AttributeLimitsHelper

--- a/glue/viewers/common/qt/tests/test_mouse_mode.py
+++ b/glue/viewers/common/qt/tests/test_mouse_mode.py
@@ -2,10 +2,9 @@
 
 from __future__ import absolute_import, division, print_function
 
-import pytest
 from mock import MagicMock
 
-from glue.utils.qt import process_dialog
+# from glue.utils.qt import process_dialog
 
 from ..mouse_mode import (MouseMode, RectangleMode, CircleMode, PolyMode,
                           ContrastMode, LassoMode)

--- a/glue/viewers/common/qt/tool.py
+++ b/glue/viewers/common/qt/tool.py
@@ -51,7 +51,6 @@ class Tool(object):
         pass
 
 
-
 class CheckableTool(Tool):
     """
     A tool that is checkable.

--- a/glue/viewers/common/viz_client.py
+++ b/glue/viewers/common/viz_client.py
@@ -112,8 +112,9 @@ class VizClient(Client):
         Sync the location and visual properties
         of each point in each subset
         """
-        junk = [self._update_subset_single(s) for d in self.data
-                for s in d.subsets]
+        for d in self.data:
+            for s in d.subsets:
+                self._update_subset_single(s)
         if redraw:
             self._redraw()
 
@@ -142,6 +143,7 @@ class VizClient(Client):
 def set_background_color(axes, color):
     axes.figure.set_facecolor(color)
     axes.patch.set_facecolor(color)
+
 
 def set_foreground_color(axes, color):
     if hasattr(axes, 'coords'):
@@ -318,8 +320,8 @@ class GenericMplClient(Client):
         super(GenericMplClient, self).register_to_hub(hub)
 
         def is_appearance_settings(msg):
-            return ('BACKGROUND_COLOR' in msg.settings
-                    or 'FOREGROUND_COLOR' in msg.settings)
+            return ('BACKGROUND_COLOR' in msg.settings or
+                    'FOREGROUND_COLOR' in msg.settings)
 
         hub.subscribe(self, SettingsChangeMessage,
                       self._update_appearance_from_settings,

--- a/glue/viewers/custom/qt/__init__.py
+++ b/glue/viewers/custom/qt/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import absolute_import, division, print_function
 
-from .custom_viewer import *
+from .custom_viewer import *  # noqa

--- a/glue/viewers/custom/qt/tests/test_custom_viewer.py
+++ b/glue/viewers/custom/qt/tests/test_custom_viewer.py
@@ -28,6 +28,7 @@ def _make_widget(viewer):
     s = simple_session()
     return viewer._widget_cls(s)
 
+
 viewer = custom_viewer('Testing Custom Viewer',
                        a=(0, 100),
                        b='att',
@@ -196,7 +197,7 @@ class TestCustomViewer(object):
 
     def test_register(self):
         with patch('glue.viewers.custom.qt.FormElement.register_to_hub') as r:
-            w = self.build()
+            self.build()
         assert r.call_count > 0
 
     def test_component(self):
@@ -217,7 +218,7 @@ class TestCustomViewer(object):
         assert w._coordinator._settings['b'].ui.count() == 3
 
     def test_settings_changed_called_on_init(self):
-        w = self.build()
+        self.build()
         assert settings_changed.call_count == 1
 
     def test_selections_enabled(self):
@@ -229,7 +230,7 @@ class TestCustomViewer(object):
 
 def test_state_save():
     app = GlueApplication()
-    w = app.new_data_viewer(viewer._widget_cls)
+    w = app.new_data_viewer(viewer._widget_cls)  # noqa
     check_clone_app(app)
 
 
@@ -352,7 +353,7 @@ class TestFormElements(object):
 
     def test_unrecognized(self):
         with pytest.raises(ValueError):
-            e = FormElement.auto(None)
+            FormElement.auto(None)
 
 
 class TestAttributeInfo(object):

--- a/glue/viewers/histogram/qt/__init__.py
+++ b/glue/viewers/histogram/qt/__init__.py
@@ -1,1 +1,1 @@
-from .data_viewer import HistogramViewer
+from .data_viewer import HistogramViewer  # noqa

--- a/glue/viewers/histogram/qt/data_viewer.py
+++ b/glue/viewers/histogram/qt/data_viewer.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function
 from glue.utils import nonpartial
 from glue.viewers.matplotlib.qt.toolbar import MatplotlibViewerToolbar
 from glue.core.edit_subset_mode import EditSubsetMode
-from glue.core import Data
 from glue.core.util import update_ticks
 from glue.core.roi import RangeROI
 from glue.utils import defer_draw
@@ -14,8 +13,6 @@ from glue.viewers.histogram.layer_artist import HistogramLayerArtist
 from glue.viewers.histogram.qt.options_widget import HistogramOptionsWidget
 from glue.viewers.histogram.state import HistogramViewerState
 from glue.viewers.histogram.compat import update_histogram_viewer_state
-
-from glue.core.state import lookup_class_with_patches
 
 __all__ = ['HistogramViewer']
 

--- a/glue/viewers/histogram/qt/options_widget.py
+++ b/glue/viewers/histogram/qt/options_widget.py
@@ -4,11 +4,9 @@ import os
 
 from qtpy import QtWidgets
 
-from glue.core import Data
 from glue.external.echo.qt import autoconnect_callbacks_to_qt
 from glue.utils import nonpartial
 from glue.utils.qt import load_ui
-from glue.core.qt.data_combo_helper import ComponentIDComboHelper
 
 __all__ = ['HistogramOptionsWidget']
 
@@ -23,7 +21,6 @@ class HistogramOptionsWidget(QtWidgets.QWidget):
                           directory=os.path.dirname(__file__))
 
         autoconnect_callbacks_to_qt(viewer_state, self.ui)
-
 
         self.viewer_state = viewer_state
 

--- a/glue/viewers/image/composite_array.py
+++ b/glue/viewers/image/composite_array.py
@@ -20,6 +20,7 @@ STRETCHES = {
     'log': LogStretch
 }
 
+
 class CompositeArray(object):
 
     def __init__(self, **kwargs):

--- a/glue/viewers/image/layer_artist.py
+++ b/glue/viewers/image/layer_artist.py
@@ -256,16 +256,12 @@ class ImageSubsetLayerArtist(BaseImageLayerArtist):
 
     def _update_image_data(self):
 
-        # Layer artist has been cleared already
-        if len(self.mpl_artists) == 0:
-            return
-
         if self._compatible_with_reference_data:
 
             try:
                 data = self._get_image_data()
             except IncompatibleAttribute:
-                self.disable_invalid_attributes(self.state.attribute)
+                self.disable("Cannot compute mask for this layer")
                 data = np.array([[np.nan]])
             else:
                 self._enabled = True
@@ -273,22 +269,21 @@ class ImageSubsetLayerArtist(BaseImageLayerArtist):
         else:
             data = np.array([[np.nan]])
 
-        self.mpl_artists[0].set_data(data)
-        self.mpl_artists[0].set_extent([-0.5, data.shape[1] - 0.5, -0.5, data.shape[0] - 0.5])
+        if len(self.mpl_artists) > 0:
+            self.mpl_artists[0].set_data(data)
+            self.mpl_artists[0].set_extent([-0.5, data.shape[1] - 0.5, -0.5, data.shape[0] - 0.5])
+
         self.redraw()
 
     @defer_draw
     def _update_visual_attributes(self):
 
-        # Layer artist has been cleared already
-        if len(self.mpl_artists) == 0:
-            return
-
         # TODO: deal with color using a colormap instead of having to change data
 
-        self.mpl_artists[0].set_visible(self.state.visible)
-        self.mpl_artists[0].set_zorder(self.state.zorder)
-        self.mpl_artists[0].set_alpha(self.state.alpha)
+        if len(self.mpl_artists) > 0:
+            self.mpl_artists[0].set_visible(self.state.visible)
+            self.mpl_artists[0].set_zorder(self.state.zorder)
+            self.mpl_artists[0].set_alpha(self.state.alpha)
 
         self.redraw()
 

--- a/glue/viewers/image/qt/__init__.py
+++ b/glue/viewers/image/qt/__init__.py
@@ -1,2 +1,2 @@
-from .data_viewer import ImageViewer
-from .standalone_image_viewer import StandaloneImageViewer
+from .data_viewer import ImageViewer  # noqa
+from .standalone_image_viewer import StandaloneImageViewer  # noqa

--- a/glue/viewers/image/qt/data_viewer.py
+++ b/glue/viewers/image/qt/data_viewer.py
@@ -6,7 +6,6 @@ from qtpy.QtWidgets import QMessageBox
 
 from glue.viewers.matplotlib.qt.toolbar import MatplotlibViewerToolbar
 from glue.core.edit_subset_mode import EditSubsetMode
-from glue.core import Data
 from glue.utils import defer_draw
 
 from glue.core.coordinates import WCSCoordinates
@@ -33,7 +32,6 @@ IDENTITY_WCS.wcs.ctype = ["X", "Y"]
 IDENTITY_WCS.wcs.crval = [0., 0.]
 IDENTITY_WCS.wcs.crpix = [1., 1.]
 IDENTITY_WCS.wcs.cdelt = [1., 1.]
-
 
 
 class ImageViewer(MatplotlibDataViewer):

--- a/glue/viewers/image/qt/layer_style_editor.py
+++ b/glue/viewers/image/qt/layer_style_editor.py
@@ -2,9 +2,6 @@ import os
 
 from qtpy import QtWidgets
 
-from astropy.visualization import (LinearStretch, SqrtStretch,
-                                   LogStretch, AsinhStretch)
-
 from glue.external.echo.qt import autoconnect_callbacks_to_qt
 from glue.utils.qt import load_ui, update_combobox
 from glue.core.qt.data_combo_helper import ComponentIDComboHelper
@@ -20,8 +17,8 @@ class ImageLayerStyleEditor(QtWidgets.QWidget):
                           directory=os.path.dirname(__file__))
 
         connect_kwargs = {'alpha': dict(value_range=(0, 1)),
-                          'contrast': dict(value_range=(-2, 4)),
-                          'bias': dict(value_range=(-2, 3))}
+                          'contrast': dict(value_range=(0.1, 10), log=True),
+                          'bias': dict(value_range=(1.5, -0.5))}
 
         percentiles = [('Min/Max', 100),
                        ('99.5%', 99.5),

--- a/glue/viewers/image/qt/layer_style_editor.ui
+++ b/glue/viewers/image/qt/layer_style_editor.ui
@@ -6,188 +6,22 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>268</width>
-    <height>298</height>
+    <width>282</width>
+    <height>170</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <property name="verticalSpacing">
-    <number>5</number>
-   </property>
    <property name="margin">
     <number>5</number>
    </property>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_2">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>limits</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label_7">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>stretch</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="14" column="0">
-    <widget class="QLabel" name="label_6">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>bias</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="1">
-    <widget class="QLineEdit" name="valuetext_v_min"/>
-   </item>
-   <item row="17" column="1">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="5" column="2">
-    <widget class="QToolButton" name="button_flip_limits">
-     <property name="styleSheet">
-      <string notr="true">padding: 0px</string>
-     </property>
-     <property name="text">
-      <string>⇄</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1" colspan="3">
-    <widget class="QComboBox" name="combodata_stretch"/>
-   </item>
-   <item row="15" column="1" colspan="3">
-    <widget class="QPushButton" name="button_reset_contrast_bias">
-     <property name="text">
-      <string>Reset contrast/bias</string>
-     </property>
-    </widget>
-   </item>
-   <item row="13" column="1" colspan="3">
-    <widget class="QSlider" name="value_contrast">
-     <property name="maximum">
-      <number>1000</number>
-     </property>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="1" colspan="3">
-    <widget class="Line" name="line">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="14" column="1" colspan="3">
-    <widget class="QSlider" name="value_bias">
-     <property name="maximum">
-      <number>1000</number>
-     </property>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="12" column="0">
-    <widget class="QLabel" name="label_4">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>transparency</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="13" column="0">
-    <widget class="QLabel" name="label_5">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>contrast</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1" colspan="3">
+   <property name="spacing">
+    <number>5</number>
+   </property>
+   <item row="0" column="1" colspan="2">
     <widget class="QComboBox" name="combodata_attribute"/>
-   </item>
-   <item row="5" column="3">
-    <widget class="QLineEdit" name="valuetext_v_max"/>
-   </item>
-   <item row="3" column="1" colspan="3">
-    <widget class="QComboBox" name="combodata_percentile"/>
-   </item>
-   <item row="12" column="1" colspan="3">
-    <widget class="QSlider" name="value_alpha">
-     <property name="maximum">
-      <number>100</number>
-     </property>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="1" colspan="3">
-    <widget class="QColormapCombo" name="combodata_cmap">
-     <property name="sizeAdjustPolicy">
-      <enum>QComboBox::AdjustToMinimumContentsLength</enum>
-     </property>
-    </widget>
    </item>
    <item row="0" column="0">
     <widget class="QLabel" name="label_3">
@@ -205,40 +39,219 @@
      </property>
     </widget>
    </item>
-   <item row="11" column="0" colspan="4">
-    <layout class="QHBoxLayout" name="horizontalLayout">
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>limits</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="13" column="1">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="4" column="1" colspan="2">
+    <layout class="QHBoxLayout" name="horizontalLayout_5">
+     <property name="spacing">
+      <number>10</number>
+     </property>
      <item>
-      <spacer name="horizontalSpacer_2">
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <widget class="QColormapCombo" name="combodata_cmap">
+         <property name="minimumSize">
+          <size>
+           <width>80</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="sizeAdjustPolicy">
+          <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+         </property>
+         <property name="frame">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QColorBox" name="color_color">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <widget class="QSlider" name="value_alpha">
+       <property name="minimumSize">
+        <size>
+         <width>50</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximum">
+        <number>100</number>
+       </property>
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
+      </widget>
      </item>
      <item>
-      <widget class="QCheckBox" name="bool_global_sync">
+      <widget class="QToolButton" name="bool_global_sync">
        <property name="text">
-        <string>Sync color and transparency with data</string>
+        <string>Sync</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
        </property>
       </widget>
      </item>
     </layout>
    </item>
-   <item row="8" column="1" colspan="3">
-    <widget class="QColorBox" name="color_color">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+   <item row="3" column="1" colspan="2">
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <property name="spacing">
+      <number>2</number>
+     </property>
+     <item>
+      <widget class="QLineEdit" name="valuetext_v_min"/>
+     </item>
+     <item>
+      <widget class="QToolButton" name="button_flip_limits">
+       <property name="styleSheet">
+        <string notr="true">padding: 0px</string>
+       </property>
+       <property name="text">
+        <string>⇄</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="valuetext_v_max"/>
+     </item>
+    </layout>
+   </item>
+   <item row="2" column="1">
+    <widget class="QComboBox" name="combodata_percentile">
+     <property name="minimumSize">
+      <size>
+       <width>50</width>
+       <height>0</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="2">
+    <widget class="QComboBox" name="combodata_stretch">
+     <property name="minimumSize">
+      <size>
+       <width>50</width>
+       <height>0</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="1" colspan="2">
+    <layout class="QHBoxLayout" name="horizontalLayout_4">
+     <property name="spacing">
+      <number>10</number>
+     </property>
+     <item>
+      <widget class="QSlider" name="value_contrast">
+       <property name="minimumSize">
+        <size>
+         <width>50</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximum">
+        <number>1000</number>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSlider" name="value_bias">
+       <property name="minimumSize">
+        <size>
+         <width>50</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximum">
+        <number>1000</number>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="button_reset_contrast_bias">
+       <property name="text">
+        <string>Reset</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="10" column="0">
+    <widget class="QLabel" name="label_5">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
      </property>
      <property name="text">
-      <string/>
+      <string>contrast/bias</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="label">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>color/opacity</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
     </widget>
    </item>

--- a/glue/viewers/image/qt/options_widget.py
+++ b/glue/viewers/image/qt/options_widget.py
@@ -32,4 +32,4 @@ class ImageOptionsWidget(QtWidgets.QWidget):
         self.viewer_state = viewer_state
 
         self.slice_helper = MultiSliceWidgetHelper(viewer_state=self.viewer_state,
-                                                   widget=self.ui.slice_tab)
+                                                   layout=self.ui.layout_slices)

--- a/glue/viewers/image/qt/options_widget.ui
+++ b/glue/viewers/image/qt/options_widget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>286</width>
-    <height>216</height>
+    <width>218</width>
+    <height>206</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -20,245 +20,194 @@
    <property name="margin">
     <number>5</number>
    </property>
-   <item row="5" column="0">
-    <widget class="QTabWidget" name="tabWidget">
-     <property name="currentIndex">
-      <number>1</number>
+   <item row="10" column="0">
+    <widget class="QLabel" name="x_lab">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
      </property>
-     <widget class="QWidget" name="tab">
-      <attribute name="title">
-       <string>Appearance</string>
-      </attribute>
-      <layout class="QGridLayout" name="gridLayout_2">
-       <item row="0" column="1">
-        <widget class="QComboBox" name="combotext_color_mode"/>
-       </item>
-       <item row="2" column="0" colspan="2">
-        <spacer name="verticalSpacer_4">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="0" column="0">
-        <widget class="QLabel" name="label_3">
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Color mode</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="1">
-        <widget class="QComboBox" name="combodata_aspect"/>
-       </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="label">
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Pixels:</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="tab_2">
-      <attribute name="title">
-       <string>Limits</string>
-      </attribute>
-      <layout class="QGridLayout" name="gridLayout">
-       <property name="verticalSpacing">
-        <number>5</number>
-       </property>
-       <property name="margin">
-        <number>5</number>
-       </property>
-       <item row="5" column="3">
-        <widget class="QToolButton" name="button_flip_x">
-         <property name="styleSheet">
-          <string notr="true">padding: 0px</string>
-         </property>
-         <property name="text">
-          <string>⇄</string>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="3">
-        <widget class="QToolButton" name="button_flip_y">
-         <property name="styleSheet">
-          <string notr="true">padding: 0px</string>
-         </property>
-         <property name="text">
-          <string>⇄</string>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="1">
-        <widget class="QLabel" name="x_lab">
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>y axis</string>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="1">
-        <widget class="QLabel" name="label_2">
-         <property name="text">
-          <string>min/max:</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="1">
-        <widget class="QLabel" name="label_2">
-         <property name="text">
-          <string>min/max:</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="1">
-        <widget class="QLabel" name="x_lab">
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>x axis</string>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="4">
-        <widget class="QLineEdit" name="valuetext_x_max"/>
-       </item>
-       <item row="6" column="2" colspan="3">
-        <widget class="QComboBox" name="combosel_y_att_world">
-         <property name="sizeAdjustPolicy">
-          <enum>QComboBox::AdjustToMinimumContentsLength</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="4">
-        <widget class="QLineEdit" name="valuetext_y_max"/>
-       </item>
-       <item row="7" column="2">
-        <widget class="QLineEdit" name="valuetext_y_min"/>
-       </item>
-       <item row="10" column="1" colspan="4">
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="5" column="2">
-        <widget class="QLineEdit" name="valuetext_x_min"/>
-       </item>
-       <item row="3" column="2">
-        <spacer name="verticalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>10</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="4" column="2" colspan="3">
-        <widget class="QComboBox" name="combosel_x_att_world">
-         <property name="sizeAdjustPolicy">
-          <enum>QComboBox::AdjustToMinimumContentsLength</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="1" colspan="4">
-        <widget class="QLabel" name="label_4">
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Reference dataset (for coordinate system)</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="1" colspan="4">
-        <widget class="QComboBox" name="combosel_reference_data"/>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="slice_tab">
-      <attribute name="title">
-       <string>Slicing</string>
-      </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout">
-       <property name="margin">
-        <number>0</number>
-       </property>
-       <item>
-        <layout class="QVBoxLayout" name="layout_slices"/>
-       </item>
-       <item>
-        <spacer name="verticalSpacer_3">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </widget>
+     <property name="text">
+      <string>y axis</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="1">
+    <widget class="QLineEdit" name="valuetext_y_min"/>
+   </item>
+   <item row="11" column="3">
+    <widget class="QLineEdit" name="valuetext_y_max"/>
+   </item>
+   <item row="9" column="1">
+    <widget class="QLineEdit" name="valuetext_x_min"/>
+   </item>
+   <item row="10" column="1" colspan="3">
+    <widget class="QComboBox" name="combosel_y_att_world">
+     <property name="sizeAdjustPolicy">
+      <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="14" column="0" colspan="4">
+    <spacer name="verticalSpacer_3">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="9" column="3">
+    <widget class="QLineEdit" name="valuetext_x_max"/>
+   </item>
+   <item row="9" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>min/max:</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1" colspan="3">
+    <widget class="QComboBox" name="combodata_aspect"/>
+   </item>
+   <item row="9" column="2">
+    <widget class="QToolButton" name="button_flip_x">
+     <property name="styleSheet">
+      <string notr="true">padding: 0px</string>
+     </property>
+     <property name="text">
+      <string>⇄</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="2">
+    <widget class="QToolButton" name="button_flip_y">
+     <property name="styleSheet">
+      <string notr="true">padding: 0px</string>
+     </property>
+     <property name="text">
+      <string>⇄</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="0">
+    <widget class="QLabel" name="x_lab">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>x axis</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1" colspan="3">
+    <widget class="QComboBox" name="combosel_reference_data"/>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>aspect:</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="13" column="0" colspan="4">
+    <layout class="QVBoxLayout" name="layout_slices"/>
+   </item>
+   <item row="7" column="0">
+    <widget class="QLabel" name="label_4">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>reference</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>min/max:</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1" colspan="3">
+    <widget class="QComboBox" name="combotext_color_mode"/>
+   </item>
+   <item row="8" column="1" colspan="3">
+    <widget class="QComboBox" name="combosel_x_att_world">
+     <property name="sizeAdjustPolicy">
+      <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>mode:</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="12" column="0" colspan="4">
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
     </widget>
    </item>
   </layout>

--- a/glue/viewers/image/qt/options_widget.ui
+++ b/glue/viewers/image/qt/options_widget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>278</width>
-    <height>408</height>
+    <width>286</width>
+    <height>216</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -20,27 +20,69 @@
    <property name="margin">
     <number>5</number>
    </property>
-   <item row="1" column="0">
-    <widget class="QComboBox" name="combosel_reference_data"/>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label_4">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Reference dataset (for coordinate system)</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
+   <item row="5" column="0">
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
+     <widget class="QWidget" name="tab">
+      <attribute name="title">
+       <string>Appearance</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout_2">
+       <item row="0" column="1">
+        <widget class="QComboBox" name="combotext_color_mode"/>
+       </item>
+       <item row="2" column="0" colspan="2">
+        <spacer name="verticalSpacer_4">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_3">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Color mode</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QComboBox" name="combodata_aspect"/>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Pixels:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
      <widget class="QWidget" name="tab_2">
       <attribute name="title">
        <string>Limits</string>
@@ -52,10 +94,7 @@
        <property name="margin">
         <number>5</number>
        </property>
-       <item row="5" column="2" colspan="3">
-        <widget class="QComboBox" name="combotext_color_mode"/>
-       </item>
-       <item row="1" column="3">
+       <item row="5" column="3">
         <widget class="QToolButton" name="button_flip_x">
          <property name="styleSheet">
           <string notr="true">padding: 0px</string>
@@ -65,95 +104,7 @@
          </property>
         </widget>
        </item>
-       <item row="1" column="4">
-        <widget class="QLineEdit" name="valuetext_x_max"/>
-       </item>
-       <item row="0" column="1">
-        <widget class="QLabel" name="x_lab">
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>x axis</string>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="1">
-        <widget class="QLabel" name="label_3">
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>mode:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="1">
-        <widget class="QLabel" name="label_2">
-         <property name="text">
-          <string>min/max:</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="1">
-        <widget class="QLabel" name="label_2">
-         <property name="text">
-          <string>min/max:</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="2" colspan="3">
-        <widget class="QComboBox" name="combodata_aspect"/>
-       </item>
-       <item row="0" column="2" colspan="3">
-        <widget class="QComboBox" name="combosel_x_att_world">
-         <property name="sizeAdjustPolicy">
-          <enum>QComboBox::AdjustToMinimumContentsLength</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="2" colspan="3">
-        <widget class="QComboBox" name="combosel_y_att_world">
-         <property name="sizeAdjustPolicy">
-          <enum>QComboBox::AdjustToMinimumContentsLength</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="1">
-        <widget class="QLabel" name="label">
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>pixels:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="4">
-        <widget class="QLineEdit" name="valuetext_y_max"/>
-       </item>
-       <item row="3" column="2">
-        <widget class="QLineEdit" name="valuetext_y_min"/>
-       </item>
-       <item row="1" column="2">
-        <widget class="QLineEdit" name="valuetext_x_min"/>
-       </item>
-       <item row="3" column="3">
+       <item row="7" column="3">
         <widget class="QToolButton" name="button_flip_y">
          <property name="styleSheet">
           <string notr="true">padding: 0px</string>
@@ -163,7 +114,7 @@
          </property>
         </widget>
        </item>
-       <item row="2" column="1">
+       <item row="6" column="1">
         <widget class="QLabel" name="x_lab">
          <property name="font">
           <font>
@@ -176,8 +127,125 @@
          </property>
         </widget>
        </item>
-       <item row="6" column="1" colspan="4">
+       <item row="7" column="1">
+        <widget class="QLabel" name="label_2">
+         <property name="text">
+          <string>min/max:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="1">
+        <widget class="QLabel" name="label_2">
+         <property name="text">
+          <string>min/max:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="QLabel" name="x_lab">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>x axis</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="4">
+        <widget class="QLineEdit" name="valuetext_x_max"/>
+       </item>
+       <item row="6" column="2" colspan="3">
+        <widget class="QComboBox" name="combosel_y_att_world">
+         <property name="sizeAdjustPolicy">
+          <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="4">
+        <widget class="QLineEdit" name="valuetext_y_max"/>
+       </item>
+       <item row="7" column="2">
+        <widget class="QLineEdit" name="valuetext_y_min"/>
+       </item>
+       <item row="10" column="1" colspan="4">
         <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="5" column="2">
+        <widget class="QLineEdit" name="valuetext_x_min"/>
+       </item>
+       <item row="3" column="2">
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Fixed</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>10</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="4" column="2" colspan="3">
+        <widget class="QComboBox" name="combosel_x_att_world">
+         <property name="sizeAdjustPolicy">
+          <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1" colspan="4">
+        <widget class="QLabel" name="label_4">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Reference dataset (for coordinate system)</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1" colspan="4">
+        <widget class="QComboBox" name="combosel_reference_data"/>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="slice_tab">
+      <attribute name="title">
+       <string>Slicing</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <property name="margin">
+        <number>0</number>
+       </property>
+       <item>
+        <layout class="QVBoxLayout" name="layout_slices"/>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_3">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>
@@ -191,29 +259,7 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="slice_tab">
-      <attribute name="title">
-       <string>Slicing</string>
-      </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout"/>
-     </widget>
     </widget>
-   </item>
-   <item row="2" column="0">
-    <spacer name="verticalSpacer_2">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Fixed</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>10</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>

--- a/glue/viewers/image/qt/slice_widget.py
+++ b/glue/viewers/image/qt/slice_widget.py
@@ -143,7 +143,7 @@ if __name__ == "__main__":
     viewer_state.y_att = data.get_pixel_component_id(3)
     viewer_state.slices = [0] * 5
 
-    widget = MultiSliceWidget(viewer_state)
+    widget = MultiSliceWidgetHelper(viewer_state)
     widget.show()
 
     app.exec_()

--- a/glue/viewers/image/qt/slice_widget.py
+++ b/glue/viewers/image/qt/slice_widget.py
@@ -11,12 +11,11 @@ __all__ = ['MultiSliceWidgetHelper']
 
 class MultiSliceWidgetHelper(object):
 
-    def __init__(self, viewer_state=None, widget=None):
+    def __init__(self, viewer_state=None, layout=None):
 
-        self.widget = widget
         self.viewer_state = viewer_state
 
-        self.layout = widget.layout()
+        self.layout = layout
         self.layout.setSpacing(4)
         self.layout.setContentsMargins(0, 3, 0, 3)
 
@@ -39,7 +38,8 @@ class MultiSliceWidgetHelper(object):
             self.layout.takeAt(0)
 
         for s in self._sliders:
-            s.close()
+            if s is not None:
+                s.close()
 
         self._sliders = []
 
@@ -47,7 +47,10 @@ class MultiSliceWidgetHelper(object):
     def sync_state_from_sliders(self, *args):
         slices = []
         for i, slider in enumerate(self._sliders):
-            slices.append(slider.state.slice_center)
+            if slider is not None:
+                slices.append(slider.state.slice_center)
+            else:
+                slices.append(self.viewer_state.slices[i])
         self.viewer_state.slices = tuple(slices)
 
     @avoid_circular
@@ -63,9 +66,31 @@ class MultiSliceWidgetHelper(object):
         # we should need to add @avoid_circular)
 
         # Update number of sliders if needed
+
         if self.data.ndim != len(self._sliders):
-            self._clear()
+            reinitialize = True
+        else:
             for i in range(self.data.ndim):
+                if i == self.viewer_state.x_att.axis or i == self.viewer_state.y_att.axis:
+                    if self._sliders[i] is not None:
+                        reinitialize = True
+                        break
+                else:
+                    if self._sliders[i] is None:
+                        reinitialize = True
+                        break
+            else:
+                reinitialize = False
+
+        if reinitialize:
+
+            self._clear()
+
+            for i in range(self.data.ndim):
+
+                if i == self.viewer_state.x_att.axis or i == self.viewer_state.y_att.axis:
+                    self._sliders.append(None)
+                    continue
 
                 # TODO: For now we simply pass a single set of world coordinates,
                 # but we will need to generalize this in future. We deliberately
@@ -89,14 +114,9 @@ class MultiSliceWidgetHelper(object):
                 self._sliders.append(slider)
                 self.layout.addWidget(slider)
 
-        # Disable sliders that correspond to visible axes and sync position
-
-        for i, slider in enumerate(self._sliders):
-            if i == self.viewer_state.x_att.axis or i == self.viewer_state.y_att.axis:
-                slider.setEnabled(False)
-            else:
-                slider.setEnabled(True)
-                slider.state.slice_center = self.viewer_state.slices[i]
+        for i in range(self.data.ndim):
+            if self._sliders[i] is not None:
+                self._sliders[i].state.slice_center = self.viewer_state.slices[i]
 
 
 if __name__ == "__main__":

--- a/glue/viewers/image/qt/tests/test_viewer_widget.py
+++ b/glue/viewers/image/qt/tests/test_viewer_widget.py
@@ -208,6 +208,20 @@ class TestImageViewer(object):
         assert self.viewer.state.x_att_world is self.image2.id['Apple']
         assert self.viewer.state.y_att_world is self.image2.id['Banana']
 
+    def test_duplicate_subsets(self):
+
+        # Regression test: make sure that when adding a seconda layer for the
+        # same dataset, we don't add the subsets all over again.
+
+        self.viewer.add_data(self.image1)
+        self.data_collection.new_subset_group(subset_state=self.image1.id['x'] > 1, label='A')
+
+        assert len(self.viewer.layers) == 2
+
+        self.viewer.add_data(self.image1)
+
+        assert len(self.viewer.layers) == 3
+
     def test_aspect_subset(self):
 
         self.viewer.add_data(self.image1)

--- a/glue/viewers/image/qt/tests/test_viewer_widget.py
+++ b/glue/viewers/image/qt/tests/test_viewer_widget.py
@@ -473,6 +473,7 @@ class TestImageViewer(object):
         assert out.strip() == ""
         assert err.strip() == ""
 
+
 class TestSessions(object):
 
     @pytest.mark.parametrize('protocol', [0, 1])

--- a/glue/viewers/image/tests/test_composite_array.py
+++ b/glue/viewers/image/tests/test_composite_array.py
@@ -66,7 +66,6 @@ class TestCompositeArray(object):
         expected_b = np.array([[cm.Reds(0.), cm.Reds(1.)],
                                [cm.Reds(0.), cm.Reds(0.)]])
 
-
         # If both layers have alpha=1, the top layer should be the only one visible
 
         assert_allclose(self.composite[...], expected_b)

--- a/glue/viewers/matplotlib/qt/data_viewer.py
+++ b/glue/viewers/matplotlib/qt/data_viewer.py
@@ -24,6 +24,7 @@ class MatplotlibDataViewer(DataViewer):
     _state_cls = MatplotlibDataViewerState
 
     allow_duplicate_data = False
+    allow_duplicate_subset = False
 
     @defer_draw
     def __init__(self, session, parent=None, wcs=None, state=None):
@@ -125,6 +126,7 @@ class MatplotlibDataViewer(DataViewer):
     @defer_draw
     def add_data(self, data):
 
+        # Check if data already exists in viewer
         if not self.allow_duplicate_data and data in self._layer_artist_container:
             return True
 
@@ -161,6 +163,10 @@ class MatplotlibDataViewer(DataViewer):
 
     @defer_draw
     def add_subset(self, subset):
+
+        # Check if subset already exists in viewer
+        if not self.allow_duplicate_subset and subset in self._layer_artist_container:
+            return True
 
         # Make sure we add the data first if it doesn't already exist in viewer.
         # This will then auto add the subsets so can just return.

--- a/glue/viewers/matplotlib/qt/data_viewer.py
+++ b/glue/viewers/matplotlib/qt/data_viewer.py
@@ -214,8 +214,8 @@ class MatplotlibDataViewer(DataViewer):
         self.remove_data(message.data)
 
     def _is_appearance_settings(self, msg):
-        return ('BACKGROUND_COLOR' in msg.settings
-                or 'FOREGROUND_COLOR' in msg.settings)
+        return ('BACKGROUND_COLOR' in msg.settings or
+                'FOREGROUND_COLOR' in msg.settings)
 
     def register_to_hub(self, hub):
 

--- a/glue/viewers/matplotlib/qt/tests/test_data_viewer.py
+++ b/glue/viewers/matplotlib/qt/tests/test_data_viewer.py
@@ -11,9 +11,11 @@ from glue.app.qt.application import GlueApplication
 
 
 class MatplotlibDrawCounter(object):
+
     def __init__(self, figure):
         self.draw_count = 0
         figure.canvas.mpl_connect('draw_event', self.on_draw)
+
     def on_draw(self, event):
         self.draw_count += 1
 

--- a/glue/viewers/matplotlib/qt/toolbar.py
+++ b/glue/viewers/matplotlib/qt/toolbar.py
@@ -4,7 +4,6 @@ from qtpy import QtCore
 from qtpy import PYQT5
 
 from glue.icons.qt import get_icon
-from glue.utils import nonpartial
 from glue.viewers.common.qt.tool import CheckableTool, Tool
 from glue.viewers.common.qt.mouse_mode import MouseMode
 from glue.viewers.common.qt.toolbar import BasicToolbar

--- a/glue/viewers/matplotlib/qt/widget.py
+++ b/glue/viewers/matplotlib/qt/widget.py
@@ -2,8 +2,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-from functools import wraps
-
 import warnings
 import matplotlib
 from matplotlib.figure import Figure
@@ -11,17 +9,13 @@ from matplotlib.figure import Figure
 from qtpy import QtCore, QtGui, QtWidgets
 from qtpy.QtCore import Qt
 from qtpy import PYQT5
-from glue.utils import DeferredMethod
 from glue.config import settings
 
 if PYQT5:
     from matplotlib.backends.backend_qt5 import FigureManagerQT as FigureManager
     from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 else:
-    try:
-        from matplotlib.backends.backend_qt4agg import FigureManagerQT as FigureManager
-    except ImportError:  # mpl < 1.4
-        from matplotlib.backends.backend_qt4agg import FigureManagerQTAgg as FigureManager
+    from matplotlib.backends.backend_qt4 import FigureManagerQT as FigureManager
     from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas
 
 # We want to ignore warnings about left==right and bottom==top since these are

--- a/glue/viewers/scatter/qt/__init__.py
+++ b/glue/viewers/scatter/qt/__init__.py
@@ -1,1 +1,1 @@
-from .data_viewer import ScatterViewer
+from .data_viewer import ScatterViewer  # noqa

--- a/glue/viewers/scatter/qt/options_widget.py
+++ b/glue/viewers/scatter/qt/options_widget.py
@@ -5,9 +5,7 @@ import os
 from qtpy import QtWidgets
 
 from glue.external.echo.qt import autoconnect_callbacks_to_qt
-from glue.core import Data, Subset
 from glue.utils.qt import load_ui
-from glue.core.qt.data_combo_helper import ComponentIDComboHelper
 
 __all__ = ['ScatterOptionsWidget']
 

--- a/glue/viewers/table/qt/__init__.py
+++ b/glue/viewers/table/qt/__init__.py
@@ -1,1 +1,1 @@
-from .viewer_widget import TableWidget
+from .viewer_widget import TableWidget  # noqa

--- a/glue/viewers/table/qt/tests/test_viewer_widget.py
+++ b/glue/viewers/table/qt/tests/test_viewer_widget.py
@@ -112,11 +112,9 @@ def test_table_widget(tmpdir):
     # We now check what the data and colors of the table are, and try various
     # sorting methods to make sure that things are still correct.
 
-    data = {
-        'a': [1, 2, 3, 4, 5],
-        'b': [3.2, 1.2, 4.5, 3.3, 2.2],
-        'c': ['e', 'b', 'c', 'a', 'f']
-    }
+    data = {'a': [1, 2, 3, 4, 5],
+            'b': [3.2, 1.2, 4.5, 3.3, 2.2],
+            'c': ['e', 'b', 'c', 'a', 'f']}
 
     colors = ['#aa0000', '#380088', '#380088', None, None]
 
@@ -124,11 +122,9 @@ def test_table_widget(tmpdir):
 
     model.sort(1, Qt.AscendingOrder)
 
-    data = {
-        'a': [2, 5, 1, 4, 3],
-        'b': [1.2, 2.2, 3.2, 3.3, 4.5],
-        'c': ['b', 'f', 'e', 'a', 'c']
-    }
+    data = {'a': [2, 5, 1, 4, 3],
+            'b': [1.2, 2.2, 3.2, 3.3, 4.5],
+            'c': ['b', 'f', 'e', 'a', 'c']}
 
     colors = ['#380088', None, '#aa0000', None, '#380088']
 
@@ -136,11 +132,9 @@ def test_table_widget(tmpdir):
 
     model.sort(2, Qt.AscendingOrder)
 
-    data = {
-        'a': [4, 2, 3, 1, 5],
-        'b': [3.3, 1.2, 4.5, 3.2, 2.2],
-        'c': ['a', 'b', 'c', 'e', 'f']
-    }
+    data = {'a': [4, 2, 3, 1, 5],
+            'b': [3.3, 1.2, 4.5, 3.2, 2.2],
+            'c': ['a', 'b', 'c', 'e', 'f']}
 
     colors = [None, '#380088', '#380088', '#aa0000', None]
 
@@ -148,11 +142,9 @@ def test_table_widget(tmpdir):
 
     model.sort(0, Qt.DescendingOrder)
 
-    data = {
-        'a': [5, 4, 3, 2, 1],
-        'b': [2.2, 3.3, 4.5, 1.2, 3.2],
-        'c': ['f', 'a', 'c', 'b', 'e']
-    }
+    data = {'a': [5, 4, 3, 2, 1],
+            'b': [2.2, 3.3, 4.5, 1.2, 3.2],
+            'c': ['f', 'a', 'c', 'b', 'e']}
 
     colors = [None, None, '#380088', '#380088', '#aa0000']
 
@@ -254,11 +246,9 @@ def test_table_widget(tmpdir):
 
     model2 = widget2.ui.table.model()
 
-    data = {
-        'a': [1, 2, 3, 4, 5],
-        'b': [3.2, 1.2, 4.5, 3.3, 2.2],
-        'c': ['e', 'b', 'c', 'a', 'f']
-    }
+    data = {'a': [1, 2, 3, 4, 5],
+            'b': [3.2, 1.2, 4.5, 3.3, 2.2],
+            'c': ['e', 'b', 'c', 'a', 'f']}
 
     # Need to take into account new selections above
     colors = ['#aa0000', '#380088', '#aa0000', "#aa0000", "#bababa"]
@@ -271,7 +261,7 @@ def test_table_widget_session_no_subset(tmpdir):
     # Regression test for a bug that caused table viewers with no subsets to
     # not be restored correctly and instead raise an exception.
 
-    app = get_qapp()
+    app = get_qapp()  # noqa
 
     d = Data(a=[1, 2, 3, 4, 5],
              b=[3.2, 1.2, 4.5, 3.3, 2.2],
@@ -291,6 +281,5 @@ def test_table_widget_session_no_subset(tmpdir):
     gapp2 = GlueApplication.restore_session(session_file)
     gapp2.show()
 
-    d = gapp2.data_collection[0]
-
-    widget2 = gapp2.viewers[0][0]
+    gapp2.data_collection[0]
+    gapp2.viewers[0][0]

--- a/glue/viewers/table/qt/viewer_widget.py
+++ b/glue/viewers/table/qt/viewer_widget.py
@@ -5,7 +5,6 @@ import numpy as np
 
 from qtpy.QtCore import Qt
 from qtpy import QtCore, QtGui, QtWidgets
-from qtpy import PYQT5
 from matplotlib.colors import ColorConverter
 
 from glue.utils.qt import get_qapp
@@ -297,7 +296,7 @@ class TableWidget(DataViewer):
         # for this viewer are from dataset, so we just get Data object
         # then just sync the layers.
         for layer in rec:
-            c = lookup_class_with_patches(layer.pop('_type'))
+            c = lookup_class_with_patches(layer.pop('_type'))  # noqa
             props = dict((k, context.object(v)) for k, v in layer.items())
             layer = props['layer']
             if isinstance(layer, Data):


### PR DESCRIPTION
This includes the following fixes:

* The spectrum tool is only shown for 3D datasets
* Fixes errors with image subsets under certain conditions
* Prevent subsets from being added multiple time to the image viewer
* Reduced the overall font size a little
* Make the selection modes visible by default
* Move the bottom right red square to a more prominent button above the canvas
* Made the image viewer options more space-efficient
* Fix an issue with the fact the text in the left panels was all bold
* Make the contrast/bias less sensitive and more sensible when clicking
* Fixed all (except E501) flake8 warnings in glue/viewers