### PR TITLE
Fix ComponentLink.compute if view causes a scalar to be returned

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ sudo: false
 addons:
   apt:
     packages:
-      - rubygems
+      - ruby
 
 notifications:
   email: false

--- a/glue/core/component_link.py
+++ b/glue/core/component_link.py
@@ -148,11 +148,12 @@ class ComponentLink(object):
         args = [data[join_component_view(f, view)] for f in self._from]
         logger.debug("shape of first argument: %s", args[0].shape)
         result = self._using(*args)
-        logger.debug("shape of result: %s", result.shape)
-        if result.shape != args[0].shape:
-            logger.warn("ComponentLink function %s changed shape. Fixing",
-                        self._using.__name__)
-            result.shape = args[0].shape
+        if not np.isscalar(result):
+            logger.debug("shape of result: %s", result.shape)
+            if result.shape != args[0].shape:
+                logger.warn("ComponentLink function %s changed shape. Fixing",
+                            self._using.__name__)
+                result.shape = args[0].shape
         return result
 
     def get_from_ids(self):

--- a/glue/core/component_link.py
+++ b/glue/core/component_link.py
@@ -148,12 +148,13 @@ class ComponentLink(object):
         args = [data[join_component_view(f, view)] for f in self._from]
         logger.debug("shape of first argument: %s", args[0].shape)
         result = self._using(*args)
-        if not np.isscalar(result):
-            logger.debug("shape of result: %s", result.shape)
-            if result.shape != args[0].shape:
-                logger.warn("ComponentLink function %s changed shape. Fixing",
-                            self._using.__name__)
-                result.shape = args[0].shape
+        # We call asarray since link functions may return Python scalars in some cases
+        result = np.asarray(result)
+        logger.debug("shape of result: %s", result.shape)
+        if result.shape != args[0].shape:
+            logger.warn("ComponentLink function %s changed shape. Fixing",
+                        self._using.__name__)
+            result.shape = args[0].shape
         return result
 
     def get_from_ids(self):

--- a/glue/core/tests/test_component_link.py
+++ b/glue/core/tests/test_component_link.py
@@ -6,6 +6,7 @@ import pytest
 import numpy as np
 from numpy.testing import assert_array_equal
 
+from ..component import DerivedComponent
 from ..component_link import ComponentLink, BinaryComponentLink
 from ..data import ComponentID, Data, Component
 from ..data_collection import DataCollection
@@ -128,6 +129,10 @@ class TestComponentLink(object):
 
         result = link.compute(data, view=(0,))
         assert_array_equal(result, 2)
+
+        data.add_component(DerivedComponent(data, link), to_id)
+
+        assert data.get_component(to_id).numeric
 
 
 l = ComponentLink([ComponentID('a')], ComponentID('b'))

--- a/glue/core/tests/test_component_link.py
+++ b/glue/core/tests/test_component_link.py
@@ -108,6 +108,28 @@ class TestComponentLink(object):
         assert exc.value.args[0].startswith('from argument is not a list '
                                             'of ComponentIDs')
 
+    def test_compute_scalar(self):
+
+        # Regression test - in some cases, link functions can return Python
+        # scalars rather than Numpy objects if a scalar is passed in, so we need
+        # to make sure that works properly.
+
+        data, from_, to_ = self.toy_data()
+        from_id = data.add_component(from_, 'from_label')
+        to_id = ComponentID('to_label')
+
+        def using(x):
+            if np.isscalar(x):
+                return float(x) * 2
+            else:
+                return x * 2
+
+        link = ComponentLink([from_id], to_id, using)
+
+        result = link.compute(data, view=(0,))
+        assert_array_equal(result, 2)
+
+
 l = ComponentLink([ComponentID('a')], ComponentID('b'))
 cid = ComponentID('a')
 scalar = 3


### PR DESCRIPTION
This was a bug introduced when changing Component.numeric to check a single value instead of all values.