### PR TITLE
Prevent ModestImage getting cursor mask data

### DIFF
--- a/glue/external/modest_image.py
+++ b/glue/external/modest_image.py
@@ -71,6 +71,9 @@ class ModestImage(mi.AxesImage):
         self._pixel2world_cache = None
         self._world2pixel_cache = None
 
+    def get_cursor_data(self, event):
+        return None
+
     def set_extent(self, extent):
         self._full_extent = extent
         self.invalidate_cache()


### PR DESCRIPTION
Otherwise every time the mouse moves we compute a subset for a point, which sometimes causes slowdowns. In future we should make modest-image use the downsampled buffer to get cursor data.