### PR TITLE
Fix clearing of layers in Matplotlib viewers

### DIFF
--- a/glue/viewers/histogram/layer_artist.py
+++ b/glue/viewers/histogram/layer_artist.py
@@ -124,6 +124,9 @@ class HistogramLayerArtist(MatplotlibLayerArtist):
     @defer_draw
     def _update_visual_attributes(self):
 
+        if not self.enabled:
+            return
+
         for mpl_artist in self.mpl_artists:
             mpl_artist.set_visible(self.state.visible)
             mpl_artist.set_zorder(self.state.zorder)

--- a/glue/viewers/image/layer_artist.py
+++ b/glue/viewers/image/layer_artist.py
@@ -190,6 +190,9 @@ class ImageLayerArtist(BaseImageLayerArtist):
     @defer_draw
     def _update_visual_attributes(self):
 
+        if not self.enabled:
+            return
+
         if self._viewer_state.color_mode == 'Colormaps':
             color = self.state.cmap
         else:
@@ -345,19 +348,22 @@ class ImageSubsetLayerArtist(BaseImageLayerArtist):
 
         self.subset_array = ImageSubsetArray(self._viewer_state, self)
 
-        self.mpl_artists = [imshow(self.axes, self.subset_array,
+        self.image_artist = imshow(self.axes, self.subset_array,
                                    origin='lower', interpolation='nearest',
-                                   vmin=0, vmax=1, aspect=self._viewer_state.aspect)]
+                                   vmin=0, vmax=1, aspect=self._viewer_state.aspect)
+        self.mpl_artists = [self.image_artist]
 
     @defer_draw
     def _update_visual_attributes(self):
 
+        if not self.enabled:
+            return
+
         # TODO: deal with color using a colormap instead of having to change data
 
-        if len(self.mpl_artists) > 0:
-            self.mpl_artists[0].set_visible(self.state.visible)
-            self.mpl_artists[0].set_zorder(self.state.zorder)
-            self.mpl_artists[0].set_alpha(self.state.alpha)
+        self.image_artist.set_visible(self.state.visible)
+        self.image_artist.set_zorder(self.state.zorder)
+        self.image_artist.set_alpha(self.state.alpha)
 
         self.redraw()
 
@@ -393,9 +399,8 @@ class ImageSubsetLayerArtist(BaseImageLayerArtist):
 
         if force or any(prop in changed for prop in ('layer', 'attribute', 'color',
                                                      'x_att', 'y_att', 'slices')):
-            if len(self.mpl_artists) > 0:
-                self.mpl_artists[0].invalidate_cache()
-                self.redraw()  # forces subset to be recomputed
+            self.image_artist.invalidate_cache()
+            self.redraw()  # forces subset to be recomputed
             force = True  # make sure scaling and visual attributes are updated
 
         if force or any(prop in changed for prop in ('zorder', 'visible', 'alpha')):

--- a/glue/viewers/image/qt/tests/test_viewer_widget.py
+++ b/glue/viewers/image/qt/tests/test_viewer_widget.py
@@ -292,6 +292,10 @@ class TestImageViewer(object):
 
         self.viewer.add_data(hypercube2)
 
+    def test_incompatible_subset(self):
+        self.viewer.add_data(self.image1)
+        self.data_collection.new_subset_group(subset_state=self.catalog.id['c'] > 1, label='A')
+
     def test_apply_roi_single(self):
 
         # Regression test for a bug that caused mode.update to be called

--- a/glue/viewers/matplotlib/layer_artist.py
+++ b/glue/viewers/matplotlib/layer_artist.py
@@ -40,10 +40,9 @@ class MatplotlibLayerArtist(LayerArtistBase):
     def clear(self):
         for artist in self.mpl_artists:
             try:
-                artist.remove()
+                artist.set_visible(False)
             except ValueError:  # already removed
                 pass
-        self.mpl_artists = []
 
     def redraw(self):
         self.axes.figure.canvas.draw()

--- a/glue/viewers/scatter/layer_artist.py
+++ b/glue/viewers/scatter/layer_artist.py
@@ -62,6 +62,9 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
     @defer_draw
     def _update_visual_attributes(self):
 
+        if not self.enabled:
+            return
+
         for mpl_artist in self.mpl_artists:
             mpl_artist.set_visible(self.state.visible)
             mpl_artist.set_zorder(self.state.zorder)
@@ -76,7 +79,7 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
 
         if (self._viewer_state.x_att is None or
             self._viewer_state.y_att is None or
-            self.state.layer is None):
+                self.state.layer is None):
             return
 
         # Figure out which attributes are different from before. Ideally we shouldn't


### PR DESCRIPTION
Make it so LayerArist.clear doesn't actually remove the Matplotlib artists but just hides them until the layer is next enabled (this sets set_visible(False) on the artist directly, bypassing LayerState.visible which can remain True/False)