### PR TITLE
Give an error if the user selects a session file when trying to open a dataset

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@ Full changelog
 v0.11.0 (unreleased)
 --------------------
 
+* Give an error if the user selects a session file when going through
+  the 'Open Data Set' menu. [#1364]
+
 * Changed order of arguments for data exporters from (data, filename)
   to (filename, data). [#1251]
 

--- a/glue/dialogs/data_wizard/qt/data_wizard_dialog.py
+++ b/glue/dialogs/data_wizard/qt/data_wizard_dialog.py
@@ -103,6 +103,18 @@ class GlueDataDialog(object):
         paths, fac = self._get_paths_and_factory()
         result = []
 
+        # Check that the user didn't select a .glu file by mistake
+        for path in paths:
+            if path.endswith('.glu'):
+                mb = QtWidgets.QMessageBox(QtWidgets.QMessageBox.Critical,
+                                           "Error loading data",
+                                           "It looks like you have selected "
+                                           "a .glu session file. You should open "
+                                           "this using 'Open Session' under the "
+                                           "'File' menu instead")
+                mb.exec_()
+                return []
+
         with set_cursor_cm(Qt.WaitCursor):
             for path in paths:
                 self._curfile = path


### PR DESCRIPTION
In future we could even be smart about it and load the session, but the issue is that this resets the session effectively, so we'd need to be sure the user knows that. For now this is the safe option.