### PR TITLE
Generalize registry for custom layer actions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,9 +6,7 @@ v0.12.0 (unreleased)
 
 * Generalize registry for data/subset actions to replace the former
   single_subset_action registry (which applied only to single subset selections).
-  Layer actions can now be registered with the @layer_action decorator.
-
-* No changes yet
+  Layer actions can now be registered with the ``@layer_action`` decorator. [#1396]
 
 v0.11.2 (unreleased)
 --------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ Full changelog
 v0.12.0 (unreleased)
 --------------------
 
+* Generalize registry for data/subset actions to replace the former
+  single_subset_action registry (which applied only to single subset selections).
+  Layer actions can now be registered with the @layer_action decorator.
+
 * No changes yet
 
 v0.11.2 (unreleased)

--- a/doc/customizing_guide/customization.rst
+++ b/doc/customizing_guide/customization.rst
@@ -348,14 +348,16 @@ Registry name                  Registry class
 ``viewer_tool``              :class:`glue.config.ViewerToolRegistry`
 ``data_factory``             :class:`glue.config.DataFactoryRegistry`
 ``data_exporter``            :class:`glue.config.DataExporterRegistry`
+``subset_mask_importer``     :class:`glue.config.SubsetMaskImporterRegistry`
+``subset_mask_exporter``     :class:`glue.config.SubsetMaskExporterRegistry`
 ``link_function``            :class:`glue.config.LinkFunctionRegistry`
 ``link_helper``              :class:`glue.config.LinkHelperRegistry`
 ``colormaps``                :class:`glue.config.ColormapRegistry`
 ``exporters``                :class:`glue.config.ExporterRegistry`
 ``settings``                 :class:`glue.config.SettingRegistry`
-``preference_panes``                 :class:`glue.config.PreferencePanesRegistry`
+``preference_panes``         :class:`glue.config.PreferencePanesRegistry`
 ``fit_plugin``               :class:`glue.config.ProfileFitterRegistry`
-``single_subset_action``     :class:`glue.config.SingleSubsetLayerActionRegistry`
+``layer_action``             :class:`glue.config.LayerActionRegistry`
 ========================== =======================================================
 
 .. _lazy_load_plugin:

--- a/doc/customizing_guide/customization.rst
+++ b/doc/customizing_guide/customization.rst
@@ -249,22 +249,42 @@ the following code into ``config.py``::
     from matplotlib.cm import Paired
     colormaps.add('Paired', Paired)
 
-Custom Subset Actions
----------------------
+Custom Actions
+--------------
 
-You can add menu items to run custom functions on subsets. Use the following
-pattern in ``config.py``::
+You can add menu items to run custom functions when selecting datasets, subset
+groups or subsets in the data collection. To do this, you should define a
+function to be called when the menu item is selected, and use the
+``@layer_action`` decorator::
 
-    from glue.config import single_subset_action
+    from glue.config import layer_action
 
-    def callback(subset, data_collection):
-        print("Called with %s, %s" % (subset, data_collection))
+    @layer_action('Do something')
+    def callback(selected_layers, data_collection):
+        print("Called with %s, %s" % (selected_layers, data_collection))
 
-    single_subset_action('Menu title', callback)
+The ``layer_action`` decorator takes an optional ``single`` keyword argument
+that can be set to `True` or `False` to indicate whether the action should only
+appear when a single dataset, subset group, or subset is selected. If ``single``
+is `True`, the following keyword arguments can be used to further control when
+to show the action:
 
-This menu item is available by right clicking on a subset when a single
-subset is selected in the Data Collection window. Note that you must select
-the subset specific to a particular Data set, and not the parent Subset Group.
+* ``data``: only show the action when selecting a dataset
+* ``subset_group``: only show the action when selecting a subset group
+* ``subset``: only show the action when selecting a subset
+
+These default to `False`, so setting e.g.::
+
+    @layer_action('Do something', single=True, data=True, subset=True)
+    ...
+
+means that the action will appear when a single dataset or subset is selected
+but not when a subset group is selected.
+
+The callback function is called with two arguments. If ``single`` is `True`, the
+first argument is the selected layer, otherwise it is the list of selected
+layers. The second argument is the
+:class:`~glue.core.data_collection.DataCollection` object.
 
 Custom Preference Panes
 -----------------------

--- a/glue/app/qt/layer_tree_widget.py
+++ b/glue/app/qt/layer_tree_widget.py
@@ -11,7 +11,7 @@ from qtpy import QtCore, QtWidgets, QtGui
 from qtpy.QtCore import Qt
 
 from glue.core.edit_subset_mode import AndMode, OrMode, XorMode, AndNotMode, EditSubsetMode
-from glue.config import single_subset_action
+from glue.config import single_subset_action, layer_action
 from glue import core
 from glue.dialogs.link_editor.qt import LinkEditor
 from glue.icons.qt import get_icon
@@ -384,33 +384,51 @@ class MergeAction(LayerAction):
 
 
 class UserAction(LayerAction):
+    """
+    User-defined callback functions to expose.
 
-    def __init__(self, layer_tree_widget, callback, **kwargs):
-        self._title = kwargs.get('name', 'User Action')
-        self._tooltip = kwargs.get('tooltip', None)
-        self._icon = kwargs.get('icon', None)
+    Users register new actions via the :member:`glue.config.layer_action` member
+
+    Callback functions are passed the layer (or list of layers) and data
+    collection
+    """
+
+    def __init__(self, layer_tree_widget, callback=None, name='User Action',
+                 tooltip=None, icon=None, single=False, data=False,
+                 subset_group=False, subset=False):
+        self._title = name
+        self._tooltip = tooltip
+        self._icon = icon
+        self._single = single
+        self._data = data
+        self._subset_group = subset_group
+        self._subset = subset
         self._callback = callback
         super(UserAction, self).__init__(layer_tree_widget)
 
-
-class SingleSubsetUserAction(UserAction):
-
-    """
-    User-defined callback functions to expose
-    when single subsets are selected.
-
-    Users register new actions via the :member:`glue.config.single_subset_action`
-    member
-
-    Callback functions are passed the subset and data collection
-    """
-
     def _can_trigger(self):
-        return self.single_selection_subset()
+        if self._single:
+            if self.single_selection():
+                layer = self.selected_layers()[0]
+                if isinstance(layer, core.Data) and self._data:
+                    return True
+                elif isinstance(layer, core.SubsetGroup) and self._subset_group:
+                    return True
+                elif isinstance(layer, core.Subset) and self._subset:
+                    return True
+                else:
+                    return False
+            else:
+                return False
+        else:
+            return len(self.selected_layers) > 0
 
     def _do_action(self):
-        subset, = self.selected_layers()
-        return self._callback(subset, self.data_collection)
+        if self._single:
+            subset = self.selected_layers()[0]
+            return self._callback(subset, self.data_collection)
+        else:
+            return self._callback(self.selected_layers(), self.data_collection)
 
 
 class LayerCommunicator(QtCore.QObject):
@@ -530,12 +548,11 @@ class LayerTreeWidget(QtWidgets.QMainWindow):
         a.triggered.connect(nonpartial(self._create_component))
         self._actions['new_component'] = a
 
-        # user-defined layer actions
-        for name, callback, tooltip, icon in single_subset_action:
-            self._actions[name] = SingleSubsetUserAction(self, callback,
-                                                         name=name,
-                                                         tooltip=tooltip,
-                                                         icon=icon)
+        # Add user-defined layer actions. Note that _asdict is actually a public
+        # method, but just has an underscore to prevent conflict with
+        # namedtuple attributes.
+        for item in layer_action:
+            self._actions[item.name] = UserAction(self, **item._asdict())
 
         # right click pulls up menu
         tree.setContextMenuPolicy(Qt.ActionsContextMenu)

--- a/glue/app/qt/layer_tree_widget.py
+++ b/glue/app/qt/layer_tree_widget.py
@@ -393,10 +393,10 @@ class UserAction(LayerAction):
     collection
     """
 
-    def __init__(self, layer_tree_widget, callback=None, name='User Action',
+    def __init__(self, layer_tree_widget, callback=None, label='User Action',
                  tooltip=None, icon=None, single=False, data=False,
                  subset_group=False, subset=False):
-        self._title = name
+        self._title = label
         self._tooltip = tooltip
         self._icon = icon
         self._single = single
@@ -421,7 +421,7 @@ class UserAction(LayerAction):
             else:
                 return False
         else:
-            return len(self.selected_layers) > 0
+            return len(self.selected_layers()) > 0
 
     def _do_action(self):
         if self._single:
@@ -552,7 +552,7 @@ class LayerTreeWidget(QtWidgets.QMainWindow):
         # method, but just has an underscore to prevent conflict with
         # namedtuple attributes.
         for item in layer_action:
-            self._actions[item.name] = UserAction(self, **item._asdict())
+            self._actions[item.label] = UserAction(self, **item._asdict())
 
         # right click pulls up menu
         tree.setContextMenuPolicy(Qt.ActionsContextMenu)

--- a/glue/config.py
+++ b/glue/config.py
@@ -12,8 +12,7 @@ Objects used to configure Glue at runtime.
 __all__ = ['Registry', 'SettingRegistry', 'ExporterRegistry',
            'ColormapRegistry', 'DataFactoryRegistry', 'QtClientRegistry',
            'LinkFunctionRegistry', 'LinkHelperRegistry', 'ViewerToolRegistry',
-           'LayerActionRegistry', 'SingleSubsetLayerActionRegistry',
-           'ProfileFitterRegistry', 'qt_client', 'data_factory',
+           'LayerActionRegistry', 'ProfileFitterRegistry', 'qt_client', 'data_factory',
            'link_function', 'link_helper', 'colormaps', 'exporters', 'settings',
            'fit_plugin', 'auto_refresh', 'importer', 'DictRegistry',
            'preference_panes', 'PreferencePanesRegistry',
@@ -550,22 +549,20 @@ class LayerActionRegistry(Registry):
     """
     item = namedtuple('LayerAction', 'label tooltip callback icon single data subset_group, subset')
 
-    def __call__(self, label, tooltip=None, icon=None, single=False,
+    def __call__(self, label, callback=None, tooltip=None, icon=None, single=False,
                  data=False, subset_group=False, subset=False):
+
+        # Backward-compatibility
+        if callback is not None:
+            self.add(self.item(label, tooltip, callback, icon, True,
+                     False, False, True))
+            return True
+
         def adder(func):
             self.add(self.item(label, tooltip, func, icon, single,
                      data, subset_group, subset))
             return func
         return adder
-
-
-class SingleSubsetLayerActionRegistry(LayerActionRegistry):
-    """
-    This registry exists for backward-compatibility, but users should make use
-    of LayerActionRegistry instead.
-    """
-    def __call__(self, label, callback, tooltip=None, icon=None):
-        self.add(self.item(label, tooltip, callback, icon, True, False, False, True))
 
 
 class LinkHelperRegistry(Registry):
@@ -636,7 +633,6 @@ exporters = ExporterRegistry()
 settings = SettingRegistry()
 fit_plugin = ProfileFitterRegistry()
 layer_action = LayerActionRegistry()
-single_subset_action = SingleSubsetLayerActionRegistry()
 menubar_plugin = MenubarPluginRegistry()
 preference_panes = PreferencePanesRegistry()
 qglue_parser = QGlueParserRegistry()
@@ -651,10 +647,13 @@ data_exporter = DataExporterRegistry()
 subset_mask_exporter = SubsetMaskExporterRegistry()
 subset_mask_importer = SubsetMaskImporterRegistry()
 
+# Backward-compatibility
+single_subset_action = layer_action
 
 
 def load_configuration(search_path=None):
-    ''' Find and import a config.py file
+    """
+    Find and import a config.py file
 
     Returns:
 
@@ -663,7 +662,7 @@ def load_configuration(search_path=None):
     Raises:
 
        Exception, if no module was found
-    '''
+    """
     search_order = search_path or _default_search_order()
     result = imp.new_module('config')
 

--- a/glue/config.py
+++ b/glue/config.py
@@ -16,7 +16,8 @@ __all__ = ['Registry', 'SettingRegistry', 'ExporterRegistry',
            'link_function', 'link_helper', 'colormaps', 'exporters', 'settings',
            'fit_plugin', 'auto_refresh', 'importer', 'DictRegistry',
            'preference_panes', 'PreferencePanesRegistry',
-           'DataExporterRegistry', 'data_exporter', 'layer_action']
+           'DataExporterRegistry', 'data_exporter', 'layer_action',
+           'SubsetMaskExporterRegistry', 'SubsetMaskImporterRegistry']
 
 
 CFG_DIR = os.path.join(os.path.expanduser('~'), '.glue')


### PR DESCRIPTION
This makes it possible to define layer actions for data, subset groups, and subsets rather than just subsets.