### PR TITLE
Add 2d vector field tab to the scatter plot viewer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@ v0.12.0 (unreleased)
   single_subset_action registry (which applied only to single subset selections).
   Layer actions can now be registered with the ``@layer_action`` decorator. [#1396]
 
+* Added support for plotting vectors in the scatter plot viewer. [#1410]
+
 v0.11.2 (unreleased)
 --------------------
 

--- a/glue/viewers/scatter/layer_artist.py
+++ b/glue/viewers/scatter/layer_artist.py
@@ -12,11 +12,13 @@ from glue.core.exceptions import IncompatibleAttribute
 CMAP_PROPERTIES = set(['cmap_mode', 'cmap_att', 'cmap_vmin', 'cmap_vmax', 'cmap'])
 SIZE_PROPERTIES = set(['size_mode', 'size_att', 'size_vmin', 'size_vmax', 'size_scaling', 'size'])
 LINE_PROPERTIES = set(['linewidth', 'linestyle'])
+
 VISUAL_PROPERTIES = (CMAP_PROPERTIES | SIZE_PROPERTIES |
                      LINE_PROPERTIES | set(['color', 'alpha', 'zorder', 'visible']))
 
 DATA_PROPERTIES = set(['layer', 'x_att', 'y_att', 'cmap_mode', 'size_mode',
-                       'xerr_att', 'yerr_att', 'xerr_visible', 'yerr_visible'])
+                       'xerr_att', 'yerr_att', 'xerr_visible', 'yerr_visible',
+                       'vx_att', 'vy_att'])
 
 
 class InvertedNormalize(Normalize):
@@ -46,13 +48,16 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
         self.scatter_artist = self.axes.scatter([], [])
         self.plot_artist = self.axes.plot([], [], 'o', mec='none')[0]
         self.errorbar_artist = self.axes.errorbar([], [], fmt='none')
+        self.vector_artist = self.axes.quiver([], [], [], [], units='xy', scale=1) # x, y, vx, vy
 
         # Line
         self.line_artist = self.axes.plot([], [], '-')[0]
 
         self.mpl_artists = [self.scatter_artist, self.plot_artist,
-                            self.errorbar_artist, self.line_artist]
+                            self.errorbar_artist, self.line_artist,
+                            self.vector_artist]
         self.errorbar_index = 2
+        self.vector_index = 3
 
         self.reset_cache()
 
@@ -132,6 +137,14 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
                 self.errorbar_artist = self.axes.errorbar(x, y, fmt='none',
                                                           xerr=xerr, yerr=yerr)
                 self.mpl_artists[self.errorbar_index] = self.errorbar_artist
+
+            if self.state.vx_att and self.state.vy_att:
+                vx = self.layer[self.state.vx_att].ravel()
+                vy = self.layer[self.state.vy_att].ravel()
+
+                self.vector_artist = self.axes.quiver(x, y, vx, vy, units='xy',
+                                                      scale=1)
+                self.mpl_artists[self.vector_index] = self.vector_artist
 
         elif self.state.style == 'Line':
 

--- a/glue/viewers/scatter/layer_artist.py
+++ b/glue/viewers/scatter/layer_artist.py
@@ -18,7 +18,8 @@ VISUAL_PROPERTIES = (CMAP_PROPERTIES | SIZE_PROPERTIES |
 
 DATA_PROPERTIES = set(['layer', 'x_att', 'y_att', 'cmap_mode', 'size_mode',
                        'xerr_att', 'yerr_att', 'xerr_visible', 'yerr_visible',
-                       'vector_visible', 'vx_att', 'vy_att', 'vector_hide_arrow'])
+                       'vector_visible', 'vx_att', 'vy_att', 'vector_show_arrow',
+                       'origin_pos'])
 
 
 class InvertedNormalize(Normalize):
@@ -49,7 +50,8 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
         self.plot_artist = self.axes.plot([], [], 'o', mec='none')[0]
         self.errorbar_artist = self.axes.errorbar([], [], fmt='none')
         self.vector_artist = self.axes.quiver([], [], [], [], units='width',
-                                              pivot='mid') # x, y, vx, vy
+                                              pivot='mid',
+                                              headwidth=1, headlength=0) # x, y, vx, vy
 
         # Line
         self.line_artist = self.axes.plot([], [], '-')[0]
@@ -153,7 +155,7 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
 
                     vx = self.layer[self.state.vx_att].ravel()
                     vy = self.layer[self.state.vy_att].ravel()
-                    if self.state.vector_mode == 'ang/length':
+                    if self.state.vector_mode == 'Polarization':
                         ang = vx
                         length = vy
                         # assume ang is anti clockwise from the x axis
@@ -163,14 +165,15 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
                     vx = None
                     vy = None
 
-                if self.state.vector_hide_arrow:
-                    hw = 0
+                if self.state.vector_show_arrow:
+                    hw = 3
+                    hl = 5
                 else:
-                    hw = 3 # matplotlib default
-
+                    hw = 1
+                    hl = 0
                 self.vector_artist = self.axes.quiver(x, y, vx, vy, units='width',
-                                                      pivot='mid',
-                                                      headwidth=hw)
+                                                      pivot=str(self.state.origin_pos),
+                                                      headwidth=hw, headlength=hl)
                 self.mpl_artists[self.vector_index] = self.vector_artist
 
         elif self.state.style == 'Line':

--- a/glue/viewers/scatter/layer_artist.py
+++ b/glue/viewers/scatter/layer_artist.py
@@ -18,7 +18,7 @@ VISUAL_PROPERTIES = (CMAP_PROPERTIES | SIZE_PROPERTIES |
 
 DATA_PROPERTIES = set(['layer', 'x_att', 'y_att', 'cmap_mode', 'size_mode',
                        'xerr_att', 'yerr_att', 'xerr_visible', 'yerr_visible',
-                       'vx_att', 'vy_att'])
+                       'vector_visible', 'vx_att', 'vy_att'])
 
 
 class InvertedNormalize(Normalize):
@@ -122,6 +122,14 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
                     except AttributeError:  # Matplotlib < 1.5
                         pass
 
+            if self.vector_artist is not None:
+                try:
+                    self.vector_artist.remove()
+                except ValueError:
+                    pass
+                except AttributeError:   # Matplotlib < 1.5
+                    pass
+
             if self.state.xerr_visible or self.state.yerr_visible:
 
                 if self.state.xerr_visible and self.state.xerr_att is not None:
@@ -138,9 +146,18 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
                                                           xerr=xerr, yerr=yerr)
                 self.mpl_artists[self.errorbar_index] = self.errorbar_artist
 
-            if self.state.vx_att and self.state.vy_att:
-                vx = self.layer[self.state.vx_att].ravel()
-                vy = self.layer[self.state.vy_att].ravel()
+            if self.state.vector_visible:
+
+                if self.state.vx_att is not None and self.state.vy_att is not None:
+                    vx = self.layer[self.state.vx_att].ravel()
+                    vy = self.layer[self.state.vy_att].ravel()
+                    print('x', x)
+                    print('y', y)
+                    print('vx', vx)
+                    print('vy', vy)
+                else:
+                    vx = None
+                    vy = None
 
                 self.vector_artist = self.axes.quiver(x, y, vx, vy, units='xy',
                                                       scale=1)
@@ -240,6 +257,20 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
 
                     if force or 'zorder' in changed:
                         eartist.set_zorder(self.state.zorder)
+
+            if self.state.vector_visible and self.vector_artist is not None:
+
+                if force or 'color' in changed:
+                    self.vector_artist.set_color(self.state.color)
+
+                if force or 'alpha' in changed:
+                    self.vector_artist.set_alpha(self.state.alpha)
+
+                if force or 'visible' in changed:
+                    self.vector_artist.set_visible(self.state.visible)
+
+                if force or 'zorder' in changed:
+                    self.vector_artist.set_zorder(self.state.zorder)
 
         elif self.state.style == 'Line':
 

--- a/glue/viewers/scatter/layer_artist.py
+++ b/glue/viewers/scatter/layer_artist.py
@@ -18,7 +18,7 @@ VISUAL_PROPERTIES = (CMAP_PROPERTIES | SIZE_PROPERTIES |
 
 DATA_PROPERTIES = set(['layer', 'x_att', 'y_att', 'cmap_mode', 'size_mode',
                        'xerr_att', 'yerr_att', 'xerr_visible', 'yerr_visible',
-                       'vector_visible', 'vx_att', 'vy_att'])
+                       'vector_visible', 'vx_att', 'vy_att', 'vector_hide_arrow'])
 
 
 class InvertedNormalize(Normalize):
@@ -159,8 +159,13 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
                     vx = None
                     vy = None
 
+                if self.state.vector_hide_arrow:
+                    hw = 0
+                else:
+                    hw = 3 # matplotlib default
+
                 self.vector_artist = self.axes.quiver(x, y, vx, vy, units='xy',
-                                                      scale=1)
+                                                      scale=1, headwidth=hw)
                 self.mpl_artists[self.vector_index] = self.vector_artist
 
         elif self.state.style == 'Line':

--- a/glue/viewers/scatter/layer_artist.py
+++ b/glue/viewers/scatter/layer_artist.py
@@ -149,12 +149,15 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
             if self.state.vector_visible:
 
                 if self.state.vx_att is not None and self.state.vy_att is not None:
+
                     vx = self.layer[self.state.vx_att].ravel()
                     vy = self.layer[self.state.vy_att].ravel()
-                    print('x', x)
-                    print('y', y)
-                    print('vx', vx)
-                    print('vy', vy)
+                    if self.state.vector_mode == 'ang/length':
+                        ang = vx
+                        length = vy
+                        # assume ang is anti clockwise from the x axis
+                        vx = length * np.cos(np.radians(ang))
+                        vy = length * np.sin(np.radians(ang))
                 else:
                     vx = None
                     vy = None

--- a/glue/viewers/scatter/layer_artist.py
+++ b/glue/viewers/scatter/layer_artist.py
@@ -48,7 +48,8 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
         self.scatter_artist = self.axes.scatter([], [])
         self.plot_artist = self.axes.plot([], [], 'o', mec='none')[0]
         self.errorbar_artist = self.axes.errorbar([], [], fmt='none')
-        self.vector_artist = self.axes.quiver([], [], [], [], units='xy', scale=1) # x, y, vx, vy
+        self.vector_artist = self.axes.quiver([], [], [], [], units='width',
+                                              pivot='mid') # x, y, vx, vy
 
         # Line
         self.line_artist = self.axes.plot([], [], '-')[0]
@@ -167,8 +168,9 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
                 else:
                     hw = 3 # matplotlib default
 
-                self.vector_artist = self.axes.quiver(x, y, vx, vy, units='xy',
-                                                      scale=1, headwidth=hw)
+                self.vector_artist = self.axes.quiver(x, y, vx, vy, units='width',
+                                                      pivot='mid',
+                                                      headwidth=hw)
                 self.mpl_artists[self.vector_index] = self.vector_artist
 
         elif self.state.style == 'Line':
@@ -218,17 +220,25 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
 
                     if self.state.cmap_mode == 'Fixed':
                         self.scatter_artist.set_facecolors(c)
+                        self.vector_artist.set_facecolors(c)
                     else:
                         self.scatter_artist.set_array(c)
                         self.scatter_artist.set_cmap(cmap)
+                        self.vector_artist.set_array(c)
+                        self.vector_artist.set_cmap(cmap)
                         if vmin > vmax:
                             self.scatter_artist.set_clim(vmax, vmin)
                             self.scatter_artist.set_norm(InvertedNormalize(vmax, vmin))
+                            self.vector_artist.set_clim(vmax, vmin)
+                            self.vector_artist.set_norm(InvertedNormalize(vmax, vmin))
                         else:
                             self.scatter_artist.set_clim(vmin, vmax)
                             self.scatter_artist.set_norm(Normalize(vmin, vmax))
+                            self.vector_artist.set_clim(vmin, vmax)
+                            self.vector_artist.set_norm(Normalize(vmin, vmax))
 
                     self.scatter_artist.set_edgecolor('none')
+                    self.vector_artist.set_edgecolor('none')
 
                 if force or any(prop in changed for prop in SIZE_PROPERTIES):
 

--- a/glue/viewers/scatter/qt/layer_style_editor.py
+++ b/glue/viewers/scatter/qt/layer_style_editor.py
@@ -32,6 +32,7 @@ class ScatterLayerStyleEditor(QtWidgets.QWidget):
         self.layer_state.add_callback('yerr_visible', self._update_yerr_att_combo)
         self.layer_state.add_callback('vector_visible', self._update_vector_att_combo)
         self.layer_state.add_callback('size_mode', self._update_size_mode)
+        self.layer_state.add_callback('vector_mode', self._update_vector_mode)
         self.layer_state.add_callback('cmap_mode', self._update_cmap_mode)
         self.layer_state.add_callback('layer', self._update_warnings)
 
@@ -39,6 +40,7 @@ class ScatterLayerStyleEditor(QtWidgets.QWidget):
         self._update_yerr_att_combo()
         self._update_vector_att_combo()
         self._update_size_mode()
+        self._update_vector_mode()
         self._update_cmap_mode()
         self._update_warnings()
 
@@ -90,6 +92,15 @@ class ScatterLayerStyleEditor(QtWidgets.QWidget):
             self.ui.value_size.hide()
             self.ui.combosel_size_att.show()
             self.ui.size_row_2.show()
+
+    def _update_vector_mode(self, vector_mode=None):
+        if self.layer_state.vector_mode == 'vx/vy':
+            self.ui.label_vector_x.setText('vx')
+            self.ui.label_vector_y.setText('vy')
+        elif self.layer_state.vector_mode == 'ang/length':
+            self.ui.label_vector_x.setText('ang')
+            self.ui.label_vector_y.setText('length')
+
 
     def _update_cmap_mode(self, cmap_mode=None):
 

--- a/glue/viewers/scatter/qt/layer_style_editor.py
+++ b/glue/viewers/scatter/qt/layer_style_editor.py
@@ -30,12 +30,14 @@ class ScatterLayerStyleEditor(QtWidgets.QWidget):
 
         self.layer_state.add_callback('xerr_visible', self._update_xerr_att_combo)
         self.layer_state.add_callback('yerr_visible', self._update_yerr_att_combo)
+        self.layer_state.add_callback('vector_visible', self._update_vector_att_combo)
         self.layer_state.add_callback('size_mode', self._update_size_mode)
         self.layer_state.add_callback('cmap_mode', self._update_cmap_mode)
         self.layer_state.add_callback('layer', self._update_warnings)
 
         self._update_xerr_att_combo()
         self._update_yerr_att_combo()
+        self._update_vector_att_combo()
         self._update_size_mode()
         self._update_cmap_mode()
         self._update_warnings()
@@ -45,6 +47,10 @@ class ScatterLayerStyleEditor(QtWidgets.QWidget):
 
     def _update_yerr_att_combo(self, *args):
         self.ui.combosel_yerr_att.setEnabled(self.layer_state.yerr_visible)
+
+    def _update_vector_att_combo(self, *args):
+        self.ui.combosel_vx_att.setEnabled(self.layer_state.vector_visible)
+        self.ui.combosel_vy_att.setEnabled(self.layer_state.vector_visible)
 
     def _update_warnings(self):
 
@@ -67,6 +73,11 @@ class ScatterLayerStyleEditor(QtWidgets.QWidget):
             self.ui.label_warning_errorbar.show()
         else:
             self.ui.label_warning_errorbar.hide()
+
+        if n_points > 10000:
+            self.ui.label_warning_vector.show()
+        else:
+            self.ui.label_warning_vector.hide()
 
     def _update_size_mode(self, size_mode=None):
 

--- a/glue/viewers/scatter/qt/layer_style_editor.py
+++ b/glue/viewers/scatter/qt/layer_style_editor.py
@@ -51,6 +51,7 @@ class ScatterLayerStyleEditor(QtWidgets.QWidget):
     def _update_vector_att_combo(self, *args):
         self.ui.combosel_vx_att.setEnabled(self.layer_state.vector_visible)
         self.ui.combosel_vy_att.setEnabled(self.layer_state.vector_visible)
+        self.ui.bool_vector_hide_arrow.setEnabled(self.layer_state.vector_visible)
 
     def _update_warnings(self):
 

--- a/glue/viewers/scatter/qt/layer_style_editor.py
+++ b/glue/viewers/scatter/qt/layer_style_editor.py
@@ -98,7 +98,7 @@ class ScatterLayerStyleEditor(QtWidgets.QWidget):
             self.ui.label_vector_x.setText('vx')
             self.ui.label_vector_y.setText('vy')
         elif self.layer_state.vector_mode == 'ang/length':
-            self.ui.label_vector_x.setText('ang')
+            self.ui.label_vector_x.setText('ang(deg)')
             self.ui.label_vector_y.setText('length')
 
 

--- a/glue/viewers/scatter/qt/layer_style_editor.py
+++ b/glue/viewers/scatter/qt/layer_style_editor.py
@@ -53,7 +53,7 @@ class ScatterLayerStyleEditor(QtWidgets.QWidget):
     def _update_vector_att_combo(self, *args):
         self.ui.combosel_vx_att.setEnabled(self.layer_state.vector_visible)
         self.ui.combosel_vy_att.setEnabled(self.layer_state.vector_visible)
-        self.ui.bool_vector_hide_arrow.setEnabled(self.layer_state.vector_visible)
+        self.ui.bool_vector_show_arrow.setEnabled(self.layer_state.vector_visible)
 
     def _update_warnings(self):
 
@@ -94,10 +94,10 @@ class ScatterLayerStyleEditor(QtWidgets.QWidget):
             self.ui.size_row_2.show()
 
     def _update_vector_mode(self, vector_mode=None):
-        if self.layer_state.vector_mode == 'vx/vy':
+        if self.layer_state.vector_mode == 'Cartesian':
             self.ui.label_vector_x.setText('vx')
             self.ui.label_vector_y.setText('vy')
-        elif self.layer_state.vector_mode == 'ang/length':
+        elif self.layer_state.vector_mode == 'Polarization':
             self.ui.label_vector_x.setText('ang(deg)')
             self.ui.label_vector_y.setText('length')
 

--- a/glue/viewers/scatter/qt/layer_style_editor_scatter.ui
+++ b/glue/viewers/scatter/qt/layer_style_editor_scatter.ui
@@ -588,13 +588,6 @@
        <property name="verticalSpacing">
         <number>5</number>
        </property>
-       <item row="3" column="3" colspan="3">
-        <widget class="QCheckBox" name="bool_vector_hide_arrow">
-         <property name="text">
-          <string>Hide arrow</string>
-         </property>
-        </widget>
-       </item>
        <item row="4" column="3">
         <spacer name="verticalSpacer_3">
          <property name="orientation">
@@ -710,6 +703,53 @@
            <string>ang/length</string>
           </property>
          </item>
+        </widget>
+       </item>
+       <item row="3" column="5">
+        <widget class="QComboBox" name="combosel_origin_pos">
+         <property name="currentText">
+          <string>Mid</string>
+         </property>
+         <item>
+          <property name="text">
+           <string>Mid</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Tail</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Middle</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Tip</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="3" column="3">
+        <widget class="QLabel" name="label_7">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Origin is:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="2">
+        <widget class="QCheckBox" name="bool_vector_show_arrow">
+         <property name="text">
+          <string>Show arrow</string>
+         </property>
         </widget>
        </item>
       </layout>

--- a/glue/viewers/scatter/qt/layer_style_editor_scatter.ui
+++ b/glue/viewers/scatter/qt/layer_style_editor_scatter.ui
@@ -14,16 +14,7 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <property name="leftMargin">
-    <number>5</number>
-   </property>
-   <property name="topMargin">
-    <number>5</number>
-   </property>
-   <property name="rightMargin">
-    <number>5</number>
-   </property>
-   <property name="bottomMargin">
+   <property name="margin">
     <number>5</number>
    </property>
    <item row="0" column="0">
@@ -70,16 +61,7 @@
           <property name="spacing">
            <number>7</number>
           </property>
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
+          <property name="margin">
            <number>0</number>
           </property>
           <item>
@@ -127,16 +109,7 @@
           <property name="spacing">
            <number>7</number>
           </property>
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
+          <property name="margin">
            <number>0</number>
           </property>
           <item>
@@ -177,16 +150,7 @@
           <property name="spacing">
            <number>7</number>
           </property>
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
+          <property name="margin">
            <number>0</number>
           </property>
           <item>
@@ -272,16 +236,7 @@
           <property name="spacing">
            <number>7</number>
           </property>
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
+          <property name="margin">
            <number>0</number>
           </property>
           <item>
@@ -336,16 +291,7 @@
           <property name="spacing">
            <number>7</number>
           </property>
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
+          <property name="margin">
            <number>0</number>
           </property>
           <item>
@@ -386,16 +332,7 @@
           <property name="spacing">
            <number>7</number>
           </property>
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
+          <property name="margin">
            <number>0</number>
           </property>
           <item>

--- a/glue/viewers/scatter/qt/layer_style_editor_scatter.ui
+++ b/glue/viewers/scatter/qt/layer_style_editor_scatter.ui
@@ -588,6 +588,26 @@
        <property name="verticalSpacing">
         <number>5</number>
        </property>
+       <item row="3" column="3" colspan="3">
+        <widget class="QCheckBox" name="bool_vector_hide_arrow">
+         <property name="text">
+          <string>Hide arrow</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="3">
+        <spacer name="verticalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
        <item row="1" column="1">
         <widget class="QCheckBox" name="bool_vector_visible">
          <property name="text">
@@ -608,10 +628,10 @@
          </property>
         </spacer>
        </item>
-       <item row="1" column="4">
+       <item row="1" column="5">
         <widget class="QComboBox" name="combosel_vx_att"/>
        </item>
-       <item row="1" column="5">
+       <item row="1" column="6">
         <spacer name="horizontalSpacer_2">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
@@ -624,11 +644,11 @@
          </property>
         </spacer>
        </item>
-       <item row="2" column="4">
+       <item row="2" column="5">
         <widget class="QComboBox" name="combosel_vy_att"/>
        </item>
-       <item row="2" column="2">
-        <widget class="QLabel" name="label_6">
+       <item row="2" column="3">
+        <widget class="QLabel" name="label_vector_y">
          <property name="font">
           <font>
            <weight>75</weight>
@@ -640,8 +660,8 @@
          </property>
         </widget>
        </item>
-       <item row="1" column="2">
-        <widget class="QLabel" name="label_5">
+       <item row="1" column="3">
+        <widget class="QLabel" name="label_vector_x">
          <property name="font">
           <font>
            <weight>75</weight>
@@ -653,7 +673,7 @@
          </property>
         </widget>
        </item>
-       <item row="0" column="0" colspan="6">
+       <item row="0" column="0" colspan="7">
         <widget class="QLabel" name="label_warning_vector">
          <property name="styleSheet">
           <string notr="true">color: #BB2200</string>
@@ -666,24 +686,30 @@
          </property>
         </widget>
        </item>
-       <item row="4" column="2">
-        <spacer name="verticalSpacer_3">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
+       <item row="1" column="2">
+        <widget class="QComboBox" name="combosel_vector_mode">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
          </property>
-         <property name="sizeHint" stdset="0">
+         <property name="maximumSize">
           <size>
-           <width>20</width>
-           <height>40</height>
+           <width>80</width>
+           <height>16777215</height>
           </size>
          </property>
-        </spacer>
-       </item>
-       <item row="3" column="2" colspan="3">
-        <widget class="QCheckBox" name="bool_vector_hide_arrow">
-         <property name="text">
-          <string>Hide arrow</string>
-         </property>
+         <item>
+          <property name="text">
+           <string>vx/vy</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>ang/length</string>
+          </property>
+         </item>
         </widget>
        </item>
       </layout>

--- a/glue/viewers/scatter/qt/layer_style_editor_scatter.ui
+++ b/glue/viewers/scatter/qt/layer_style_editor_scatter.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>351</width>
+    <width>368</width>
     <height>151</height>
    </rect>
   </property>
@@ -14,13 +14,22 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <property name="margin">
+   <property name="leftMargin">
+    <number>5</number>
+   </property>
+   <property name="topMargin">
+    <number>5</number>
+   </property>
+   <property name="rightMargin">
+    <number>5</number>
+   </property>
+   <property name="bottomMargin">
     <number>5</number>
    </property>
    <item row="0" column="0">
     <widget class="QTabWidget" name="tab_widget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>3</number>
      </property>
      <widget class="QWidget" name="tab_2">
       <attribute name="title">
@@ -61,7 +70,16 @@
           <property name="spacing">
            <number>7</number>
           </property>
-          <property name="margin">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
            <number>0</number>
           </property>
           <item>
@@ -109,7 +127,16 @@
           <property name="spacing">
            <number>7</number>
           </property>
-          <property name="margin">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
            <number>0</number>
           </property>
           <item>
@@ -150,7 +177,16 @@
           <property name="spacing">
            <number>7</number>
           </property>
-          <property name="margin">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
            <number>0</number>
           </property>
           <item>
@@ -236,7 +272,16 @@
           <property name="spacing">
            <number>7</number>
           </property>
-          <property name="margin">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
            <number>0</number>
           </property>
           <item>
@@ -291,7 +336,16 @@
           <property name="spacing">
            <number>7</number>
           </property>
-          <property name="margin">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
            <number>0</number>
           </property>
           <item>
@@ -332,7 +386,16 @@
           <property name="spacing">
            <number>7</number>
           </property>
-          <property name="margin">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
            <number>0</number>
           </property>
           <item>
@@ -501,6 +564,88 @@
         </widget>
        </item>
       </layout>
+     </widget>
+     <widget class="QWidget" name="tab_3">
+      <attribute name="title">
+       <string>Vector</string>
+      </attribute>
+      <widget class="QComboBox" name="combosel_vy_att">
+       <property name="geometry">
+        <rect>
+         <x>150</x>
+         <y>53</y>
+         <width>104</width>
+         <height>26</height>
+        </rect>
+       </property>
+      </widget>
+      <widget class="QLabel" name="label_warning_errorbar_2">
+       <property name="geometry">
+        <rect>
+         <x>12</x>
+         <y>9</y>
+         <width>328</width>
+         <height>16</height>
+        </rect>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">color: #BB2200</string>
+       </property>
+       <property name="text">
+        <string>Warning: rendering may be slow if you show vectors</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+      <widget class="QLabel" name="label_7">
+       <property name="geometry">
+        <rect>
+         <x>102</x>
+         <y>55</y>
+         <width>31</width>
+         <height>20</height>
+        </rect>
+       </property>
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>vy:</string>
+       </property>
+      </widget>
+      <widget class="QComboBox" name="combosel_vx_att">
+       <property name="geometry">
+        <rect>
+         <x>150</x>
+         <y>28</y>
+         <width>104</width>
+         <height>26</height>
+        </rect>
+       </property>
+      </widget>
+      <widget class="QLabel" name="label_8">
+       <property name="geometry">
+        <rect>
+         <x>102</x>
+         <y>30</y>
+         <width>31</width>
+         <height>20</height>
+        </rect>
+       </property>
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>vx:</string>
+       </property>
+      </widget>
      </widget>
     </widget>
    </item>

--- a/glue/viewers/scatter/qt/layer_style_editor_scatter.ui
+++ b/glue/viewers/scatter/qt/layer_style_editor_scatter.ui
@@ -572,18 +572,18 @@
       <widget class="QComboBox" name="combosel_vy_att">
        <property name="geometry">
         <rect>
-         <x>150</x>
-         <y>53</y>
+         <x>120</x>
+         <y>40</y>
          <width>104</width>
          <height>26</height>
         </rect>
        </property>
       </widget>
-      <widget class="QLabel" name="label_warning_errorbar_2">
+      <widget class="QLabel" name="label_warning_vector">
        <property name="geometry">
         <rect>
          <x>12</x>
-         <y>9</y>
+         <y>0</y>
          <width>328</width>
          <height>16</height>
         </rect>
@@ -601,8 +601,8 @@
       <widget class="QLabel" name="label_7">
        <property name="geometry">
         <rect>
-         <x>102</x>
-         <y>55</y>
+         <x>90</x>
+         <y>37</y>
          <width>31</width>
          <height>20</height>
         </rect>
@@ -620,8 +620,8 @@
       <widget class="QComboBox" name="combosel_vx_att">
        <property name="geometry">
         <rect>
-         <x>150</x>
-         <y>28</y>
+         <x>120</x>
+         <y>15</y>
          <width>104</width>
          <height>26</height>
         </rect>
@@ -630,8 +630,8 @@
       <widget class="QLabel" name="label_8">
        <property name="geometry">
         <rect>
-         <x>102</x>
-         <y>30</y>
+         <x>90</x>
+         <y>17</y>
          <width>31</width>
          <height>20</height>
         </rect>
@@ -644,6 +644,19 @@
        </property>
        <property name="text">
         <string>vx:</string>
+       </property>
+      </widget>
+      <widget class="QCheckBox" name="bool_vector_visible">
+       <property name="geometry">
+        <rect>
+         <x>60</x>
+         <y>27</y>
+         <width>19</width>
+         <height>18</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string/>
        </property>
       </widget>
      </widget>

--- a/glue/viewers/scatter/qt/layer_style_editor_scatter.ui
+++ b/glue/viewers/scatter/qt/layer_style_editor_scatter.ui
@@ -569,96 +569,124 @@
       <attribute name="title">
        <string>Vector</string>
       </attribute>
-      <widget class="QComboBox" name="combosel_vy_att">
-       <property name="geometry">
-        <rect>
-         <x>120</x>
-         <y>40</y>
-         <width>104</width>
-         <height>26</height>
-        </rect>
+      <layout class="QGridLayout" name="gridLayout_2">
+       <property name="leftMargin">
+        <number>12</number>
        </property>
-      </widget>
-      <widget class="QLabel" name="label_warning_vector">
-       <property name="geometry">
-        <rect>
-         <x>12</x>
-         <y>0</y>
-         <width>328</width>
-         <height>16</height>
-        </rect>
+       <property name="topMargin">
+        <number>3</number>
        </property>
-       <property name="styleSheet">
-        <string notr="true">color: #BB2200</string>
+       <property name="rightMargin">
+        <number>12</number>
        </property>
-       <property name="text">
-        <string>Warning: rendering may be slow if you show vectors</string>
+       <property name="bottomMargin">
+        <number>3</number>
        </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
+       <property name="horizontalSpacing">
+        <number>10</number>
        </property>
-      </widget>
-      <widget class="QLabel" name="label_7">
-       <property name="geometry">
-        <rect>
-         <x>90</x>
-         <y>37</y>
-         <width>31</width>
-         <height>20</height>
-        </rect>
+       <property name="verticalSpacing">
+        <number>5</number>
        </property>
-       <property name="font">
-        <font>
-         <weight>75</weight>
-         <bold>true</bold>
-        </font>
-       </property>
-       <property name="text">
-        <string>vy:</string>
-       </property>
-      </widget>
-      <widget class="QComboBox" name="combosel_vx_att">
-       <property name="geometry">
-        <rect>
-         <x>120</x>
-         <y>15</y>
-         <width>104</width>
-         <height>26</height>
-        </rect>
-       </property>
-      </widget>
-      <widget class="QLabel" name="label_8">
-       <property name="geometry">
-        <rect>
-         <x>90</x>
-         <y>17</y>
-         <width>31</width>
-         <height>20</height>
-        </rect>
-       </property>
-       <property name="font">
-        <font>
-         <weight>75</weight>
-         <bold>true</bold>
-        </font>
-       </property>
-       <property name="text">
-        <string>vx:</string>
-       </property>
-      </widget>
-      <widget class="QCheckBox" name="bool_vector_visible">
-       <property name="geometry">
-        <rect>
-         <x>60</x>
-         <y>27</y>
-         <width>19</width>
-         <height>18</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
+       <item row="1" column="1">
+        <widget class="QCheckBox" name="bool_vector_visible">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="1" column="4">
+        <widget class="QComboBox" name="combosel_vx_att"/>
+       </item>
+       <item row="1" column="5">
+        <spacer name="horizontalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="2" column="4">
+        <widget class="QComboBox" name="combosel_vy_att"/>
+       </item>
+       <item row="2" column="2">
+        <widget class="QLabel" name="label_6">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>vy:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="2">
+        <widget class="QLabel" name="label_5">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>vx:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0" colspan="6">
+        <widget class="QLabel" name="label_warning_vector">
+         <property name="styleSheet">
+          <string notr="true">color: #BB2200</string>
+         </property>
+         <property name="text">
+          <string>Warning: rendering may be slow if you show vectors</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="2">
+        <spacer name="verticalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="3" column="2" colspan="3">
+        <widget class="QCheckBox" name="bool_vector_hide_arrow">
+         <property name="text">
+          <string>Hide arrow</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </widget>
     </widget>
    </item>

--- a/glue/viewers/scatter/qt/layer_style_editor_scatter.ui
+++ b/glue/viewers/scatter/qt/layer_style_editor_scatter.ui
@@ -707,9 +707,6 @@
        </item>
        <item row="3" column="5">
         <widget class="QComboBox" name="combosel_origin_pos">
-         <property name="currentText">
-          <string>Mid</string>
-         </property>
          <item>
           <property name="text">
            <string>Mid</string>

--- a/glue/viewers/scatter/state.py
+++ b/glue/viewers/scatter/state.py
@@ -150,6 +150,7 @@ class ScatterLayerState(MatplotlibLayerState):
     vy_att = DDSCProperty(docstring="The attribute to use for the y vector arrow")
     vector_visible = DDCProperty(False, docstring="Whether to show vector plot")
     vector_hide_arrow = DDCProperty(False, docstring="Whether to hide vector arrow")
+    vector_mode = DDSCProperty(docstring="Which attribute to use for plotting vectors")
 
     # Line plot layer
 
@@ -192,6 +193,7 @@ class ScatterLayerState(MatplotlibLayerState):
         ScatterLayerState.style.set_choices(self, ['Scatter', 'Line'])
         ScatterLayerState.cmap_mode.set_choices(self, ['Fixed', 'Linear'])
         ScatterLayerState.size_mode.set_choices(self, ['Fixed', 'Linear'])
+        ScatterLayerState.vector_mode.set_choices(self, ['vx/vy', 'ang/length'])
 
         linestyle_display = {'solid': '–––––––',
                              'dashed': '– – – – –',

--- a/glue/viewers/scatter/state.py
+++ b/glue/viewers/scatter/state.py
@@ -149,6 +149,7 @@ class ScatterLayerState(MatplotlibLayerState):
     vx_att = DDSCProperty(docstring="The attribute to use for the x vector arrow")
     vy_att = DDSCProperty(docstring="The attribute to use for the y vector arrow")
     vector_visible = DDCProperty(False, docstring="Whether to show vector plot")
+    vector_hide_arrow = DDCProperty(False, docstring="Whether to hide vector arrow")
 
     # Line plot layer
 

--- a/glue/viewers/scatter/state.py
+++ b/glue/viewers/scatter/state.py
@@ -149,8 +149,9 @@ class ScatterLayerState(MatplotlibLayerState):
     vx_att = DDSCProperty(docstring="The attribute to use for the x vector arrow")
     vy_att = DDSCProperty(docstring="The attribute to use for the y vector arrow")
     vector_visible = DDCProperty(False, docstring="Whether to show vector plot")
-    vector_hide_arrow = DDCProperty(False, docstring="Whether to hide vector arrow")
+    vector_show_arrow = DDCProperty(False, docstring="Whether to show vector arrow")
     vector_mode = DDSCProperty(docstring="Which attribute to use for plotting vectors")
+    origin_pos = DDSCProperty(docstring="The attribute to use for the arrow position")
 
     # Line plot layer
 
@@ -193,7 +194,8 @@ class ScatterLayerState(MatplotlibLayerState):
         ScatterLayerState.style.set_choices(self, ['Scatter', 'Line'])
         ScatterLayerState.cmap_mode.set_choices(self, ['Fixed', 'Linear'])
         ScatterLayerState.size_mode.set_choices(self, ['Fixed', 'Linear'])
-        ScatterLayerState.vector_mode.set_choices(self, ['vx/vy', 'ang/length'])
+        ScatterLayerState.vector_mode.set_choices(self, ['Cartesian', 'Polarization'])
+        ScatterLayerState.origin_pos.set_choices(self, ['mid', 'tail', 'middle', 'tip'])
 
         linestyle_display = {'solid': '–––––––',
                              'dashed': '– – – – –',

--- a/glue/viewers/scatter/state.py
+++ b/glue/viewers/scatter/state.py
@@ -146,6 +146,8 @@ class ScatterLayerState(MatplotlibLayerState):
     xerr_att = DDSCProperty(docstring="The attribute to use for the x error bars")
     yerr_att = DDSCProperty(docstring="The attribute to use for the y error bars")
 
+    vx_att = DDSCProperty(docstring="The attribute to use for the x vector arrow")
+    vy_att = DDSCProperty(docstring="The attribute to use for the y vector arrow")
     # Line plot layer
 
     linewidth = DDCProperty(1, docstring="The line width")
@@ -176,6 +178,13 @@ class ScatterLayerState(MatplotlibLayerState):
 
         self.yerr_att_helper = ComponentIDComboHelper(self, 'yerr_att',
                                                       numeric=True, categorical=False)
+
+        self.vx_att_helper = ComponentIDComboHelper(self, 'vx_att',
+                                                      numeric=True, categorical=False)
+
+        self.vy_att_helper = ComponentIDComboHelper(self, 'vy_att',
+                                                      numeric=True, categorical=False)
+
 
         ScatterLayerState.style.set_choices(self, ['Scatter', 'Line'])
         ScatterLayerState.cmap_mode.set_choices(self, ['Fixed', 'Linear'])
@@ -218,6 +227,13 @@ class ScatterLayerState(MatplotlibLayerState):
             else:
                 self.xerr_att_helper.set_multiple_data([self.layer])
                 self.yerr_att_helper.set_multiple_data([self.layer])
+
+            if self.layer is None:
+                self.vx_att_helper.set_multiple_data([])
+                self.vy_att_helper.set_multiple_data([])
+            else:
+                self.vx_att_helper.set_multiple_data([self.layer])
+                self.vy_att_helper.set_multiple_data([self.layer])
 
     def flip_cmap(self):
         """

--- a/glue/viewers/scatter/state.py
+++ b/glue/viewers/scatter/state.py
@@ -148,6 +148,8 @@ class ScatterLayerState(MatplotlibLayerState):
 
     vx_att = DDSCProperty(docstring="The attribute to use for the x vector arrow")
     vy_att = DDSCProperty(docstring="The attribute to use for the y vector arrow")
+    vector_visible = DDCProperty(False, docstring="Whether to show vector plot")
+
     # Line plot layer
 
     linewidth = DDCProperty(1, docstring="The line width")


### PR DESCRIPTION
As shown below, vx and vy are arrow vectors, the arrow dimensions (except for length) are measured in multiples of the square root of x square plus y square, ref to [matplotlib_quiver](https://matplotlib.org/devdocs/api/_as_gen/matplotlib.axes.Axes.quiver.html) definition.

![photo_2017-10-01_16-23-25](https://user-images.githubusercontent.com/13411839/31058638-e01f7798-a6c4-11e7-8375-4683b2429195.jpg)