### PR TITLE
Implement on-the-fly reprojection

### DIFF
--- a/glue/viewers/image/layer_artist.py
+++ b/glue/viewers/image/layer_artist.py
@@ -73,32 +73,9 @@ class BaseImageLayerArtist(MatplotlibLayerArtist, HubListener):
             self.enable()
             return
 
-        # Check whether the pixel component IDs of the dataset are equivalent
-        # to that of the reference dataset. In future this is where we could
-        # allow for these to be different and implement reprojection.
-        if self.layer.ndim != self._viewer_state.reference_data.ndim:
-            self._compatible_with_reference_data = False
-            self.disable('Data dimensions do not match reference data')
-            return
-
-        # Determine whether pixel component IDs are equivalent
-
-        pids = self.layer.pixel_component_ids
-        pids_ref = self._viewer_state.reference_data.pixel_component_ids
-
-        if isinstance(self.layer, Data):
-            data = self.layer
-        else:
-            data = self.layer.data
-
-        for i in range(data.ndim):
-            if not is_equivalent_cid(data, pids[i], pids_ref[i]):
-                self._compatible_with_reference_data = False
-                self.disable('Pixel component IDs do not match. You can try '
-                             'fixing this by linking the pixel component IDs '
-                             'of this dataset with those of the reference '
-                             'dataset.')
-                return
+        # TEMP: for now just assume we are compatible, then need to reimplement
+        # this check based on any coordinate links, not necessarily exact
+        # equivalence of pixel coordinates.
 
         self._compatible_with_reference_data = True
         self.enable()
@@ -282,7 +259,7 @@ class ImageSubsetArray(object):
         x_axis = self.viewer_state.x_att.axis
         y_axis = self.viewer_state.y_att.axis
 
-        full_shape = self.layer_state.layer.shape
+        full_shape = self.viewer_state.reference_data.shape
 
         return full_shape[y_axis], full_shape[x_axis]
 

--- a/glue/viewers/image/layer_artist.py
+++ b/glue/viewers/image/layer_artist.py
@@ -270,6 +270,9 @@ class ImageSubsetArray(object):
                 self.viewer_state is None):
             return None
 
+        if not self.layer_artist.visible:
+            return self.nan_array
+
         if not self.layer_artist._compatible_with_reference_data:
             return None
 

--- a/glue/viewers/image/python_export.py
+++ b/glue/viewers/image/python_export.py
@@ -3,7 +3,7 @@ from glue.viewers.common.python_export import code, serialize_options
 
 def python_export_image_layer(layer, *args):
 
-    if not layer.enabled or not layer.visible or not layer._compatible_with_reference_data:
+    if not layer.enabled or not layer.visible:
         return [], None
 
     script = ""
@@ -45,7 +45,7 @@ def python_export_image_layer(layer, *args):
 
 def python_export_image_subset_layer(layer, *args):
 
-    if not layer.enabled or not layer.visible or not layer._compatible_with_reference_data:
+    if not layer.enabled or not layer.visible:
         return [], None
 
     script = ""

--- a/glue/viewers/image/qt/tests/test_data_viewer.py
+++ b/glue/viewers/image/qt/tests/test_data_viewer.py
@@ -634,7 +634,7 @@ class TestImageViewer(object):
         self.viewer.add_data(self.hypercube)
         self.viewer.state.reference_data = self.hypercube
 
-        assert self.viewer.layers[1].subset_array.shape is None
+        assert self.viewer.layers[1].subset_array.shape == (4, 5)
         assert self.viewer.layers[3].subset_array.shape == (4, 5)
 
     def test_preserve_slice(self):

--- a/glue/viewers/image/state.py
+++ b/glue/viewers/image/state.py
@@ -370,7 +370,7 @@ class BaseImageLayerState(MatplotlibLayerState):
             return image[view]
 
     def _get_reprojected_image(self, view=None):
-        if self.layer is self.viewer_state.reference_data:
+        if self.layer.data is self.viewer_state.reference_data:
             # Also if pixel coordinates are the same
             return self._get_image(view=view)
         else:

--- a/glue/viewers/image/state.py
+++ b/glue/viewers/image/state.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function
 from collections import defaultdict
 
 import numpy as np
-from scipy.ndimage import map_coordinates
 
 from glue.core import Data
 from glue.config import colormaps

--- a/glue/viewers/image/state.py
+++ b/glue/viewers/image/state.py
@@ -344,7 +344,7 @@ class BaseImageLayerState(MatplotlibLayerState):
 
             view_applied = False
 
-        image = self._get_image(view=full_view)
+        image = self._get_reprojected_image(view=full_view)
 
         # Apply aggregation functions if needed
 
@@ -368,6 +368,32 @@ class BaseImageLayerState(MatplotlibLayerState):
             return image
         else:
             return image[view]
+
+    def _get_reprojected_image(self, view=None):
+        if self.layer is self.viewer_state.reference_data:
+            # Also if pixel coordinates are the same
+            return self._get_image(view=view)
+        else:
+            pixel_coords = [self.viewer_state.reference_data[pix, view]
+                            for pix in self.layer.pixel_component_ids]
+            coords = np.array([p.ravel() for p in pixel_coords])
+            # Now prepare a view that we can use to get the value to interpolate
+            # since we want to avoid having to access the full array of values
+            interp_view = []
+            for icoord, coord in enumerate(coords):
+                cmin, cmax = coord.min(), coord.max()
+                nmax = self.layer.shape[icoord]
+                # TODO: figure out exact thresholds to use here
+                if cmin > nmax or cmax < 0:
+                    return np.ones(pixel_coords[0].shape) * np.nan
+                cmin = max(0, cmin)
+                cmax = min(nmax, cmax)
+                interp_view.append(slice(int(cmin), int(np.ceil(cmax))))
+                coord -= cmin
+            original = self._get_image(view=interp_view).astype(float)
+            # order=3 (default) doesn't work if there are NaN values
+            result = map_coordinates(original, coords, cval=np.nan, order=0)
+            return result.reshape(pixel_coords[0].shape)
 
     def _get_image(self, view=None):
         raise NotImplementedError()
@@ -462,30 +488,7 @@ class ImageLayerState(BaseImageLayerState):
             self._sync_alpha.disable_syncing()
 
     def _get_image(self, view=None):
-        if self.layer is self.viewer_state.reference_data:
-            # Also if pixel coordinates are the same
-            return self.layer[self.attribute, view]
-        else:
-            pixel_coords = [self.viewer_state.reference_data[pix, view]
-                            for pix in self.layer.pixel_component_ids]
-            coords = np.array([p.ravel() for p in pixel_coords])
-            # Now prepare a view that we can use to get the value to interpolate
-            # since we want to avoid having to access the full array of values
-            interp_view = []
-            for icoord, coord in enumerate(coords):
-                cmin, cmax = coord.min(), coord.max()
-                nmax = self.layer.shape[icoord]
-                # TODO: figure out exact thresholds to use here
-                if cmin > nmax or cmax < 0:
-                    return np.ones(pixel_coords[0].shape) * np.nan
-                cmin = max(0, cmin)
-                cmax = min(nmax, cmax)
-                interp_view.append(slice(int(cmin), int(np.ceil(cmax))))
-                coord -= cmin
-            original = self.layer[self.attribute, interp_view].astype(float)
-            # order=3 (default) doesn't work if there are NaN values
-            result = map_coordinates(original, coords, cval=np.nan, order=1)
-            return result.reshape(pixel_coords[0].shape)
+        return self.layer[self.attribute, view]
 
     def flip_limits(self):
         """
@@ -508,12 +511,4 @@ class ImageSubsetLayerState(BaseImageLayerState):
     # different image datasets since the footprint should be the same.
 
     def _get_image(self, view=None):
-        if self.layer.data is self.viewer_state.reference_data:
-            # Also if pixel coordinates are the same
-            return self.layer.to_mask(view=view)
-        else:
-            pixel_coords = [self.viewer_state.reference_data[pix, view]
-                            for pix in self.layer.pixel_component_ids]
-            coords = np.array([p.ravel() for p in pixel_coords])
-            result = map_coordinates(self.layer.to_mask().astype(float), coords, cval=0., order=0)
-            return result.reshape(pixel_coords[0].shape)
+        return self.layer.to_mask(view=view)

--- a/glue/viewers/image/tests/test_state.py
+++ b/glue/viewers/image/tests/test_state.py
@@ -1,7 +1,11 @@
+import pytest
+
 import numpy as np
 from numpy.testing import assert_equal
 
-from glue.core import Data
+from glue.core import Data, DataCollection
+from glue.core.link_helpers import LinkSame
+from glue.core.exceptions import IncompatibleDataException, IncompatibleAttribute
 
 from ..state import ImageViewerState, ImageLayerState, AggregateSlice
 
@@ -54,6 +58,7 @@ class TestImageViewerState(object):
         assert self.state.y_att_world is w2
         assert self.state.x_att is p1
         assert self.state.x_att_world is w1
+
 
 class TestSlicingAggregation():
 
@@ -109,3 +114,139 @@ class TestSlicingAggregation():
         result = self.layer_state.get_sliced_data()
         assert result.shape == (7, 5)
         assert_equal(result, 3)  # sum along 3 indices in one of the dimensions
+
+
+class TestReprojection():
+
+    def setup_method(self, method):
+
+        self.data_collection = DataCollection()
+
+        self.array = np.arange(3024).reshape((6, 7, 8, 9))
+
+        # The reference dataset. Shape is (6, 7, 8, 9).
+        self.data1 = Data(x=self.array)
+        self.data_collection.append(self.data1)
+
+        # A dataset with the same shape but not linked. Shape is (6, 7, 8, 9).
+        self.data2 = Data(x=self.array)
+        self.data_collection.append(self.data2)
+
+        # A dataset with the same number of dimesnions but in a different
+        # order, linked to the first. Shape is (9, 7, 6, 8).
+        self.data3 = Data(x=np.moveaxis(self.array, (3, 1, 0, 2), (0, 1, 2, 3)))
+        self.data_collection.append(self.data3)
+        self.data_collection.add_link(LinkSame(self.data1.pixel_component_ids[0],
+                                               self.data3.pixel_component_ids[2]))
+        self.data_collection.add_link(LinkSame(self.data1.pixel_component_ids[1],
+                                               self.data3.pixel_component_ids[1]))
+        self.data_collection.add_link(LinkSame(self.data1.pixel_component_ids[2],
+                                               self.data3.pixel_component_ids[3]))
+        self.data_collection.add_link(LinkSame(self.data1.pixel_component_ids[3],
+                                               self.data3.pixel_component_ids[0]))
+
+        # A dataset with fewer dimensions, linked to the first one. Shape is
+        # (8, 7, 6)
+        self.data4 = Data(x=self.array[:, :, :, 0].transpose())
+        self.data_collection.append(self.data4)
+        self.data_collection.add_link(LinkSame(self.data1.pixel_component_ids[0],
+                                               self.data4.pixel_component_ids[2]))
+        self.data_collection.add_link(LinkSame(self.data1.pixel_component_ids[1],
+                                               self.data4.pixel_component_ids[1]))
+        self.data_collection.add_link(LinkSame(self.data1.pixel_component_ids[2],
+                                               self.data4.pixel_component_ids[0]))
+
+        # A dataset with even fewer dimensions, linked to the first one. Shape
+        # is (8, 6)
+        self.data5 = Data(x=self.array[:, 0, :, 0].transpose())
+        self.data_collection.append(self.data5)
+        self.data_collection.add_link(LinkSame(self.data1.pixel_component_ids[0],
+                                               self.data5.pixel_component_ids[1]))
+        self.data_collection.add_link(LinkSame(self.data1.pixel_component_ids[2],
+                                               self.data5.pixel_component_ids[0]))
+
+        self.viewer_state = ImageViewerState()
+        self.viewer_state.layers.append(ImageLayerState(viewer_state=self.viewer_state, layer=self.data1))
+        self.viewer_state.layers.append(ImageLayerState(viewer_state=self.viewer_state, layer=self.data2))
+        self.viewer_state.layers.append(ImageLayerState(viewer_state=self.viewer_state, layer=self.data3))
+        self.viewer_state.layers.append(ImageLayerState(viewer_state=self.viewer_state, layer=self.data4))
+        self.viewer_state.layers.append(ImageLayerState(viewer_state=self.viewer_state, layer=self.data5))
+
+        self.viewer_state.reference_data = self.data1
+
+    def test_default_axis_order(self):
+
+        # Start off with a combination of x/y that means that only one of the
+        # other datasets will be matched.
+
+        self.viewer_state.x_att = self.data1.pixel_component_ids[3]
+        self.viewer_state.y_att = self.data1.pixel_component_ids[2]
+        self.viewer_state.slices = (3, 2, 4, 1)
+
+        image = self.viewer_state.layers[0].get_sliced_data()
+        assert_equal(image, self.array[3, 2, :, :])
+
+        with pytest.raises(IncompatibleAttribute):
+            self.viewer_state.layers[1].get_sliced_data()
+
+        image = self.viewer_state.layers[2].get_sliced_data()
+        assert_equal(image, self.array[3, 2, :, :])
+
+        with pytest.raises(IncompatibleDataException):
+            self.viewer_state.layers[3].get_sliced_data()
+
+        with pytest.raises(IncompatibleDataException):
+            self.viewer_state.layers[4].get_sliced_data()
+
+    def test_transpose_axis_order(self):
+
+        # Next make it so the x/y axes correspond to the dimensions with length
+        # 6 and 8 which most datasets will be compatible with, and this also
+        # requires a tranposition.
+
+        self.viewer_state.x_att = self.data1.pixel_component_ids[0]
+        self.viewer_state.y_att = self.data1.pixel_component_ids[2]
+        self.viewer_state.slices = (3, 2, 4, 1)
+
+        image = self.viewer_state.layers[0].get_sliced_data()
+        print(image.shape)
+        assert_equal(image, self.array[:, 2, :, 1].transpose())
+
+        with pytest.raises(IncompatibleAttribute):
+            self.viewer_state.layers[1].get_sliced_data()
+
+        image = self.viewer_state.layers[2].get_sliced_data()
+        print(image.shape)
+        assert_equal(image, self.array[:, 2, :, 1].transpose())
+
+        image = self.viewer_state.layers[3].get_sliced_data()
+        assert_equal(image, self.array[:, 2, :, 0].transpose())
+
+        image = self.viewer_state.layers[4].get_sliced_data()
+        assert_equal(image, self.array[:, 0, :, 0].transpose())
+
+    def test_transpose_axis_order_view(self):
+
+        # As for the previous test, but this time with a view applied
+
+        self.viewer_state.x_att = self.data1.pixel_component_ids[0]
+        self.viewer_state.y_att = self.data1.pixel_component_ids[2]
+        self.viewer_state.slices = (3, 2, 4, 1)
+
+        view = [slice(1, None, 2), slice(None, None, 3)]
+
+        image = self.viewer_state.layers[0].get_sliced_data(view=view)
+        assert_equal(image, self.array[::3, 2, 1::2, 1].transpose())
+
+        with pytest.raises(IncompatibleAttribute):
+            self.viewer_state.layers[1].get_sliced_data(view=view)
+
+        image = self.viewer_state.layers[2].get_sliced_data(view=view)
+        print(image.shape)
+        assert_equal(image, self.array[::3, 2, 1::2, 1].transpose())
+
+        image = self.viewer_state.layers[3].get_sliced_data(view=view)
+        assert_equal(image, self.array[::3, 2, 1::2, 0].transpose())
+
+        image = self.viewer_state.layers[4].get_sliced_data(view=view)
+        assert_equal(image, self.array[::3, 0, 1::2, 0].transpose())


### PR DESCRIPTION
With this PR, if datasets are linked by world coordinates, they can be over-plotted in the image viewer. This is still a work in progress.

Things to do:

* [x] Improve the efficiency of the ``map_coordinates`` calls by figuring out the min/max of the coordinates and only getting that range of values from the attribute to interpolate
* [x] Add back support for quick rendering if the pixel coordinates are linked
* [x] Re-implement the _update_compatibility method to properly indicate that datasets are compatible if pixel or world coordinates are linked [note: might not actually be needed?]
* [x] Add tests - this is going to be super important, especially for the lined up but out of order pixel axes
* [ ] Figure out how to reproject to the full view of the axes, not just the footprint of the existing data. This might be a bit harder and we could potentially postpone to another PR?