### PR TITLE
Improve plugin loading

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -165,6 +165,7 @@ install:
       pip uninstall --yes qtpy || true;
       find . -name "qt" -type d -exec rm -r {} \; || true;
       rm glue/external/qt.py || true;
+      sed -i.bak 's/in REQUIRED_PLUGINS/in REQUIRED_PLUGINS and False/' glue/main.py || true;
     fi
 
   # Set MPLBACKEND to Agg by default - this will get overriden if Qt is present,

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: c
 
-os:
-    - linux
-    - osx
-
 sudo: false
 
 addons:
@@ -15,9 +11,6 @@ notifications:
   email: false
 
 env:
-  matrix:
-    - PYTHON_VERSION=2.7
-    - PYTHON_VERSION=3.6
   global:
     # We add astropy-ci-extras to have the latest version of Astropy with older Numpy versions.
     - CONDA_CHANNELS="astropy-ci-extras astropy glueviz"
@@ -36,6 +29,10 @@ env:
     - AWS_ACCESS_KEY_ID: AKIAI2ERWDHLW3W24X3A
     - AWS_SECRET_ACCESS_KEY: $AWS_SECRET_KEY_ID
 
+stages:
+    - name: Initial
+    - name: Full
+
 matrix:
 
     # Don't wait for allowed failures
@@ -43,19 +40,38 @@ matrix:
 
     include:
 
+        - os: linux
+          stage: Initial
+          PYTHON_VERSION=2.7
+
+        - os: linux
+          stage: Initial
+          PYTHON_VERSION=3.6
+
+        - os: osx
+          stage: Full
+          PYTHON_VERSION=2.7
+
+        - os: osx
+          stage: Full
+          PYTHON_VERSION=3.6
+
         # Astropy dev
         - os: linux
+          stage: Full
           env: PYTHON_VERSION=3.6
                ASTROPY_VERSION=dev
 
         # Numpy dev
         - os: linux
+          stage: Full
           env: PYTHON_VERSION=3.6
                NUMPY_VERSION=dev
 
         # The following configuration tests that glue functions with minimal
         # dependencies.
         - os: linux
+          stage: Full
           env: PYTHON_VERSION=3.6
                PYTEST_ARGS="--cov glue"
                CONDA_DEPENDENCIES="pip setuptools pandas mock matplotlib qtpy ipython ipykernel qtconsole mpl-scatter-density"
@@ -63,6 +79,7 @@ matrix:
                REMOVE_INSTALL_REQUIRES=1
 
         - os: linux
+          stage: Full
           env: PYTHON_VERSION=3.6
                DOC_TRIGGER=1
                PYTEST_ARGS="--cov glue --no-optional-skip"
@@ -71,6 +88,7 @@ matrix:
         # Test with older package versions:
 
         - os: linux
+          stage: Full
           env: PYTHON_VERSION=2.7
                MATPLOTLIB_VERSION=1.5
                NUMPY_VERSION=1.11
@@ -82,6 +100,7 @@ matrix:
         # Test with PySide, but due to segmentation faults, mark as an
         # allowed failure.
         - os: linux
+          stage: Full
           env: PYTHON_VERSION=2.7
                QT_PKG=pyside
 
@@ -89,6 +108,7 @@ matrix:
         # sub-directories to be removed, to make sure that no non-Qt code has
         # any dependence on Qt code.
         - os: linux
+          stage: Full
           env: PYTHON_VERSION=3.6
                QT_PKG=False
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,19 +42,19 @@ matrix:
 
         - os: linux
           stage: Initial
-          PYTHON_VERSION=2.7
+          env: PYTHON_VERSION=2.7
 
         - os: linux
           stage: Initial
-          PYTHON_VERSION=3.6
+          env: PYTHON_VERSION=3.6
 
         - os: osx
           stage: Full
-          PYTHON_VERSION=2.7
+          env: PYTHON_VERSION=2.7
 
         - os: osx
           stage: Full
-          PYTHON_VERSION=3.6
+          env: PYTHON_VERSION=3.6
 
         # Astropy dev
         - os: linux

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,9 @@ v0.12.4 (unreleased)
 * Fixed a bug that caused errors when removing items from a selection
   property linked to a QComboBox.
 
+* Improve plugin loading to be less sensitive to exact versions of
+  installed dependencies for plugins.
+
 v0.12.3 (2017-11-14)
 --------------------
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,9 @@ environment:
       - PYTHON_VERSION: "3.5"
       - PYTHON_VERSION: "3.6"
 
+matrix:
+    fast_finish: true
+
 platform:
     -x64
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts=-p no:logging


### PR DESCRIPTION
Import entry point manually instead of using .load() to bypass strict requirement check which causes issues for users for unimportant dependencies. For example, a common error type would be:

```
INFO:glue:Loading plugin fits_format failed (Exception: (pytest 2.6.0 (/Users/tom/miniconda3/envs/py27/lib/python2.7/site-packages), Requirement.parse('pytest>=2.8'), set(['astropy'])))
```

whereas importing astropy directly would work, so users would be confused. This often indicates an environment in which there may be conda and pip versions of packages. In most cases it's safer to just proceed and not check the versions of all the requirements of requirements, as this is what would happen anyway if importing e.g. astropy directly.