### PR TITLE
Fix error related to weakref if creating a viewer failed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,9 @@ v0.13.0 (unreleased)
 v0.12.4 (unreleased)
 --------------------
 
+* Fixed a bug that caused an error in the terminal if creating a data
+  viewer failed properly (with a GUI error message).
+
 * Improve plugin loading to be less sensitive to exact versions of
   installed dependencies for plugins. [#1487]
 

--- a/glue/core/command.py
+++ b/glue/core/command.py
@@ -214,9 +214,10 @@ class NewDataViewer(Command):
     label = 'new data viewer'
 
     def do(self, session):
-        v = session.application.new_data_viewer(self.viewer, self.data)
-        self.created = weakref.ref(v)
-        return v
+        viewer = session.application.new_data_viewer(self.viewer, self.data)
+        if viewer is not None:
+            self.created = weakref.ref(viewer)
+        return viewer
 
     def undo(self, session):
         created = self.created()

--- a/glue/core/tests/test_command.py
+++ b/glue/core/tests/test_command.py
@@ -113,8 +113,7 @@ class TestCommandStack(object):
         cmd = c.NewDataViewer(viewer=None, data=None)
         v = self.stack.do(cmd)
 
-        self.session.application.new_data_viewer.assert_called_once_with(
-            None, None)
+        self.session.application.new_data_viewer.assert_called_once_with(None, None)
 
         self.stack.undo()
         v.close.assert_called_once_with(warn=False)


### PR DESCRIPTION
This fixes the following exception:

```
Traceback (most recent call last):
  File "/Users/tom/Dropbox/Code/Glue/glue/glue/app/qt/mdi_area.py", line 61, in dropEvent
    new_layer(layer)
  File "/Users/tom/Dropbox/Code/Glue/glue/glue/app/qt/mdi_area.py", line 51, in new_layer
    self._application.choose_new_data_viewer(layer)
  File "/Users/tom/Dropbox/Code/Glue/glue/glue/app/qt/application.py", line 849, in choose_new_data_viewer
    return self.do(cmd)
  File "/Users/tom/Dropbox/Code/Glue/glue/glue/core/application_base.py", line 218, in do
    return self._cmds.do(command)
  File "/Users/tom/Dropbox/Code/Glue/glue/glue/core/command.py", line 127, in do
    result = cmd.do(self._session)
  File "/Users/tom/Dropbox/Code/Glue/glue/glue/core/command.py", line 218, in do
    self.created = weakref.ref(v)
TypeError: cannot create weak reference to 'NoneType' object
```

if e.g. trying to initialize a 3D volume viewer with a 1D dataset, which causes a GUI error and makes ``add_data`` return ``False``.