### PR TITLE
Add support for datetime64 dtype

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,9 @@ v0.13.0 (unreleased)
 
 * Added new messages ``DataReorderComponentMessage`` and
   ``DataRenameComponentMessage`` which can be subscribed to. [#1479]
+
+* Add support for the datetime64 dtype in Data objects, and adjust
+  Matplotlib viewers to correctly show this data. [#1510]
   
 * Make it possible to reorder components in ``Data`` using the new
   ``Data.reorder_components`` method. [#1479]

--- a/glue/core/component.py
+++ b/glue/core/component.py
@@ -704,15 +704,16 @@ class CategoricalComponent(Component):
 
 
 class DateTimeComponent(Component):
+    """
+    A component representing a date/time.
+
+    Parameters
+    ----------
+    data : `~numpy.ndarray`
+        The data to store, with `~numpy.datetime64` dtype
+    """
 
     def __init__(self, data, units=None):
-        """
-        :param data: The data to store
-        :type data: :class:`numpy.ndarray`
-
-        :param units: Optional unit label
-        :type units: str
-        """
 
         self.units = units
 

--- a/glue/core/component.py
+++ b/glue/core/component.py
@@ -714,7 +714,11 @@ class DateTimeComponent(Component):
         if not isinstance(data, np.ndarray) or data.dtype.kind != 'M':
             raise TypeError("DateTimeComponent should be initialized with a datetim64 Numpy array")
 
-        self._data = datetime64_to_mpl(data)
+        self._data = data
+
+    @property
+    def numeric(self):
+        return True
 
     @property
     def date(self):

--- a/glue/core/component.py
+++ b/glue/core/component.py
@@ -711,6 +711,8 @@ class DateTimeComponent(Component):
         :type units: str
         """
 
+        self.units = units
+
         if not isinstance(data, np.ndarray) or data.dtype.kind != 'M':
             raise TypeError("DateTimeComponent should be initialized with a datetim64 Numpy array")
 

--- a/glue/core/component.py
+++ b/glue/core/component.py
@@ -110,7 +110,10 @@ class Component(object):
         return False
 
     @property
-    def date(self):
+    def datetime(self):
+        """
+        Whether or not or not the datatype is a date/time
+        """
         return False
 
     def __str__(self):
@@ -723,5 +726,5 @@ class DateTimeComponent(Component):
         return True
 
     @property
-    def date(self):
+    def datetime(self):
         return True

--- a/glue/core/roi.py
+++ b/glue/core/roi.py
@@ -89,13 +89,19 @@ class Roi(object):  # pragma: no cover
     def to_polygon(self):
         """ Returns a tuple of x and y points, approximating the ROI
         as a polygon."""
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def copy(self):
         """
         Return a clone of the ROI
         """
         return copy.copy(self)
+
+    def transformed(self, xfunc=None, yfunc=None):
+        """
+        A transformed version of the ROI
+        """
+        raise NotImplementedError()
 
 
 class PointROI(Roi):
@@ -190,6 +196,7 @@ class RectangularROI(Roi):
             A list of True/False values, for whether each (x,y)
             point falls within the ROI
         """
+
         if not self.defined():
             raise UndefinedROI
 
@@ -219,10 +226,17 @@ class RectangularROI(Roi):
 
     def to_polygon(self):
         if self.defined():
-            return [self.xmin, self.xmax, self.xmax, self.xmin, self.xmin], \
-                [self.ymin, self.ymin, self.ymax, self.ymax, self.ymin]
+            return (np.array([self.xmin, self.xmax, self.xmax, self.xmin, self.xmin]),
+                    np.array([self.ymin, self.ymin, self.ymax, self.ymax, self.ymin]))
         else:
             return [], []
+
+    def transformed(self, xfunc=None, yfunc=None):
+        xmin = self.xmin if xfunc is None else xfunc(self.xmin)
+        xmax = self.xmax if xfunc is None else xfunc(self.xmax)
+        ymin = self.ymin if yfunc is None else yfunc(self.ymin)
+        ymax = self.ymax if yfunc is None else yfunc(self.ymax)
+        return RectangularROI(xmin=xmin, xmax=xmax, ymin=ymin, ymax=ymax)
 
     def __gluestate__(self, context):
         return dict(xmin=self.xmin, xmax=self.xmax, ymin=self.ymin, ymax=self.ymax)
@@ -281,6 +295,15 @@ class RangeROI(Roi):
 
         coord = x if self.ori == 'x' else y
         return (coord > self.min) & (coord < self.max)
+
+    def transformed(self, xfunc=None, yfunc=None):
+        if self.ori == 'x':
+            vmin = self.min if xfunc is None else xfunc(self.min)
+            vmax = self.max if xfunc is None else xfunc(self.max)
+        else:
+            vmin = self.min if yfunc is None else yfunc(self.min)
+            vmax = self.max if yfunc is None else yfunc(self.max)
+        return RangeROI(orientation=self.ori, min=vmin, max=vmax)
 
     def reset(self):
         self.min = None
@@ -418,6 +441,11 @@ class VertexROIBase(Roi):
             self.vx = []
         if self.vy is None:
             self.vy = []
+
+    def transformed(self, xfunc=None, yfunc=None):
+        vx = self.vx if xfunc is None else xfunc(np.asarray(self.vx))
+        vy = self.vy if yfunc is None else yfunc(np.asarray(self.vy))
+        return self.__class__(vx=vx, vy=vy)
 
     def add_point(self, x, y):
         """

--- a/glue/core/roi.py
+++ b/glue/core/roi.py
@@ -239,7 +239,10 @@ class RectangularROI(Roi):
         return RectangularROI(xmin=xmin, xmax=xmax, ymin=ymin, ymax=ymax)
 
     def __gluestate__(self, context):
-        return dict(xmin=self.xmin, xmax=self.xmax, ymin=self.ymin, ymax=self.ymax)
+        return dict(xmin=context.id(self.xmin),
+                    xmax=context.id(self.xmax),
+                    ymin=context.id(self.ymin),
+                    ymax=context.id(self.ymax))
 
     @classmethod
     def __setgluestate__(cls, rec, context):
@@ -322,7 +325,7 @@ class RangeROI(Roi):
             return [], []
 
     def __gluestate__(self, context):
-        return dict(ori=self.ori, min=self.min, max=self.max)
+        return dict(ori=self.ori, min=context.id(self.min), max=context.id(self.max))
 
     @classmethod
     def __setgluestate__(cls, rec, context):
@@ -421,7 +424,9 @@ class CircularROI(Roi):
         return PolygonalROI(*self.to_polygon()).transformed(xfunc=xfunc, yfunc=yfunc)
 
     def __gluestate__(self, context):
-        return dict(xc=self.xc, yc=self.yc, radius=self.radius)
+        return dict(xc=context.id(self.xc),
+                    yc=context.id(self.yc),
+                    radius=context.id(self.radius))
 
     @classmethod
     def __setgluestate__(cls, rec, context):
@@ -505,12 +510,13 @@ class VertexROIBase(Roi):
         return self.vx, self.vy
 
     def __gluestate__(self, context):
-        return dict(vx=np.asarray(self.vx).tolist(),
-                    vy=np.asarray(self.vy).tolist())
+        return dict(vx=context.id(np.asarray(self.vx)),
+                    vy=context.id(np.asarray(self.vy)))
 
     @classmethod
     def __setgluestate__(cls, rec, context):
-        return cls(vx=rec['vx'], vy=rec['vy'])
+        return cls(vx=context.object(rec['vx']),
+                   vy=context.object(rec['vy']))
 
 
 class PolygonalROI(VertexROIBase):

--- a/glue/core/roi.py
+++ b/glue/core/roi.py
@@ -417,6 +417,9 @@ class CircularROI(Roi):
         y = self.yc + self.radius * np.sin(theta)
         return x, y
 
+    def transformed(self, xfunc=None, yfunc=None):
+        return PolygonalROI(*self.to_polygon()).transformed(xfunc=xfunc, yfunc=yfunc)
+
     def __gluestate__(self, context):
         return dict(xc=self.xc, yc=self.yc, radius=self.radius)
 

--- a/glue/core/roi.py
+++ b/glue/core/roi.py
@@ -239,10 +239,10 @@ class RectangularROI(Roi):
         return RectangularROI(xmin=xmin, xmax=xmax, ymin=ymin, ymax=ymax)
 
     def __gluestate__(self, context):
-        return dict(xmin=context.id(self.xmin),
-                    xmax=context.id(self.xmax),
-                    ymin=context.id(self.ymin),
-                    ymax=context.id(self.ymax))
+        return dict(xmin=context.do(self.xmin),
+                    xmax=context.do(self.xmax),
+                    ymin=context.do(self.ymin),
+                    ymax=context.do(self.ymax))
 
     @classmethod
     def __setgluestate__(cls, rec, context):
@@ -325,7 +325,7 @@ class RangeROI(Roi):
             return [], []
 
     def __gluestate__(self, context):
-        return dict(ori=self.ori, min=context.id(self.min), max=context.id(self.max))
+        return dict(ori=self.ori, min=context.do(self.min), max=context.do(self.max))
 
     @classmethod
     def __setgluestate__(cls, rec, context):
@@ -424,9 +424,9 @@ class CircularROI(Roi):
         return PolygonalROI(*self.to_polygon()).transformed(xfunc=xfunc, yfunc=yfunc)
 
     def __gluestate__(self, context):
-        return dict(xc=context.id(self.xc),
-                    yc=context.id(self.yc),
-                    radius=context.id(self.radius))
+        return dict(xc=context.do(self.xc),
+                    yc=context.do(self.yc),
+                    radius=context.do(self.radius))
 
     @classmethod
     def __setgluestate__(cls, rec, context):
@@ -510,8 +510,8 @@ class VertexROIBase(Roi):
         return self.vx, self.vy
 
     def __gluestate__(self, context):
-        return dict(vx=context.id(np.asarray(self.vx)),
-                    vy=context.id(np.asarray(self.vy)))
+        return dict(vx=context.do(np.asarray(self.vx)),
+                    vy=context.do(np.asarray(self.vy)))
 
     @classmethod
     def __setgluestate__(cls, rec, context):

--- a/glue/core/state.py
+++ b/glue/core/state.py
@@ -516,12 +516,16 @@ def _load_subset_state(rec, context):
 
 @saver(RangeSubsetState)
 def _save_range_subset_state(state, context):
-    return dict(lo=state.lo, hi=state.hi, att=context.id(state.att))
+    return dict(lo=context.id(state.lo),
+                hi=context.id(state.hi),
+                att=context.id(state.att))
 
 
 @loader(RangeSubsetState)
 def _load_range_subset_state(rec, context):
-    return RangeSubsetState(rec['lo'], rec['hi'], context.object(rec['att']))
+    return RangeSubsetState(context.object(rec['lo']),
+                            context.object(rec['hi']),
+                            context.object(rec['att']))
 
 
 @saver(RoiSubsetState)

--- a/glue/core/state.py
+++ b/glue/core/state.py
@@ -91,7 +91,7 @@ if six.PY2:
     literals += (long,)
 
 
-literals += np.ScalarType
+literals += tuple(s for s in np.ScalarType if s not in (np.datetime64, np.timedelta64))
 
 
 
@@ -818,8 +818,10 @@ def _load_component(rec, context):
     if 'log' in rec:
         return context.object(rec['log']).component(rec['log_item'])
 
-    return Component(data=context.object(rec['data']),
-                     units=rec['units'])
+    cls = lookup_class_with_patches(rec['_type'])
+
+    return cls(data=context.object(rec['data']),
+               units=rec['units'])
 
 
 @saver(CategoricalComponent)
@@ -945,10 +947,22 @@ def _save_numpy(obj, context):
     data = b64encode(f.getvalue()).decode('ascii')
     return dict(data=data)
 
+
 @saver(Colormap)
 def _save_cmap(cmap, context):
-    return {'cmap':cmap.name}
+    return {'cmap': cmap.name}
+
 
 @loader(Colormap)
 def _load_cmap(rec, context):
     return cm.get_cmap(rec['cmap'])
+
+
+@saver(np.datetime64)
+def _save_datetime64(dt, context):
+    return {'datetime64': str(dt)}
+
+
+@loader(np.datetime64)
+def _load_datetime64(rec, context):
+    return np.datetime64(rec['datetime64'])

--- a/glue/core/state_objects.py
+++ b/glue/core/state_objects.py
@@ -323,23 +323,34 @@ class StateAttributeLimitsHelper(StateAttributeCacheHelper):
             if data_values.size > self.percentile_subset:
                 data_values = np.random.choice(data_values.ravel(), self.percentile_subset)
 
-            if log:
-                data_values = data_values[data_values > 0]
-                if len(data_values) == 0:
-                    self.set(lower=0.1, upper=1, percentile=percentile, log=log)
-                    return
+            if percentile == 100:
 
-            try:
-                lower = np.nanpercentile(data_values, exclude)
-                upper = np.nanpercentile(data_values, 100 - exclude)
-            except AttributeError:  # Numpy < 1.9
-                data_values = data_values[~np.isnan(data_values)]
-                lower = np.percentile(data_values, exclude)
-                upper = np.percentile(data_values, 100 - exclude)
+                if data_values.dtype.kind == 'M':
+                    lower = data_values.min()
+                    upper = data_values.max()
+                else:
+                    lower = np.nanmin(data_values)
+                    upper = np.nanmax(data_values)
 
-            if self.data_component.categorical:
-                lower = np.floor(lower - 0.5) + 0.5
-                upper = np.ceil(upper + 0.5) - 0.5
+            else:
+
+                if log:
+                    data_values = data_values[data_values > 0]
+                    if len(data_values) == 0:
+                        self.set(lower=0.1, upper=1, percentile=percentile, log=log)
+                        return
+
+                try:
+                    lower = np.nanpercentile(data_values, exclude)
+                    upper = np.nanpercentile(data_values, 100 - exclude)
+                except AttributeError:  # Numpy < 1.9
+                    data_values = data_values[~np.isnan(data_values)]
+                    lower = np.percentile(data_values, exclude)
+                    upper = np.percentile(data_values, 100 - exclude)
+
+                if self.data_component.categorical:
+                    lower = np.floor(lower - 0.5) + 0.5
+                    upper = np.ceil(upper + 0.5) - 0.5
 
             self.set(lower=lower, upper=upper, percentile=percentile, log=log)
 

--- a/glue/core/state_objects.py
+++ b/glue/core/state_objects.py
@@ -348,9 +348,9 @@ class StateAttributeLimitsHelper(StateAttributeCacheHelper):
                     lower = np.percentile(data_values, exclude)
                     upper = np.percentile(data_values, 100 - exclude)
 
-                if self.data_component.categorical:
-                    lower = np.floor(lower - 0.5) + 0.5
-                    upper = np.ceil(upper + 0.5) - 0.5
+            if self.data_component.categorical:
+                lower = np.floor(lower - 0.5) + 0.5
+                upper = np.ceil(upper + 0.5) - 0.5
 
             self.set(lower=lower, upper=upper, percentile=percentile, log=log)
 

--- a/glue/core/state_objects.py
+++ b/glue/core/state_objects.py
@@ -453,8 +453,13 @@ class StateAttributeHistogramHelper(StateAttributeCacheHelper):
                     n_bin = self._common_n_bin
 
                 values = self.data_values
-                lower = np.nanmin(values)
-                upper = np.nanmax(values)
+
+                if comp.datetime:
+                    lower = values.min()
+                    upper = values.max()
+                else:
+                    lower = np.nanmin(values)
+                    upper = np.nanmax(values)
 
             self.set(lower=lower, upper=upper, n_bin=n_bin)
 

--- a/glue/core/state_objects.py
+++ b/glue/core/state_objects.py
@@ -323,6 +323,12 @@ class StateAttributeLimitsHelper(StateAttributeCacheHelper):
             if data_values.size > self.percentile_subset:
                 data_values = np.random.choice(data_values.ravel(), self.percentile_subset)
 
+            if log:
+                data_values = data_values[data_values > 0]
+                if len(data_values) == 0:
+                    self.set(lower=0.1, upper=1, percentile=percentile, log=log)
+                    return
+
             if percentile == 100:
 
                 if data_values.dtype.kind == 'M':
@@ -333,12 +339,6 @@ class StateAttributeLimitsHelper(StateAttributeCacheHelper):
                     upper = np.nanmax(data_values)
 
             else:
-
-                if log:
-                    data_values = data_values[data_values > 0]
-                    if len(data_values) == 0:
-                        self.set(lower=0.1, upper=1, percentile=percentile, log=log)
-                        return
 
                 try:
                     lower = np.nanpercentile(data_values, exclude)

--- a/glue/core/tests/test_data.py
+++ b/glue/core/tests/test_data.py
@@ -728,3 +728,10 @@ def test_parent_preserved_session():
 
     assert dc2[1].id['w'].parent.label == 'test2'
     assert dc2[1].id['v'].parent.label == 'test2'
+
+
+def test_preserve_datetime():
+    # Make sure that we recognize and preserve the Numpy datetime64 format
+    dates = np.array([1, 2, 3], dtype='M8[D]')
+    data = Data(dates=dates)
+    assert data['dates'].dtype.name == 'datetime64[D]'

--- a/glue/core/tests/test_data.py
+++ b/glue/core/tests/test_data.py
@@ -9,7 +9,7 @@ from mock import MagicMock
 from glue.external import six
 from glue import core
 
-from ..component import Component, DerivedComponent, CategoricalComponent
+from ..component import Component, DerivedComponent, CategoricalComponent, DateTimeComponent
 from ..component_id import ComponentID
 from ..component_link import ComponentLink
 from ..coordinates import Coordinates
@@ -734,4 +734,4 @@ def test_preserve_datetime():
     # Make sure that we recognize and preserve the Numpy datetime64 format
     dates = np.array([1, 2, 3], dtype='M8[D]')
     data = Data(dates=dates)
-    assert data['dates'].dtype.name == 'datetime64[D]'
+    assert isinstance(data.get_component('dates'), DateTimeComponent)

--- a/glue/core/tests/test_state.py
+++ b/glue/core/tests/test_state.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from glue.external import six
 from glue import core
-from glue.core.component import CategoricalComponent
+from glue.core.component import CategoricalComponent, DateTimeComponent
 from glue.tests.helpers import requires_astropy, make_file
 
 from ..data_factories import load_data
@@ -241,6 +241,14 @@ def test_categorical_component():
     np.testing.assert_array_equal(c.codes, [0, 1, 2, 0, 1])
     np.testing.assert_array_equal(c.labels, ['a','b','c','a','b'])
     np.testing.assert_array_equal(c.categories, ['a','b','c'])
+
+
+def test_datetime_component():
+    c = DateTimeComponent(np.array([100, 200, 300], dtype='M8[D]'))
+    c2 = clone(c)
+    assert isinstance(c2, DateTimeComponent)
+    np.testing.assert_array_equal(c.data, c2.data)
+    assert isinstance(c2.data[0], np.datetime64)
 
 
 class DummyClass(object):

--- a/glue/core/tests/test_state.py
+++ b/glue/core/tests/test_state.py
@@ -5,6 +5,7 @@ from io import BytesIO
 
 import pytest
 import numpy as np
+from numpy.testing import assert_equal
 
 from glue.external import six
 from glue import core
@@ -225,8 +226,8 @@ def test_polygonal_roi():
     roi.add_point(0, 1)
     roi.add_point(1, 0)
     r2 = clone(roi)
-    assert r2.vx == [0, 0, 1]
-    assert r2.vy == [0, 1, 0]
+    assert_equal(r2.vx, [0, 0, 1])
+    assert_equal(r2.vy, [0, 1, 0])
 
 
 def test_matplotlib_cmap():

--- a/glue/core/tests/test_state_objects.py
+++ b/glue/core/tests/test_state_objects.py
@@ -408,5 +408,4 @@ def test_state_serialization_datetime64():
 
     state2 = clone(state1)
 
-    print(state2.a)
     assert state2.a == np.datetime64(100, 'D')

--- a/glue/core/tests/test_state_objects.py
+++ b/glue/core/tests/test_state_objects.py
@@ -369,7 +369,6 @@ def test_histogram_helper_common_n_bin_active():
     assert state.n_bin == 11
 
 
-
 def test_limits_helper_initial_values():
 
     # Regression test for a bug that occurred if the limits cache was empty
@@ -396,3 +395,18 @@ def test_limits_helper_initial_values():
 
     assert helper.lower == 1
     assert helper.upper == 2
+
+
+class DatetimeState(State):
+    a = CallbackProperty()
+
+
+def test_state_serialization_datetime64():
+
+    state1 = DatetimeState()
+    state1.a = np.datetime64(100, 'D')
+
+    state2 = clone(state1)
+
+    print(state2.a)
+    assert state2.a == np.datetime64(100, 'D')

--- a/glue/core/util.py
+++ b/glue/core/util.py
@@ -355,7 +355,7 @@ def update_ticks(axes, coord, components, is_log):
         raise TypeError("coord must be one of x,y")
 
     is_cat = any(comp.categorical for comp in components)
-    is_date = any(comp.date for comp in components)
+    is_date = any(comp.datetime for comp in components)
 
     if is_date:
         loc = AutoDateLocator()

--- a/glue/core/util.py
+++ b/glue/core/util.py
@@ -11,6 +11,7 @@ import pandas as pd
 from matplotlib.ticker import AutoLocator, MaxNLocator, LogLocator
 from matplotlib.ticker import (LogFormatterMathtext, ScalarFormatter,
                                FuncFormatter)
+from matplotlib.dates import AutoDateLocator, AutoDateFormatter
 
 __all__ = ["relim", "split_component_view", "join_component_view",
            "facet_subsets", "colorize_subsets", "disambiguate",
@@ -354,7 +355,14 @@ def update_ticks(axes, coord, components, is_log):
         raise TypeError("coord must be one of x,y")
 
     is_cat = all(comp.categorical for comp in components)
-    if is_log:
+    is_date = all(comp.date for comp in components)
+
+    if is_date:
+        loc = AutoDateLocator(maxticks=5)
+        fmt = AutoDateFormatter(loc)
+        axis.set_major_locator(loc)
+        axis.set_major_formatter(fmt)
+    elif is_log:
         axis.set_major_locator(LogLocator())
         axis.set_major_formatter(LogFormatterMathtext())
     elif is_cat:

--- a/glue/core/util.py
+++ b/glue/core/util.py
@@ -354,11 +354,11 @@ def update_ticks(axes, coord, components, is_log):
     else:
         raise TypeError("coord must be one of x,y")
 
-    is_cat = all(comp.categorical for comp in components)
-    is_date = all(comp.date for comp in components)
+    is_cat = any(comp.categorical for comp in components)
+    is_date = any(comp.date for comp in components)
 
     if is_date:
-        loc = AutoDateLocator(maxticks=5)
+        loc = AutoDateLocator()
         fmt = AutoDateFormatter(loc)
         axis.set_major_locator(loc)
         axis.set_major_formatter(fmt)

--- a/glue/external/echo/qt/connect.py
+++ b/glue/external/echo/qt/connect.py
@@ -9,6 +9,8 @@ from functools import partial
 from qtpy import QtGui
 from qtpy.QtCore import Qt
 
+import numpy as np
+
 from ..core import add_callback
 from ..selection import SelectionCallbackProperty, ChoiceSeparator
 
@@ -176,14 +178,21 @@ def connect_float_text(instance, prop, widget, fmt="{:g}"):
         format_func = fmt
     else:
         def format_func(x):
-            return fmt.format(x)
+            try:
+                return fmt.format(x)
+            except ValueError:
+                return str(x)
 
     def update_prop():
         val = widget.text()
         try:
-            setattr(instance, prop, float(val))
+            val = float(val)
         except ValueError:
-            setattr(instance, prop, 0)
+            try:
+                val = np.datetime64(val)
+            except Exception:
+                val = 0
+        setattr(instance, prop, val)
 
     def update_widget(val):
         if val is None:

--- a/glue/utils/array.py
+++ b/glue/utils/array.py
@@ -107,10 +107,16 @@ def coerce_numeric(arr):
     arr : `numpy.ndarray`
         The array to coerce
     """
-    # already numeric type
+
+    # Already numeric type
     if np.issubdtype(arr.dtype, np.number):
         return arr
 
+    # Numpy datetime64 format
+    if np.issubdtype(arr.dtype, np.datetime64):
+        return arr
+
+    # Convert booleans to integers
     if np.issubdtype(arr.dtype, np.bool_):
         return arr.astype(np.int)
 

--- a/glue/utils/geometry.py
+++ b/glue/utils/geometry.py
@@ -9,6 +9,14 @@ __all__ = ['points_inside_poly', 'polygon_line_intersections']
 
 def points_inside_poly(x, y, vx, vy):
 
+    if x.dtype.kind == 'M' and vx.dtype.kind == 'M':
+        vx = vx.astype(x.dtype).astype(float)
+        x = x.astype(float)
+
+    if y.dtype.kind == 'M' and vy.dtype.kind == 'M':
+        vy = vy.astype(y.dtype).astype(float)
+        y = y.astype(float)
+
     original_shape = x.shape
 
     x = unbroadcast(x)

--- a/glue/utils/matplotlib.py
+++ b/glue/utils/matplotlib.py
@@ -415,11 +415,11 @@ def datetime64_to_mpl(d):
 
 def mpl_to_datetime64(dt):
 
-    dt = np.asarray(dt, float)
+    dt = np.asarray(dt, np.float64)
 
     dt = (dt - 1.0) * SEC_PER_DAY
-    dt_s = dt.astype(int) + T0.astype(int)
-    dt_ns = ((dt % 1) * 1e9).astype(int)
+    dt_s = dt.astype(np.int64) + T0.astype(np.int64)
+    dt_ns = ((dt % 1) * 1e9).astype(np.int64)
 
     dt_s = np.array(dt_s, dtype='datetime64[s]')
     dt_ns = np.array(dt_ns, dtype='timedelta64[ns]')

--- a/glue/utils/matplotlib.py
+++ b/glue/utils/matplotlib.py
@@ -415,6 +415,8 @@ def datetime64_to_mpl(d):
 
 def mpl_to_datetime64(dt):
 
+    dt = np.asarray(dt, float)
+
     dt = (dt - 1.0) * SEC_PER_DAY
     dt_s = dt.astype(int) + T0.astype(int)
     dt_ns = ((dt % 1) * 1e9).astype(int)

--- a/glue/utils/tests/test_matplotlib.py
+++ b/glue/utils/tests/test_matplotlib.py
@@ -15,7 +15,8 @@ from glue.utils.misc import DeferredMethod
 
 from ..matplotlib import (point_contour, fast_limits, all_artists, new_artists,
                           remove_artists, view_cascade, get_extent, color2rgb,
-                          defer_draw, freeze_margins)
+                          defer_draw, freeze_margins, datetime64_to_mpl,
+                          mpl_to_datetime64)
 
 
 @requires_scipy
@@ -175,3 +176,10 @@ def test_freeze_margins():
     np.testing.assert_allclose(bbox.y0, 0.25)
     np.testing.assert_allclose(bbox.x1, 0.875)
     np.testing.assert_allclose(bbox.y1, 0.5)
+
+
+def test_mpl_datetime64():
+    # Make sure the mpl <-> datetime64 conversion round-trips
+    mpl1 = 719313
+    mpl2 = datetime64_to_mpl(mpl_to_datetime64(mpl1))
+    assert mpl1 == mpl2

--- a/glue/viewers/histogram/layer_artist.py
+++ b/glue/viewers/histogram/layer_artist.py
@@ -50,8 +50,12 @@ class HistogramLayerArtist(MatplotlibLayerArtist):
         else:
             self.enable()
 
-        x = x[~np.isnan(x) & (x >= self._viewer_state.hist_x_min) &
-                             (x <= self._viewer_state.hist_x_max)]
+        keep = (x >= self._viewer_state.hist_x_min) & (x <= self._viewer_state.hist_x_max)
+
+        if x.dtype.kind != 'M':
+            keep &= ~np.isnan(x)
+
+        x = x[keep]
 
         if len(x) == 0:
             self.redraw()

--- a/glue/viewers/histogram/qt/data_viewer.py
+++ b/glue/viewers/histogram/qt/data_viewer.py
@@ -1,10 +1,9 @@
 from __future__ import absolute_import, division, print_function
 
 from glue.viewers.matplotlib.qt.toolbar import MatplotlibViewerToolbar
-from glue.core.edit_subset_mode import EditSubsetMode
 from glue.core.util import update_ticks
 from glue.core.roi import RangeROI
-from glue.core import command
+from glue.utils import mpl_to_datetime64
 
 from glue.viewers.matplotlib.qt.data_viewer import MatplotlibDataViewer
 from glue.viewers.histogram.qt.layer_style_editor import HistogramLayerStyleEditor
@@ -58,6 +57,11 @@ class HistogramViewer(MatplotlibDataViewer):
     def _roi_to_subset_state(self, roi):
 
         # TODO Does subset get applied to all data or just visible data?
+
+        x_date = any(comp.datetime for comp in self.state._get_x_components())
+
+        if x_date:
+            roi = roi.transformed(xfunc=mpl_to_datetime64 if x_date else None)
 
         bins = self.state.bins
 

--- a/glue/viewers/histogram/qt/options_widget.py
+++ b/glue/viewers/histogram/qt/options_widget.py
@@ -29,7 +29,7 @@ class HistogramOptionsWidget(QtWidgets.QWidget):
 
     def _update_attribute(self, *args):
         # If at least one of the components is categorical or a date, disable log button
-        log_enabled = not any(comp.categorical or comp.date for comp in self.viewer_state._get_x_components())
+        log_enabled = not any(comp.categorical or comp.datetime for comp in self.viewer_state._get_x_components())
         self.ui.bool_x_log.setEnabled(log_enabled)
         self.ui.bool_x_log_.setEnabled(log_enabled)
         if not log_enabled:

--- a/glue/viewers/histogram/qt/options_widget.py
+++ b/glue/viewers/histogram/qt/options_widget.py
@@ -28,8 +28,8 @@ class HistogramOptionsWidget(QtWidgets.QWidget):
         viewer_state.add_callback('x_att', self._update_attribute)
 
     def _update_attribute(self, *args):
-        # If at least one of the components is categorical, disable log button
-        log_enabled = not any(comp.categorical for comp in self.viewer_state._get_x_components())
+        # If at least one of the components is categorical or a date, disable log button
+        log_enabled = not any(comp.categorical or comp.date for comp in self.viewer_state._get_x_components())
         self.ui.bool_x_log.setEnabled(log_enabled)
         self.ui.bool_x_log_.setEnabled(log_enabled)
         if not log_enabled:

--- a/glue/viewers/histogram/state.py
+++ b/glue/viewers/histogram/state.py
@@ -150,6 +150,10 @@ class HistogramViewerState(MatplotlibDataViewerState):
             return np.logspace(np.log10(self.hist_x_min),
                                np.log10(self.hist_x_max),
                                self.hist_n_bin + 1)
+        elif isinstance(self.hist_x_min, np.datetime64):
+            x_min = self.hist_x_min.astype(int)
+            x_max = self.hist_x_max.astype(self.hist_x_min.dtype).astype(int)
+            return np.linspace(x_min, x_max, self.hist_n_bin + 1).astype(self.hist_x_min.dtype)
         else:
             return np.linspace(self.hist_x_min, self.hist_x_max,
                                self.hist_n_bin + 1)

--- a/glue/viewers/matplotlib/qt/data_viewer.py
+++ b/glue/viewers/matplotlib/qt/data_viewer.py
@@ -1,10 +1,12 @@
 from __future__ import absolute_import, division, print_function
 
+import numpy as np
+
 from glue.viewers.common.qt.data_viewer_with_state import DataViewerWithState
 from glue.viewers.matplotlib.qt.widget import MplWidget
 from glue.viewers.common.viz_client import init_mpl, update_appearance_from_settings
 from glue.external.echo import delay_callback
-from glue.utils import defer_draw
+from glue.utils import defer_draw, mpl_to_datetime64
 from glue.utils.decorators import avoid_circular
 from glue.viewers.matplotlib.qt.toolbar import MatplotlibViewerToolbar
 from glue.viewers.matplotlib.state import MatplotlibDataViewerState
@@ -73,9 +75,22 @@ class MatplotlibDataViewer(DataViewerWithState):
 
     @avoid_circular
     def limits_from_mpl(self, *args):
+
         with delay_callback(self.state, 'x_min', 'x_max', 'y_min', 'y_max'):
-            self.state.x_min, self.state.x_max = self.axes.get_xlim()
-            self.state.y_min, self.state.y_max = self.axes.get_ylim()
+
+            if isinstance(self.state.x_min, np.datetime64):
+                x_min, x_max = [mpl_to_datetime64(x) for x in self.axes.get_xlim()]
+            else:
+                x_min, x_max = self.axes.get_xlim()
+
+            self.state.x_min, self.state.x_max = x_min, x_max
+
+            if isinstance(self.state.y_min, np.datetime64):
+                y_min, y_max = [mpl_to_datetime64(y) for y in self.axes.get_ylim()]
+            else:
+                y_min, y_max = self.axes.get_ylim()
+
+            self.state.y_min, self.state.y_max = y_min, y_max
 
     @avoid_circular
     def limits_to_mpl(self, *args):

--- a/glue/viewers/matplotlib/qt/data_viewer.py
+++ b/glue/viewers/matplotlib/qt/data_viewer.py
@@ -115,6 +115,7 @@ class MatplotlibDataViewer(DataViewerWithState):
             # And propagate any changes back to the state since we have the
             # @avoid_circular decorator
             with delay_callback(self.state, 'x_min', 'x_max', 'y_min', 'y_max'):
+                # TODO: fix case with datetime64 here
                 self.state.x_min, self.state.x_max = self.axes.get_xlim()
                 self.state.y_min, self.state.y_max = self.axes.get_ylim()
 

--- a/glue/viewers/scatter/qt/data_viewer.py
+++ b/glue/viewers/scatter/qt/data_viewer.py
@@ -1,10 +1,9 @@
 from __future__ import absolute_import, division, print_function
 
-from glue.core import command
 from glue.viewers.matplotlib.qt.toolbar import MatplotlibViewerToolbar
-from glue.core.edit_subset_mode import EditSubsetMode
 from glue.core.util import update_ticks
 
+from glue.utils import mpl_to_datetime64
 from glue.viewers.matplotlib.qt.data_viewer import MatplotlibDataViewer
 from glue.viewers.scatter.qt.layer_style_editor import ScatterLayerStyleEditor
 from glue.viewers.scatter.layer_artist import ScatterLayerArtist
@@ -64,6 +63,13 @@ class ScatterViewer(MatplotlibDataViewer):
     # TODO: move some of the ROI stuff to state class?
 
     def _roi_to_subset_state(self, roi):
+
+        x_date = any(comp.date for comp in self.state._get_x_components())
+        y_date = any(comp.date for comp in self.state._get_y_components())
+
+        if x_date or y_date:
+            roi = roi.transformed(xfunc=mpl_to_datetime64 if x_date else None,
+                                  yfunc=mpl_to_datetime64 if y_date else None)
 
         x_comp = self.state.x_att.parent.get_component(self.state.x_att)
         y_comp = self.state.y_att.parent.get_component(self.state.y_att)

--- a/glue/viewers/scatter/qt/data_viewer.py
+++ b/glue/viewers/scatter/qt/data_viewer.py
@@ -64,8 +64,8 @@ class ScatterViewer(MatplotlibDataViewer):
 
     def _roi_to_subset_state(self, roi):
 
-        x_date = any(comp.date for comp in self.state._get_x_components())
-        y_date = any(comp.date for comp in self.state._get_y_components())
+        x_date = any(comp.datetime for comp in self.state._get_x_components())
+        y_date = any(comp.datetime for comp in self.state._get_y_components())
 
         if x_date or y_date:
             roi = roi.transformed(xfunc=mpl_to_datetime64 if x_date else None,

--- a/glue/viewers/scatter/qt/options_widget.py
+++ b/glue/viewers/scatter/qt/options_widget.py
@@ -30,7 +30,7 @@ class ScatterOptionsWidget(QtWidgets.QWidget):
 
     def _update_x_attribute(self, *args):
         # If at least one of the components is categorical or a date, disable log button
-        log_enabled = not any(comp.categorical or comp.date for comp in self.viewer_state._get_x_components())
+        log_enabled = not any(comp.categorical or comp.datetime for comp in self.viewer_state._get_x_components())
         self.ui.bool_x_log.setEnabled(log_enabled)
         self.ui.bool_x_log_.setEnabled(log_enabled)
         if not log_enabled:
@@ -39,7 +39,7 @@ class ScatterOptionsWidget(QtWidgets.QWidget):
 
     def _update_y_attribute(self, *args):
         # If at least one of the components is categorical or a date, disable log button
-        log_enabled = not any(comp.categorical or comp.date for comp in self.viewer_state._get_y_components())
+        log_enabled = not any(comp.categorical or comp.datetime for comp in self.viewer_state._get_y_components())
         self.ui.bool_y_log.setEnabled(log_enabled)
         self.ui.bool_y_log_.setEnabled(log_enabled)
         if not log_enabled:

--- a/glue/viewers/scatter/qt/options_widget.py
+++ b/glue/viewers/scatter/qt/options_widget.py
@@ -22,3 +22,26 @@ class ScatterOptionsWidget(QtWidgets.QWidget):
         fix_tab_widget_fontsize(self.ui.tab_widget)
 
         autoconnect_callbacks_to_qt(viewer_state, self.ui)
+
+        self.viewer_state = viewer_state
+
+        viewer_state.add_callback('x_att', self._update_x_attribute)
+        viewer_state.add_callback('y_att', self._update_y_attribute)
+
+    def _update_x_attribute(self, *args):
+        # If at least one of the components is categorical or a date, disable log button
+        log_enabled = not any(comp.categorical or comp.date for comp in self.viewer_state._get_x_components())
+        self.ui.bool_x_log.setEnabled(log_enabled)
+        self.ui.bool_x_log_.setEnabled(log_enabled)
+        if not log_enabled:
+            self.ui.bool_x_log.setChecked(False)
+            self.ui.bool_x_log_.setChecked(False)
+
+    def _update_y_attribute(self, *args):
+        # If at least one of the components is categorical or a date, disable log button
+        log_enabled = not any(comp.categorical or comp.date for comp in self.viewer_state._get_y_components())
+        self.ui.bool_y_log.setEnabled(log_enabled)
+        self.ui.bool_y_log_.setEnabled(log_enabled)
+        if not log_enabled:
+            self.ui.bool_y_log.setChecked(False)
+            self.ui.bool_y_log_.setChecked(False)

--- a/glue/viewers/scatter/qt/tests/test_data_viewer.py
+++ b/glue/viewers/scatter/qt/tests/test_data_viewer.py
@@ -534,3 +534,16 @@ class TestScatterViewer(object):
         roi = CircularROI(xc=719463, yc=719563, radius=200)
         self.viewer.apply_roi(roi)
         assert_equal(self.data.subsets[0].to_mask(), [0, 1, 1, 1])
+
+        # Make sure that the Qt labels look ok
+        self.viewer.state.y_att = self.data.id['y']
+        options = self.viewer.options_widget().ui
+        assert options.valuetext_x_min.text() == '1970-04-11'
+        assert options.valuetext_x_max.text() == '1971-02-05'
+        assert options.valuetext_y_min.text() == '3.2'
+        assert options.valuetext_y_max.text() == '3.5'
+
+        # Make sure that we can set the xmin/xmax to a string date
+        options.valuetext_x_min.setText('1970-04-14')
+        options.valuetext_x_min.editingFinished.emit()
+        assert self.viewer.axes.get_xlim() == (719266.0, 719563.0)

--- a/glue/viewers/scatter/qt/tests/test_data_viewer.py
+++ b/glue/viewers/scatter/qt/tests/test_data_viewer.py
@@ -10,6 +10,7 @@ import numpy as np
 
 from numpy.testing import assert_allclose, assert_equal
 
+from glue.core.edit_subset_mode import EditSubsetMode
 from glue.config import colormaps
 from glue.core.message import SubsetUpdateMessage
 from glue.core import HubListener, Data
@@ -52,9 +53,6 @@ class TestScatterViewer(object):
         self.data_collection.append(self.data_2d)
 
         self.viewer = self.app.new_data_viewer(ScatterViewer)
-
-        self.data_collection.register_to_hub(self.hub)
-        self.viewer.register_to_hub(self.hub)
 
     def teardown_method(self, method):
         self.viewer.close()
@@ -503,7 +501,7 @@ class TestScatterViewer(object):
 
         self.viewer.state.x_att_helper.pixel_coord = False
 
-    def test_datetime64_support(self):
+    def test_datetime64_support(self, tmpdir):
 
         self.data.add_component(np.array([100, 200, 300, 400], dtype='M8[D]'), 't1')
         self.data.add_component(np.array([200, 300, 400, 500], dtype='M8[D]'), 't2')
@@ -531,9 +529,11 @@ class TestScatterViewer(object):
         assert self.viewer.axes.get_ylim() == (719363.0, 719663.0)
 
         # Apply an ROI selection in plotting coordinates
+        edit = EditSubsetMode()
+        edit.edit_subset = []
         roi = CircularROI(xc=719463, yc=719563, radius=200)
         self.viewer.apply_roi(roi)
-        assert_equal(self.data.subsets[0].to_mask(), [0, 1, 1, 1])
+        assert_equal(self.data.subsets[1].to_mask(), [0, 1, 1, 1])
 
         # Make sure that the Qt labels look ok
         self.viewer.state.y_att = self.data.id['y']
@@ -544,6 +544,25 @@ class TestScatterViewer(object):
         assert options.valuetext_y_max.text() == '3.5'
 
         # Make sure that we can set the xmin/xmax to a string date
+        assert_equal(self.viewer.state.x_min, np.datetime64('1970-04-11', 'D'))
         options.valuetext_x_min.setText('1970-04-14')
         options.valuetext_x_min.editingFinished.emit()
         assert self.viewer.axes.get_xlim() == (719266.0, 719563.0)
+        assert_equal(self.viewer.state.x_min, np.datetime64('1970-04-14', 'D'))
+
+        # Make sure that everything works fine after saving/reloading
+        filename = tmpdir.join('test_datetime64.glu').strpath
+        self.session.application.save_session(filename)
+        with open(filename, 'r') as f:
+            session = f.read()
+        state = GlueUnSerializer.loads(session)
+        ga = state.object('__main__')
+        viewer = ga.viewers[0][0]
+        options = viewer.options_widget().ui
+
+        assert_equal(self.viewer.state.x_min, np.datetime64('1970-04-14', 'D'))
+
+        assert options.valuetext_x_min.text() == '1970-04-14'
+        assert options.valuetext_x_max.text() == '1971-02-05'
+        assert options.valuetext_y_min.text() == '3.2'
+        assert options.valuetext_y_max.text() == '3.5'


### PR DESCRIPTION
This adds support for having Numpy datetime64 components in Data objects, and also updates the Matplotlib viewers to properly support this and show date/time labels.

@rsangole - feel free to try out this branch if you are familiar with git! (otherwise this will be available in the developer conda package for glue shortly after this is merged). Just to clarify, this never actually worked properly before - what you saw before was that datetime columns got converted to strings and glue would then show it as a categorical component, but the points were not actually properly spaced in time.

NOTE: selections don't work yet, I'm working on fixing that

Remaining TODOs:

* [x] Add test of making a viewer with datetime data and modifying the xmin/xmax limits
* [x] Add test of saving/reloading session
* [ ] Add documentation about this
* [x] Add changelog entry

Fixes https://github.com/glue-viz/glue/issues/1490