### PR TITLE
Fix minor bug preventing the use of native pytest command

### DIFF
--- a/glue/conftest.py
+++ b/glue/conftest.py
@@ -10,7 +10,7 @@ STDERR_ORIGINAL = sys.stderr
 
 
 def pytest_addoption(parser):
-    parser.addoption("--no-optional-skip", action="store_true",
+    parser.addoption("--no-optional-skip", action="store_true", default=False,
                      help="don't skip any tests with optional dependencies")
 
 


### PR DESCRIPTION
This allows the native `pytest` command to be used to run the test suite. Consequently, it should be easier to run specific test modules and test cases since all native `pytest` command line options are available.

Am I starting to sound like a broken record? 😉 

This isn't included in this changeset, but it might be worth considering using the [pytest-runner](https://pypi.python.org/pypi/pytest-runner) package instead of providing a custom `setuptools` command for testing.