### PR TITLE
Make JSON circular reference errors more explicit

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -63,6 +63,8 @@ v0.12.4 (unreleased)
 * Fixed a bug that caused layers to not always be properly removed
   when deleting a row from the layer list. [#1502]
 
+* Make JSON circular reference errors more explicit. [#1529]
+
 v0.12.3 (2017-11-14)
 --------------------
 

--- a/glue/core/state.py
+++ b/glue/core/state.py
@@ -93,7 +93,7 @@ if six.PY2:
 
 literals += tuple(s for s in np.ScalarType if s not in (np.datetime64, np.timedelta64))
 
-
+JSON_ENCODER = json.JSONEncoder()
 
 # We need to make sure that we don't break backward-compatibility when we move
 # classes/functions around in Glue, so we have a file that maps the old paths to
@@ -377,9 +377,12 @@ class GlueSerializer(object):
         """
         if np.isscalar(o) and isinstance(o, np.generic):
             return np.asscalar(o)  # coerce numpy number to pure-python type
-        if isinstance(o, (tuple, set)):
+        elif isinstance(o, (tuple, set)):
             return list(o)
-        return o
+        else:
+            # Dispatch to JSONEncoder so that we see errors straight away
+            # if an object can't be serialized.
+            return JSON_ENCODER.default(o)
 
     def dumps(self, indent=None):
         result = self.dumpo()

--- a/glue/core/tests/test_state.py
+++ b/glue/core/tests/test_state.py
@@ -257,7 +257,7 @@ def test_no_circular():
 
     with pytest.raises(TypeError) as exc:
         clone(Spam())
-    assert exc.value.args[0] == "Object of type 'Spam' is not JSON serializable"
+    assert "is not JSON serializable" in exc.value.args[0]
 
 
 def test_categorical_component():

--- a/glue/core/tests/test_state.py
+++ b/glue/core/tests/test_state.py
@@ -235,6 +235,31 @@ def test_matplotlib_cmap():
     assert clone(cm.gist_heat) is cm.gist_heat
 
 
+class Spam(object):
+    pass
+
+
+@saver(Spam)
+def _save_spam(spam, context):
+    return {'spam': spam}
+
+
+@loader(Spam)
+def _load_spam(rec, context):
+    pass
+
+
+def test_no_circular():
+
+    # If a saver/loader is implemented incorrectly, this used to lead to
+    # non-informative circular references, so we check that the error message
+    # is more useful now
+
+    with pytest.raises(TypeError) as exc:
+        clone(Spam())
+    assert exc.value.args[0] == "Object of type 'Spam' is not JSON serializable"
+
+
 def test_categorical_component():
     c = CategoricalComponent(['a','b','c','a','b'], categories=['a','b','c'])
     c2 = clone(c)


### PR DESCRIPTION
This should provide better errors than the cryptic 'Circular reference detected' when saving a session