### PR TITLE
Refactor link handling

### DIFF
--- a/glue/core/component.py
+++ b/glue/core/component.py
@@ -68,11 +68,6 @@ class Component(object):
             self._units = str(value)
 
     @property
-    def hidden(self):
-        """Whether the Component is hidden by default"""
-        return False
-
-    @property
     def data(self):
         """ The underlying :class:`numpy.ndarray` """
         return self._data
@@ -249,10 +244,6 @@ class DerivedComponent(Component):
     def set_parent(self, data):
         """ Reassign the Data object that this DerivedComponent operates on """
         self._data = data
-
-    @property
-    def hidden(self):
-        return self._link.hidden
 
     @property
     def data(self):

--- a/glue/core/component_id.py
+++ b/glue/core/component_id.py
@@ -48,13 +48,15 @@ class ComponentID(object):
 
        component_id = data.id[name]
        data[component_id] -> numpy array
+
+    Parameters
+    ----------
+    label : str
+        Name for the component ID
     """
 
-    def __init__(self, label, hidden=False, parent=None):
-        """:param label: Name for the ID
-           :type label: str"""
+    def __init__(self, label, parent=None):
         self._label = str(label)
-        self._hidden = hidden
         self.parent = parent
         # We assign a UUID which can then be used for example in equations
         # for derived components - the idea is that this doesn't change over
@@ -83,15 +85,6 @@ class ComponentID(object):
         if self.parent is not None and self.parent.hub:
             msg = DataRenameComponentMessage(self.parent, self)
             self.parent.hub.broadcast(msg)
-
-    @property
-    def hidden(self):
-        """Whether to hide the component by default"""
-        return self._hidden
-
-    @hidden.setter
-    def hidden(self, value):
-        self._hidden = value
 
     def __str__(self):
         return str(self._label)
@@ -176,6 +169,6 @@ class PixelComponentID(ComponentID):
     dimensions.
     """
 
-    def __init__(self, axis, label, hidden=False, parent=None):
+    def __init__(self, axis, label, parent=None):
         self.axis = axis
-        super(PixelComponentID, self).__init__(label, hidden=hidden, parent=parent)
+        super(PixelComponentID, self).__init__(label, parent=parent)

--- a/glue/core/component_link.py
+++ b/glue/core/component_link.py
@@ -98,7 +98,6 @@ class ComponentLink(object):
         self._using = using
         self._inverse = inverse
 
-        self.hidden = False  # show in widgets?
         self.identity = self._using is identity
 
         if not isinstance(comp_from, list):
@@ -322,7 +321,6 @@ class CoordinateComponentLink(ComponentLink):
         comp_from = [comp_from[i] for i in self.from_needed]
         super(CoordinateComponentLink, self).__init__(
             comp_from, comp_to, self.using)
-        self.hidden = True
 
     def using(self, *args):
 

--- a/glue/core/component_link.py
+++ b/glue/core/component_link.py
@@ -18,6 +18,11 @@ __all__ = ['ComponentLink', 'BinaryComponentLink', 'CoordinateComponentLink']
 def identity(x):
     return x
 
+
+def null(*args):
+    return None
+
+
 OPSYM = {operator.add: '+', operator.sub: '-',
          operator.truediv: '/', operator.mul: '*',
          operator.pow: '**'}
@@ -382,7 +387,6 @@ class BinaryComponentLink(ComponentLink):
                             right)
 
         to = ComponentID("")
-        null = lambda *args: None
         super(BinaryComponentLink, self).__init__(from_, to, null)
 
     def replace_ids(self, old, new):

--- a/glue/core/component_link.py
+++ b/glue/core/component_link.py
@@ -401,13 +401,26 @@ class BinaryComponentLink(ComponentLink):
             self._right.replace_ids(old, new)
 
     def compute(self, data, view=None):
-        l = self._left
-        r = self._right
+        left = self._left
+        right = self._right
         if not isinstance(self._left, numbers.Number):
-            l = data[self._left, view]
+            left = data[self._left, view]
         if not isinstance(self._right, numbers.Number):
-            r = data[self._right, view]
-        return self._op(l, r)
+            right = data[self._right, view]
+        return self._op(left, right)
+
+    def __gluestate__(self, context):
+        left = context.id(self._left)
+        right = context.id(self._right)
+        operator = context.do(self._op)
+        return dict(left=left, right=right, operator=operator)
+
+    @classmethod
+    def __setgluestate__(cls, rec, context):
+        left = context.object(rec['left'])
+        right = context.object(rec['right'])
+        operator = context.object(rec['operator'])
+        return cls(left, right, operator)
 
     def __str__(self):
         sym = OPSYM.get(self._op, self._op.__name__)

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -481,6 +481,10 @@ class Data(object):
             raise TypeError("Cannot add component_link: "
                             "has no 'to' ComponentID")
 
+        for cid in link.get_from_ids():
+            if cid not in self.components:
+                raise ValueError("Can only add internal links with add_component_link - use DataCollection.add_link to add inter-data links")
+
         dc = DerivedComponent(self, link)
         to_ = link.get_to_id()
         self.add_component(dc, label=to_, hidden=hidden)
@@ -536,6 +540,10 @@ class Data(object):
         :rtype: list
         """
         return list(self._components.keys())
+
+    @property
+    def externally_derivable_components(self):
+        return list(self._externally_derivable_components.keys())
 
     @property
     def visible_components(self):

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -458,10 +458,8 @@ class Data(object):
         values are DerivedComponent instances which can be used to get the
         data.
         """
-        print("_set_externally_derivable_components", len(derivable_components))
         if len(self._externally_derivable_components) == 0 and len(derivable_components) == 0:
             return
-        print("HERE", self.hub)
         self._externally_derivable_components = derivable_components
         if self.hub:
             msg = ExternallyDerivableComponentsChangedMessage(self)

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -620,12 +620,27 @@ class Data(object):
         return None
 
     @property
+    def links(self):
+        """
+        A list of all the links internal to the dataset.
+        """
+        return self.coordinate_links + self.derived_links
+
+    @property
     def coordinate_links(self):
-        """A list of the ComponentLinks that connect pixel and
-        world. If no coordinate transformation object is present,
-        return an empty list.
+        """
+        A list of the ComponentLinks that connect pixel and world. If no
+        coordinate transformation object is present, return an empty list.
         """
         return self._coordinate_links
+
+    @property
+    def derived_links(self):
+        """
+        A list of the links present inside all of the DerivedComponent objects
+        in this dataset.
+        """
+        return [self.get_component(cid).link for cid in self.derived_components]
 
     @contract(axis=int, returns=ComponentID)
     def get_pixel_component_id(self, axis):

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -425,6 +425,7 @@ class Data(object):
             component_id = ComponentID(label, hidden=hidden, parent=self)
 
         if len(self._components) == 0:
+            # TODO: make sure the following doesn't raise a componentsraised message
             self._create_pixel_and_world_components(ndim=component.ndim)
 
         # In some cases, such as when loading a session, we actually disable the
@@ -457,6 +458,8 @@ class Data(object):
         values are DerivedComponent instances which can be used to get the
         data.
         """
+        if len(self._externally_derivable_components) == 0 and len(derivable_components) == 0:
+            return
         self._externally_derivable_components = derivable_components
         if self.hub:
             msg = ExternallyDerivableComponentsChangedMessage(self)

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -468,16 +468,23 @@ class Data(object):
     @contract(link=ComponentLink,
               label='cid_like|None',
               returns=DerivedComponent)
-    def add_component_link(self, link, label=None, hidden=False):
-        """ Shortcut method for generating a new :class:`~glue.core.component.DerivedComponent`
-        from a ComponentLink object, and adding it to a data set.
+    def add_component_link(self, link, label=None):
+        """
+        Shortcut method for generating a new
+        :class:`~glue.core.component.DerivedComponent` from a ComponentLink
+        object, and adding it to a data set.
 
-        :param link: :class:`~glue.core.component_link.ComponentLink`
-        :param label: The ComponentID or label to attach to.
-        :type label: :class:`~glue.core.component_id.ComponentID` or str
+        Parameters
+        ----------
+        link : :class:`~glue.core.component_link.ComponentLink`
+            The link to use to generate a new component
+        label : :class:`~glue.core.component_id.ComponentID` or str
+            The ComponentID or label to attach to.
 
-        :returns:
-            The :class:`~glue.core.component.DerivedComponent` that was added
+        Returns
+        -------
+        component : :class:`~glue.core.component.DerivedComponent`
+            The component that was added
         """
         if label is not None:
             if not isinstance(label, ComponentID):
@@ -554,7 +561,7 @@ class Data(object):
 
     @property
     def visible_components(self):
-        """ :class:`ComponentIDs <glue.core.component_id.ComponentID>` for all non-hidden components.
+        """All :class:`ComponentIDs <glue.core.component_id.ComponentID>` in the Data that aren't coordinate.
 
         :rtype: list
         """

--- a/glue/core/data_collection.py
+++ b/glue/core/data_collection.py
@@ -134,6 +134,13 @@ class DataCollection(HubListener):
         """
         return tuple(self._link_manager.links)
 
+    @property
+    def external_links(self):
+        """
+        Tuple of :class:`~glue.core.component_link.ComponentLink` objects.
+        """
+        return tuple(self._link_manager.external_links)
+
     def add_link(self, links):
         """Add one or more links to the data collection.
 

--- a/glue/core/data_collection.py
+++ b/glue/core/data_collection.py
@@ -37,7 +37,8 @@ class DataCollection(HubListener):
         :param data: :class:`~glue.core.data.Data` object, or list of such objects
         """
         super(DataCollection, self).__init__()
-        self._link_manager = LinkManager()
+
+        self._link_manager = LinkManager(self)
         self._data = []
 
         self.hub = None
@@ -76,6 +77,7 @@ class DataCollection(HubListener):
                 s.register()
             msg = DataCollectionAddMessage(self, data)
             self.hub.broadcast(msg)
+
         self._sync_link_manager()
 
     def extend(self, data):
@@ -117,16 +119,7 @@ class DataCollection(HubListener):
 
         # Avoid circular calls
         with self._no_sync_link_manager():
-
-            # add any links in the data
-            for d in self._data:
-                for derived in d.derived_components:
-                    self._link_manager.add_link(d.get_component(derived).link)
-                for link in d.coordinate_links:
-                    self._link_manager.add_link(link)
-
-            for d in self._data:
-                self._link_manager.update_data_components(d)
+            self._link_manager.update_externally_derivable_components()
 
     @contextmanager
     def _no_sync_link_manager(self):
@@ -151,13 +144,7 @@ class DataCollection(HubListener):
            :class:`~glue.core.component_link.ComponentLink`
            instances, or a :class:`~glue.core.link_helpers.LinkCollection`
         """
-        # Adding derived comments can trigger _sync_link_manager but we
-        # don't need to do this since we are explicitly calling
-        # update_data_components here.
-        with self._no_sync_link_manager():
-            self._link_manager.add_link(links)
-            for d in self._data:
-                self._link_manager.update_data_components(d)
+        self._link_manager.add_link(links)
 
     def remove_link(self, links):
         """
@@ -170,38 +157,22 @@ class DataCollection(HubListener):
            :class:`~glue.core.component_link.ComponentLink`
            instances, or a :class:`~glue.core.link_helpers.LinkCollection`
         """
-        # Removing derived comments can trigger _sync_link_manager but we
-        # don't need to do this since we are explicitly calling
-        # update_data_components here.
-        with self._no_sync_link_manager():
-            self._link_manager.remove_link(links)
-            for d in self._data:
-                self._link_manager.update_data_components(d)
+        self._link_manager.remove_link(links)
 
     def _merge_link(self, link):
         pass
 
     def set_links(self, links):
-        """Override the links in the collection, and update data
-        objects as necessary.
+        """
+        Override the links in the collection, and update data objects as
+        necessary.
 
         :param links: The new links. An iterable of
             :class:`~glue.core.component_link.ComponentLink` instances
         """
+        self._link_manager.clear_links()
+        self._link_manager.add_link(links)
 
-        # Adding derived comments can trigger _sync_link_manager but we
-        # don't need to do this since we are explicitly calling
-        # update_data_components here.
-
-        with self._no_sync_link_manager():
-
-            self._link_manager.clear()
-
-            for link in links:
-                self._link_manager.add_link(link)
-
-            for d in self._data:
-                self._link_manager.update_data_components(d)
 
     def register_to_hub(self, hub):
         """ Register managed data objects to a hub.

--- a/glue/core/data_combo_helper.py
+++ b/glue/core/data_combo_helper.py
@@ -311,8 +311,7 @@ class ComponentIDComboHelper(ComboHelper):
             if self.numeric and self.derived:
                 cids = [ChoiceSeparator('Derived components')]
                 for cid in derived_components:
-                    if not cid.hidden:
-                        cids.append(cid)
+                    cids.append(cid)
                 if len(cids) > 1:
                     choices += cids
 

--- a/glue/core/fitters.py
+++ b/glue/core/fitters.py
@@ -149,7 +149,7 @@ class BaseFitter1D(object):
         :type y:  :class:`numpy.ndarray`
         :param dy: 1 sigma uncertainties on each datum (optional)
         :type dy: :class:`numpy.ndarray`
-        :param constraints: The current value of :attr:`constraints`
+        :param constraints: The current value of the ``constraints`` property
         :param options: kwargs for model hyperparameters.
 
         :returns: An object representing the fit result.

--- a/glue/core/hub.py
+++ b/glue/core/hub.py
@@ -83,14 +83,12 @@ class Hub(object):
            An optional function of the form handler(message) that will
            receive the message on behalf of the subscriber. If not provided,
            this defaults to the HubListener's notify method
-        :type handler: Callable
 
 
         :param filter:
            An optional function of the form filter(message). Messages
            are only passed to the subscriber if filter(message) == True.
            The default is to always pass messages.
-        :type filter: Callable
 
 
         Raises:

--- a/glue/core/link_manager.py
+++ b/glue/core/link_manager.py
@@ -256,6 +256,10 @@ class LinkManager(HubListener):
     def links(self):
         return list(self._links)
 
+    @property
+    def external_links(self):
+        return list(self._external_links)
+
     def clear(self):
         self._external_links.clear()
 

--- a/glue/core/link_manager.py
+++ b/glue/core/link_manager.py
@@ -51,7 +51,8 @@ def accessible_links(cids, links):
 
 
 def discover_links(data, links):
-    """ Discover all links to components that can be derived
+    """
+    Discover all links to components that can be derived
     based on the current components known to a dataset, and a set
     of ComponentLinks.
 

--- a/glue/core/link_manager.py
+++ b/glue/core/link_manager.py
@@ -21,7 +21,7 @@ import logging
 
 from glue.external import six
 from glue.core.hub import HubListener
-from glue.core.message import DataCollectionDeleteMessage, ComponentsChangedMessage, DataAddComponentMessage, DataRemoveComponentMessage
+from glue.core.message import DataCollectionDeleteMessage, DataRemoveComponentMessage
 from glue.core.contracts import contract
 from glue.core.link_helpers import LinkCollection
 from glue.core.component_link import ComponentLink
@@ -131,18 +131,34 @@ class LinkManager(HubListener):
     and compute which components are accesible from which data sets
     """
 
-    def __init__(self):
-        self._links = set()
+    def __init__(self, data_collection=None):
+        self._external_links = set()
         self.hub = None
+        self.trigger = False
+        self.data_collection = data_collection
 
     def register_to_hub(self, hub):
         self.hub = hub
+        self.hub.subscribe(self, DataRemoveComponentMessage,
+                           handler=self._component_removed)
         self.hub.subscribe(self, DataCollectionDeleteMessage,
                            handler=self._data_removed)
 
+    def _component_removed(self, msg):
+        remove = []
+        remove_cid = msg.component_id
+        for link in self._external_links:
+            ids = set(link.get_from_ids()) | set([link.get_to_id()])
+            for cid in ids:
+                if cid is remove_cid:
+                    remove.append(link)
+                    break
+        for link in remove:
+            self.remove_link(link)
+
     def _data_removed(self, msg):
         remove = []
-        for link in self._links:
+        for link in self._external_links:
             ids = set(link.get_from_ids()) | set([link.get_to_id()])
             for cid in ids:
                 if cid.parent is msg.data:
@@ -151,7 +167,10 @@ class LinkManager(HubListener):
         for link in remove:
             self.remove_link(link)
 
-    def add_link(self, link):
+    def clear_links(self):
+        self._external_links.clear()
+
+    def add_link(self, link, update_external=True):
         """
         Ingest one or more ComponentLinks to the manager
 
@@ -162,24 +181,33 @@ class LinkManager(HubListener):
         """
         if isinstance(link, (LinkCollection, list)):
             for l in link:
-                self.add_link(l)
+                self.add_link(l, update_external=False)
+            if update_external:
+                self.update_externally_derivable_components()
         else:
-            if link.inverse not in self._links:
-                self._links.add(link)
+            if link.inverse not in self._external_links:
+                self._external_links.add(link)
+                if update_external:
+                    self.update_externally_derivable_components()
 
     @contract(link=ComponentLink)
-    def remove_link(self, link):
+    def remove_link(self, link, update_external=True):
         if isinstance(link, (LinkCollection, list)):
             for l in link:
-                self.remove_link(l)
+                self.remove_link(l, update_exernal=False)
+            if update_external:
+                self.update_externally_derivable_components()
         else:
             logging.getLogger(__name__).debug('removing link %s', link)
-            self._links.remove(link)
+            self._external_links.remove(link)
+            if update_external:
+                self.update_externally_derivable_components()
 
     @contract(data=Data)
-    def update_data_components(self, data):
-        """Update all the DerivedComponents in a data object, based on
-        all the Components deriveable based on the links in self.
+    def update_externally_derivable_components(self, data=None):
+        """
+        Update all the externally derived components in all data objects, based
+        on all the Components deriveable based on the links in self.
 
         This overrides any ComponentLinks stored in the
         DerivedComponents of the data itself -- any components which
@@ -195,62 +223,41 @@ class LinkManager(HubListener):
         DerivedComponents will be replaced / added into
         the data object
         """
-        if self.hub is None:
-            self._remove_underiveable_components(data)
-            self._add_deriveable_components(data)
+
+        if self.data_collection is None:
+            if data is None:
+                return
+            else:
+                data_collection = [data]
         else:
-            before = data.components[:]
-            with self.hub.ignore_callbacks(DataRemoveComponentMessage):
-                with self.hub.ignore_callbacks(DataAddComponentMessage):
-                    with self.hub.ignore_callbacks(ComponentsChangedMessage):
-                        self._remove_underiveable_components(data)
-                        self._add_deriveable_components(data)
-            after = data.components[:]
-            if len(before) != len(after) or any(before[i] is not after[i] for i in range(len(before))):
-                msg = ComponentsChangedMessage(data)
-                self.hub.broadcast(msg)
+            data_collection = self.data_collection
+
+        for data in data_collection:
+            links = discover_links(data, self._links | self._inverse_links)
+            comps = {}
+            for cid, link in six.iteritems(links):
+                d = DerivedComponent(data, link)
+                comps[cid] = d
+            data._set_externally_derivable_components(comps)
+
+    @property
+    def _links(self):
+        if self.data_collection is None:
+            data_links = set()
+        else:
+            data_links = set(link for data in self.data_collection for link in data.links)
+        return data_links | self._external_links
 
     @property
     def _inverse_links(self):
         return set(link.inverse for link in self._links if link.inverse is not None)
-
-    def _remove_underiveable_components(self, data):
-        """ Find and remove any DerivedComponent in the data
-        which requires a ComponentLink not tracked by this LinkManager
-        """
-        data_links = set(data.get_component(dc).link
-                         for dc in data.derived_components)
-        missing_links = data_links - self._links - self._inverse_links
-        to_remove = []
-        for m in missing_links:
-            to_remove.extend(find_dependents(data, m))
-
-        if getattr(data, 'hub', None) is None:
-            for r in to_remove:
-                data.remove_component(r)
-        else:
-            with data.hub.delay_callbacks():
-                for r in to_remove:
-                    data.remove_component(r)
-
-    def _add_deriveable_components(self, data):
-        """Find and add any DerivedComponents that a data object can
-        calculate given the ComponentLinks tracked by this
-        LinkManager
-
-        """
-        links = discover_links(data, self._links | self._inverse_links)
-        for cid, link in six.iteritems(links):
-            d = DerivedComponent(data, link)
-            if cid not in data.components:
-                data.add_component(d, cid)
 
     @property
     def links(self):
         return list(self._links)
 
     def clear(self):
-        self._links.clear()
+        self._external_links.clear()
 
     def __contains__(self, item):
         return item in self._links

--- a/glue/core/link_manager.py
+++ b/glue/core/link_manager.py
@@ -194,7 +194,7 @@ class LinkManager(HubListener):
     def remove_link(self, link, update_external=True):
         if isinstance(link, (LinkCollection, list)):
             for l in link:
-                self.remove_link(l, update_exernal=False)
+                self.remove_link(l, update_external=False)
             if update_external:
                 self.update_externally_derivable_components()
         else:

--- a/glue/core/message.py
+++ b/glue/core/message.py
@@ -156,6 +156,10 @@ class DataReorderComponentMessage(DataMessage):
         self.component_ids = component_ids
 
 
+class ExternallyDerivableComponentsChangedMessage(DataMessage):
+    pass
+
+
 class ComponentsChangedMessage(DataMessage):
     pass
 

--- a/glue/core/simpleforms.py
+++ b/glue/core/simpleforms.py
@@ -11,20 +11,20 @@ See :ref:`fit_plugins` for example usage.
 
 
 class Option(object):
-
     """
     Base class for other options.
 
     This shouldn't be used directly
+
+    Parameters
+    ----------
+    default : object
+        The default value for this option.
+    label : str
+        A short label for this option, to use in the GUI
     """
 
     def __init__(self, default, label):
-        """
-        :param default: The default value for this option.
-        :type default: object
-        :param label: A short label for this option, to use in the GUI
-        :type label: str
-        """
         self.label = label
         """A UI label for the setting"""
         self.default = default
@@ -46,22 +46,23 @@ class Option(object):
 
 
 class IntOption(Option):
+    """
+    An integer-valued option.
+
+    Parameters
+    ----------
+    min : int, optional
+        The minimum valid value
+    max : int, optional
+        The maximum valid value
+    default : int, optional
+        The default value
+    label : str, optional
+        A short label for this option
+    """
 
     def __init__(self, min=0, max=10, default=1, label="Integer"):
-        """
-        An integer-valued option
-
-        :param min: The minimum valid value
-        :type min: integer
-        :param max: The maximum valid value
-        :type max: integer
-        :param default: The default value
-        :type default: integer
-        :param label: A short label for this option
-        :type label: str
-        """
         super(IntOption, self).__init__(default, label)
-
         self.min = min
         self.max = max
 
@@ -84,20 +85,22 @@ class IntOption(Option):
 
 
 class FloatOption(Option):
+    """
+    A floating-point option.
+
+    Parameters
+    ----------
+    min : float, optional
+        The minimum valid value
+    max : float, optional
+        The maximum valid value
+    default : float, optional
+        The default value
+    label : str, optional
+        A short label for this option
+    """
 
     def __init__(self, min=0, max=10, default=1, label="Float"):
-        """
-        An floating-point option
-
-        :param min: The minimum valid value
-        :type min: float
-        :param max: The maximum valid value
-        :type max: float
-        :param default: The default value
-        :type default: float
-        :param label: A short label for this option
-        :type label: str
-        """
         super(FloatOption, self).__init__(default, label)
         self.min = min
         self.max = max
@@ -112,17 +115,18 @@ class FloatOption(Option):
 
 
 class BoolOption(Option):
+    """
+    A boolean-valued option.
+
+    Parameters
+    ----------
+    label : str, optional
+        A short label for this option
+    default : bool, optional
+        The default `True`/`False` value
+    """
 
     def __init__(self, label="Bool", default=False):
-        """
-        A boolean-valued option
-
-        :param default: The default True/False value
-        :type default: bool
-
-        :param label: A short label for this option
-        :type label: str
-        """
         super(BoolOption, self).__init__(default, label)
 
     def _validate(self, value):

--- a/glue/core/state.py
+++ b/glue/core/state.py
@@ -772,8 +772,7 @@ def _load_data(rec, context):
             # and upgrade it to one. This can be removed once we no longer
             # support pre-v0.8 session files.
             if not comp.world and not isinstance(cid, PixelComponentID):
-                cid = PixelComponentID(comp.axis, cid.label,
-                                       hidden=cid.hidden, parent=cid.parent)
+                cid = PixelComponentID(comp.axis, cid.label, parent=cid.parent)
                 comps[icomp] = (cid, comp)
 
         result.add_component(comp, cid)
@@ -873,17 +872,17 @@ def _load_data_5(rec, context):
 
 @saver(ComponentID)
 def _save_component_id(cid, context):
-    return dict(label=cid.label, hidden=cid.hidden)
+    return dict(label=cid.label)
 
 
 @loader(ComponentID)
 def _load_component_id(rec, context):
-    return ComponentID(rec['label'], rec['hidden'])
+    return ComponentID(rec['label'])
 
 
 @saver(PixelComponentID)
 def _save_pixel_component_id(cid, context):
-    return dict(axis=cid.axis, label=cid.label, hidden=cid.hidden)
+    return dict(axis=cid.axis, label=cid.label)
 
 
 @loader(PixelComponentID)
@@ -892,7 +891,7 @@ def _load_pixel_component_id(rec, context):
         axis = rec['axis']
     else:  # backward-compatibility
         axis = int(rec['label'].split()[2])
-    return PixelComponentID(axis, rec['label'], rec['hidden'])
+    return PixelComponentID(axis, rec['label'])
 
 
 @saver(Component)
@@ -959,8 +958,7 @@ def _save_component_link(link, context):
     to = list(map(context.id, [link.get_to_id()]))
     using = context.do(link.get_using())
     inverse = context.do(link.get_inverse())
-    hidden = link.hidden
-    return dict(frm=frm, to=to, using=using, inverse=inverse, hidden=hidden)
+    return dict(frm=frm, to=to, using=using, inverse=inverse)
 
 
 @loader(ComponentLink)
@@ -970,7 +968,6 @@ def _load_component_link(rec, context):
     using = context.object(rec['using'])
     inverse = context.object(rec['inverse'])
     result = ComponentLink(frm, to, using, inverse)
-    result.hidden = rec['hidden']
     return result
 
 

--- a/glue/core/state.py
+++ b/glue/core/state.py
@@ -995,6 +995,17 @@ def _load_coordinate_component_link(rec, context):
     return CoordinateComponentLink(frm, to, coords, index, pix2world)
 
 
+@saver(types.BuiltinFunctionType)
+def _save_builtin_function(function, context):
+    ref = "%s.%s" % (function.__module__, function.__name__)
+    return {'function': ref}
+
+
+@loader(types.BuiltinFunctionType)
+def _load_builtin_function(rec, context):
+    return lookup_class_with_patches(rec['function'])
+
+
 @saver(types.FunctionType)
 def _save_function(function, context):
     ref = "%s.%s" % (function.__module__, function.__name__)

--- a/glue/core/state_path_patches.txt
+++ b/glue/core/state_path_patches.txt
@@ -24,3 +24,4 @@ glue.viewers.table.qt.viewer_widget.TableWidget -> glue.viewers.table.qt.TableVi
 glue_vispy_viewers.common.toolbar.PatchedElementSubsetState -> glue.core.subset.ElementSubsetState
 glue.plugins.dendro_viewer.qt.viewer_widget.DendroWidget -> glue.plugins.dendro_viewer.qt.DendrogramViewer
 glue.plugins.dendro_viewer.layer_artist.DendroLayerArtist -> glue.plugins.dendro_viewer.layer_artist.DendrogramLayerArtist
+builtins.builtin_function_or_method ->  types.BuiltinFunctionType

--- a/glue/core/state_path_patches.txt
+++ b/glue/core/state_path_patches.txt
@@ -25,3 +25,4 @@ glue_vispy_viewers.common.toolbar.PatchedElementSubsetState -> glue.core.subset.
 glue.plugins.dendro_viewer.qt.viewer_widget.DendroWidget -> glue.plugins.dendro_viewer.qt.DendrogramViewer
 glue.plugins.dendro_viewer.layer_artist.DendroLayerArtist -> glue.plugins.dendro_viewer.layer_artist.DendrogramLayerArtist
 builtins.builtin_function_or_method ->  types.BuiltinFunctionType
+__builtin__.builtin_function_or_method -> types.BuiltinFunctionType

--- a/glue/core/tests/test_component_link.py
+++ b/glue/core/tests/test_component_link.py
@@ -293,30 +293,3 @@ def test_link_str():
     assert str(x + x + y) == ('((x + x) + y)')
 
     assert repr(x + y) == '<BinaryComponentLink: (x + y)>'
-
-
-def test_duplicated_links_remove_first_input():
-    """
-    # test changes introduced for #508
-    """
-
-    d1 = Data(x=[1, 2, 3])
-    d2 = Data(y=[2, 4, 6])
-
-    x = d1.id['x']
-    y = d2.id['y']
-
-    dc = DataCollection([d1, d2])
-
-    dc.add_link(LinkSame(x, y))
-    assert x in d2.components
-    assert x in d2.components
-
-    # NOTE: the behavior tested here is not desirable anymore, so the relevant
-    #       parts that are no longer true have been commented out and replaced
-    #       by the new behavior.
-
-    # assert y not in d2.components
-    # assert y not in d1.components
-    assert y in d2.components
-    assert y in d1.components

--- a/glue/core/tests/test_data.py
+++ b/glue/core/tests/test_data.py
@@ -370,6 +370,31 @@ class TestData(object):
         # There should be five components: x, y, z, pixel, and world
         assert len(data.components) == 5
 
+    def test_remove_derived_dependency(self):
+
+        # Regression test for a bug that occurred when removing a component
+        # used in a derived component, which should also remove the derived
+        # component itself.
+
+        data = Data(x=[1, 2, 3], y=[2, 3, 4], label='data1')
+
+        data['z'] = data.id['x'] + 1
+
+        x_id = data.id['x']
+        z_id = data.id['z']
+
+        # There should be five components: x, y, z, pixel, and world
+        assert len(data.components) == 5
+
+        data.remove_component(data.id['x'])
+
+        # This should also remove z since it depends on x
+
+        assert len(data.components) == 3
+
+        assert x_id not in data.components
+        assert z_id not in data.components
+
 
 class TestROICreation(object):
 
@@ -377,7 +402,7 @@ class TestROICreation(object):
 
         d = Data(xdata=[1, 2, 3], ydata=[1, 2, 3])
         comp = d.get_component(d.id['xdata'])
-        roi = RangeROI('x', min=2,max=3)
+        roi = RangeROI('x', min=2, max=3)
         s = comp.subset_from_roi('xdata', roi)
         assert isinstance(s, RangeSubsetState)
         np.testing.assert_array_equal((s.lo, s.hi),

--- a/glue/core/tests/test_data.py
+++ b/glue/core/tests/test_data.py
@@ -11,7 +11,7 @@ from glue import core
 
 from ..component import Component, DerivedComponent, CategoricalComponent, DateTimeComponent
 from ..component_id import ComponentID
-from ..component_link import ComponentLink
+from ..component_link import ComponentLink, CoordinateComponentLink, BinaryComponentLink
 from ..coordinates import Coordinates
 from ..data import Data, pixel_label
 from ..exceptions import IncompatibleAttribute
@@ -24,6 +24,7 @@ from ..subset import (Subset, CategoricalROISubsetState, SubsetState,
 from ..roi import PolygonalROI, CategoricalROI, RangeROI, RectangularROI
 
 from .test_state import clone
+
 
 class _TestCoordinates(Coordinates):
 
@@ -407,6 +408,20 @@ class TestData(object):
         assert e_id not in data.components
         assert f_id not in data.components
 
+    def test_links_property(self):
+
+        data = Data(a=[1, 2, 3], b=[2, 3, 4], label='data1')
+
+        assert len(data.links) == 2
+        assert isinstance(data.links[0], CoordinateComponentLink)
+        assert isinstance(data.links[1], CoordinateComponentLink)
+
+        data['c'] = data.id['a'] + 1
+
+        assert len(data.links) == 3
+
+        assert isinstance(data.links[2], BinaryComponentLink)
+
 
 class TestROICreation(object):
 
@@ -420,7 +435,7 @@ class TestROICreation(object):
         np.testing.assert_array_equal((s.lo, s.hi),
                                       [2, 3])
 
-        roi = RangeROI('y', min=2,max=3)
+        roi = RangeROI('y', min=2, max=3)
         s = comp.subset_from_roi('xdata', roi, other_att='ydata',
                                  other_comp=d.get_component(d.id['ydata']))
         assert isinstance(s, RangeSubsetState)

--- a/glue/core/tests/test_data.py
+++ b/glue/core/tests/test_data.py
@@ -374,26 +374,38 @@ class TestData(object):
 
         # Regression test for a bug that occurred when removing a component
         # used in a derived component, which should also remove the derived
-        # component itself.
+        # component itself. To make things more fun, we set up a chain of
+        # derived components to make sure they are all removed.
 
-        data = Data(x=[1, 2, 3], y=[2, 3, 4], label='data1')
+        data = Data(a=[1, 2, 3], b=[2, 3, 4], label='data1')
 
-        data['z'] = data.id['x'] + 1
+        data['c'] = data.id['a'] + 1
+        data['d'] = data.id['c'] + 1
+        data['e'] = data.id['d'] + 1
+        data['f'] = data.id['e'] + 1
 
-        x_id = data.id['x']
-        z_id = data.id['z']
+        a_id = data.id['a']
+        b_id = data.id['b']
+        c_id = data.id['c']
+        d_id = data.id['d']
+        e_id = data.id['e']
+        f_id = data.id['f']
 
-        # There should be five components: x, y, z, pixel, and world
+        # There should be five components: pixel, world, a, b, c, d, e, f
+        assert len(data.components) == 8
+
+        data.remove_component(data.id['d'])
+
+        # This should also remove e and f since they depend on d
+
         assert len(data.components) == 5
 
-        data.remove_component(data.id['x'])
-
-        # This should also remove z since it depends on x
-
-        assert len(data.components) == 3
-
-        assert x_id not in data.components
-        assert z_id not in data.components
+        assert a_id in data.components
+        assert b_id in data.components
+        assert c_id in data.components
+        assert d_id not in data.components
+        assert e_id not in data.components
+        assert f_id not in data.components
 
 
 class TestROICreation(object):

--- a/glue/core/tests/test_data_collection.py
+++ b/glue/core/tests/test_data_collection.py
@@ -13,11 +13,12 @@ from ..data import Data, Component, ComponentID, DerivedComponent
 from ..data_collection import DataCollection
 from ..hub import HubListener
 from ..message import (Message, DataCollectionAddMessage, DataRemoveComponentMessage,
-                       DataCollectionDeleteMessage,
+                       DataCollectionDeleteMessage, DataAddComponentMessage,
                        ComponentsChangedMessage, ExternallyDerivableComponentsChangedMessage)
 from ..exceptions import IncompatibleAttribute
 
 from .test_state import clone
+
 
 class HubLog(HubListener):
 
@@ -29,6 +30,9 @@ class HubLog(HubListener):
 
     def notify(self, message):
         self.messages.append(message)
+
+    def clear(self):
+        self.messages[:] = []
 
 
 class TestDataCollection(object):
@@ -159,10 +163,15 @@ class TestDataCollection(object):
         self.dc.append(d)
         d.add_component(Component(np.array([1, 2, 3])), id1)
         assert link not in self.dc._link_manager
+        self.log.clear()
         d.add_component(dc, id2)
 
-        msg = self.log.messages[-1]
-        assert isinstance(msg, ComponentsChangedMessage)
+        msgs = sorted(self.log.messages, key=lambda x: str(type(x)))
+
+        assert isinstance(msgs[0], ComponentsChangedMessage)
+        assert isinstance(msgs[1], DataAddComponentMessage)
+        assert isinstance(msgs[2], ExternallyDerivableComponentsChangedMessage)
+
         assert link in self.dc._link_manager
 
     def test_links_auto_added(self):

--- a/glue/core/tests/test_data_collection.py
+++ b/glue/core/tests/test_data_collection.py
@@ -166,13 +166,12 @@ class TestDataCollection(object):
         self.log.clear()
         d.add_component(dc, id2)
 
+        assert link in self.dc._link_manager
+
         msgs = sorted(self.log.messages, key=lambda x: str(type(x)))
 
         assert isinstance(msgs[0], ComponentsChangedMessage)
         assert isinstance(msgs[1], DataAddComponentMessage)
-        assert isinstance(msgs[2], ExternallyDerivableComponentsChangedMessage)
-
-        assert link in self.dc._link_manager
 
     def test_links_auto_added(self):
         id1 = ComponentID("id1")

--- a/glue/core/tests/test_data_collection.py
+++ b/glue/core/tests/test_data_collection.py
@@ -14,7 +14,7 @@ from ..data_collection import DataCollection
 from ..hub import HubListener
 from ..message import (Message, DataCollectionAddMessage, DataRemoveComponentMessage,
                        DataCollectionDeleteMessage,
-                       ComponentsChangedMessage)
+                       ComponentsChangedMessage, ExternallyDerivableComponentsChangedMessage)
 from ..exceptions import IncompatibleAttribute
 
 
@@ -393,9 +393,14 @@ class TestDataCollection(object):
 
         data.remove_component(remove_id)
 
-        msg = self.log.messages[-2]
+        print(self.log.messages)
+
+        msg = self.log.messages[-3]
         assert isinstance(msg, DataRemoveComponentMessage)
         assert msg.component_id is remove_id
+
+        msg = self.log.messages[-2]
+        assert isinstance(msg, ExternallyDerivableComponentsChangedMessage)
 
         msg = self.log.messages[-1]
         assert isinstance(msg, ComponentsChangedMessage)

--- a/glue/core/tests/test_data_collection.py
+++ b/glue/core/tests/test_data_collection.py
@@ -401,19 +401,18 @@ class TestDataCollection(object):
 
         remove_id = data.id['y']
 
+        self.log.clear()
+
         data.remove_component(remove_id)
 
-        print(self.log.messages)
+        msgs = sorted(self.log.messages, key=lambda x: str(type(x)))
 
-        msg = self.log.messages[-3]
-        assert isinstance(msg, DataRemoveComponentMessage)
-        assert msg.component_id is remove_id
+        print([type(msg) for msg in msgs])
 
-        msg = self.log.messages[-2]
-        assert isinstance(msg, ExternallyDerivableComponentsChangedMessage)
+        assert isinstance(msgs[0], ComponentsChangedMessage)
 
-        msg = self.log.messages[-1]
-        assert isinstance(msg, ComponentsChangedMessage)
+        assert isinstance(msgs[1], DataRemoveComponentMessage)
+        assert msgs[1].component_id is remove_id
 
     def test_links_preserved_session(self):
 

--- a/glue/core/tests/test_data_collection.py
+++ b/glue/core/tests/test_data_collection.py
@@ -17,6 +17,7 @@ from ..message import (Message, DataCollectionAddMessage, DataRemoveComponentMes
                        ComponentsChangedMessage, ExternallyDerivableComponentsChangedMessage)
 from ..exceptions import IncompatibleAttribute
 
+from .test_state import clone
 
 class HubLog(HubListener):
 
@@ -404,3 +405,26 @@ class TestDataCollection(object):
 
         msg = self.log.messages[-1]
         assert isinstance(msg, ComponentsChangedMessage)
+
+    def test_links_preserved_session(self):
+
+        # This tests that the separation of internal vs external links is
+        # preserved in session files.
+
+        d1 = Data(a=[1, 2, 3])
+        d2 = Data(b=[2, 3, 4])
+
+        dc = DataCollection([d1, d2])
+        dc.add_link(ComponentLink([d2.id['b']], d1.id['a']))
+
+        d1['x'] = d1.id['a'] + 1
+
+        assert len(d1.coordinate_links) == 2
+        assert len(d1.derived_links) == 1
+        assert len(dc._link_manager._external_links) == 1
+
+        dc2 = clone(dc)
+
+        assert len(dc2[0].coordinate_links) == 2
+        assert len(dc2[0].derived_links) == 1
+        assert len(dc2._link_manager._external_links) == 1

--- a/glue/core/tests/test_link_manager.py
+++ b/glue/core/tests/test_link_manager.py
@@ -86,7 +86,7 @@ class TestDiscoverLinks(object):
         links = discover_links(self.data, self.links)
 
         for i in self.inaccessible:
-            assert not i in links
+            assert i not in links
 
         for d in self.direct:
             assert d in links
@@ -95,7 +95,7 @@ class TestDiscoverLinks(object):
             assert d in links
 
         for p in self.primary:
-            assert not p in links
+            assert p not in links
 
     def test_links_point_to_proper_ids(self):
         """ Dictionary values are ComponentLinks which

--- a/glue/core/tests/test_link_manager.py
+++ b/glue/core/tests/test_link_manager.py
@@ -258,3 +258,34 @@ class TestLinkManager(object):
         # Removing dataset should remove related links
         dc.remove(d1)
         assert len(dc.links) == 2
+
+    def test_remove_component_removes_links(self):
+
+        d1 = Data(x=[[1, 2], [3, 4]], label='image')
+        d2 = Data(a=[1, 2, 3], b=[4, 5, 6], label='catalog')
+
+        dc = DataCollection([d1, d2])
+
+        assert len(dc.links) == 6
+
+        dc.add_link(LinkSame(d1.id['x'], d2.id['a']))
+
+        assert len(dc.links) == 7
+
+        assert len(d1.components) == 6
+        assert len(d2.components) == 5
+
+        assert d1.id['x'] in d2.components
+        assert d2.id['a'] in d1.components
+
+        # Removing component x from d1 should remove related links and
+        # derived components.
+        d1.remove_component(d2.id['a'])
+
+        assert len(dc.links) == 6
+
+        assert len(d1.components) == 5
+        assert len(d2.components) == 4
+
+        assert not any(cid.label == 'a' for cid in d1.components)
+        assert not any(cid.label == 'x' for cid in d2.components)

--- a/glue/core/tests/test_links.py
+++ b/glue/core/tests/test_links.py
@@ -18,7 +18,7 @@ def test_1d_world_link():
 
     dc.add_link(LinkSame(d2.get_world_component_id(0), d1.id['x']))
 
-    assert d2.get_world_component_id(0) in d1.components
+    assert d2.get_world_component_id(0) in d1.externally_derivable_components
     np.testing.assert_array_equal(d1[d2.get_world_component_id(0)], x)
     np.testing.assert_array_equal(d1[d2.get_pixel_component_id(0)], x)
 

--- a/glue/core/tests/test_state.py
+++ b/glue/core/tests/test_state.py
@@ -238,8 +238,8 @@ def test_matplotlib_cmap():
 def test_binary_component_link():
     d1 = core.Data(x=[1, 2, 3])
     d1['y'] = d1.id['x'] + 1
+    assert_equal(d1['y'], [2, 3, 4])
     d2 = clone(d1)
-    assert_equal(d1['x'], [1, 2, 3])
     assert_equal(d2['y'], [2, 3, 4])
 
 

--- a/glue/core/tests/test_state.py
+++ b/glue/core/tests/test_state.py
@@ -235,6 +235,14 @@ def test_matplotlib_cmap():
     assert clone(cm.gist_heat) is cm.gist_heat
 
 
+def test_binary_component_link():
+    d1 = core.Data(x=[1, 2, 3])
+    d1['y'] = d1.id['x'] + 1
+    d2 = clone(d1)
+    assert_equal(d1['x'], [1, 2, 3])
+    assert_equal(d2['y'], [2, 3, 4])
+
+
 class Spam(object):
     pass
 

--- a/glue/core/util.py
+++ b/glue/core/util.py
@@ -33,18 +33,21 @@ def relim(lo, hi, log=False):
 
 
 def split_component_view(arg):
-    """Split the input to data or subset.__getitem__ into its pieces.
+    """
+    Split the input to data or subset.__getitem__ into its pieces.
 
-    :param arg: The input passed to data or subset.__getitem__.
-                Assumed to be either a scalar or tuple
+    Parameters
+    ----------
+    arg
+        The input passed to ``data`` or ``subset.__getitem__``. Assumed to be
+        either a scalar or tuple
 
-    :rtype: tuple
-
-    The first item is the Component selection (a ComponentID or
-    string)
-
-    The second item is a view (tuple of slices, slice scalar, or view
-    object)
+    Returns
+    -------
+    selection
+        The Component selection (a ComponentID or string)
+    view
+        Tuple of slices, slice scalar, or view
     """
     if isinstance(arg, tuple):
         if len(arg) == 1:
@@ -58,14 +61,18 @@ def split_component_view(arg):
 
 
 def join_component_view(component, view):
-    """Pack a componentID and optional view into single tuple
+    """
+    Pack a ComponentID and optional view into single tuple.
 
-    Returns an object compatible with data.__getitem__ and related
-    methods.  Handles edge cases of when view is None, a scalar, a
-    tuple, etc.
+    Returns an object compatible with ``data.__getitem__`` and related methods.
+    Handles edge cases of when view is None, a scalar, a tuple, etc.
 
-    :param component: ComponentID
-    :param view: view into data, or None
+    Parameters
+    ----------
+    component : `~glue.core.component_id.ComponentID`
+        The ComponentID to pack
+    view
+        The view into the data, or `None`
 
     """
     if view is None:
@@ -81,39 +88,40 @@ def join_component_view(component, view):
 
 def facet_subsets(data_collection, cid, lo=None, hi=None, steps=5,
                   prefix='', log=False):
-    """Create a series of subsets that partition the values of
-    a particular attribute into several bins
+    """
+    Create a series of subsets that partition the values of a particular
+    attribute into several bins
 
-    This creates `steps` new subet groups, adds them to the data collection,
-    and returns the list of newly created subset groups.
+    This creates `steps` new subet groups, adds them to the data collection, and
+    returns the list of newly created subset groups.
 
-    :param data: DataCollection object to use
-    :type data: :class:`~glue.core.data_collection.DataCollection`
+    Parameters
+    ----------
+    data : :class:`~glue.core.data_collection.DataCollection`
+        The DataCollection object to use
+    cid : :class:`~glue.core.component_id.ComponentID`
+         The ComponentID to facet on
+    lo : float, optional
+        The lower bound for the faceting. Defaults to minimum value in data
+    hi : float, optional
+        The upper bound for the faceting. Defaults to maximum value in data
+    steps : int, optional
+        The number of subsets to create. Defaults to 5
+    prefix : str, optional
+        If present, the new subset labels will begin with `prefix`
+    log : bool, optional
+        If `True`, space divisions logarithmically. Default is `False`
 
-    :param cid: ComponentID to facet on
-    :type data: :class:`~glue.core.component_id.ComponentID`
+    Returns
+    -------
+    subset_groups : iterable
+        List of :class:`~glue.core.subset_group.SubsetGroup` instances added to
+        `data`
 
-    :param lo: The lower bound for the faceting. Defaults to minimum value
-               in data
-    :type lo: float
+    Examples
+    --------
 
-    :param hi: The upper bound for the faceting. Defaults to maximum
-               value in data
-    :type hi: float
-
-    :param steps: The number of subsets to create. Defaults to 5
-    :type steps: int
-
-    :param prefix: If present, the new subset labels will begin with `prefix`
-    :type prefix: str
-
-    :param log: If True, space divisions logarithmically. Default=False
-    :type log: bool
-
-    :returns: List of :class:`~glue.core.subset_group.SubsetGroup` instances
-              added to `data`
-
-    Example::
+    ::
 
         facet_subset(data, data.id['mass'], lo=0, hi=10, steps=2)
 
@@ -132,7 +140,6 @@ def facet_subsets(data_collection, cid, lo=None, hi=None, steps=5,
     Note that the last range is inclusive on both sides. For example, if ``lo``
     is 0 and ``hi`` is 5, and ``steps`` is 5, then the intervals for the subsets
     are [0,1), [1,2), [2,3), [3,4), and [4,5].
-
     """
     from glue.core.exceptions import IncompatibleAttribute
     if lo is None or hi is None:
@@ -188,16 +195,23 @@ def facet_subsets(data_collection, cid, lo=None, hi=None, steps=5,
 
 
 def colorize_subsets(subsets, cmap, lo=0, hi=1):
-    """Re-color a list of subsets according to a colormap
-
-    :param subsets: List of subsets
-    :param cmap: Matplotlib colormap instance
-    :param lo: Start location in colormap. 0-1. Defaults to 0
-    :param hi: End location in colormap. 0-1. Defaults to 1
+    """
+    Re-color a list of subsets according to a colormap.
 
     The colormap will be sampled at `len(subsets)` even intervals
     between `lo` and `hi`. The color at the `ith` interval will be
     applied to `subsets[i]`
+
+    Parameters
+    ----------
+    subsets : list
+        List of subsets
+    cmap : `~matplotlib.colors.Colormap`
+        Matplotlib colormap instance
+    lo : float, optional
+        Start location in colormap. 0-1. Defaults to 0
+    hi : float, optional
+        End location in colormap. 0-1. Defaults to 1
     """
 
     from matplotlib import cm
@@ -217,13 +231,18 @@ def colorize_subsets(subsets, cmap, lo=0, hi=1):
 
 
 def disambiguate(label, taken):
-    """If necessary, add a suffix to label to avoid name conflicts
+    """
+    If necessary, add a suffix to label to avoid name conflicts
 
-    :param label: desired label
-    :param taken: set of taken names
+    Returns label if it is not in the taken set. Otherwise, returns label_NN
+    where NN is the lowest integer such that label_NN not in taken.
 
-    Returns label if it is not in the taken set. Otherwise, returns
-    label_NN where NN is the lowest integer such that label_NN not in taken.
+    Parameters
+    ----------
+    label : str
+        Desired label
+    taken : iterable
+        The set of already taken names
     """
     if label not in taken:
         return label
@@ -239,12 +258,18 @@ def row_lookup(data, categories):
     """
     Lookup which row in categories each data item is equal to
 
-    :param data: array-like
-    :param categories: array-like of unique values
+    Parameters
+    ----------
+    data
+        An array-like object
+    categories
+        Array-like of unique values
 
-    :returns: Float array.
-              If result[i] is finite, then data[i] = categoreis[result[i]]
-              Otherwise, data[i] is not in the categories list
+    Returns
+    -------
+    array
+      If result[i] is finite, then data[i] = categoreis[result[i]]
+      Otherwise, data[i] is not in the categories list
     """
 
     # np.searchsorted doesn't work on mixed types in Python3
@@ -262,8 +287,7 @@ def row_lookup(data, categories):
 
 def small_view(data, attribute):
     """
-    Extract a downsampled view from a dataset, for quick
-    statistical summaries
+    Extract a downsampled view from a dataset, for quick statistical summaries
     """
     shp = data.shape
     view = tuple([slice(None, None, np.intp(max(s / 50, 1))) for s in shp])
@@ -290,8 +314,12 @@ def visible_limits(artists, axis):
     Returns a tuple of min, max for the requested axis, or None if no data
     present
 
-    :param artists: An iterable collection of artists
-    :param axis: Which axis to compute. 0=xaxis, 1=yaxis
+    Parameters
+    ----------
+    artists : iterable
+        An iterable collection of artists
+    axis : int
+        Which axis to compute. 0=xaxis, 1=yaxis
     """
     data = []
     for art in artists:
@@ -339,12 +367,18 @@ def update_ticks(axes, coord, components, is_log):
     Changes the axes to have the proper tick formatting based on the type of
     component.
 
-    :param axes: A matplotlib axis object to alter
-    :param coord: 'x' or 'y'
-    :param components: A list() of components that are plotted along this axis
-    :param is_log: Boolean for log-scale.
-    :kwarg max_categories: The maximum number of categories to display.
-    :return: None or #categories if components is Categorical
+    Returns `None` or the number of categories if components is Categorical.
+
+    Parameters
+    ----------
+    axes : `~matplotlib.axes.Axes`
+        A matplotlib axis object to alter
+    coord : { 'x' | 'y' }
+        The coordinate axis on which to update the ticks
+    components : iterable
+        A list of components that are plotted along this axis
+    if_log : boolean
+        Whether the axis has a log-scale
     """
 
     if coord == 'x':

--- a/glue/dialogs/component_manager/qt/component_manager.py
+++ b/glue/dialogs/component_manager/qt/component_manager.py
@@ -88,13 +88,12 @@ class ComponentManagerWidget(QtWidgets.QDialog):
 
         for data in data_collection:
 
-            for cid in data.primary_components:
-                if not cid.hidden:
-                    comp_state = {}
-                    comp_state['cid'] = cid
-                    comp_state['label'] = cid.label
-                    self._state[data][cid] = comp_state
-                    self._components[data]['main'].append(cid)
+            for cid in data.main_components:
+                comp_state = {}
+                comp_state['cid'] = cid
+                comp_state['label'] = cid.label
+                self._state[data][cid] = comp_state
+                self._components[data]['main'].append(cid)
 
             self._components[data]['derived'] = []
 

--- a/glue/dialogs/component_manager/qt/component_manager.py
+++ b/glue/dialogs/component_manager/qt/component_manager.py
@@ -108,6 +108,17 @@ class ComponentManagerWidget(QtWidgets.QDialog):
                     self._state[data][cid] = comp_state
                     self._components[data]['derived'].append(cid)
 
+            self._components[data]['other'] = []
+
+            handled_components = (data.pixel_component_ids +
+                                  data.world_component_ids +
+                                  self._components[data]['main'] +
+                                  self._components[data]['derived'])
+
+            for cid in data.components:
+                if cid not in handled_components:
+                    self._components[data]['other'].append(cid)
+
         # Populate data combo
         for data in self.data_collection:
             self.ui.combosel_data.addItem(data.label, userData=data)
@@ -302,6 +313,7 @@ class ComponentManagerWidget(QtWidgets.QDialog):
 
             cids_main = self._components[data]['main']
             cids_derived = self._components[data]['derived']
+            cids_other = self._components[data]['other']
 
             # First deal with renaming of components
             for cid_new in cids_main + cids_derived:
@@ -309,7 +321,7 @@ class ComponentManagerWidget(QtWidgets.QDialog):
                 if label != cid_new.label:
                     cid_new.label = label
 
-            cids_all = data.pixel_component_ids + data.world_component_ids + cids_main + cids_derived
+            cids_all = data.pixel_component_ids + data.world_component_ids + cids_main + cids_derived + cids_other
 
             cids_existing = data.components
 

--- a/glue/dialogs/component_manager/qt/tests/test_component_manager.py
+++ b/glue/dialogs/component_manager/qt/tests/test_component_manager.py
@@ -7,6 +7,7 @@ from numpy.testing import assert_equal
 from glue.core import Data, DataCollection, HubListener, ComponentID
 from glue.core import message as msg
 from glue.utils.qt import get_qapp
+from glue.core.component_link import ComponentLink
 from glue.core.parse import ParsedCommand, ParsedComponentLink
 
 from ..component_manager import ComponentManagerWidget, EquationEditorDialog
@@ -86,14 +87,16 @@ class ChangeListener(HubListener):
         assert set(added) == set(self.added)
         assert set(removed) == set(self.removed)
         assert set(renamed) == set(self.renamed)
-        assert set(reordered) == set(self.reordered)
+        assert reordered == self.reordered
         assert numerical is self.numerical
 
 
 class TestComponentManagerWidget:
 
     def setup_method(self):
+
         self.app = get_qapp()
+
         self.data1 = Data(x=[1, 2, 3], y=[3.5, 4.5, -1.0], z=['a', 'r', 'w'])
         self.data2 = Data(a=[3, 4, 1], b=[1.5, -2.0, 3.5], c=['y', 'e', 'r'])
 
@@ -104,6 +107,10 @@ class TestComponentManagerWidget:
         self.data2.add_component_link(link)
 
         self.data_collection = DataCollection([self.data1, self.data2])
+
+        link = ComponentLink([self.data1.id['x']], self.data2.id['a'])
+        self.data_collection.add_link(link)
+
         self.listener1 = ChangeListener(self.data1)
         self.listener2 = ChangeListener(self.data2)
 

--- a/glue/dialogs/link_editor/qt/link_editor.py
+++ b/glue/dialogs/link_editor/qt/link_editor.py
@@ -106,7 +106,7 @@ class LinkEditor(QtWidgets.QDialog):
 
     def links(self):
         current = self._ui.current_links
-        return current.data.values()
+        return list(current.data.values())
 
     def _remove_link(self):
         current = self._ui.current_links

--- a/glue/viewers/common/qt/data_viewer_with_state.py
+++ b/glue/viewers/common/qt/data_viewer_with_state.py
@@ -201,6 +201,10 @@ class DataViewerWithState(DataViewer):
                       handler=self._update_data,
                       filter=self._has_data_or_subset)
 
+        hub.subscribe(self, msg.ExternallyDerivableComponentsChangedMessage,
+                      handler=self._update_data,
+                      filter=self._has_data_or_subset)
+
         hub.subscribe(self, msg.SettingsChangeMessage,
                       self._update_appearance_from_settings,
                       filter=self._is_appearance_settings)

--- a/glue/viewers/custom/qt/custom_viewer.py
+++ b/glue/viewers/custom/qt/custom_viewer.py
@@ -1377,13 +1377,12 @@ class ComponenentElement(FormElement, core.hub.HubListener):
         """
         Determine which components to list.
 
-
         This can be overridden by subclassing to limit which components are
         visible to the user.
 
         """
         comps = list(set([c for l in self.container.layers
-                          for c in l.data.components if not c._hidden]))
+                          for c in (l.data.main_components + l.data.derived_components)]))
         comps = sorted(comps, key=lambda x: x.label)
         return comps
 

--- a/glue/viewers/image/layer_artist.py
+++ b/glue/viewers/image/layer_artist.py
@@ -14,7 +14,7 @@ from glue.core.exceptions import IncompatibleAttribute
 from glue.utils import color2rgb
 from glue.core.link_manager import is_equivalent_cid
 from glue.core import Data, HubListener
-from glue.core.message import ComponentsChangedMessage
+from glue.core.message import ComponentsChangedMessage, ExternallyDerivableComponentsChangedMessage
 from glue.external.modest_image import imshow
 
 
@@ -33,6 +33,10 @@ class BaseImageLayerArtist(MatplotlibLayerArtist, HubListener):
         self.state.add_global_callback(self._update_image)
 
         self.layer.hub.subscribe(self, ComponentsChangedMessage,
+                                 handler=self._update_compatibility,
+                                 filter=self._is_data_object)
+
+        self.layer.hub.subscribe(self, ExternallyDerivableComponentsChangedMessage,
                                  handler=self._update_compatibility,
                                  filter=self._is_data_object)
 


### PR DESCRIPTION
This started off as a small bug fix for https://github.com/glue-viz/glue/issues/1532, but I've now refactored how links and derived components from links are stored internally. More explanations soon...

Things that still need doing:

* [x] Figure out whether we can deprecate the concept of a hidden component
* [x] Make sure we are happy with new message names here
* [x] Check for performance issues with existing large session files

Things we can do in a future PR:

* [ ] Recognize binary component links in link editor
* [ ] Have a way to visualize the links