### PR TITLE
Add a graph of data links in link editor

### DIFF
--- a/glue/dialogs/common/qt/component_selector.ui
+++ b/glue/dialogs/common/qt/component_selector.ui
@@ -28,7 +28,7 @@
      <item>
       <widget class="QLabel" name="label">
        <property name="text">
-        <string>Data Set</string>
+        <string>Datasets</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignCenter</set>
@@ -48,7 +48,7 @@
         <enum>Qt::LeftToRight</enum>
        </property>
        <property name="text">
-        <string>Component Identifiers</string>
+        <string>Components</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignCenter</set>

--- a/glue/dialogs/link_editor/qt/data_graph.py
+++ b/glue/dialogs/link_editor/qt/data_graph.py
@@ -1,0 +1,466 @@
+import numpy as np
+
+from qtpy.QtCore import Qt, Signal
+from qtpy.QtGui import QPainter, QTransform, QPen
+from qtpy.QtWidgets import (QGraphicsView, QGraphicsScene, QApplication,
+                            QGraphicsTextItem, QGraphicsEllipseItem,
+                            QGraphicsLineItem)
+
+from glue.utils.qt import mpl_to_qt4_color, qt4_to_mpl_color
+
+PI = 3.14256
+TWOPI = PI * 2
+
+COLOR_SELECTED = (0.2, 0.9, 0.2)
+
+COLOR_DIRECT = (0.6, 0.9, 0.6)
+COLOR_INDIRECT = (0.6, 0.9, 0.9)
+COLOR_DISCONNECTED = (0.9, 0.6, 0.6)
+
+
+def get_pen(color, linewidth=1):
+    color = mpl_to_qt4_color(color)
+    return QPen(color, linewidth, Qt.SolidLine, Qt.RoundCap, Qt.RoundJoin)
+
+
+class Edge(QGraphicsLineItem):
+
+    def __init__(self, node_source, node_dest):
+        self.linewidth = 3
+        self.node_source = node_source
+        self.node_dest = node_dest
+        super(Edge, self).__init__(0, 0, 1, 1)
+        self.setZValue(5)
+        self.color = '0.5'
+
+    def update_position(self):
+        x0, y0 = self.node_source.node_position
+        x1, y1 = self.node_dest.node_position
+        self.setLine(x0, y0, x1, y1)
+
+    @property
+    def color(self):
+        return qt4_to_mpl_color(self.pen().color())
+
+    @color.setter
+    def color(self, value):
+        self.setPen(get_pen(value, self.linewidth))
+
+    def add_to_scene(self, scene):
+        scene.addItem(self)
+
+    def contains(self, point):
+
+        x0 = point.x()
+        y0 = point.y()
+        x1, y1 = self.node_source.node_position
+        x2, y2 = self.node_dest.node_position
+
+        dot = (x0 - x1) * (x2 - x1) + (y0 - y1) * (y2 - y1)
+        vec = (x2 - x1) * (x2 - x1) + (y2 - y1) * (y2 - y1)
+
+        frac = dot / vec
+
+        if frac < 0 or frac > 1:
+            return False
+
+        x3 = x1 + (x2 - x1) * frac
+        y3 = y1 + (y2 - y1) * frac
+
+        return np.hypot(x3 - x0, y3 - y0) < self.linewidth * 2
+
+
+class DataNode:
+
+    def __init__(self, data, radius=15):
+
+        self.data = data
+
+        # Add circular node
+        self.node = QGraphicsEllipseItem(0, 0, 1, 1)
+
+        # Set radius
+        self.radius = radius
+
+        # Add text label
+        self.label = QGraphicsTextItem(data.label)
+        font = self.label.font()
+        font.setPointSize(8)
+        self.label.setFont(font)
+
+        # Add line between label and node
+        self.line1 = QGraphicsLineItem(0, 0, 1, 1)
+        self.line2 = QGraphicsLineItem(0, 0, 1, 1)
+
+        self.node.setZValue(20)
+        self.label.setZValue(10)
+        self.line1.setZValue(10)
+        self.line2.setZValue(10)
+
+        self.line1.setPen(get_pen('0.5'))
+        self.line2.setPen(get_pen('0.5'))
+
+        self.color = '0.8'
+
+    @property
+    def radius(self):
+        return self._radius
+
+    @radius.setter
+    def radius(self, value):
+        self._radius = value
+        self.node.setRect(-value, -value, 2 * value, 2 * value)
+
+    def contains(self, point):
+        x, y = self.node_position
+        return np.hypot(point.x() - x, point.y() - y) <= self.radius
+
+    def update(self):
+        self.node.update()
+
+    def add_to_scene(self, scene):
+        scene.addItem(self.node)
+        scene.addItem(self.label)
+        scene.addItem(self.line1)
+        scene.addItem(self.line2)
+
+    @property
+    def node_position(self):
+        pos = self.node.pos()
+        return pos.x(), pos.y()
+
+    @node_position.setter
+    def node_position(self, value):
+        self.node.setPos(value[0], value[1])
+        self.update_lines()
+
+    @property
+    def label_position(self):
+        pos = self.label.pos()
+        return pos.x(), pos.y()
+
+    @label_position.setter
+    def label_position(self, value):
+        self.label.setPos(value[0], value[1])
+        self.update_lines()
+
+    def update_lines(self):
+        x0, y0 = self.label_position
+        x2, y2 = self.node_position
+        x1 = 0.5 * (x0 + x2)
+        y1 = y0
+        self.line1.setLine(x0, y0, x1, y1)
+        self.line2.setLine(x1, y1, x2, y2)
+
+    @property
+    def color(self):
+        return qt4_to_mpl_color(self.node.brush().color())
+
+    @color.setter
+    def color(self, value):
+        self.node.setBrush(mpl_to_qt4_color(value))
+
+
+def get_connections(data_collection):
+    links = set()
+    for link in data_collection.links:
+        to_id = link.get_to_id()
+        for from_id in link.get_from_ids():
+            data1 = from_id.parent
+            data2 = to_id.parent
+            if data1 is data2:
+                continue
+            if (data1, data2) not in links and (data2, data1) not in links:
+                links.add((data1, data2))
+    return links
+
+
+def layout_simple_circle(nodes, edges, center=None, radius=None):
+
+    # Place nodes around a circle
+
+    nodes = order_nodes_by_connections(nodes, edges)
+
+    for i, node in enumerate(nodes):
+        angle = 2 * np.pi * i / len(nodes)
+        nx = radius * np.cos(angle) + center[0]
+        ny = radius * np.sin(angle) + center[1]
+        node.node_position = nx, ny
+
+
+def order_nodes_by_connections(nodes, edges):
+
+    search_nodes = list(nodes)
+    sorted_nodes = []
+
+    while len(search_nodes) > 0:
+
+        lengths = []
+        connections = []
+
+        for node in search_nodes:
+            direct, indirect = find_connections(node, search_nodes, edges)
+            connections.append((indirect, direct))
+            lengths.append((len(indirect), len(direct)))
+
+        m = max(lengths)
+
+        for i in range(len(lengths)):
+            if lengths[i] == m:
+                for node in connections[i][0] + connections[i][1]:
+                    if node not in sorted_nodes:
+                        sorted_nodes.append(node)
+
+        search_nodes = [node for node in nodes if node not in sorted_nodes]
+
+    return sorted_nodes
+
+
+class DataGraphWidget(QGraphicsView):
+
+    selection_changed = Signal()
+
+    def __init__(self, parent=None):
+
+        super(DataGraphWidget, self).__init__(parent=parent)
+
+        # Set up scene
+
+        self.scene = QGraphicsScene(self)
+        self.scene.setItemIndexMethod(QGraphicsScene.NoIndex)
+        self.scene.setSceneRect(0, 0, 800, 300)
+
+        self.setScene(self.scene)
+
+        self.setWindowTitle("Glue data graph")
+
+        self.setRenderHint(QPainter.Antialiasing)
+        self.setTransformationAnchor(QGraphicsView.AnchorUnderMouse)
+        self.setResizeAnchor(QGraphicsView.AnchorViewCenter)
+
+    def resizeEvent(self, event):
+        self.scene.setSceneRect(0, 0, self.width(), self.height())
+        self.relayout()
+
+    def relayout(self):
+
+        # Update radius
+        for node in self.nodes.values():
+            node.radius = self.height() / 30.
+
+        layout_simple_circle(self.nodes.values(), self.edges,
+                             center=(self.width() / 2, self.height() / 2),
+                             radius=self.height() / 3)
+
+        # Update edge positions
+        for edge in self.edges:
+            edge.update_position()
+
+        # Set up labels
+        self.left_nodes = [node for node in self.nodes.values() if node.node_position[0] < self.width() / 2]
+        self.left_nodes = sorted(self.left_nodes, key=lambda x: x.node_position[1], reverse=True)
+
+        self.right_nodes = [node for node in self.nodes.values() if node.node_position[0] > self.width() / 2]
+        self.right_nodes = sorted(self.right_nodes, key=lambda x: x.node_position[1], reverse=True)
+
+        for i, node in enumerate(self.left_nodes):
+            y = self.height() - (i + 1) / (len(self.left_nodes) + 1) * self.height()
+            node.label_position = self.width() / 2 - self.height() / 2, y
+
+        for i, node in enumerate(self.right_nodes):
+            y = self.height() - (i + 1) / (len(self.right_nodes) + 1) * self.height()
+            node.label_position = self.width() / 2 + self.height() / 2, y
+
+    def set_data_collection(self, data_collection):
+
+        # Get data and initialize nodes
+        self.nodes = dict((data, DataNode(data)) for data in data_collection)
+
+        # Get links and set up edges
+        self.edges = [Edge(self.nodes[data1], self.nodes[data2])
+                      for data1, data2 in get_connections(data_collection)]
+
+        # Figure out positions
+        self.relayout()
+
+        # Add nodes and edges to graph
+
+        for node in self.nodes.values():
+            node.add_to_scene(self.scene)
+
+        for edge in self.edges:
+            edge.add_to_scene(self.scene)
+
+        self.text_adjusted = False
+
+        self.selected_edge = None
+        self.selected_node1 = None
+        self.selected_node2 = None
+
+    def paintEvent(self, event):
+
+        super(DataGraphWidget, self).paintEvent(event)
+
+        if not self.text_adjusted:
+
+            for node in self.nodes.values():
+
+                width = node.label.boundingRect().width()
+                height = node.label.boundingRect().height()
+
+                transform = QTransform()
+                if node in self.left_nodes:
+                    transform.translate(-width, -height / 2)
+                else:
+                    transform.translate(0, -height / 2)
+
+                node.label.setTransform(transform)
+
+            self.text_adjusted = True
+
+    def find_object(self, event):
+        for obj in list(self.nodes.values()) + self.edges:
+            if obj.contains(event.localPos()):
+                return obj
+
+    def mouseMoveEvent(self, event):
+
+        # TODO: Don't update until the end
+        # TODO: Only select object on top
+
+        if self.selected_node1 is not None or self.selected_node2 is not None:
+            return
+
+        selected = self.find_object(event)
+
+        colors = {}
+
+        if isinstance(selected, DataNode):
+
+            colors[selected] = COLOR_DIRECT
+
+            direct, indirect = find_connections(selected, self.nodes.values(), self.edges)
+
+            for node in self.nodes.values():
+                if node in direct:
+                    colors[node] = COLOR_DIRECT
+                elif node in indirect:
+                    colors[node] = COLOR_INDIRECT
+                else:
+                    colors[node] = COLOR_DISCONNECTED
+
+        elif isinstance(selected, Edge):
+
+            colors[selected] = COLOR_DIRECT
+            colors[selected.node_source] = COLOR_DIRECT
+            colors[selected.node_dest] = COLOR_DIRECT
+
+        self.set_colors(colors)
+
+    def mousePressEvent(self, event):
+
+        # TODO: Don't update until the end
+        # TODO: Only select object on top
+
+        selected = self.find_object(event)
+
+        if isinstance(selected, DataNode):
+
+            if self.selected_node1 is None:
+                self.selected_node1 = selected
+            elif self.selected_node1 is selected:
+                self.selected_node1 = None
+            elif self.selected_node2 is selected:
+                self.selected_node2 = None
+            else:
+                self.selected_node2 = selected
+
+            self._update_selected_edge()
+
+        elif isinstance(selected, Edge):
+
+            if self.selected_edge is selected:
+                self.selected_edge = None
+                self.selected_node1 = None
+                self.selected_node2 = None
+            else:
+                self.selected_edge = selected
+                self.selected_node1 = selected.node_source
+                self.selected_node2 = selected.node_dest
+
+        self._update_selected_colors()
+
+        self.mouseMoveEvent(event)
+
+        self.selection_changed.emit()
+
+    def _update_selected_edge(self):
+        for edge in self.edges:
+            if (edge.node_source is self.selected_node1 and edge.node_dest is self.selected_node2 or
+                    edge.node_source is self.selected_node2 and edge.node_dest is self.selected_node1):
+                self.selected_edge = edge
+                break
+        else:
+            self.selected_edge = None
+
+    def _update_selected_colors(self):
+
+        colors = {}
+
+        if self.selected_edge is not None:
+            colors[self.selected_edge] = COLOR_SELECTED
+
+        if self.selected_node1 is not None:
+            colors[self.selected_node1] = COLOR_SELECTED
+
+        if self.selected_node2 is not None:
+            colors[self.selected_node2] = COLOR_SELECTED
+
+        self.set_colors(colors)
+
+    def set_colors(self, colors):
+
+        for obj in list(self.nodes.values()) + self.edges:
+            default_color = '0.8' if isinstance(obj, DataNode) else '0.5'
+            obj.color = colors.get(obj, default_color)
+            obj.update()
+
+
+def find_connections(node, nodes, edges):
+
+    direct = [node]
+    indirect = []
+    current = direct
+    connected = [node]
+
+    changed = True
+    while changed:
+        changed = False
+        for edge in edges:
+            source = edge.node_source
+            dest = edge.node_dest
+            if source in connected and dest not in connected:
+                current.append(dest)
+                changed = True
+            if dest in connected and source not in connected:
+                current.append(source)
+                changed = True
+        current = indirect
+        connected.extend(current)
+    return direct, indirect
+
+
+if __name__ == '__main__':
+
+    import sys
+
+    app = QApplication(sys.argv)
+    app.setAttribute(Qt.AA_UseHighDpiPixmaps)
+
+    from glue.core.state import load
+    dc = load('links.glu')
+
+    widget = DataGraphWidget(dc)
+    widget.show()
+
+    sys.exit(app.exec_())

--- a/glue/dialogs/link_editor/qt/data_graph.py
+++ b/glue/dialogs/link_editor/qt/data_graph.py
@@ -8,13 +8,8 @@ from qtpy.QtWidgets import (QGraphicsView, QGraphicsScene, QApplication,
 
 from glue.utils.qt import mpl_to_qt4_color, qt4_to_mpl_color
 
-PI = 3.14256
-TWOPI = PI * 2
-
 COLOR_SELECTED = (0.2, 0.9, 0.2)
-
-COLOR_DIRECT = (0.6, 0.9, 0.9)
-COLOR_INDIRECT = (0.6, 0.9, 0.9)
+COLOR_CONNECTED = (0.6, 0.9, 0.9)
 COLOR_DISCONNECTED = (0.9, 0.6, 0.6)
 
 
@@ -476,17 +471,15 @@ class DataGraphWidget(QGraphicsView):
             direct, indirect = find_connections(self.selected_node1, self.nodes.values(), self.edges)
 
             for node in self.nodes.values():
-                if node in direct:
-                    colors[node] = COLOR_DIRECT
-                elif node in indirect:
-                    colors[node] = COLOR_INDIRECT
+                if node in direct or node in indirect:
+                    colors[node] = COLOR_CONNECTED
                 else:
                     colors[node] = COLOR_DISCONNECTED
 
             for edge in self.edges:
                 if (edge.node_source is self.selected_node1 or
                         edge.node_dest is self.selected_node1):
-                    colors[edge] = COLOR_DIRECT
+                    colors[edge] = COLOR_CONNECTED
 
         if self.selected_edge is not None:
             colors[self.selected_edge] = COLOR_SELECTED

--- a/glue/dialogs/link_editor/qt/link_editor.py
+++ b/glue/dialogs/link_editor/qt/link_editor.py
@@ -48,10 +48,7 @@ class LinkEditor(QtWidgets.QDialog):
     @avoid_circular
     def _on_data_change_combo(self):
         graph = self._ui.graph_widget
-        graph.selected_node1 = graph.nodes.get(self._ui.left_components.data, None)
-        graph.selected_node2 = graph.nodes.get(self._ui.right_components.data, None)
-        graph._update_selected_edge()
-        graph._update_selected_colors()
+        graph.manual_select(self._ui.left_components.data, self._ui.right_components.data)
         self._update_links_list()
 
     def _init_widgets(self):

--- a/glue/dialogs/link_editor/qt/link_editor.ui
+++ b/glue/dialogs/link_editor/qt/link_editor.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>824</width>
-    <height>706</height>
+    <height>576</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -24,6 +24,12 @@
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>200</height>
+      </size>
      </property>
      <property name="verticalScrollBarPolicy">
       <enum>Qt::ScrollBarAlwaysOff</enum>
@@ -81,46 +87,6 @@
        </item>
        <item>
         <spacer name="horizontalSpacer_5">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </item>
-     <item row="2" column="2">
-      <layout class="QHBoxLayout" name="horizontalLayout_7">
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <item>
-        <spacer name="horizontalSpacer">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="QPushButton" name="add_link">
-         <property name="text">
-          <string>Glue</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="horizontalSpacer_3">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
          </property>
@@ -193,35 +159,6 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="2">
-      <layout class="QVBoxLayout" name="verticalLayout_4">
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <item>
-        <widget class="LinkEquation" name="signature_editor" native="true">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-           <horstretch>100</horstretch>
-           <verstretch>100</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>250</height>
-          </size>
-         </property>
-         <property name="acceptDrops">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
      <item row="1" column="6">
       <widget class="QTreeWidget" name="current_links">
        <property name="minimumSize">
@@ -247,7 +184,17 @@
        </column>
       </widget>
      </item>
-     <item row="0" column="3" rowspan="2">
+     <item row="0" column="0" rowspan="3">
+      <widget class="ComponentSelector" name="left_components" native="true">
+       <property name="minimumSize">
+        <size>
+         <width>100</width>
+         <height>0</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="3" rowspan="3">
       <widget class="ComponentSelector" name="right_components" native="true">
        <property name="minimumSize">
         <size>
@@ -257,15 +204,101 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="0" rowspan="2">
-      <widget class="ComponentSelector" name="left_components" native="true">
-       <property name="minimumSize">
-        <size>
-         <width>100</width>
-         <height>0</height>
-        </size>
+     <item row="1" column="2" rowspan="2">
+      <layout class="QVBoxLayout" name="verticalLayout_4">
+       <property name="leftMargin">
+        <number>0</number>
        </property>
-      </widget>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="LinkEquation" name="signature_editor" native="true">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>100</horstretch>
+           <verstretch>100</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>200</height>
+          </size>
+         </property>
+         <property name="acceptDrops">
+          <bool>true</bool>
+         </property>
+         <zorder></zorder>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_7">
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <spacer name="horizontalSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QPushButton" name="add_link">
+           <property name="text">
+            <string>Glue</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_3">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
      </item>
     </layout>
    </item>

--- a/glue/dialogs/link_editor/qt/link_editor.ui
+++ b/glue/dialogs/link_editor/qt/link_editor.ui
@@ -17,10 +17,16 @@
    <bool>false</bool>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="topMargin">
+    <number>5</number>
+   </property>
+   <property name="bottomMargin">
+    <number>5</number>
+   </property>
    <item>
     <widget class="QLabel" name="label">
      <property name="text">
-      <string>Click on two datasets to set up links or click on an existing connection to edit links. When one node is selected, the colors show directly and indirectly linked (blue) and inaccessible (red) datasets. </string>
+      <string>Click on two datasets to set up links or click on an existing connection to edit links. Selected datasets are shown in green. When one dataset is selected, the colors show directly and indirectly linked (blue) and inaccessible (red) datasets. </string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>

--- a/glue/dialogs/link_editor/qt/link_editor.ui
+++ b/glue/dialogs/link_editor/qt/link_editor.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>674</width>
-    <height>621</height>
+    <width>824</width>
+    <height>706</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -16,234 +16,286 @@
   <property name="sizeGripEnabled">
    <bool>false</bool>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout_6">
+  <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QVBoxLayout" name="verticalLayout_3">
-     <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_4" stretch="1">
-       <item>
-        <layout class="QVBoxLayout" name="verticalLayout_2">
-         <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_3">
-           <item>
-            <widget class="ComponentSelector" name="left_components" native="true">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-               <horstretch>1</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize">
-              <size>
-               <width>250</width>
-               <height>0</height>
-              </size>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <layout class="QVBoxLayout" name="verticalLayout_4">
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <item>
-              <layout class="QHBoxLayout" name="horizontalLayout_8">
-               <property name="topMargin">
-                <number>0</number>
-               </property>
-               <item>
-                <spacer name="horizontalSpacer_4">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-               <item>
-                <widget class="QToolButton" name="toggle_editor">
-                 <property name="whatsThis">
-                  <string>Show/hide advanced linking</string>
-                 </property>
-                 <property name="text">
-                  <string>Advanced linking</string>
-                 </property>
-                 <property name="autoRaise">
-                  <bool>true</bool>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <spacer name="horizontalSpacer_5">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-              </layout>
-             </item>
-             <item>
-              <widget class="LinkEquation" name="signature_editor" native="true">
-               <property name="enabled">
-                <bool>true</bool>
-               </property>
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                 <horstretch>100</horstretch>
-                 <verstretch>100</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="minimumSize">
-                <size>
-                 <width>0</width>
-                 <height>300</height>
-                </size>
-               </property>
-               <property name="acceptDrops">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <layout class="QHBoxLayout" name="horizontalLayout_7">
-               <property name="topMargin">
-                <number>0</number>
-               </property>
-               <item>
-                <spacer name="horizontalSpacer">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-               <item>
-                <widget class="QPushButton" name="add_link">
-                 <property name="text">
-                  <string>Glue</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <spacer name="horizontalSpacer_3">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-              </layout>
-             </item>
-            </layout>
-           </item>
-           <item>
-            <widget class="ComponentSelector" name="right_components" native="true">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-               <horstretch>1</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize">
-              <size>
-               <width>250</width>
-               <height>0</height>
-              </size>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-        </layout>
-       </item>
-      </layout>
+    <widget class="DataGraphWidget" name="graph_widget">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="verticalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
+     <property name="horizontalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="1" column="4">
+      <spacer name="horizontalSpacer_6">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
      </item>
-     <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_5"/>
-     </item>
-     <item>
-      <layout class="QVBoxLayout" name="verticalLayout">
+     <item row="0" column="2">
+      <layout class="QHBoxLayout" name="horizontalLayout_8">
+       <property name="topMargin">
+        <number>0</number>
+       </property>
        <item>
-        <widget class="QLabel" name="label">
-         <property name="text">
-          <string>Current Links</string>
+        <spacer name="horizontalSpacer_4">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
          </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QToolButton" name="toggle_editor">
+         <property name="whatsThis">
+          <string>Show/hide advanced linking</string>
+         </property>
+         <property name="text">
+          <string>Advanced linking</string>
+         </property>
+         <property name="autoRaise">
+          <bool>true</bool>
          </property>
         </widget>
        </item>
        <item>
-        <widget class="GlueMimeListWidget" name="current_links"/>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_2">
-         <item>
-          <widget class="QPushButton" name="remove_link">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Unglue</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout">
-         <item>
-          <spacer name="horizontalSpacer_2">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <widget class="QDialogButtonBox" name="buttonBox">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="standardButtons">
-            <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-           </property>
-           <property name="centerButtons">
-            <bool>false</bool>
-           </property>
-          </widget>
-         </item>
-        </layout>
+        <spacer name="horizontalSpacer_5">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
        </item>
       </layout>
+     </item>
+     <item row="2" column="2">
+      <layout class="QHBoxLayout" name="horizontalLayout_7">
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QPushButton" name="add_link">
+         <property name="text">
+          <string>Glue</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
+     <item row="2" column="6">
+      <layout class="QHBoxLayout" name="horizontalLayout_9">
+       <item>
+        <spacer name="horizontalSpacer_8">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QPushButton" name="remove_link">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Unglue</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer_7">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
+     <item row="0" column="6">
+      <widget class="QLabel" name="label_4">
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>Current Links</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <layout class="QVBoxLayout" name="verticalLayout_4">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="LinkEquation" name="signature_editor" native="true">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>100</horstretch>
+           <verstretch>100</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>250</height>
+          </size>
+         </property>
+         <property name="acceptDrops">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item row="1" column="6">
+      <widget class="QTreeWidget" name="current_links">
+       <property name="minimumSize">
+        <size>
+         <width>300</width>
+         <height>0</height>
+        </size>
+       </property>
+       <column>
+        <property name="text">
+         <string>Function</string>
+        </property>
+       </column>
+       <column>
+        <property name="text">
+         <string>Component 1</string>
+        </property>
+       </column>
+       <column>
+        <property name="text">
+         <string>Component 2</string>
+        </property>
+       </column>
+      </widget>
+     </item>
+     <item row="0" column="3" rowspan="2">
+      <widget class="ComponentSelector" name="right_components" native="true">
+       <property name="minimumSize">
+        <size>
+         <width>100</width>
+         <height>0</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0" rowspan="2">
+      <widget class="ComponentSelector" name="left_components" native="true">
+       <property name="minimumSize">
+        <size>
+         <width>100</width>
+         <height>0</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+       </property>
+       <property name="centerButtons">
+        <bool>false</bool>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>
@@ -251,21 +303,22 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>ComponentSelector</class>
-   <extends>QWidget</extends>
-   <header>glue.dialogs.common.qt.component_selector</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>LinkEquation</class>
    <extends>QWidget</extends>
    <header>glue.dialogs.link_editor.qt.link_equation</header>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>GlueMimeListWidget</class>
-   <extends>QListWidget</extends>
-   <header>glue.core.qt.mime</header>
+   <class>DataGraphWidget</class>
+   <extends>QGraphicsView</extends>
+   <header>glue.dialogs.link_editor.qt.data_graph</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ComponentSelector</class>
+   <extends>QWidget</extends>
+   <header>glue.dialogs.common.qt.component_selector</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/glue/dialogs/link_editor/qt/link_editor.ui
+++ b/glue/dialogs/link_editor/qt/link_editor.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>824</width>
-    <height>576</height>
+    <width>781</width>
+    <height>684</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,6 +17,16 @@
    <bool>false</bool>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Click on two datasets to set up links or click on an existing connection to edit links. When one node is selected, the colors show directly and indirectly linked (blue) and inaccessible (red) datasets. </string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
    <item>
     <widget class="DataGraphWidget" name="graph_widget">
      <property name="sizePolicy">
@@ -53,52 +63,6 @@
         </size>
        </property>
       </spacer>
-     </item>
-     <item row="0" column="2">
-      <layout class="QHBoxLayout" name="horizontalLayout_8">
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <item>
-        <spacer name="horizontalSpacer_4">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="QToolButton" name="toggle_editor">
-         <property name="whatsThis">
-          <string>Show/hide advanced linking</string>
-         </property>
-         <property name="text">
-          <string>Advanced linking</string>
-         </property>
-         <property name="autoRaise">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="horizontalSpacer_5">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
      </item>
      <item row="2" column="6">
       <layout class="QHBoxLayout" name="horizontalLayout_9">
@@ -204,24 +168,14 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="2" rowspan="2">
+     <item row="0" column="2" rowspan="3">
       <layout class="QVBoxLayout" name="verticalLayout_4">
+       <property name="spacing">
+        <number>0</number>
+       </property>
        <property name="leftMargin">
         <number>0</number>
        </property>
-       <item>
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
        <item>
         <widget class="LinkEquation" name="signature_editor" native="true">
          <property name="enabled">
@@ -242,7 +196,6 @@
          <property name="acceptDrops">
           <bool>true</bool>
          </property>
-         <zorder></zorder>
         </widget>
        </item>
        <item>
@@ -285,25 +238,25 @@
          </item>
         </layout>
        </item>
-       <item>
-        <spacer name="verticalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
       </layout>
      </item>
     </layout>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QToolButton" name="toggle_editor">
+       <property name="whatsThis">
+        <string>Show/hide advanced linking</string>
+       </property>
+       <property name="text">
+        <string>Advanced linking</string>
+       </property>
+       <property name="autoRaise">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
      <item>
       <spacer name="horizontalSpacer_2">
        <property name="orientation">

--- a/glue/dialogs/link_editor/qt/link_equation.py
+++ b/glue/dialogs/link_editor/qt/link_equation.py
@@ -8,7 +8,6 @@ except ImportError:  # Python 2.7
     from inspect import getargspec as getfullargspec
 
 from qtpy import QtWidgets
-from qtpy import PYSIDE
 from glue import core
 from glue.config import link_function, link_helper
 from glue.utils import nonpartial
@@ -133,7 +132,6 @@ class LinkEquation(QtWidgets.QWidget):
 
         # Set up mapping of function/helper name -> function/helper tuple. For the helpers, we use the 'display' name if available.
         self._argument_widgets = []
-        self.spacer = None
         self._output_widget = ArgumentWidget("")
 
         # pyqt4 can't take self as second argument here
@@ -144,7 +142,8 @@ class LinkEquation(QtWidgets.QWidget):
         l.addWidget(self._ui)
         self.setLayout(l)
 
-        self._init_widgets()
+        self._ui.outputs_layout.addWidget(self._output_widget)
+
         self._populate_category_combo()
         self.category = 'General'
         self._populate_function_combo()
@@ -152,7 +151,7 @@ class LinkEquation(QtWidgets.QWidget):
         self._setup_editor()
 
     def set_result_visible(self, state):
-        self._ui.output_canvas.setVisible(state)
+        self._output_widget.setVisible(state)
         self._ui.output_label.setVisible(state)
 
     def is_helper(self):
@@ -162,26 +161,6 @@ class LinkEquation(QtWidgets.QWidget):
     def is_function(self):
         return self.function is not None and \
             type(self.function).__name__ == 'LinkFunction'
-
-    def _init_widgets(self):
-
-        layout = QtWidgets.QVBoxLayout()
-        layout.setSpacing(1)
-        self._ui.input_canvas.setLayout(layout)
-
-        layout = QtWidgets.QVBoxLayout()
-        layout.setContentsMargins(1, 0, 1, 1)
-        self._ui.output_canvas.setLayout(layout)
-
-        layout.addWidget(self._output_widget)
-        spacer = QtWidgets.QSpacerItem(5, 5,
-                                       QtWidgets.QSizePolicy.Minimum,
-                                       QtWidgets.QSizePolicy.Expanding)
-        layout.addItem(spacer)
-
-        font = self._ui.info.font()
-        font.setPointSize(font.pointSize() * 1.4)
-        self._ui.info.setFont(font)
 
     @property
     def signature(self):
@@ -261,10 +240,6 @@ class LinkEquation(QtWidgets.QWidget):
         for a in args:
             self._add_argument_widget(a)
 
-        self.spacer = QtWidgets.QSpacerItem(5, 5, QtWidgets.QSizePolicy.Minimum,
-                                        QtWidgets.QSizePolicy.Expanding)
-        self._ui.input_canvas.layout().addItem(self.spacer)
-
     def _setup_editor_helper(self):
         """Setup the editor for the selected link helper"""
         assert self.is_helper()
@@ -277,29 +252,21 @@ class LinkEquation(QtWidgets.QWidget):
         for a in args:
             self._add_argument_widget(a)
 
-        self.spacer = QtWidgets.QSpacerItem(5, 5, QtWidgets.QSizePolicy.Minimum,
-                                        QtWidgets.QSizePolicy.Expanding)
-        self._ui.input_canvas.layout().addItem(self.spacer)
-
     def _add_argument_widget(self, argument):
         """ Create and add a single argument widget to the input canvas
         :param arguement: The argument name (string)
         """
         widget = ArgumentWidget(argument)
         widget.editor.textChanged.connect(nonpartial(self._update_add_enabled))
-        self._ui.input_canvas.layout().addWidget(widget)
+        self._ui.inputs_layout.addWidget(widget)
         self._argument_widgets.append(widget)
 
     def _clear_input_canvas(self):
         """ Remove all widgets from the input canvas """
-        layout = self._ui.input_canvas.layout()
+        layout = self._ui.inputs_layout
         for a in self._argument_widgets:
             layout.removeWidget(a)
             a.close()
-
-        if not PYSIDE:
-            # PySide crashing here
-            layout.removeItem(self.spacer)
 
         self._argument_widgets = []
 

--- a/glue/dialogs/link_editor/qt/link_equation.ui
+++ b/glue/dialogs/link_editor/qt/link_equation.ui
@@ -6,187 +6,120 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>357</width>
-    <height>300</height>
+    <width>190</width>
+    <height>180</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
     <width>0</width>
-    <height>300</height>
+    <height>0</height>
    </size>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout_4">
-   <property name="margin">
-    <number>4</number>
-   </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
-    <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,8,8">
-     <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_6">
-       <item>
-        <widget class="QLabel" name="label">
-         <property name="text">
-          <string>Category:</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QComboBox" name="category">
-         <property name="sizeAdjustPolicy">
-          <enum>QComboBox::AdjustToMinimumContentsLength</enum>
-         </property>
-         <property name="minimumContentsLength">
-          <number>5</number>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="horizontalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>10</width>
-           <height>10</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="QLabel" name="label_2">
-         <property name="text">
-          <string>Function:</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QComboBox" name="function">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>Select a translation function to use</string>
-         </property>
-         <property name="sizeAdjustPolicy">
-          <enum>QComboBox::AdjustToMinimumContentsLength</enum>
-         </property>
-         <property name="minimumContentsLength">
-          <number>5</number>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-     <item>
-      <widget class="QLabel" name="info">
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
        <property name="text">
-        <string>result = f(x, y)</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
+        <string>Category:</string>
        </property>
       </widget>
      </item>
+     <item row="0" column="1">
+      <widget class="QComboBox" name="category">
+       <property name="sizeAdjustPolicy">
+        <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+       </property>
+       <property name="minimumContentsLength">
+        <number>5</number>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Function:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QComboBox" name="function">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string>Select a translation function to use</string>
+       </property>
+       <property name="sizeAdjustPolicy">
+        <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+       </property>
+       <property name="minimumContentsLength">
+        <number>5</number>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QLabel" name="info">
+     <property name="text">
+      <string>result = f(x, y)</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayout">
      <item>
-      <widget class="QLabel" name="help_txt">
+      <widget class="QLabel" name="input_label">
        <property name="font">
         <font>
-         <italic>true</italic>
+         <weight>75</weight>
+         <bold>true</bold>
         </font>
        </property>
        <property name="text">
-        <string>Drag Component Identifiers from above</string>
+        <string>Inputs</string>
        </property>
        <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-       <property name="margin">
-        <number>0</number>
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
        </property>
       </widget>
      </item>
      <item>
-      <layout class="QHBoxLayout" name="horizontalLayout">
-       <item>
-        <widget class="QLabel" name="input_label">
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Inputs</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QWidget" name="input_canvas" native="true">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>0</height>
-          </size>
-         </property>
-        </widget>
-       </item>
-      </layout>
+      <layout class="QVBoxLayout" name="inputs_layout"/>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayout2">
+     <item>
+      <widget class="QLabel" name="output_label">
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>Result</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+       </property>
+      </widget>
      </item>
      <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_2">
-       <item>
-        <widget class="QLabel" name="output_label">
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Result</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QWidget" name="output_canvas" native="true">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>0</height>
-          </size>
-         </property>
-        </widget>
-       </item>
-      </layout>
+      <layout class="QVBoxLayout" name="outputs_layout"/>
      </item>
     </layout>
    </item>


### PR DESCRIPTION
This adds a graph of all links in the link editor, which makes it much easier to see which datasets have already been connected.

Things that remain to be done:

* [ ] Grey out link data if only one dataset is present
* [ ] Add changelog entry