### PR TITLE
Improve error message when _slice_index fails in PV slicer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -56,6 +56,8 @@ v0.13.0 (unreleased)
 v0.12.4 (unreleased)
 --------------------
 
+* Improve error message in PV slicer when _slice_index fails. [#1536]
+
 * Fixed a bug that caused an error in the terminal if creating a data
   viewer failed properly (with a GUI error message).
 

--- a/glue/plugins/tools/pv_slicer/qt/pv_slicer.py
+++ b/glue/plugins/tools/pv_slicer/qt/pv_slicer.py
@@ -240,9 +240,10 @@ def _slice_index(data, slc):
     """
     The axis over which to extract PV slices
     """
-    return max([i for i in range(len(slc))
-                if isinstance(slc[i], int)],
-               key=lambda x: data.shape[x])
+    for i in range(len(slc)):
+        if np.isreal(slc[i]):
+            return i
+    raise ValueError("Could not find slice index with slc={0}".format(slc))
 
 
 def _slice_label(data, slc):

--- a/glue/plugins/tools/pv_slicer/qt/tests/test_pv_slicer.py
+++ b/glue/plugins/tools/pv_slicer/qt/tests/test_pv_slicer.py
@@ -51,9 +51,9 @@ def test_slice_label():
 
 
 def test_slice_index():
-    d = Data(x=np.zeros((2, 3, 4, 1)))
-    assert _slice_index(d, (0, 'y', 'x', 0)) == 0
-    assert _slice_index(d, (0, 'y', 0, 'x')) == 2
+    d = Data(x=np.zeros((2, 3, 4)))
+    assert _slice_index(d, (0, 'y', 'x')) == 0
+    assert _slice_index(d, ('y', 0, 'x')) == 1
 
 
 class TestStandaloneImageViewer(object):


### PR DESCRIPTION
Users occasionally report an error in this function but the output is not enough to debug this, so clarifying the error message to include the slice data.