### PR TITLE
Pin Sphinx version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ env:
     - PYTEST_ARGS="--cov glue -vs"
     - ASTROPY_VERSION=stable
     - NUMPY_VERSION=1.13
+    # We pin Sphinx due to https://github.com/sphinx-doc/sphinx/issues/4689
+    - SPHINX_VERSION=1.7.0
     - NO_CFG_FILES=false
     - QT_PKG=pyqt5
     - SETUP_XVFB=True


### PR DESCRIPTION
Sphinx 1.7.1 has a bug that causes issues with the detection of the first line of docstrings: https://github.com/sphinx-doc/sphinx/issues/4689