### PR TITLE
Fix click and drag of ROI when using NewMode

### DIFF
--- a/glue/core/command.py
+++ b/glue/core/command.py
@@ -286,8 +286,10 @@ class ApplySubsetState(Command):
         DataCollection to operate on
     subset_state: :class:`~glue.core.subset_state.SubsetState`
         Subset state to apply
+    use_current: bool
+        Flag indicating whether to update current subset or create a new one
     """
-    kwargs = ['data_collection', 'subset_state']
+    kwargs = ['data_collection', 'subset_state', 'use_current']
     label = 'apply subset'
 
     def do(self, session):
@@ -298,7 +300,7 @@ class ApplySubsetState(Command):
                 self.old_states[subset] = subset.subset_state
 
         mode = session.edit_subset_mode
-        mode.update(self.data_collection, self.subset_state)
+        mode.update(self.data_collection, self.subset_state, use_current=self.use_current)
 
     def undo(self, session):
         for data in self.data_collection:

--- a/glue/core/edit_subset_mode.py
+++ b/glue/core/edit_subset_mode.py
@@ -42,7 +42,7 @@ class EditSubsetMode(object):
         if self.data_collection is not None:
             self.data_collection.hub.broadcast(EditSubsetMessage(self, value))
 
-    def _combine_data(self, new_state):
+    def _combine_data(self, new_state, use_current=False):
         """ Dispatches to the combine method of mode attribute.
 
         The behavior is dependent on the mode it dispatches to.
@@ -51,8 +51,9 @@ class EditSubsetMode(object):
 
         :param edit_subset: The current edit_subset
         :param new_state: The new SubsetState
+        :param use_current: Do not create a new subset even if using NewMode
         """
-        if not self._edit_subset or self.mode is NewMode:
+        if not self._edit_subset or (self.mode is NewMode and not use_current):
             if self.data_collection is None:
                 raise RuntimeError("Must set data_collection before "
                                    "calling update")
@@ -64,7 +65,7 @@ class EditSubsetMode(object):
     @contract(d='inst($DataCollection, $Data)',
               new_state='isinstance(SubsetState)',
               focus_data='inst($Data)|None')
-    def update(self, d, new_state, focus_data=None):
+    def update(self, d, new_state, focus_data=None, use_current=False):
         """ Apply a new subset state to editable subsets within a
         :class:`~glue.core.data.Data` or
         :class:`~glue.core.data_collection.DataCollection` instance
@@ -78,11 +79,14 @@ class EditSubsetMode(object):
         :param focus_data: The main data set in focus by the client,
         if relevant. If a data set is in focus and has no subsets,
         a new one will be created using new_state.
+
+        :param use_current: Do not create a new subset even if using NewMode
+        :type use_current: bool
         """
         logging.getLogger(__name__).debug("Update subset for %s", d)
 
         if isinstance(d, (Data, DataCollection)):
-            self._combine_data(new_state)
+            self._combine_data(new_state, use_current=use_current)
         else:
             raise TypeError("input must be a Data or DataCollection: %s" %
                             type(d))

--- a/glue/viewers/image/qt/mouse_mode.py
+++ b/glue/viewers/image/qt/mouse_mode.py
@@ -81,7 +81,7 @@ class RoiClickAndDragMode(MouseMode):
     def release(self, event):
         if self._roi:
             self._roi.finalize_selection(event)
-            self._viewer.apply_roi(self._roi.roi())
+            self._viewer.apply_roi(self._roi.roi(), use_current=True)
 
             self._roi = None
             self._subset = None

--- a/glue/viewers/matplotlib/qt/data_viewer.py
+++ b/glue/viewers/matplotlib/qt/data_viewer.py
@@ -208,14 +208,15 @@ class MatplotlibDataViewer(DataViewerWithState):
 
     # TODO: move some of the ROI stuff to state class?
 
-    def apply_roi(self, roi):
+    def apply_roi(self, roi, use_current=False):
         """ This method relies on _roi_to_subset_state to be implemented by
         subclasses.
         """
         if len(self.layers) > 0:
             subset_state = self._roi_to_subset_state(roi)
             cmd = ApplySubsetState(data_collection=self._data,
-                                   subset_state=subset_state)
+                                   subset_state=subset_state,
+                                   use_current=use_current)
             self._session.command_stack.do(cmd)
         else:
             # Make sure we force a redraw to get rid of the ROI


### PR DESCRIPTION
Prior to this fix, clicking and dragging an existing ROI in `NewMode` would create a new ROI instead of relocating the existing one.