### PR TITLE
Improve performance of slicing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -138,6 +138,9 @@ v0.12.6 (unreleased)
 
 * Fixed ticks on log x-axis in histogram viewer. [#7310]
 
+* Fixed a bug that led to poor performance when slicing through data cubes.
+  [#1554]
+
 v0.12.5 (unreleased)
 --------------------
 

--- a/glue/viewers/image/qt/data_viewer.py
+++ b/glue/viewers/image/qt/data_viewer.py
@@ -74,6 +74,7 @@ class ImageViewer(MatplotlibDataViewer):
 
     def __init__(self, session, parent=None, state=None):
         self._wcs_set = False
+        self._changing_slice_requires_wcs_update = None
         super(ImageViewer, self).__init__(session, parent=parent, wcs=True, state=state)
         self.axes.set_adjustable('datalim')
         self.state.add_callback('x_att', self._set_wcs)

--- a/glue/viewers/image/qt/tests/test_data_viewer.py
+++ b/glue/viewers/image/qt/tests/test_data_viewer.py
@@ -44,6 +44,23 @@ class TestImageCommon(BaseTestMatplotlibDataViewer):
     def test_double_add_ignored(self):
         pass
 
+    def test_slice_change_single_draw(self):
+
+        # Regression test for a bug that caused Matplotlib to draw once per
+        # data/subset when changing slices.
+
+        self.viewer.add_data(self.data)
+
+        self.data_collection.new_subset_group(label='a', subset_state=self.data.id['x'] > 1)
+        self.data_collection.new_subset_group(label='b', subset_state=self.data.id['x'] > 2)
+        self.data_collection.new_subset_group(label='c', subset_state=self.data.id['x'] > 3)
+
+        self.init_draw_count()
+
+        assert self.draw_count == 0
+        self.viewer.state.slices = (1, 1, 1)
+        assert self.draw_count == 1
+
 
 class MyCoords(Coordinates):
     def axis_label(self, i):

--- a/glue/viewers/matplotlib/state.py
+++ b/glue/viewers/matplotlib/state.py
@@ -85,6 +85,10 @@ class MatplotlibDataViewerState(State):
     def layers_data(self):
         return [layer_state.layer for layer_state in self.layers]
 
+    @defer_draw
+    def _notify_global(self, *args, **kwargs):
+        super(MatplotlibDataViewerState, self)._notify_global(*args, **kwargs)
+
 
 class MatplotlibLayerState(State):
     """
@@ -125,3 +129,7 @@ class MatplotlibLayerState(State):
         message = LayerArtistUpdatedMessage(self)
         if self.layer is not None and self.layer.hub is not None:
             self.layer.hub.broadcast(message)
+
+    @defer_draw
+    def _notify_global(self, *args, **kwargs):
+        super(MatplotlibLayerState, self)._notify_global(*args, **kwargs)


### PR DESCRIPTION
For now this PR doesn't do much but I plan to investigate whether we can use ``redraw_frame`` to avoid calling WCSAxes every time a slice is changed.