### PR TITLE
WIP: Provide persistent ROI selection

### DIFF
--- a/glue/viewers/image/qt/data_viewer.py
+++ b/glue/viewers/image/qt/data_viewer.py
@@ -68,6 +68,8 @@ class ImageViewer(MatplotlibDataViewer):
                                             origin='lower', interpolation='nearest')
         self._set_wcs()
 
+        self._active_roi = None
+
     @defer_draw
     def update_x_ticklabel(self, *event):
         # We need to overload this here for WCSAxes
@@ -147,6 +149,14 @@ class ImageViewer(MatplotlibDataViewer):
         if iy in y_dep:
             y_dep.remove(iy)
         self._changing_slice_requires_wcs_update = bool(x_dep or y_dep)
+
+    def _apply_subset(self, *args, **kwargs):
+        super(ImageViewer, self)._apply_subset(*args, **kwargs)
+        self._active_roi = args[0]
+
+    def _apply_empty_subset(self, *args, **kwargs):
+        super(ImageViewer, self)._apply_empty_subset(*args, **kwargs)
+        self._active_roi = None
 
     def _roi_to_subset_state(self, roi):
         """ This method must be implemented in order for apply_roi from the

--- a/glue/viewers/image/qt/data_viewer.py
+++ b/glue/viewers/image/qt/data_viewer.py
@@ -6,6 +6,7 @@ from qtpy.QtWidgets import QMessageBox
 from .toolbar import ImageViewerToolbar
 
 from glue.core import command
+from glue.core.qt.roi import QtPolygonalROI
 from glue.viewers.matplotlib.qt.data_viewer import MatplotlibDataViewer
 from glue.viewers.scatter.qt.layer_style_editor import ScatterLayerStyleEditor
 from glue.viewers.scatter.layer_artist import ScatterLayerArtist
@@ -149,13 +150,22 @@ class ImageViewer(MatplotlibDataViewer):
             y_dep.remove(iy)
         self._changing_slice_requires_wcs_update = bool(x_dep or y_dep)
 
+    @property
+    def active_roi(self):
+        return self._active_roi
+
+    @active_roi.setter
+    def active_roi(self, roi):
+        pass
+        #self._active_roi = QtPolygonalROI(self._axes, roi=roi)
+
     def _apply_subset(self, *args, **kwargs):
         super(ImageViewer, self)._apply_subset(*args, **kwargs)
-        self._active_roi = args[0]
+        self.active_roi = args[0]
 
     def _apply_empty_subset(self, *args, **kwargs):
         super(ImageViewer, self)._apply_empty_subset(*args, **kwargs)
-        self._active_roi = None
+        self.active_roi = None
 
     def _roi_to_subset_state(self, roi):
         """ This method must be implemented in order for apply_roi from the

--- a/glue/viewers/image/qt/data_viewer.py
+++ b/glue/viewers/image/qt/data_viewer.py
@@ -1,10 +1,9 @@
 from __future__ import absolute_import, division, print_function
-
 from astropy.wcs import WCS
 
 from qtpy.QtWidgets import QMessageBox
 
-from glue.viewers.matplotlib.qt.toolbar import MatplotlibViewerToolbar
+from .toolbar import ImageViewerToolbar
 
 from glue.core import command
 from glue.viewers.matplotlib.qt.data_viewer import MatplotlibDataViewer
@@ -37,7 +36,7 @@ IDENTITY_WCS.wcs.cdelt = [1., 1.]
 class ImageViewer(MatplotlibDataViewer):
 
     LABEL = '2D Image'
-    _toolbar_cls = MatplotlibViewerToolbar
+    _toolbar_cls = ImageViewerToolbar
     _default_mouse_mode_cls = RoiClickAndDragMode
     _layer_style_widget_cls = {ImageLayerArtist: ImageLayerStyleEditor,
                                ImageSubsetLayerArtist: ImageLayerSubsetStyleEditor,

--- a/glue/viewers/image/qt/mouse_mode.py
+++ b/glue/viewers/image/qt/mouse_mode.py
@@ -41,6 +41,7 @@ class RoiClickAndDragMode(MouseMode):
     def _deselect_roi(self, event):
         if self._roi:
             self._roi.finalize_selection(event)
+            self._edit_subset_mode.edit_subset = []
 
             self._roi = None
             self._subset = None

--- a/glue/viewers/image/qt/mouse_mode.py
+++ b/glue/viewers/image/qt/mouse_mode.py
@@ -50,6 +50,7 @@ class RoiClickAndDragMode(MouseMode):
 
         def delete_roi(event):
             self._dc.remove_subset_group(self._dc.subset_groups[roi_index])
+            self._deselect_roi(event)
 
         context_menu = QMenu()
         action = QAction("Delete ROI", context_menu)
@@ -76,9 +77,10 @@ class RoiClickAndDragMode(MouseMode):
                     if event.button == _MPL_LEFT_CLICK:
                         self._select_roi(subset_state.roi, roi_index, event)
                         self._subset = layer.state.layer
+                        self._selected = True
                     elif event.button == _MPL_RIGHT_CLICK:
+                        self._select_roi(subset_state.roi, roi_index, event)
                         self._display_roi_context_menu(roi_index)
-                    self._selected = True
                     break
             roi_index += 1
         else:

--- a/glue/viewers/image/qt/mouse_mode.py
+++ b/glue/viewers/image/qt/mouse_mode.py
@@ -33,9 +33,18 @@ class RoiClickAndDragMode(MouseMode):
         self._subset = None
         self._selected = False
 
+    def _draw_stuff(self, event):
+        self._roi._roi_store()
+        self._roi._scrubbing = True
+        self._roi._cx = event.xdata
+        self._roi._cy = event.ydata
+        self._roi._mid_selection = True
+        self._roi._sync_patch()
+
     def _select_roi(self, roi, index, event):
         self._roi = QtPolygonalROI(self._axes, roi=roi)
-        self._roi.start_selection(event, scrubbing=True)
+        #self._roi.start_selection(event, scrubbing=True)
+        self._draw_stuff(event)
         self._edit_subset_mode.edit_subset = [self._dc.subset_groups[index]]
 
     def _deselect_roi(self, event):

--- a/glue/viewers/image/qt/mouse_mode.py
+++ b/glue/viewers/image/qt/mouse_mode.py
@@ -31,11 +31,19 @@ class RoiClickAndDragMode(MouseMode):
 
         self._roi = None
         self._subset = None
+        self._selected = False
 
     def _select_roi(self, roi, index, event):
         self._roi = QtPolygonalROI(self._axes, roi=roi)
         self._roi.start_selection(event, scrubbing=True)
         self._edit_subset_mode.edit_subset = [self._dc.subset_groups[index]]
+
+    def _deselect_roi(self, event):
+        if self._roi:
+            self._roi.finalize_selection(event)
+
+            self._roi = None
+            self._subset = None
 
     def _display_roi_context_menu(self, roi_index):
 
@@ -69,19 +77,20 @@ class RoiClickAndDragMode(MouseMode):
                         self._subset = layer.state.layer
                     elif event.button == _MPL_RIGHT_CLICK:
                         self._display_roi_context_menu(roi_index)
+                    self._selected = True
                     break
             roi_index += 1
+        else:
+            self._selected = False
+            self._deselect_roi(event)
 
     def move(self, event):
-        if self._roi is None:
+        if self._roi is None or not self._selected:
             return
 
         self._roi.update_selection(event)
 
     def release(self, event):
         if self._roi:
-            self._roi.finalize_selection(event)
             self._viewer.apply_roi(self._roi.roi(), use_current=True)
-
-            self._roi = None
-            self._subset = None
+            self._selected = False

--- a/glue/viewers/image/qt/toolbar.py
+++ b/glue/viewers/image/qt/toolbar.py
@@ -1,0 +1,19 @@
+from __future__ import absolute_import, division, print_function
+
+from glue.viewers.matplotlib.qt.toolbar import MatplotlibViewerToolbar
+
+from .mouse_mode import RoiClickAndDragMode
+
+
+class ImageViewerToolbar(MatplotlibViewerToolbar):
+
+    def __init__(self, *args, **kwargs):
+        super(ImageViewerToolbar, self).__init__(*args, **kwargs)
+
+    def activate_tool(self, tool):
+        print("ACTIVATING!")
+        super(ImageViewerToolbar, self).activate_tool(tool)
+
+    def deactivate_tool(self, tool):
+        print("DEACTIVATING!")
+        super(ImageViewerToolbar, self).deactivate_tool(tool)

--- a/glue/viewers/matplotlib/qt/data_viewer.py
+++ b/glue/viewers/matplotlib/qt/data_viewer.py
@@ -208,19 +208,25 @@ class MatplotlibDataViewer(DataViewerWithState):
 
     # TODO: move some of the ROI stuff to state class?
 
+    def _apply_subset(self, roi, use_current=False):
+        subset_state = self._roi_to_subset_state(roi)
+        cmd = ApplySubsetState(data_collection=self._data,
+                               subset_state=subset_state,
+                               use_current=use_current)
+        self._session.command_stack.do(cmd)
+
+    def _apply_empty_subset(self):
+        # Make sure we force a redraw to get rid of the ROI
+        self.axes.figure.canvas.draw()
+
     def apply_roi(self, roi, use_current=False):
         """ This method relies on _roi_to_subset_state to be implemented by
         subclasses.
         """
         if len(self.layers) > 0:
-            subset_state = self._roi_to_subset_state(roi)
-            cmd = ApplySubsetState(data_collection=self._data,
-                                   subset_state=subset_state,
-                                   use_current=use_current)
-            self._session.command_stack.do(cmd)
+            self._apply_subset(roi, use_current=use_current)
         else:
-            # Make sure we force a redraw to get rid of the ROI
-            self.axes.figure.canvas.draw()
+            self._apply_empty_subset()
 
     def _script_header(self):
         state_dict = self.state.as_dict()


### PR DESCRIPTION
Previously when clicking on an existing ROI, the yellow selection overlay was only present until the mouse button was released. Now, after clicking on an ROI, the selection overlay is present until clicking on another ROI, or until clicking on an area without any ROI. Clicking on an area without any ROI will also cause there to be no active subset.

This has some interesting consequences for creating and resizing ROIs. If an existing ROI is currently selected, then activating one of the ROI mouse modes will edit the corresponding subset. If no ROI is selected, then activating one of the mouse modes will cause a new subset to be created. This all assumes that `NewMode` is not the active subset mode.'

@astrofrog we should discuss whether this seems like reasonable behavior, and if so, what the interaction should be with `NewMode`. If we want to move forward with this, there are a few more things that need to be accounted for:

- [ ] It should only be possible to have a single active ROI selection across *all* active viewers
- [ ] In some cases it makes sense to display the active selection between different mouse modes. For example, if I have an active selection, and then I activate circle mode, the ROI selection should remain until I click to create a new selection (this is not currently the case).
- [ ] If we adopt this, the tool tip for mouse modes should be context-sensitive. Display one message when an ROI is selected, and another when no ROI is selected (thanks @brechmos-stsci)

This PR is based on top of #1553.