### PR TITLE
Improve performance of image viewer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -63,6 +63,8 @@ v0.13.0 (unreleased)
 * EditSubsetMode is now no longer a singleton class and is
   instead instantiated at the Application/Session level. [#1538]
 
+* Improve performance of image viewer. [#1558]
+
 v0.12.4 (unreleased)
 --------------------
 

--- a/glue/core/state_objects.py
+++ b/glue/core/state_objects.py
@@ -289,6 +289,7 @@ class StateAttributeLimitsHelper(StateAttributeCacheHelper):
 
         self.margin = margin
         self.percentile_subset = percentile_subset
+        self.subset_indices = None
 
         if self.attribute is not None:
 
@@ -326,7 +327,11 @@ class StateAttributeLimitsHelper(StateAttributeCacheHelper):
             data_values = self.data_values
 
             if data_values.size > self.percentile_subset:
-                data_values = np.random.choice(data_values.ravel(), self.percentile_subset)
+                if self.subset_indices is None or self.subset_indices[0] != data_values.size:
+                    self.subset_indices = (data_values.size,
+                                           np.random.randint(0, data_values.size,
+                                                             self.percentile_subset))
+                data_values = data_values.ravel()[self.subset_indices[1]]
 
             if log:
                 data_values = data_values[data_values > 0]

--- a/glue/viewers/image/state.py
+++ b/glue/viewers/image/state.py
@@ -57,13 +57,9 @@ class ImageViewerState(MatplotlibDataViewerState):
 
         self.limits_cache = {}
 
-        self.x_lim_helper = StateAttributeLimitsHelper(self, attribute='x_att',
-                                                       lower='x_min', upper='x_max',
-                                                       limits_cache=self.limits_cache)
-
-        self.y_lim_helper = StateAttributeLimitsHelper(self, attribute='y_att',
-                                                       lower='y_min', upper='y_max',
-                                                       limits_cache=self.limits_cache)
+        # NOTE: we don't need to use StateAttributeLimitsHelper here because
+        # we can simply call reset_limits below when x/y attributes change.
+        # Using StateAttributeLimitsHelper makes things a lot slower.
 
         self.ref_data_helper = ManualDataComboHelper(self, 'reference_data')
 
@@ -184,11 +180,13 @@ class ImageViewerState(MatplotlibDataViewerState):
     def _on_xatt_change(self, *args):
         if self.x_att is not None:
             self.x_att_world = self.reference_data.world_component_ids[self.x_att.axis]
+        self.reset_limits()
 
     @defer_draw
     def _on_yatt_change(self, *args):
         if self.y_att is not None:
             self.y_att_world = self.reference_data.world_component_ids[self.y_att.axis]
+        self.reset_limits()
 
     @defer_draw
     def _on_xatt_world_change(self, *args):
@@ -306,6 +304,8 @@ class BaseImageLayerState(MatplotlibLayerState):
 
     def get_sliced_data(self, view=None):
 
+        print("GET SLICED DATA", view)
+
         slices, agg_func, transpose = self.viewer_state.numpy_slice_aggregation_transpose
 
         full_view = slices
@@ -323,6 +323,8 @@ class BaseImageLayerState(MatplotlibLayerState):
         else:
 
             view_applied = False
+
+        print('  full view:', full_view)
 
         image = self._get_image(view=full_view)
 

--- a/glue/viewers/image/state.py
+++ b/glue/viewers/image/state.py
@@ -273,13 +273,15 @@ class ImageViewerState(MatplotlibDataViewerState):
         """
         Flip the x_min/x_max limits.
         """
-        self.x_lim_helper.flip_limits()
+        with delay_callback(self, 'x_min', 'x_max'):
+            self.x_min, self.x_max = self.x_max, self.x_min
 
     def flip_y(self):
         """
         Flip the y_min/y_max limits.
         """
-        self.y_lim_helper.flip_limits()
+        with delay_callback(self, 'y_min', 'y_max'):
+            self.y_min, self.y_max = self.y_max, self.y_min
 
 
 class BaseImageLayerState(MatplotlibLayerState):
@@ -304,8 +306,6 @@ class BaseImageLayerState(MatplotlibLayerState):
 
     def get_sliced_data(self, view=None):
 
-        print("GET SLICED DATA", view)
-
         slices, agg_func, transpose = self.viewer_state.numpy_slice_aggregation_transpose
 
         full_view = slices
@@ -323,8 +323,6 @@ class BaseImageLayerState(MatplotlibLayerState):
         else:
 
             view_applied = False
-
-        print('  full view:', full_view)
 
         image = self._get_image(view=full_view)
 


### PR DESCRIPTION
This makes two performance improvements: it avoids sampling a new percentile subset every time update_values is called in the StateAttributeLimitsHelper, and it avoids using ``StateAttributeLimitsHelper`` for the limits in the image viewer.