### PR TITLE
Fix performance with incompatible subsets in large images

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -68,7 +68,7 @@ v0.13.0 (unreleased)
 * EditSubsetMode is now no longer a singleton class and is
   instead instantiated at the Application/Session level. [#1538]
 
-* Improve performance of image viewer. [#1558]
+* Improve performance of image viewer. [#1558, #1562]
 
 v0.12.4 (unreleased)
 --------------------

--- a/glue/utils/array.py
+++ b/glue/utils/array.py
@@ -64,7 +64,8 @@ def view_shape(shape, view):
     """
     Return the shape of a view of an array.
 
-    Returns equivalent of ``np.zeros(shape)[view].shape``
+    Returns equivalent of ``np.zeros(shape)[view].shape`` but with minimal
+    memory usage.
 
     Parameters
     ----------
@@ -75,11 +76,8 @@ def view_shape(shape, view):
     """
     if view is None:
         return shape
-    shp = tuple(slice(0, s, 1) for s in shape)
-    xy = np.broadcast_arrays(*np.ogrid[shp])
-    assert xy[0].shape == shape
-
-    return xy[0][view].shape
+    else:
+        return np.broadcast_to(1, shape)[view].shape
 
 
 def stack_view(shape, *views):

--- a/glue/viewers/image/composite_array.py
+++ b/glue/viewers/image/composite_array.py
@@ -5,9 +5,12 @@ from __future__ import absolute_import
 
 import numpy as np
 
+from glue.utils import view_shape
+
 from matplotlib.colors import ColorConverter, Colormap
 from astropy.visualization import (LinearStretch, SqrtStretch, AsinhStretch,
                                    LogStretch, ManualInterval, ContrastBiasStretch)
+
 
 __all__ = ['CompositeArray']
 
@@ -156,7 +159,7 @@ class CompositeArray(object):
             if self.shape is None:
                 return None
             else:
-                img = np.zeros(self.shape + (4,))[view]
+                img = np.zeros(view_shape(self.shape, view) + (4,))
         else:
             img = np.clip(img, 0, 1)
 

--- a/glue/viewers/image/layer_artist.py
+++ b/glue/viewers/image/layer_artist.py
@@ -280,25 +280,21 @@ class ImageSubsetArray(object):
         full_shape = self.layer_state.layer.shape
         return full_shape[y_axis], full_shape[x_axis]
 
-    @property
-    def nan_array(self):
-        return np.ones(self.shape) * np.nan
-
     def __getitem__(self, view=None):
 
         if (self.layer_artist is None or
                 self.layer_state is None or
                 self.viewer_state is None):
-            return self.nan_array
+            return None
 
         if not self.layer_artist._compatible_with_reference_data:
-            return self.nan_array
+            return None
 
         try:
             mask = self.layer_state.get_sliced_data(view=view)
         except IncompatibleAttribute:
             self.layer_artist.disable_incompatible_subset()
-            return self.nan_array
+            return None
         else:
             self.layer_artist.enable()
 


### PR DESCRIPTION
Previously we made a NaN array - this was buggy because it didn't take the view into account and was therefore very slow. Rather than applying the view, we can now just return None and CompositeArray does the right thing and ignores the layer.