### PR TITLE
Fix bug that caused pressing delete key to mess up viewers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,10 @@ v0.13.0 (unreleased)
 
 * Added support for whether symbols are shown filled or not. [#1559]
 
+* Fixed issues when attempting to close a viewer with the delete key. [#1574]
+
+* Disabled default Matplotlib key bindings. [#1574]
+
 * Improved link editor to include a graph of links. [#1534]
 
 * Improve mouse interaction with ROIs in image viewers, including

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,10 +9,6 @@ v0.13.0 (unreleased)
 
 * Added support for whether symbols are shown filled or not. [#1559]
 
-* Fixed issues when attempting to close a viewer with the delete key. [#1574]
-
-* Disabled default Matplotlib key bindings. [#1574]
-
 * Improved link editor to include a graph of links. [#1534]
 
 * Improve mouse interaction with ROIs in image viewers, including
@@ -94,6 +90,10 @@ v0.13.0 (unreleased)
 
 v0.12.5 (unreleased)
 --------------------
+
+* Fixed issues when attempting to close a viewer with the delete key. [#1574]
+
+* Disabled default Matplotlib key bindings. [#1574]
 
 * Fix compatibility with Matplotlib 2.2. [#1566]
 

--- a/glue/_mpl_backend.py
+++ b/glue/_mpl_backend.py
@@ -33,6 +33,11 @@ def set_mpl_backend():
     else:
         rcParams['backend'] = 'Qt4Agg'
 
+    # disable key bindings in matplotlib
+    for setting in list(rcParams.keys()):
+        if setting.startswith('keymap'):
+            rcParams[setting] = ''
+
     # The following is a workaround for the fact that Matplotlib checks the
     # rcParams at import time, not at run-time. I have opened an issue with
     # Matplotlib here: https://github.com/matplotlib/matplotlib/issues/5513

--- a/glue/app/qt/keyboard_shortcuts.py
+++ b/glue/app/qt/keyboard_shortcuts.py
@@ -48,4 +48,4 @@ def delete_current_window(session):
     if check_duplicate_shortcut("backspace"):
         return
 
-    return session.application.current_tab.activeSubWindow().widget().close(warn=True)
+    return session.application._viewer_in_focus.close(warn=True)

--- a/glue/viewers/common/qt/data_viewer.py
+++ b/glue/viewers/common/qt/data_viewer.py
@@ -147,7 +147,10 @@ class DataViewer(ViewerBase, QtWidgets.QMainWindow):
 
     def close(self, warn=True):
 
-        self._warn_close = warn
+        if warn and not self._confirm_close():
+            return
+
+        self._warn_close = False
 
         if getattr(self, '_mdi_wrapper', None) is not None:
             self._mdi_wrapper.close()

--- a/glue/viewers/image/qt/data_viewer.py
+++ b/glue/viewers/image/qt/data_viewer.py
@@ -81,6 +81,7 @@ class ImageViewer(MatplotlibDataViewer):
         self.redraw()
 
     def closeEvent(self, *args):
+        super(ImageViewer, self).closeEvent(*args)
         if self.axes._composite_image is not None:
             self.axes._composite_image.remove()
             self.axes._composite_image = None

--- a/glue/viewers/image/qt/data_viewer.py
+++ b/glue/viewers/image/qt/data_viewer.py
@@ -80,8 +80,7 @@ class ImageViewer(MatplotlibDataViewer):
         self.axes.coords[1].set_ticklabel(size=self.state.y_ticklabel_size)
         self.redraw()
 
-    def close(self, **kwargs):
-        super(ImageViewer, self).close(**kwargs)
+    def closeEvent(self, *args):
         if self.axes._composite_image is not None:
             self.axes._composite_image.remove()
             self.axes._composite_image = None


### PR DESCRIPTION
There are two separate issues here:

* Pressing delete causes the viewer to be closed, but the warning about closing comes after the MDI container has already been closed, causing chaos.

* Pressing delete activates the Matplotlib 'back' tool even though it is hidden.