### PR TITLE
Fixed a bug related to subset array shape

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -91,6 +91,9 @@ v0.13.0 (unreleased)
 v0.12.5 (unreleased)
 --------------------
 
+* Fixed a bug when two datasets with a different number of dimensions
+  were in an image viewer and a subset was created. [#1577]
+
 * Fixed issues when attempting to close a viewer with the delete key. [#1574]
 
 * Disabled default Matplotlib key bindings. [#1574]

--- a/glue/viewers/image/layer_artist.py
+++ b/glue/viewers/image/layer_artist.py
@@ -275,9 +275,15 @@ class ImageSubsetArray(object):
 
     @property
     def shape(self):
+
+        if not self.layer_artist._compatible_with_reference_data:
+            return None
+
         x_axis = self.viewer_state.x_att.axis
         y_axis = self.viewer_state.y_att.axis
+
         full_shape = self.layer_state.layer.shape
+
         return full_shape[y_axis], full_shape[x_axis]
 
     def __getitem__(self, view=None):

--- a/glue/viewers/image/qt/tests/test_data_viewer.py
+++ b/glue/viewers/image/qt/tests/test_data_viewer.py
@@ -582,7 +582,7 @@ class TestImageViewer(object):
 
     def test_save_aggregate_slice(self, tmpdir):
 
-        # Regressin test to make sure that image viewers that include
+        # Regression test to make sure that image viewers that include
         # aggregate slice objects in the slices can be saved/restored
 
         self.viewer.add_data(self.hypercube)
@@ -603,6 +603,22 @@ class TestImageViewer(object):
         assert slices[1:] == (3, 0, 0)
 
         app2.close()
+
+    def test_subset_cube_image(self):
+
+        # Regression test to make sure that if an image and cube are present
+        # in an image viewer and a subset is also present, we don't get an
+        # error when trying to access the subset shape
+
+        self.viewer.add_data(self.image1)
+        self.data_collection.new_subset_group(label='subset',
+                                              subset_state=self.image1.id['x'] > 1.5)
+
+        self.viewer.add_data(self.hypercube)
+        self.viewer.state.reference_data = self.hypercube
+
+        assert self.viewer.layers[1].subset_array.shape is None
+        assert self.viewer.layers[3].subset_array.shape == (4, 5)
 
 
 class TestSessions(object):


### PR DESCRIPTION
Fixed a bug when two datasets with a different number of dimensions were in an image viewer and a subset was created, causing this error:

```
>       return full_shape[y_axis], full_shape[x_axis]
E       IndexError: tuple index out of range
```