### PR TITLE
Preserve slices when adding a dataset to an existing image viewer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -91,6 +91,9 @@ v0.13.0 (unreleased)
 v0.12.5 (unreleased)
 --------------------
 
+* Fixed a bug which caused the current slices to be lost when adding a second
+  dataset to the image viewer. [#1581]
+
 * Fixed a bug when two datasets with a different number of dimensions
   were in an image viewer and a subset was created. [#1577]
 

--- a/glue/viewers/image/qt/tests/test_data_viewer.py
+++ b/glue/viewers/image/qt/tests/test_data_viewer.py
@@ -620,6 +620,16 @@ class TestImageViewer(object):
         assert self.viewer.layers[1].subset_array.shape is None
         assert self.viewer.layers[3].subset_array.shape == (4, 5)
 
+    def test_preserve_slice(self):
+
+        # Regression test to make sure that when adding a second dataset to
+        # an image viewer, the current slice in a cube does not change.
+
+        self.viewer.add_data(self.hypercube)
+        self.viewer.state.slices = (1, 2, 3, 4)
+        self.viewer.add_data(self.image1)
+        assert self.viewer.state.slices == (1, 2, 3, 4)
+
 
 class TestSessions(object):
 

--- a/glue/viewers/image/state.py
+++ b/glue/viewers/image/state.py
@@ -112,9 +112,14 @@ class ImageViewerState(MatplotlibDataViewerState):
             self.y_max = ny - 0.5
 
     def _reference_data_changed(self, *args):
-        with delay_callback(self, 'x_att_world', 'y_att_world', 'slices'):
-            self._update_combo_att()
-            self._set_default_slices()
+        # This signal can get emitted if just the choices but not the actual
+        # reference data change, so we check here that the reference data has
+        # actually changed
+        if self.reference_data is not getattr(self, '_last_reference_data', None):
+            self._last_reference_data = self.reference_data
+            with delay_callback(self, 'x_att_world', 'y_att_world', 'slices'):
+                self._update_combo_att()
+                self._set_default_slices()
 
     def _layers_changed(self, *args):
 


### PR DESCRIPTION
... if the reference data does not actually change