### PR TITLE
Deselect active tools when viewer focus changes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@ v0.13.0 (unreleased)
 * Improve hiding/showing of side-panels. No longer hide side-panels
   when glue application goes out of focus. [#1535]
 
+* Deselect tools when the viewer focus changes. [#1584]
+
 * Added support for whether symbols are shown filled or not. [#1559]
 
 * Improved link editor to include a graph of links. [#1534]

--- a/glue/app/qt/application.py
+++ b/glue/app/qt/application.py
@@ -244,8 +244,17 @@ class GlueApplication(Application, QtWidgets.QMainWindow):
 
     def _update_viewer_in_focus(self, *args):
 
+        if not hasattr(self, '_viewer_in_focus'):
+            self._viewer_in_focus = None
+
         mdi_area = self.current_tab
         active = mdi_area.activeSubWindow()
+
+        # Disable any active tool in the viewer that was previously in focus.
+        # Note that we want to do this even if active is None, which means that
+        # the user may have switched application.
+        if self._viewer_in_focus is not None:
+            self._viewer_in_focus.toolbar.active_tool = None
 
         if active is None:
             first_viewer = None

--- a/glue/app/qt/application.py
+++ b/glue/app/qt/application.py
@@ -254,7 +254,10 @@ class GlueApplication(Application, QtWidgets.QMainWindow):
         # Note that we want to do this even if active is None, which means that
         # the user may have switched application.
         if self._viewer_in_focus is not None:
-            self._viewer_in_focus.toolbar.active_tool = None
+            try:
+                self._viewer_in_focus.toolbar.active_tool = None
+            except AttributeError:
+                pass  # not all viewers have toolbars
 
         if active is None:
             first_viewer = None


### PR DESCRIPTION
This should help avoid accidental selections when changing viewers.