### PR TITLE
Fix RowSelectTool.deactivate if viewer has already been closed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -93,6 +93,9 @@ v0.13.0 (unreleased)
 v0.12.6 (unreleased)
 --------------------
 
+* Fixed a non-deterministic error that happened when closing the
+  TableViewer. [#7310]
+
 * Fixed size of markers when value for size is out of vmin/vmax range. [#1609]
 
 * Fixed a bug which caused the y-axis in the PV slice viewer to be

--- a/glue/viewers/table/qt/data_viewer.py
+++ b/glue/viewers/table/qt/data_viewer.py
@@ -163,6 +163,9 @@ class RowSelectTool(CheckableTool):
         self.viewer.ui.table.setSelectionMode(QtWidgets.QAbstractItemView.ExtendedSelection)
 
     def deactivate(self):
+        # Don't do anything if the viewer has already been closed
+        if self.viewer is None:
+            return
         self.viewer.ui.table.setSelectionMode(QtWidgets.QAbstractItemView.NoSelection)
         self.viewer.ui.table.clearSelection()
 


### PR DESCRIPTION
Fixes https://github.com/glue-viz/glue/issues/1594