### PR TITLE
Improvements to PV slice view

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -95,8 +95,12 @@ v0.12.6 (unreleased)
 
 * Fixed size of markers when value for size is out of vmin/vmax range. [#1609]
 
-* Fix a bug which caused the y-axis in the PV slice viewer to be
+* Fixed a bug which caused the y-axis in the PV slice viewer to be
   incorrect if the WCS could not be computed. [#1615]
+
+* Fixed a bug that caused the WCS of a PV slice to be incorrect if the
+  user has selected a custom order of the axes of a cube in the image
+  viewer. [#1615]
 
 v0.12.5 (unreleased)
 --------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -95,6 +95,9 @@ v0.12.6 (unreleased)
 
 * Fixed size of markers when value for size is out of vmin/vmax range. [#1609]
 
+* Fix a bug which caused the y-axis in the PV slice viewer to be
+  incorrect if the WCS could not be computed. [#1615]
+
 v0.12.5 (unreleased)
 --------------------
 

--- a/glue/plugins/tools/pv_slicer/qt/pv_slicer.py
+++ b/glue/plugins/tools/pv_slicer/qt/pv_slicer.py
@@ -218,7 +218,11 @@ def _slice_from_path(x, y, data, attribute, slc):
     _swap(dims, s, ind, 0)
     _swap(dims, s, s.index('y'), 1)
     _swap(dims, s, s.index('x'), 2)
+
     cube = cube.transpose(dims)
+
+    if cube_wcs is not None:
+        cube_wcs = cube_wcs.sub([data.ndim - x for x in dims[::-1]])
 
     # slice down from >3D to 3D if needed
     s = [slice(None)] * 3 + [slc[d] for d in dims[3:]]

--- a/glue/plugins/tools/pv_slicer/qt/pv_slicer.py
+++ b/glue/plugins/tools/pv_slicer/qt/pv_slicer.py
@@ -57,8 +57,12 @@ class PVSlicerMode(PathMode):
                                          x=x, y=y, interpolation='nearest')
 
         result = self._slice_widget
-        result.axes.set_xlabel("Position Along Slice")
-        result.axes.set_ylabel(_slice_label(self.viewer.state.reference_data, self.viewer.state.wcsaxes_slice[::-1]))
+        result.axes.set_xlabel("Position along path")
+        if wcs is None:
+            result.axes.set_ylabel("Cube slice index")
+        else:
+            result.axes.set_ylabel(_slice_label(self.viewer.state.reference_data,
+                                                self.viewer.state.wcsaxes_slice[::-1]))
 
         result.show()
 
@@ -224,14 +228,16 @@ def _slice_from_path(x, y, data, attribute, slc):
     spacing = 1  # pixel
     x, y = [np.round(_x).astype(int) for _x in p.sample_points(spacing)]
 
+    from astropy.wcs import WCS
+
     try:
         result = extract_pv_slice(cube, path=p, wcs=cube_wcs, order=0)
-    except:  # sometimes pvextractor complains due to wcs. Try to recover
+        wcs = WCS(result.header)
+    except Exception:  # sometimes pvextractor complains due to wcs. Try to recover
         result = extract_pv_slice(cube, path=p, wcs=None, order=0)
+        wcs = None
 
-    from astropy.wcs import WCS
     data = result.data
-    wcs = WCS(result.header)
 
     return data, x, y, wcs
 


### PR DESCRIPTION
This fixes the y-axis of the PV slice if the WCS could not be computed, and also fixes the case where the user changes the order of the dimensions in the image viewer.

Fixes https://github.com/glue-viz/glue/issues/1602