### PR TITLE
Do projection for 3D ROI in chunks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@ Full changelog
 v0.13.0 (unreleased)
 --------------------
 
+* Improve performance when changing visual attributes of subsets.
+  [#1617]
+
 * Added a new ``FloodFillSubsetState`` class to represent and
   calculate subsets made by a flood-fill algorithm. [#1616]
 

--- a/glue/core/roi.py
+++ b/glue/core/roi.py
@@ -612,7 +612,9 @@ class Projected3dROI(Roi):
         z = np.asarray(z)
 
         # Since the projection can significantly increase the memory usage, we
-        # do the following operation in chunks.
+        # do the following operation in chunks. In future we could likely use
+        # e.g. vaex, dask, or other multi-threaded/fast libraries to speed this
+        # and other ROI code up.
 
         mask = np.zeros(x.shape, dtype=bool)
 

--- a/glue/viewers/common/qt/data_viewer_with_state.py
+++ b/glue/viewers/common/qt/data_viewer_with_state.py
@@ -150,6 +150,8 @@ class DataViewerWithState(DataViewer):
             self.redraw()
 
     def _update_subset(self, message):
+        if message.attribute == 'style':
+            return
         if message.subset in self._layer_artist_container:
             for layer_artist in self._layer_artist_container[message.subset]:
                 layer_artist.update()


### PR DESCRIPTION
This ports over some performance optimizations that were present in the 3D viewers - basically the projection step can take a lot of memory so it's better to do it in chunks to avoid using too much memory in one go.

@maartenbreddels - let me know if you have any ideas on doing this better!