### PR TITLE
Improve UI for saving/exporting data

### DIFF
--- a/glue/app/qt/application.py
+++ b/glue/app/qt/application.py
@@ -664,7 +664,7 @@ class GlueApplication(Application, QtWidgets.QMainWindow):
         menu.addAction(self._actions['session_save'])
         menu.addAction(self._actions['export_data'])
         if 'session_export' in self._actions:
-            submenu = menu.addMenu("E&xport")
+            submenu = menu.addMenu("Advanced E&xporters")
             for a in self._actions['session_export']:
                 submenu.addAction(a)
         menu.addSeparator()
@@ -795,7 +795,7 @@ class GlueApplication(Application, QtWidgets.QMainWindow):
         a.triggered.connect(nonpartial(self.gather_current_tab))
         self._actions['gather'] = a
 
-        a = action('&Save Session', self,
+        a = action('&Export Session', self,
                    tip='Save the current session')
         a.triggered.connect(nonpartial(self._choose_save_session))
         self._actions['session_save'] = a

--- a/glue/app/qt/application.py
+++ b/glue/app/qt/application.py
@@ -311,7 +311,7 @@ class GlueApplication(Application, QtWidgets.QMainWindow):
         self._data_toolbar.addWidget(self._button_open_data)
 
         self._button_save_data = QtWidgets.QToolButton()
-        self._button_save_data.setText("Save Data")
+        self._button_save_data.setText("Export Data/Subsets")
         self._button_save_data.setIcon(get_icon('glue_filesave'))
         self._button_save_data.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
         self._button_save_data.clicked.connect(nonpartial(self._choose_save_data))
@@ -345,7 +345,7 @@ class GlueApplication(Application, QtWidgets.QMainWindow):
         self._data_toolbar.addWidget(self._button_open_session)
 
         self._button_save_session = QtWidgets.QToolButton()
-        self._button_save_session.setText("Save Session")
+        self._button_save_session.setText("Export Session")
         self._button_save_session.setIcon(get_icon('glue_filesave'))
         self._button_save_session.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
         self._button_save_session.clicked.connect(nonpartial(self._choose_save_session))
@@ -662,6 +662,7 @@ class GlueApplication(Application, QtWidgets.QMainWindow):
         menu.addAction(self._actions['session_reset'])
         menu.addAction(self._actions['session_restore'])
         menu.addAction(self._actions['session_save'])
+        menu.addAction(self._actions['export_data'])
         if 'session_export' in self._actions:
             submenu = menu.addMenu("E&xport")
             for a in self._actions['session_export']:
@@ -850,6 +851,11 @@ class GlueApplication(Application, QtWidgets.QMainWindow):
                    tip='Reset session to clean state')
         a.triggered.connect(nonpartial(self._reset_session))
         self._actions['session_reset'] = a
+
+        a = action('Export D&ata/Subsets', self,
+                   tip='Export data to a file')
+        a.triggered.connect(nonpartial(self._choose_save_data))
+        self._actions['export_data'] = a
 
         a = action("Undo", self,
                    tip='Undo last action',

--- a/glue/app/qt/save_data.py
+++ b/glue/app/qt/save_data.py
@@ -58,7 +58,7 @@ class SaveDataState(State):
 
         def display_func(subset):
             if subset is None:
-                return "All data"
+                return "All data (no subsets applied)"
             else:
                 return subset.label
 

--- a/glue/app/qt/save_data.ui
+++ b/glue/app/qt/save_data.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>330</width>
-    <height>427</height>
+    <width>384</width>
+    <height>473</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -35,6 +35,62 @@
    <property name="verticalSpacing">
     <number>7</number>
    </property>
+   <item row="6" column="2">
+    <spacer name="horizontalSpacer_4">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="7" column="0" colspan="5">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Select the file format to save to:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1" colspan="3">
+    <widget class="QComboBox" name="combosel_subset"/>
+   </item>
+   <item row="1" column="1" colspan="3">
+    <widget class="QComboBox" name="combosel_data"/>
+   </item>
+   <item row="8" column="1" colspan="3">
+    <widget class="QComboBox" name="combosel_exporter"/>
+   </item>
+   <item row="1" column="0">
+    <spacer name="horizontalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="5" column="1" colspan="3">
+    <widget class="QListWidget" name="list_component">
+     <property name="alternatingRowColors">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="3">
+    <widget class="QToolButton" name="button_select_all">
+     <property name="text">
+      <string>Select All</string>
+     </property>
+    </widget>
+   </item>
    <item row="2" column="0" colspan="5">
     <widget class="QLabel" name="label_3">
      <property name="text">
@@ -67,7 +123,7 @@
      <item>
       <widget class="QPushButton" name="button_ok">
        <property name="text">
-        <string>OK</string>
+        <string>Export</string>
        </property>
        <property name="default">
         <bool>true</bool>
@@ -103,61 +159,15 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="1" colspan="3">
-    <widget class="QComboBox" name="combosel_data"/>
-   </item>
-   <item row="8" column="1" colspan="3">
-    <widget class="QComboBox" name="combosel_exporter"/>
-   </item>
-   <item row="1" column="0">
-    <spacer name="horizontalSpacer_2">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="7" column="0" colspan="5">
-    <widget class="QLabel" name="label_2">
+   <item row="9" column="0" colspan="5">
+    <widget class="QLabel" name="label_4">
      <property name="text">
-      <string>Select the file format to save to:</string>
+      <string>Once you click on 'Export' you will be prompted for the name of the file to export to</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
      </property>
     </widget>
-   </item>
-   <item row="6" column="3">
-    <widget class="QToolButton" name="button_select_all">
-     <property name="text">
-      <string>Select All</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="2">
-    <spacer name="horizontalSpacer_4">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="5" column="1" colspan="3">
-    <widget class="QListWidget" name="list_component">
-     <property name="alternatingRowColors">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1" colspan="3">
-    <widget class="QComboBox" name="combosel_subset"/>
    </item>
   </layout>
  </widget>

--- a/glue/app/qt/save_data.ui
+++ b/glue/app/qt/save_data.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>384</width>
-    <height>473</height>
+    <width>420</width>
+    <height>472</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -94,7 +94,7 @@
    <item row="2" column="0" colspan="5">
     <widget class="QLabel" name="label_3">
      <property name="text">
-      <string>Pick what part of the data you want to save:</string>
+      <string>Choose what part of the data you want to save:</string>
      </property>
     </widget>
    </item>
@@ -155,14 +155,14 @@
    <item row="0" column="0" colspan="5">
     <widget class="QLabel" name="label">
      <property name="text">
-      <string>Pick the dataset and component you want to save:</string>
+      <string>Choose the dataset and component you want to save:</string>
      </property>
     </widget>
    </item>
    <item row="9" column="0" colspan="5">
     <widget class="QLabel" name="label_4">
      <property name="text">
-      <string>Once you click on 'Export' you will be prompted for the name of the file to export to</string>
+      <string>Once you click on &quot;Export&quot; you will be prompted to choose the filename.</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>


### PR DESCRIPTION
This is to address https://github.com/spacetelescope/cubeviz/issues/324

This makes several changes:

* The button for saving data is now called 'Export Data/Subsets' to make it clear subsets can be exported, and using 'export' instead of 'save' makes it clearer that this will not overwrite the existing data files:

<img width="198" alt="screen shot 2018-03-29 at 11 46 29" src="https://user-images.githubusercontent.com/314716/38085180-8b5decd4-3347-11e8-8a27-dc46cacf6e2d.png">

* 'Export Data/Subsets' is now also available via the 'File' dialog:

<img width="229" alt="screen shot 2018-03-29 at 11 57 32" src="https://user-images.githubusercontent.com/314716/38085443-7494a780-3348-11e8-9dc1-98ca36b7155b.png">

* Finally I have included a sentence at the bottom of the save dialog to make it clearer that the user will be prompted for a filename, and changed the button from 'OK' to 'Export':

<img width="384" alt="screen shot 2018-03-29 at 11 46 33" src="https://user-images.githubusercontent.com/314716/38085267-c489127c-3347-11e8-8bfe-d70321dc451b.png">

@brechmos-stsci @kassin - does this seem ok?

Fixes https://github.com/glue-viz/glue/issues/1569