### PR TITLE
Only deactivate default mouse mode if new tool is checkable

### DIFF
--- a/glue/viewers/common/qt/toolbar.py
+++ b/glue/viewers/common/qt/toolbar.py
@@ -92,7 +92,7 @@ class BasicToolbar(QtWidgets.QToolBar):
             self.tool_deactivated.emit()
 
     def activate_tool(self, tool):
-        if self._default_mouse_mode is not None:
+        if isinstance(tool, CheckableTool) and self._default_mouse_mode is not None:
             self._default_mouse_mode.deactivate()
         tool.activate()
 


### PR DESCRIPTION
The default mouse mode should only be deactivated in cases where the new mouse mode corresponds to a checkable tool. This ensures that tools that do not enable persistent effects do not disrupt the functioning of the default mouse mode.

This fixes https://github.com/spacetelescope/cubeviz/issues/353.