### PR TITLE
Fix ignoring of matplotlibrc file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -121,6 +121,8 @@ v0.13.0 (unreleased)
 v0.12.6 (unreleased)
 --------------------
 
+* Fixed a bug that caused matplotlibrc files to not be ignored. [#1649]
+
 * Fixed a non-deterministic error that happened when closing the
   TableViewer. [#7310]
 

--- a/glue/_mpl_backend.py
+++ b/glue/_mpl_backend.py
@@ -12,13 +12,16 @@ class MatplotlibBackendSetter(object):
             set_mpl_backend()
 
     def find_spec(self, name, import_path, target_module=None):
-        pass
+        if self.enabled and name.startswith('matplotlib'):
+            self.enabled = False
+            set_mpl_backend()
+
 
 def set_mpl_backend():
 
     try:
         from qtpy import PYQT5
-    except:
+    except Exception:
         # If Qt isn't available, we don't have to worry about
         # setting the backend
         return


### PR DESCRIPTION
This was broken because find_spec should now be used instead of find_module