### PR TITLE
Make it possible to have a 'None' entry in ComponentIDComboHelper

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@ v0.13.0 (unreleased)
 * Started adding helpful information dialogs that can be
   hidden. [#1669]
 
+* Make it possible to have a 'None' entry in the ComponentIDComboHelper. [#1661]
+
 * Added a new metadata/header viewer for datasets/subsets. [#1659]
 
 * Re-write spectrum viewer into a generic profile viewer that uses

--- a/glue/core/data_combo_helper.py
+++ b/glue/core/data_combo_helper.py
@@ -103,6 +103,13 @@ class ComboHelper(HubListener):
         return prop.set_display_func(self.state, display)
 
 
+def display_func_label(cid):
+    if cid is None:
+        return ''
+    else:
+        return cid.label
+
+
 class ComponentIDComboHelper(ComboHelper):
     """
     The purpose of this class is to set up a combo (represented by a
@@ -134,22 +141,25 @@ class ComponentIDComboHelper(ComboHelper):
         Show world coordinate components
     derived : bool, optional
         Show derived components
+    none : bool, optional
+        Add an entry that means 'None'
     """
 
     def __init__(self, state, selection_property,
                  data_collection=None, data=None,
                  numeric=True, categorical=True,
-                 pixel_coord=False, world_coord=False, derived=True):
+                 pixel_coord=False, world_coord=False, derived=True, none=False):
 
         super(ComponentIDComboHelper, self).__init__(state, selection_property)
 
-        self.display = lambda x: x.label
+        self.display = display_func_label
 
         self._numeric = numeric
         self._categorical = categorical
         self._pixel_coord = pixel_coord
         self._world_coord = world_coord
         self._derived = derived
+        self._none = none
 
         if data is None:
             self._manual_data = False
@@ -219,6 +229,15 @@ class ComponentIDComboHelper(ComboHelper):
         self._derived = value
         self.refresh()
 
+    @property
+    def none(self):
+        return self._none
+
+    @none.setter
+    def none(self, value):
+        self._none = value
+        self.refresh()
+
     def append_data(self, data, refresh=True):
 
         if self._manual_data:
@@ -284,6 +303,10 @@ class ComponentIDComboHelper(ComboHelper):
     def refresh(self, *args):
 
         choices = []
+
+        if self._none:
+            choices.append(None)
+
 
         for data in self._data:
 
@@ -386,7 +409,7 @@ class BaseDataComboHelper(ComboHelper):
 
         super(BaseDataComboHelper, self).__init__(state, selection_property)
 
-        self.display = lambda x: x.label
+        self.display = display_func_label
 
         self._component_id_helpers = []
         self.state.add_callback(self.selection_property, self.refresh_component_ids)

--- a/glue/core/data_combo_helper.py
+++ b/glue/core/data_combo_helper.py
@@ -15,6 +15,7 @@ from glue.core.message import (DataReorderComponentMessage,
                                ComponentReplacedMessage,
                                DataRenameComponentMessage)
 from glue.external.echo import delay_callback, ChoiceSeparator
+from glue.external.six import string_types
 
 __all__ = ['ComponentIDComboHelper', 'ManualDataComboHelper',
            'DataCollectionComboHelper']
@@ -103,13 +104,6 @@ class ComboHelper(HubListener):
         return prop.set_display_func(self.state, display)
 
 
-def display_func_label(cid):
-    if cid is None:
-        return ''
-    else:
-        return cid.label
-
-
 class ComponentIDComboHelper(ComboHelper):
     """
     The purpose of this class is to set up a combo (represented by a
@@ -152,6 +146,19 @@ class ComponentIDComboHelper(ComboHelper):
 
         super(ComponentIDComboHelper, self).__init__(state, selection_property)
 
+        if isinstance(none, string_types):
+            self._none = True
+            self._none_label = none
+        else:
+            self._none = none
+            self._none_label = ''
+
+        def display_func_label(cid):
+            if cid is None:
+                return self._none_label
+            else:
+                return cid.label
+
         self.display = display_func_label
 
         self._numeric = numeric
@@ -159,7 +166,6 @@ class ComponentIDComboHelper(ComboHelper):
         self._pixel_coord = pixel_coord
         self._world_coord = world_coord
         self._derived = derived
-        self._none = none
 
         if data is None:
             self._manual_data = False
@@ -235,7 +241,12 @@ class ComponentIDComboHelper(ComboHelper):
 
     @none.setter
     def none(self, value):
-        self._none = value
+        if isinstance(value, string_types):
+            self._none = True
+            self._none_label = value
+        else:
+            self._none = value
+            self._none_label = ''
         self.refresh()
 
     def append_data(self, data, refresh=True):
@@ -408,6 +419,9 @@ class BaseDataComboHelper(ComboHelper):
     def __init__(self, state, selection_property, data_collection=None):
 
         super(BaseDataComboHelper, self).__init__(state, selection_property)
+
+        def display_func_label(cid):
+            return cid.label
 
         self.display = display_func_label
 

--- a/glue/core/data_combo_helper.py
+++ b/glue/core/data_combo_helper.py
@@ -135,8 +135,10 @@ class ComponentIDComboHelper(ComboHelper):
         Show world coordinate components
     derived : bool, optional
         Show derived components
-    none : bool, optional
-        Add an entry that means 'None'
+    none : bool or str, optional
+        Add an entry that means `None`. If a string, this is the display string
+        that will be shown for the `None` entry, otherwise an empty string is
+        shown.
     """
 
     def __init__(self, state, selection_property,

--- a/glue/core/tests/test_data_combo_helper.py
+++ b/glue/core/tests/test_data_combo_helper.py
@@ -324,3 +324,22 @@ def test_component_id_combo_helper_reorder():
     data.reorder_components(data.components[::-1])
 
     assert selection_choices(state, 'combo') == "y:x"
+
+
+def test_component_id_combo_helper_none():
+
+    # Make sure the none=True option works
+
+    state = ExampleState()
+
+    data = Data(x=[1, 2, 3], y=[2, 3, 4], label='data1')
+    dc = DataCollection([data])
+
+    helper = ComponentIDComboHelper(state, 'combo', dc)  # noqa
+    helper.append_data(data)
+
+    assert selection_choices(state, 'combo') == "x:y"
+
+    helper.none = True
+
+    assert selection_choices(state, 'combo') == ":x:y"

--- a/glue/core/tests/test_data_combo_helper.py
+++ b/glue/core/tests/test_data_combo_helper.py
@@ -335,7 +335,7 @@ def test_component_id_combo_helper_none():
     data = Data(x=[1, 2, 3], y=[2, 3, 4], label='data1')
     dc = DataCollection([data])
 
-    helper = ComponentIDComboHelper(state, 'combo', dc)  # noqa
+    helper = ComponentIDComboHelper(state, 'combo', dc)
     helper.append_data(data)
 
     assert selection_choices(state, 'combo') == "x:y"
@@ -343,3 +343,17 @@ def test_component_id_combo_helper_none():
     helper.none = True
 
     assert selection_choices(state, 'combo') == ":x:y"
+
+    helper.none = 'banana'
+
+    assert selection_choices(state, 'combo') == "banana:x:y"
+
+    # Try with initializing none=... from the start
+
+    helper = ComponentIDComboHelper(state, 'combo', dc, none=True)
+    helper.append_data(data)
+    assert selection_choices(state, 'combo') == ":x:y"
+
+    helper = ComponentIDComboHelper(state, 'combo', dc, none='banana')
+    helper.append_data(data)
+    assert selection_choices(state, 'combo') == "banana:x:y"


### PR DESCRIPTION
Fixes https://github.com/glue-viz/glue/issues/1509

@brechmos-stsci - do you have any thoughts on what the 'None' entry should show up as in the combo - should it be an empty string, or should it actually say 'None'?