### PR TITLE
Fix bug related to indexing order

### DIFF
--- a/glue/core/coordinates.py
+++ b/glue/core/coordinates.py
@@ -89,9 +89,12 @@ class Coordinates(object):
 
         original_shape = pixel[0].shape
         pixel_new = []
-        dep_axes = self.dependent_axes(axis)
+
+        # NOTE: the axis passed to this function is the WCS axis not the Numpy
+        # axis, so we need to convert it as needed.
+        dep_axes = self.dependent_axes(len(pixel) - 1 - axis)
         for ip, p in enumerate(pixel):
-            if ip in dep_axes:
+            if (len(pixel) - 1 - ip) in dep_axes:
                 pixel_new.append(unbroadcast(p))
             else:
                 pixel_new.append(p.flat[0])
@@ -134,9 +137,11 @@ class Coordinates(object):
 
         original_shape = world[0].shape
         world_new = []
-        dep_axes = self.dependent_axes(axis)
+        # NOTE: the axis passed to this function is the WCS axis not the Numpy
+        # axis, so we need to convert it as needed.
+        dep_axes = self.dependent_axes(len(world) - 1 - axis)
         for iw, w in enumerate(world):
-            if iw in dep_axes:
+            if (len(world) - 1 - iw) in dep_axes:
                 world_new.append(unbroadcast(w))
             else:
                 world_new.append(w.flat[0])

--- a/glue/core/tests/test_coordinates.py
+++ b/glue/core/tests/test_coordinates.py
@@ -346,3 +346,26 @@ def test_dependent_axes_non_diagonal_pc():
     assert_equal(coord.dependent_axes(0), [0])
     assert_equal(coord.dependent_axes(1), [1, 2])
     assert_equal(coord.dependent_axes(2), [1, 2])
+
+
+def test_pixel2world_single_axis():
+
+    # Regression test for a bug in pixel2world_single_axis which was due to
+    # incorrect indexing order (WCS vs Numpy)
+
+    from astropy.wcs import WCS
+
+    wcs = WCS(naxis=3)
+    wcs.wcs.ctype = 'HPLN-TAN', 'HPLT-TAN', 'Time'
+    wcs.wcs.crval = 1, 1, 1
+    wcs.wcs.crpix = 1, 1, 1
+    wcs.wcs.cd = [[0.9, 0.1, 0], [-0.1, 0.9, 0], [0, 0, 1]]
+
+    x = np.array([0.2, 0.4, 0.6])
+    y = np.array([0.3, 0.6, 0.9])
+    z = np.array([0.5, 0.5, 0.5])
+
+    coord = WCSCoordinates(wcs=wcs)
+    assert_allclose(coord.pixel2world_single_axis(x, y, z, axis=0), [1.21004705, 1.42012044, 1.63021455])
+    assert_allclose(coord.pixel2world_single_axis(x, y, z, axis=1), [1.24999002, 1.499947, 1.74985138])
+    assert_allclose(coord.pixel2world_single_axis(x, y, z, axis=2), [1.5, 1.5, 1.5])

--- a/glue/viewers/image/state.py
+++ b/glue/viewers/image/state.py
@@ -563,7 +563,7 @@ class BaseImageLayerState(MatplotlibLayerState):
 
         if self._image_cache is not None:
             if self._image_cache['reset_slices'] is True:
-                self.reset_cache()
+                self._image_cache = None
             else:
                 reset_slices = self._image_cache['reset_slices']
                 for islice in range(len(slice_before)):

--- a/glue/viewers/image/state.py
+++ b/glue/viewers/image/state.py
@@ -576,11 +576,12 @@ class BaseImageLayerState(MatplotlibLayerState):
         if self._pixel_cache is not None:
             for ipix in range(self.layer.ndim):
                 reset_slices = self._pixel_cache['reset_slices'][ipix]
-                for islice in range(len(slice_before)):
-                    if slice_before[islice] != slice_after[islice] and reset_slices[islice]:
-                        self._pixel_cache['coord'][ipix] = None
-                        self._pixel_cache['reset_slices'][ipix] = None
-                        break
+                if reset_slices is not None:
+                    for islice in range(len(slice_before)):
+                        if slice_before[islice] != slice_after[islice] and reset_slices[islice]:
+                            self._pixel_cache['coord'][ipix] = None
+                            self._pixel_cache['reset_slices'][ipix] = None
+                            break
 
     def reset_cache(self, *event):
         self._image_cache = None

--- a/glue/viewers/image/state.py
+++ b/glue/viewers/image/state.py
@@ -452,9 +452,9 @@ class BaseImageLayerState(MatplotlibLayerState):
                 if self._pixel_cache is None:
                     # The cache hasn't been set yet or has been reset so we
                     # initialize it here.
-                    self._pixel_cache = {'reset_slices': [None] * len(full_view),
-                                         'coord': [None] * len(full_view),
-                                         'shape': [None] * len(full_view),
+                    self._pixel_cache = {'reset_slices': [None] * self.layer.ndim,
+                                         'coord': [None] * self.layer.ndim,
+                                         'shape': [None] * self.layer.ndim,
                                          'view': None}
 
                 coords = []

--- a/glue/viewers/image/state.py
+++ b/glue/viewers/image/state.py
@@ -313,7 +313,7 @@ class ImageViewerState(MatplotlibDataViewerState):
 class BaseImageLayerState(MatplotlibLayerState):
 
     _viewer_callbacks_set = False
-    _cache = None
+    _image_cache = None
     _pixel_cache = None
 
     def get_sliced_data_shape(self, view=None):
@@ -359,9 +359,9 @@ class BaseImageLayerState(MatplotlibLayerState):
                 self.add_callback('attribute', self.reset_cache, priority=100000)
             self._viewer_callbacks_set = True
 
-        if self._cache is not None:
-            if view == self._cache['view']:
-                return self._cache['image']
+        if self._image_cache is not None:
+            if view == self._image_cache['view']:
+                return self._image_cache['image']
 
         # In the cache, we need to keep track of which slice indices should
         # cause the cache to be reset. By default, we assume that any changes
@@ -452,60 +452,44 @@ class BaseImageLayerState(MatplotlibLayerState):
                 if self._pixel_cache is None:
                     # The cache hasn't been set yet or has been reset so we
                     # initialize it here.
-                    self._pixel_cache = {'view': full_view,
-                                         'related': [None] * len(full_view),
+                    self._pixel_cache = {'reset_slices': [None] * len(full_view),
                                          'coord': [None] * len(full_view),
-                                         'shape': None}
-                else:
-                    # The cache is still active, so we construct a list called
-                    # view_changes which has a list of booleans that indicate
-                    # for each dimention whether the view has changed since the
-                    # lasst call.
-                    cached_view = self._pixel_cache['view']
-                    view_changed = [cv != v for (cv, v) in zip(cached_view, full_view)]
+                                         'shape': [None] * len(full_view),
+                                         'view': None}
 
                 coords = []
 
+                sub_data_view = [slice(0, 2)] * self.viewer_state.reference_data.ndim
+
                 for ipix, pix in enumerate(self.layer.pixel_component_ids):
 
-                    # We now figure out whether we need to recompute the
-                    # pixel transformation for this coordinate. Start off by
-                    # assuming that we need to
-                    recompute = True
-                    if self._pixel_cache['related'][ipix] is not None:
-                        # If the cache is set and none of the dimensions where
-                        # the view changed are also dimensions related to the
-                        # current one, then we are fine using the cache.
-                        if not np.any(np.logical_and(view_changed,
-                                                     self._pixel_cache['related'][ipix])):
-                            recompute = False
-
-
-                    if recompute:
+                    if self._pixel_cache['view'] != view or self._pixel_cache['coord'][ipix] is None:
 
                         # Start off by finding all the pixel coordinates of the current
                         # view in the reference frame of the current layer data.
                         pixel_coord = self.viewer_state.reference_data[pix, full_view]
                         coord = np.round(pixel_coord.ravel()).astype(int)
 
-                        # Now update cache - basically check which dimesnions in
+                        # Now update cache - basically check which dimensions in
                         # the output of the transformation rely on broadcasting.
-                        sub_data = self.viewer_state.reference_data[pix, [slice(0, 2)] * self.viewer_state.reference_data.ndim]
+                        # The 'reset_slices' item is a list that indicates
+                        # whether the cache should be reset when the index along
+                        # a given dimension changes.
+                        sub_data = self.viewer_state.reference_data[pix, sub_data_view]
                         sub_data = unbroadcast(sub_data)
-                        related = [x > 1 for x in sub_data.shape]
-                        self._pixel_cache['related'][ipix] = related
+                        self._pixel_cache['reset_slices'][ipix] = [x > 1 for x in sub_data.shape]
                         self._pixel_cache['coord'][ipix] = coord
-                        self._pixel_cache['shape'] = pixel_coord.shape
+                        self._pixel_cache['shape'][ipix] = pixel_coord.shape
                         original_shape = pixel_coord.shape
 
                     else:
 
                         coord = self._pixel_cache['coord'][ipix]
-                        original_shape = self._pixel_cache['shape']
+                        original_shape = self._pixel_cache['shape'][ipix]
 
                     coords.append(coord)
 
-                self._pixel_cache['view'] = full_view
+                self._pixel_cache['view'] = view
 
                 # TODO: add test when image is smaller than cube
 
@@ -560,7 +544,7 @@ class BaseImageLayerState(MatplotlibLayerState):
         if transpose:
             image = image.transpose()
 
-        self._cache = {'view': view, 'image': image, 'reset_slices': reset_slices}
+        self._image_cache = {'view': view, 'image': image, 'reset_slices': reset_slices}
 
         return image
 
@@ -574,17 +558,31 @@ class BaseImageLayerState(MatplotlibLayerState):
         # if any change in slice should cause the cache to get reset, or it is
         # a list of boolean values for each slice dimension.
 
-        if self._cache is not None:
-            if self._cache['reset_slices'] is True:
+        # We do this first for the image cache, which is the cache of the
+        # reprojected slice.
+
+        if self._image_cache is not None:
+            if self._image_cache['reset_slices'] is True:
                 self.reset_cache()
             else:
-                reset_slices = self._cache['reset_slices']
+                reset_slices = self._image_cache['reset_slices']
                 for islice in range(len(slice_before)):
                     if slice_before[islice] != slice_after[islice] and reset_slices[islice]:
-                        return self.reset_cache()
+                        self._image_cache = None
+                        break
+
+        # And we then deal with the pixel transformation cache.
+
+        if self._pixel_cache is not None:
+            for islice in range(len(slice_before)):
+                reset_slices = self._pixel_cache['reset_slices'][islice]
+                if slice_before[islice] != slice_after[islice] and reset_slices[islice]:
+                    self._pixel_cache['coord'][islice] = None
+                    self._pixel_cache['reset_slices'][islice] = None
 
     def reset_cache(self, *event):
-        self._cache = None
+        self._image_cache = None
+        self._pixel_cache = None
 
     def _get_image(self, view=None):
         raise NotImplementedError()

--- a/glue/viewers/image/state.py
+++ b/glue/viewers/image/state.py
@@ -574,11 +574,13 @@ class BaseImageLayerState(MatplotlibLayerState):
         # And we then deal with the pixel transformation cache.
 
         if self._pixel_cache is not None:
-            for islice in range(len(slice_before)):
-                reset_slices = self._pixel_cache['reset_slices'][islice]
-                if slice_before[islice] != slice_after[islice] and reset_slices[islice]:
-                    self._pixel_cache['coord'][islice] = None
-                    self._pixel_cache['reset_slices'][islice] = None
+            for ipix in range(self.layer.ndim):
+                reset_slices = self._pixel_cache['reset_slices'][ipix]
+                for islice in range(len(slice_before)):
+                    if slice_before[islice] != slice_after[islice] and reset_slices[islice]:
+                        self._pixel_cache['coord'][ipix] = None
+                        self._pixel_cache['reset_slices'][ipix] = None
+                        break
 
     def reset_cache(self, *event):
         self._image_cache = None

--- a/glue/viewers/image/tests/test_state.py
+++ b/glue/viewers/image/tests/test_state.py
@@ -19,6 +19,12 @@ class SimpleCoordinates(Coordinates):
     def pixel2world(self, *pixel):
         return tuple([2.5 * p for p in pixel])
 
+    def dependent_axes(self, axis):
+        if axis in (1, 2):
+            return (1, 2)
+        else:
+            return (axis,)
+
 
 class TestImageViewerState(object):
 
@@ -322,3 +328,40 @@ class TestReprojection():
 
         with pytest.raises(IncompatibleAttribute):
             self.viewer_state.layers[0].get_sliced_data()
+
+    def test_reset_pixel_cache(self):
+
+        # Test to make sure that resetting the pixel cache works properly
+
+        self.viewer_state.x_att = self.data1.pixel_component_ids[0]
+        self.viewer_state.y_att = self.data1.pixel_component_ids[2]
+
+        self.viewer_state.slices = (1, 1, 1, 1)
+
+        layer = self.viewer_state.layers[5]
+
+        assert layer._pixel_cache is None
+
+        layer.get_sliced_data()
+
+        assert layer._pixel_cache['reset_slices'][0] == [False, False, True, False]
+        assert layer._pixel_cache['reset_slices'][1] == [True, True, False, False]
+        assert layer._pixel_cache['reset_slices'][2] == [True, True, False, False]
+
+        self.viewer_state.slices = (1, 1, 1, 2)
+
+        assert layer._pixel_cache['reset_slices'][0] == [False, False, True, False]
+        assert layer._pixel_cache['reset_slices'][1] == [True, True, False, False]
+        assert layer._pixel_cache['reset_slices'][2] == [True, True, False, False]
+
+        self.viewer_state.slices = (1, 2, 1, 2)
+
+        assert layer._pixel_cache['reset_slices'][0] == [False, False, True, False]
+        assert layer._pixel_cache['reset_slices'][1] is None
+        assert layer._pixel_cache['reset_slices'][2] is None
+
+        self.viewer_state.slices = (1, 2, 2, 2)
+
+        assert layer._pixel_cache['reset_slices'][0] is None
+        assert layer._pixel_cache['reset_slices'][1] is None
+        assert layer._pixel_cache['reset_slices'][2] is None

--- a/glue/viewers/profile/layer_artist.py
+++ b/glue/viewers/profile/layer_artist.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 
+from glue.core import Data
 from glue.utils import defer_draw, nanmin, nanmax
 from glue.viewers.profile.state import ProfileLayerState
 from glue.viewers.matplotlib.layer_artist import MatplotlibLayerArtist
@@ -141,6 +142,14 @@ class ProfileLayerArtist(MatplotlibLayerArtist):
 
     @defer_draw
     def update(self):
-        self.state._update_profile()
+        try:
+            self.state._update_profile()
+        except IncompatibleAttribute:
+            if isinstance(self.state.layer, Data):
+                self.disable_invalid_attributes(self.state.attribute)
+            else:
+                self.disable_incompatible_subset()
+        else:
+            self.enable()
         self._update_profile(force=True)
         self.redraw()


### PR DESCRIPTION
Fixing the issue reduced the performance of slicing of reprojected cubes, which was previously over-simplified. To speed this up, I've adding caching of the pixel coordinate transformations. I've also fixed an unrelated bug in the profile viewer.
