### PR TITLE
Fix segmentation fault

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,9 @@ v0.13.3 (unreleased)
 * Fixed a bug related to callback functions when restoring sessions.
   [#1695]
 
+* Fixed a Qt-related segmentation fault that occurred during the
+  testing process and may also affect users. [#1703]
+
 v0.13.2 (2018-05-01)
 --------------------
 

--- a/glue/external/echo/qt/autoconnect.py
+++ b/glue/external/echo/qt/autoconnect.py
@@ -90,11 +90,13 @@ def autoconnect_callbacks_to_qt(instance, widget, connect_kwargs={}):
     if not hasattr(widget, 'children'):
         return
 
-    for full_name in dir(widget):
+    for original_name in dir(widget):
         # FIXME: this is a temorary workaround to allow multiple widgets to be
         # connected to a state attribute.
-        if full_name.endswith('_'):
-            full_name = full_name[:-1]
+        if original_name.endswith('_'):
+            full_name = original_name[:-1]
+        else:
+            full_name = original_name
         if '_' in full_name:
             wtype, wname = full_name.split('_', 1)
             if full_name in connect_kwargs:
@@ -105,5 +107,5 @@ def autoconnect_callbacks_to_qt(instance, widget, connect_kwargs={}):
                 kwargs = {}
             if hasattr(instance, wname):
                 if wtype in HANDLERS:
-                    child = getattr(widget, full_name)
+                    child = getattr(widget, original_name)
                     HANDLERS[wtype](instance, wname, child, **kwargs)

--- a/glue/external/echo/qt/autoconnect.py
+++ b/glue/external/echo/qt/autoconnect.py
@@ -91,6 +91,8 @@ def autoconnect_callbacks_to_qt(instance, widget, connect_kwargs={}):
         return
 
     for original_name in dir(widget):
+        if original_name.startswith('_') or '_' not in original_name:
+            continue
         # FIXME: this is a temorary workaround to allow multiple widgets to be
         # connected to a state attribute.
         if original_name.endswith('_'):

--- a/glue/external/echo/qt/autoconnect.py
+++ b/glue/external/echo/qt/autoconnect.py
@@ -90,8 +90,7 @@ def autoconnect_callbacks_to_qt(instance, widget, connect_kwargs={}):
     if not hasattr(widget, 'children'):
         return
 
-    for child in widget.findChildren(QtWidgets.QWidget):
-        full_name = child.objectName()
+    for full_name in dir(widget):
         # FIXME: this is a temorary workaround to allow multiple widgets to be
         # connected to a state attribute.
         if full_name.endswith('_'):
@@ -106,4 +105,5 @@ def autoconnect_callbacks_to_qt(instance, widget, connect_kwargs={}):
                 kwargs = {}
             if hasattr(instance, wname):
                 if wtype in HANDLERS:
+                    child = getattr(widget, full_name)
                     HANDLERS[wtype](instance, wname, child, **kwargs)

--- a/glue/viewers/common/qt/tests/test_data_viewer.py
+++ b/glue/viewers/common/qt/tests/test_data_viewer.py
@@ -19,11 +19,6 @@ from glue.utils.qt import get_qapp
 # registered Qt viewers.
 
 
-def setup_function(func):
-    import os
-    os.environ['GLUE_TESTING'] = 'True'
-
-
 class BaseTestDataViewer(object):
 
     ndim = 1

--- a/glue/viewers/histogram/qt/options_widget.py
+++ b/glue/viewers/histogram/qt/options_widget.py
@@ -23,6 +23,7 @@ class HistogramOptionsWidget(QtWidgets.QWidget):
         fix_tab_widget_fontsize(self.ui.tab_widget)
 
         autoconnect_callbacks_to_qt(viewer_state, self.ui)
+        autoconnect_callbacks_to_qt(viewer_state, self.ui.axes_editor.ui)
 
         self.viewer_state = viewer_state
 

--- a/glue/viewers/image/qt/options_widget.py
+++ b/glue/viewers/image/qt/options_widget.py
@@ -24,6 +24,7 @@ class ImageOptionsWidget(QtWidgets.QWidget):
         fix_tab_widget_fontsize(self.ui.tab_widget)
 
         autoconnect_callbacks_to_qt(viewer_state, self.ui)
+        autoconnect_callbacks_to_qt(viewer_state, self.ui.axes_editor.ui)
 
         self.viewer_state = viewer_state
 

--- a/glue/viewers/profile/qt/options_widget.py
+++ b/glue/viewers/profile/qt/options_widget.py
@@ -28,6 +28,7 @@ class ProfileOptionsWidget(QtWidgets.QWidget):
         fix_tab_widget_fontsize(self.ui.tab_widget)
 
         autoconnect_callbacks_to_qt(viewer_state, self.ui)
+        autoconnect_callbacks_to_qt(viewer_state, self.ui.axes_editor.ui)
 
         self.viewer_state = viewer_state
 

--- a/glue/viewers/scatter/qt/options_widget.py
+++ b/glue/viewers/scatter/qt/options_widget.py
@@ -23,6 +23,7 @@ class ScatterOptionsWidget(QtWidgets.QWidget):
         fix_tab_widget_fontsize(self.ui.tab_widget)
 
         autoconnect_callbacks_to_qt(viewer_state, self.ui)
+        autoconnect_callbacks_to_qt(viewer_state, self.ui.axes_editor.ui)
 
         self.viewer_state = viewer_state
 


### PR DESCRIPTION
Work around segmentation fault that appears to occur when accessing objectName - the new approach should avoid this but means that ``autoconnect_callbacks_to_qt`` no longer operates recursively.