### PR TITLE
Asynchronous profile computation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,8 @@ Full changelog
 v0.14.0 (unreleased)
 --------------------
 
-* Compute profiles asynchronously to avoid holding up the UI. [#1736]
+* Compute profiles asynchronously to avoid holding up the UI,
+  and in chunks to avoid excessive memory usage. [#1736]
 
 * Improved naming of components when merging datasets. [#1249]
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ Full changelog
 v0.14.0 (unreleased)
 --------------------
 
+* Compute profiles asynchronously to avoid holding up the UI. [#1736]
+
 * Improved naming of components when merging datasets. [#1249]
 
 v0.13.4 (unreleased)

--- a/glue/core/message.py
+++ b/glue/core/message.py
@@ -256,3 +256,9 @@ class LayerArtistDisabledMessage(Message):
     def __init__(self, sender, tag=None):
         super(LayerArtistDisabledMessage, self).__init__(sender, tag=tag)
         self.layer_artist = self.sender
+
+
+class LayerArtistComputationMessage(Message):
+    def __init__(self, sender, tag=None):
+        super(LayerArtistComputationMessage, self).__init__(sender, tag=tag)
+        self.layer_artist = self.sender

--- a/glue/core/message.py
+++ b/glue/core/message.py
@@ -258,7 +258,15 @@ class LayerArtistDisabledMessage(Message):
         self.layer_artist = self.sender
 
 
-class LayerArtistComputationMessage(Message):
+class ComputationMessage(Message):
     def __init__(self, sender, tag=None):
-        super(LayerArtistComputationMessage, self).__init__(sender, tag=tag)
+        super(ComputationMessage, self).__init__(sender, tag=tag)
         self.layer_artist = self.sender
+
+
+class ComputationStartedMessage(ComputationMessage):
+    pass
+
+
+class ComputationEndedMessage(ComputationMessage):
+    pass

--- a/glue/utils/qt/threading.py
+++ b/glue/utils/qt/threading.py
@@ -14,24 +14,28 @@ class Worker(QtCore.QThread):
 
     def __init__(self, func, *args, **kwargs):
         """
-        Execute a function call on a different QThread
+        Execute a function call on a different thread.
 
-        :param func: The function object to call
-        :param args: arguments to pass to the function
-        :param kwargs: kwargs to pass to the function
+        Parameters
+        ----------
+        func : callable
+            The function object to call
+        args
+            Positional arguments to pass to the function
+        kwargs
+            Keyword arguments to pass to the function
         """
         super(Worker, self).__init__()
         self.func = func
-        self.args = args
-        self.kwargs = kwargs
+        self.args = args or ()
+        self.kwargs = kwargs or {}
 
     def run(self):
         """
-        Invoke the function
-        Upon successful completion, the result signal will be fired
-        with the output of the function
-        If an exception occurs, the error signal will be fired with
-        the result form sys.exc_infno()
+        Invoke the function. Upon successful completion, the result signal
+        will be fired with the output of the function If an exception
+        occurs, the error signal will be fired with the result form
+        sys.exc_infno()
         """
         try:
             result = self.func(*self.args, **self.kwargs)

--- a/glue/utils/qt/threading.py
+++ b/glue/utils/qt/threading.py
@@ -9,6 +9,7 @@ class Worker(QtCore.QThread):
 
     result = QtCore.Signal(object)
     error = QtCore.Signal(object)
+    running = False
 
     def __init__(self, func, *args, **kwargs):
         """
@@ -32,7 +33,9 @@ class Worker(QtCore.QThread):
         the result form sys.exc_infno()
         """
         try:
+            self.running = True
             result = self.func(*self.args, **self.kwargs)
+            self.running = False
             self.result.emit(result)
         except Exception:
             import sys

--- a/glue/utils/qt/threading.py
+++ b/glue/utils/qt/threading.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
+import sys
+
 from qtpy import QtCore
 
 __all__ = ['Worker']
@@ -9,7 +11,6 @@ class Worker(QtCore.QThread):
 
     result = QtCore.Signal(object)
     error = QtCore.Signal(object)
-    running = False
 
     def __init__(self, func, *args, **kwargs):
         """
@@ -33,10 +34,7 @@ class Worker(QtCore.QThread):
         the result form sys.exc_infno()
         """
         try:
-            self.running = True
             result = self.func(*self.args, **self.kwargs)
-            self.running = False
             self.result.emit(result)
         except Exception:
-            import sys
             self.error.emit(sys.exc_info())

--- a/glue/utils/qt/threading.py
+++ b/glue/utils/qt/threading.py
@@ -35,7 +35,7 @@ class Worker(QtCore.QThread):
         Invoke the function. Upon successful completion, the result signal
         will be fired with the output of the function If an exception
         occurs, the error signal will be fired with the result form
-        sys.exc_infno()
+        sys.exc_info()
         """
         try:
             self.running = True

--- a/glue/utils/qt/threading.py
+++ b/glue/utils/qt/threading.py
@@ -38,7 +38,10 @@ class Worker(QtCore.QThread):
         sys.exc_infno()
         """
         try:
+            self.running = True
             result = self.func(*self.args, **self.kwargs)
+            self.running = False
             self.result.emit(result)
         except Exception:
+            self.running = False
             self.error.emit(sys.exc_info())

--- a/glue/viewers/common/qt/data_viewer_with_state.py
+++ b/glue/viewers/common/qt/data_viewer_with_state.py
@@ -226,6 +226,16 @@ class DataViewerWithState(DataViewer):
                       self._update_appearance_from_settings,
                       filter=self._is_appearance_settings)
 
+        hub.subscribe(self, msg.LayerArtistComputationMessage,
+                      self._update_computation,
+                      filter=self._has_layer_artist)
+
+    def _has_layer_artist(self, message):
+        return message.layer_artist in self.layers
+
+    def _update_computation(self, *args):
+        pass
+
     def _update_appearance_from_settings(self, message=None):
         pass
 

--- a/glue/viewers/common/qt/data_viewer_with_state.py
+++ b/glue/viewers/common/qt/data_viewer_with_state.py
@@ -226,7 +226,7 @@ class DataViewerWithState(DataViewer):
                       self._update_appearance_from_settings,
                       filter=self._is_appearance_settings)
 
-        hub.subscribe(self, msg.LayerArtistComputationMessage,
+        hub.subscribe(self, msg.ComputationMessage,
                       self._update_computation,
                       filter=self._has_layer_artist)
 

--- a/glue/viewers/matplotlib/layer_artist.py
+++ b/glue/viewers/matplotlib/layer_artist.py
@@ -4,7 +4,13 @@ from glue.external.echo import keep_in_sync
 from glue.core.layer_artist import LayerArtistBase
 from glue.viewers.matplotlib.state import DeferredDrawCallbackProperty
 from glue.core.message import ComputationStartedMessage, ComputationEndedMessage
-from glue.tests.helpers import QT_INSTALLED
+
+try:
+    import qtpy  # noqa
+except Exception:
+    QT_INSTALLED = False
+else:
+    QT_INSTALLED = True
 
 # TODO: should use the built-in class for this, though we don't need
 #       the _sync_style method, so just re-define here for now.

--- a/glue/viewers/matplotlib/qt/data_viewer.py
+++ b/glue/viewers/matplotlib/qt/data_viewer.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 
-import matplotlib.pyplot as plt
 from matplotlib.patches import Rectangle
 
 from glue.viewers.common.qt.data_viewer_with_state import DataViewerWithState

--- a/glue/viewers/matplotlib/qt/data_viewer.py
+++ b/glue/viewers/matplotlib/qt/data_viewer.py
@@ -2,6 +2,9 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 
+import matplotlib.pyplot as plt
+from matplotlib.patches import Rectangle
+
 from glue.viewers.common.qt.data_viewer_with_state import DataViewerWithState
 from glue.viewers.matplotlib.qt.widget import MplWidget
 from glue.viewers.common.viz_client import init_mpl, update_appearance_from_settings
@@ -64,6 +67,17 @@ class MatplotlibDataViewer(DataViewerWithState):
 
         self.figure, self._axes = init_mpl(self.mpl_widget.canvas.fig, wcs=wcs)
 
+        self.loading_rectangle = Rectangle((0, 0), 1, 1, color='0.9', alpha=0.9,
+                                           zorder=100000, transform=self.axes.transAxes)
+        self.loading_rectangle.set_visible(False)
+        self.axes.add_patch(self.loading_rectangle)
+
+        self.loading_text = self.axes.text(0.5, 0.5, 'Loading...', color='k',
+                                           zorder=self.loading_rectangle.get_zorder() + 1,
+                                           ha='center', va='center',
+                                           transform=self.axes.transAxes)
+        self.loading_text.set_visible(False)
+
         self.state.add_callback('aspect', self.update_aspect)
 
         self.update_aspect()
@@ -103,6 +117,17 @@ class MatplotlibDataViewer(DataViewerWithState):
 
         self.central_widget.resize(600, 400)
         self.resize(self.central_widget.size())
+
+    @defer_draw
+    def _update_computation(self, *args):
+        for layer_artist in self.layers:
+            if layer_artist.computing:
+                self.loading_rectangle.set_visible(True)
+                self.loading_text.set_visible(True)
+                return
+        self.loading_rectangle.set_visible(False)
+        self.loading_text.set_visible(False)
+        self.redraw()
 
     @defer_draw
     def update_x_axislabel(self, *event):

--- a/glue/viewers/matplotlib/qt/data_viewer.py
+++ b/glue/viewers/matplotlib/qt/data_viewer.py
@@ -124,6 +124,7 @@ class MatplotlibDataViewer(DataViewerWithState):
             if layer_artist.computing:
                 self.loading_rectangle.set_visible(True)
                 self.loading_text.set_visible(True)
+                self.redraw()
                 return
         self.loading_rectangle.set_visible(False)
         self.loading_text.set_visible(False)

--- a/glue/viewers/matplotlib/qt/data_viewer.py
+++ b/glue/viewers/matplotlib/qt/data_viewer.py
@@ -45,6 +45,8 @@ fig.savefig('glue_plot.png')
 plt.close(fig)
 """.strip()
 
+ZORDER_MAX = 100000
+
 
 class MatplotlibDataViewer(DataViewerWithState):
 
@@ -66,12 +68,15 @@ class MatplotlibDataViewer(DataViewerWithState):
 
         self.figure, self._axes = init_mpl(self.mpl_widget.canvas.fig, wcs=wcs)
 
+        for spine in self._axes.spines.values():
+            spine.set_zorder(ZORDER_MAX)
+
         self.loading_rectangle = Rectangle((0, 0), 1, 1, color='0.9', alpha=0.9,
-                                           zorder=100000, transform=self.axes.transAxes)
+                                           zorder=ZORDER_MAX - 1, transform=self.axes.transAxes)
         self.loading_rectangle.set_visible(False)
         self.axes.add_patch(self.loading_rectangle)
 
-        self.loading_text = self.axes.text(0.5, 0.5, 'Loading...', color='k',
+        self.loading_text = self.axes.text(0.5, 0.5, 'Computing...', color='k',
                                            zorder=self.loading_rectangle.get_zorder() + 1,
                                            ha='center', va='center',
                                            transform=self.axes.transAxes)
@@ -120,7 +125,7 @@ class MatplotlibDataViewer(DataViewerWithState):
     @defer_draw
     def _update_computation(self, *args):
         for layer_artist in self.layers:
-            if layer_artist.computing:
+            if layer_artist.is_computing:
                 self.loading_rectangle.set_visible(True)
                 self.loading_text.set_visible(True)
                 self.redraw()

--- a/glue/viewers/profile/layer_artist.py
+++ b/glue/viewers/profile/layer_artist.py
@@ -8,7 +8,13 @@ from glue.utils import defer_draw, nanmin, nanmax
 from glue.viewers.profile.state import ProfileLayerState
 from glue.viewers.matplotlib.layer_artist import MatplotlibLayerArtist
 from glue.core.exceptions import IncompatibleAttribute, IncompatibleDataException
-from glue.tests.helpers import QT_INSTALLED
+
+try:
+    import qtpy  # noqa
+except Exception:
+    QT_INSTALLED = False
+else:
+    QT_INSTALLED = True
 
 
 class ProfileLayerArtist(MatplotlibLayerArtist):
@@ -78,17 +84,6 @@ class ProfileLayerArtist(MatplotlibLayerArtist):
 
     def _calculate_profile_postthread(self):
 
-        # TODO: the following was copy/pasted from the histogram viewer, maybe
-        # we can find a way to avoid duplication?
-
-        # We have to do the following to make sure that we reset the y_max as
-        # needed. We can't simply reset based on the maximum for this layer
-        # because other layers might have other values, and we also can't do:
-        #
-        #   self._viewer_state.y_max = max(self._viewer_state.y_max, result[0].max())
-        #
-        # because this would never allow y_max to get smaller.
-
         self.notify_end_computation()
 
         visible_data = self.state.profile
@@ -112,6 +107,17 @@ class ProfileLayerArtist(MatplotlibLayerArtist):
             # We need to do this otherwise we get issues on Windows when
             # passing an empty list to plot_artist
             self.plot_artist.set_visible(False)
+
+        # TODO: the following was copy/pasted from the histogram viewer, maybe
+        # we can find a way to avoid duplication?
+
+        # We have to do the following to make sure that we reset the y_max as
+        # needed. We can't simply reset based on the maximum for this layer
+        # because other layers might have other values, and we also can't do:
+        #
+        #   self._viewer_state.y_max = max(self._viewer_state.y_max, result[0].max())
+        #
+        # because this would never allow y_max to get smaller.
 
         if not self._viewer_state.normalize and len(y) > 0:
 

--- a/glue/viewers/profile/layer_artist.py
+++ b/glue/viewers/profile/layer_artist.py
@@ -162,5 +162,6 @@ class ProfileLayerArtist(MatplotlibLayerArtist):
 
     @defer_draw
     def update(self):
+        self.state.reset_cache()
         self._update_profile(force=True)
         self.redraw()

--- a/glue/viewers/profile/qt/profile_tools.py
+++ b/glue/viewers/profile/qt/profile_tools.py
@@ -247,13 +247,12 @@ class ProfileTools(QtWidgets.QWidget):
         results = {}
         for layer in self.viewer.layers:
             if layer.enabled and layer.visible:
-                if hasattr(layer, '_visible_data'):
-                    x, y = layer._visible_data
-                    x = np.asarray(x)
-                    y = np.asarray(y)
-                    keep = (x >= min(xlim)) & (x <= max(xlim))
-                    if len(x) > 0:
-                        results[layer] = fitter.build_and_fit(x[keep], y[keep])
+                x, y = layer.state.profile
+                x = np.asarray(x)
+                y = np.asarray(y)
+                keep = (x >= min(xlim)) & (x <= max(xlim))
+                if len(x) > 0:
+                    results[layer] = fitter.build_and_fit(x[keep], y[keep])
 
         return results, x, y
 

--- a/glue/viewers/profile/qt/tests/test_data_viewer.py
+++ b/glue/viewers/profile/qt/tests/test_data_viewer.py
@@ -65,6 +65,7 @@ class TestProfileViewer(object):
         self.viewer.state.function = nanmean
         assert len(self.viewer.layers) == 1
         layer_artist = self.viewer.layers[0]
+        layer_artist.wait()
         assert_allclose(layer_artist._visible_data[0], [0, 2, 4])
         assert_allclose(layer_artist._visible_data[1], [3.5, 11.5, 19.5])
 

--- a/glue/viewers/profile/qt/tests/test_data_viewer.py
+++ b/glue/viewers/profile/qt/tests/test_data_viewer.py
@@ -74,6 +74,8 @@ class TestProfileViewer(object):
         data2 = Data(y=np.random.random((3, 4, 2)))
         self.data_collection.append(data2)
         self.viewer.add_data(data2)
+        for layer in self.viewer.layers:
+            layer.wait()
         assert len(self.viewer.layers) == 2
         assert self.viewer.layers[0].enabled
         assert not self.viewer.layers[1].enabled
@@ -108,10 +110,16 @@ class TestProfileViewer(object):
         self.viewer.add_data(self.data)
         self.viewer.add_data(data2)
 
+        for layer in self.viewer.layers:
+            layer.wait()
+
         assert self.viewer.layers[0].enabled
         assert not self.viewer.layers[1].enabled
 
         self.data_collection.add_link(ComponentLink([data2.world_component_ids[1]], self.data.world_component_ids[0], using=lambda x: 2 * x))
+
+        for layer in self.viewer.layers:
+            layer.wait()
 
         assert self.viewer.layers[0].enabled
         assert self.viewer.layers[1].enabled

--- a/glue/viewers/profile/qt/tests/test_data_viewer.py
+++ b/glue/viewers/profile/qt/tests/test_data_viewer.py
@@ -66,8 +66,8 @@ class TestProfileViewer(object):
         assert len(self.viewer.layers) == 1
         layer_artist = self.viewer.layers[0]
         layer_artist.wait()
-        assert_allclose(layer_artist._visible_data[0], [0, 2, 4])
-        assert_allclose(layer_artist._visible_data[1], [3.5, 11.5, 19.5])
+        assert_allclose(layer_artist.state.profile[0], [0, 2, 4])
+        assert_allclose(layer_artist.state.profile[1], [3.5, 11.5, 19.5])
 
     def test_incompatible(self):
         self.viewer.add_data(self.data)

--- a/glue/viewers/profile/qt/tests/test_profile_tools.py
+++ b/glue/viewers/profile/qt/tests/test_profile_tools.py
@@ -54,6 +54,12 @@ class TestProfileTools(object):
 
         self.viewer.state.x_att = self.data.pixel_component_ids[0]
 
+        # Force events to be processed to make sure that the callback functions
+        # for the computation thread are executed (since they rely on signals)
+        self.viewer.layers[0].wait()
+        app = get_qapp()
+        app.processEvents()
+
         x, y = self.viewer.axes.transData.transform([[1, 4]])[0]
         self.viewer.axes.figure.canvas.button_press_event(x, y, 1)
         self.viewer.axes.figure.canvas.button_release_event(x, y, 1)
@@ -78,6 +84,12 @@ class TestProfileTools(object):
 
         self.viewer.state.x_att = self.data.pixel_component_ids[0]
 
+        # Force events to be processed to make sure that the callback functions
+        # for the computation thread are executed (since they rely on signals)
+        self.viewer.layers[0].wait()
+        app = get_qapp()
+        app.processEvents()
+
         x, y = self.viewer.axes.transData.transform([[0.9, 4]])[0]
         self.viewer.axes.figure.canvas.button_press_event(x, y, 1)
         x, y = self.viewer.axes.transData.transform([[15.1, 4]])[0]
@@ -87,7 +99,9 @@ class TestProfileTools(object):
 
         self.profile_tools.ui.button_fit.click()
         self.profile_tools.wait_for_fit()
-        app = get_qapp()
+
+        # Force events to be processed to make sure that the callback functions
+        # for the computation thread are executed (since they rely on signals)
         app.processEvents()
 
         pixel_log = self.profile_tools.text_log.toPlainText().splitlines()
@@ -134,6 +148,12 @@ class TestProfileTools(object):
 
         self.viewer.state.x_att = self.data.pixel_component_ids[0]
 
+        # Force events to be processed to make sure that the callback functions
+        # for the computation thread are executed (since they rely on signals)
+        self.viewer.layers[0].wait()
+        app = get_qapp()
+        app.processEvents()
+
         x, y = self.viewer.axes.transData.transform([[0.9, 4]])[0]
         self.viewer.axes.figure.canvas.button_press_event(x, y, 1)
         x, y = self.viewer.axes.transData.transform([[15.1, 4]])[0]
@@ -150,6 +170,11 @@ class TestProfileTools(object):
         # Next, try in world coordinates
 
         self.viewer.state.x_att = self.data.world_component_ids[0]
+
+        # Force events to be processed to make sure that the callback functions
+        # for the computation thread are executed (since they rely on signals)
+        self.viewer.layers[0].wait()
+        app.processEvents()
 
         x, y = self.viewer.axes.transData.transform([[1.9, 4]])[0]
         self.viewer.axes.figure.canvas.button_press_event(x, y, 1)

--- a/glue/viewers/profile/state.py
+++ b/glue/viewers/profile/state.py
@@ -176,13 +176,12 @@ class ProfileLayerState(MatplotlibLayerState):
     def viewer_state(self, viewer_state):
         self._viewer_state = viewer_state
 
-    def update_limits(self):
-        with delay_callback(self, 'v_min', 'v_max'):
-            profile_values = self.get_profile()
-            self.v_min = nanmin(profile_values)
-            self.v_max = nanmax(profile_values)
+    @property
+    def profile(self):
+        self.update_profile()
+        return self._profile_cache
 
-    def get_profile(self, *event):
+    def update_profile(self, update_limits=True):
 
         if self._profile_cache is not None:
             return self._profile_cache
@@ -244,4 +243,12 @@ class ProfileLayerState(MatplotlibLayerState):
 
         self._profile_cache = axis_values, profile_values
 
-        return axis_values, profile_values
+        if update_limits:
+            self.update_limits(update_profile=False)
+
+    def update_limits(self, update_profile=True):
+        with delay_callback(self, 'v_min', 'v_max'):
+            if update_profile:
+                self.update_profile(update_limits=False)
+            self.v_min = nanmin(self._profile_cache[1])
+            self.v_max = nanmax(self._profile_cache[1])

--- a/glue/viewers/profile/state.py
+++ b/glue/viewers/profile/state.py
@@ -15,7 +15,7 @@ from glue.core.state_objects import StateAttributeLimitsHelper
 from glue.core.data_combo_helper import ManualDataComboHelper, ComponentIDComboHelper
 from glue.utils import defer_draw, nanmean, nanmedian, nansum, nanmin, nanmax
 from glue.core.link_manager import is_convertible_to_single_pixel_cid
-from glue.core.exceptions import IncompatibleAttribute, IncompatibleDataException
+from glue.core.exceptions import IncompatibleDataException
 from glue.core.subset import SliceSubsetState
 
 __all__ = ['ProfileViewerState', 'ProfileLayerState']

--- a/glue/viewers/profile/state.py
+++ b/glue/viewers/profile/state.py
@@ -276,5 +276,6 @@ class ProfileLayerState(MatplotlibLayerState):
         with delay_callback(self, 'v_min', 'v_max'):
             if update_profile:
                 self.update_profile(update_limits=False)
-            self.v_min = nanmin(self._profile_cache[1])
-            self.v_max = nanmax(self._profile_cache[1])
+            if self._profile_cache is not None and len(self._profile_cache[1]) > 0:
+                self.v_min = nanmin(self._profile_cache[1])
+                self.v_max = nanmax(self._profile_cache[1])

--- a/glue/viewers/profile/state.py
+++ b/glue/viewers/profile/state.py
@@ -145,8 +145,8 @@ class ProfileLayerState(MatplotlibLayerState):
         ProfileLayerState.percentile.set_display_func(self, percentile_display.get)
 
         self.add_callback('layer', self._update_attribute, priority=1000)
-        self.add_callback('layer', self._update_profile, priority=1000)
-        self.add_callback('attribute', self._update_profile, priority=1000)
+        # self.add_callback('layer', self._update_profile, priority=1000)
+        # self.add_callback('attribute', self._update_profile, priority=1000)
 
         if layer is not None:
             self._update_attribute()
@@ -171,27 +171,21 @@ class ProfileLayerState(MatplotlibLayerState):
     @viewer_state.setter
     def viewer_state(self, viewer_state):
         self._viewer_state = viewer_state
-        if viewer_state is not None:
-            self._viewer_state.add_callback('x_att', self._update_profile, priority=1000)
-            self._viewer_state.add_callback('function', self._update_profile, priority=1000)
-            self._update_profile()
+        # if viewer_state is not None:
+        #     self._viewer_state.add_callback('x_att', self._update_profile, priority=1000)
+        #     self._viewer_state.add_callback('function', self._update_profile, priority=1000)
+        #     self._update_profile()
 
-    @property
-    def profile(self):
-        return self._profile
-
-    def _update_profile(self, *event):
+    def get_profile(self, *event):
 
         if self.viewer_state is None or self.viewer_state.x_att is None or self.attribute is None:
-            self._profile = None, None
-            return
+            return None, None
 
         # Check what pixel axis in the current dataset x_att corresponds to
         pix_cid = is_convertible_to_single_pixel_cid(self.layer, self.viewer_state.x_att)
 
         if pix_cid is None:
-            self._profile = None, None
-            return
+            return None, None
 
         # If we get here, then x_att does correspond to a single pixel axis in
         # the cube, so we now prepare a list of axes to collapse over.
@@ -220,8 +214,7 @@ class ProfileLayerState(MatplotlibLayerState):
                         return
                     data_values[~mask] = np.nan
         except IncompatibleAttribute:
-            self._profile = None, None
-            return
+            return None, None
 
         # Collapse along all dimensions except x_att
         if self.layer.ndim > 1:
@@ -237,6 +230,6 @@ class ProfileLayerState(MatplotlibLayerState):
         axis_values = data[self.viewer_state.x_att, axis_view]
 
         with delay_callback(self, 'v_min', 'v_max'):
-            self._profile = axis_values, profile_values
             self.v_min = nanmin(profile_values)
             self.v_max = nanmax(profile_values)
+            return axis_values, profile_values

--- a/glue/viewers/profile/state.py
+++ b/glue/viewers/profile/state.py
@@ -176,6 +176,12 @@ class ProfileLayerState(MatplotlibLayerState):
     def viewer_state(self, viewer_state):
         self._viewer_state = viewer_state
 
+    def update_limits(self):
+        with delay_callback(self, 'v_min', 'v_max'):
+            profile_values = self.get_profile()
+            self.v_min = nanmin(profile_values)
+            self.v_max = nanmax(profile_values)
+
     def get_profile(self, *event):
 
         if self._profile_cache is not None:
@@ -237,9 +243,5 @@ class ProfileLayerState(MatplotlibLayerState):
         axis_values = data[self.viewer_state.x_att, axis_view]
 
         self._profile_cache = axis_values, profile_values
-
-        with delay_callback(self, 'v_min', 'v_max'):
-            self.v_min = nanmin(profile_values)
-            self.v_max = nanmax(profile_values)
 
         return axis_values, profile_values

--- a/glue/viewers/profile/tests/test_state.py
+++ b/glue/viewers/profile/tests/test_state.py
@@ -96,7 +96,8 @@ class TestProfileViewerState:
         subset.subset_state = self.data.id['x'] > 100
 
         # TODO: the fact we have to call this isn't ideal
-        self.layer_state._update_profile()
+        self.layer_state.reset_cache()
+
         x, y = self.layer_state.profile
         assert len(x) == 0
         assert len(y) == 0


### PR DESCRIPTION
This is a proof of concept for dealing with asynchronous computation of the profiles.

* [x] Use a single-shot ``QTimer`` to emit the layer computation signal so that we only show this for cases where the computation takes more than e.g. 0.5 seconds
* [x] Create computation started and ended signals, even if we don't really use them for now
* [x] Move some of the layer artist functionality to the generic matplotlib layer artist class so that it can be used for other matplotlib plot types
* [x] Add back caching for the state method that computes the profile (as or the image viewer)
* [ ] Try and implement this for the histogram
* [x] Avoid direct imports to timer and thread in layer artists

Fixes https://github.com/glue-viz/glue/issues/310