### PR TITLE
Fix thread issue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ Full changelog
 v0.14.0 (unreleased)
 --------------------
 
+* Add a new method ``Data.compute_statistic`` which can be used
+  to find scalar and array statistics on the data, and use for
+  the profile viewer and the state limits helpers. [#1737]
+
 * Compute profiles asynchronously to avoid holding up the UI,
   and in chunks to avoid excessive memory usage. [#1736]
 

--- a/glue/viewers/profile/layer_artist.py
+++ b/glue/viewers/profile/layer_artist.py
@@ -54,6 +54,9 @@ class ProfileLayerArtist(MatplotlibLayerArtist):
         super(ProfileLayerArtist, self).remove()
         if QT_INSTALLED and self._worker is not None:
             self._worker.exit()
+            # Need to wait otherwise the thread will be destroyed while still
+            # running, causing a segmentation fault
+            self._worker.wait()
             self._worker = None
 
     @property


### PR DESCRIPTION
This ensures we don't destroy a thread without waiting for it to be interrupted properly. Prior to this this could result in segmentation faults.

Also added the missing changelog entry for #1737