### PR TITLE
Move computation of histogram to the Data object

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@ v0.14.0 (unreleased)
 
 * Improved naming of components when merging datasets. [#1249]
 
+* Moved calculation of histograms to Data.compute_histogram. [#1739]
+
 v0.13.4 (unreleased)
 --------------------
 

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -1261,9 +1261,11 @@ class Data(object):
         """
         Compute an n-dimensional histogram with regularly spaced bins.
 
+        Currently this only implements 1-D histograms.
+
         Parameters
         ----------
-        cids : str or ComponentID or list of str or `ComponentID`
+        cids : list of str or `ComponentID`
             Component IDs to compute the histogram over
         weights : str or ComponentID
             Component IDs to use for the histogram weights
@@ -1271,7 +1273,7 @@ class Data(object):
             The ``(min, max)`` of the histogram range
         bins : list of int
             The number of bins
-        log : bool or list of bool
+        log : list of bool
             Whether to compute the histogram in log space
         subset_state : `SubsetState`, optional
             If specified, the histogram will only take into account values in

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -1257,19 +1257,21 @@ class Data(object):
         return compute_statistic(statistic, data, mask=mask, axis=axis, finite=finite,
                                  positive=positive, percentile=percentile)
 
-    def compute_histogram(self, cids, range=None, bins=None, log=None, subset_state=None):
+    def compute_histogram(self, cids, weights=None, range=None, bins=None, log=None, subset_state=None):
         """
         Compute an n-dimensional histogram with regularly spaced bins.
 
         Parameters
         ----------
-        cids : list of `ComponentID`
+        cids : str or ComponentID or list of str or `ComponentID`
             Component IDs to compute the histogram over
+        weights : str or ComponentID
+            Component IDs to use for the histogram weights
         range : list of tuple
             The ``(min, max)`` of the histogram range
         bins : list of int
             The number of bins
-        log : bool
+        log : bool or list of bool
             Whether to compute the histogram in log space
         subset_state : `SubsetState`, optional
             If specified, the histogram will only take into account values in
@@ -1285,10 +1287,14 @@ class Data(object):
             log = log[0]
 
         x = self[cid]
+        if weights is not None:
+            w = self[weights]
 
         if subset_state is not None:
             mask = subset_state.to_mask(self)
             x = x[mask]
+            if weights is not None:
+                w = w[mask]
 
         xmin, xmax = sorted(range)
 
@@ -1298,6 +1304,8 @@ class Data(object):
             keep &= ~np.isnan(x)
 
         x = x[keep]
+        if weights is not None:
+            w = w[keep]
 
         if len(x) == 0:
             return np.zeros(bins)
@@ -1309,7 +1317,7 @@ class Data(object):
             range = [xmin, xmax]
             bins = self._viewer_state.hist_n_bin
 
-        return np.histogram(x, range=range, bins=bins)
+        return np.histogram(x, range=range, bins=bins, weights=w)
 
 
 @contract(i=int, ndim=int)

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -1289,11 +1289,13 @@ class Data(object):
         x = self[cid]
         if weights is not None:
             w = self[weights]
+        else:
+            w = None
 
         if subset_state is not None:
             mask = subset_state.to_mask(self)
             x = x[mask]
-            if weights is not None:
+            if w is not None:
                 w = w[mask]
 
         xmin, xmax = sorted(range)
@@ -1304,7 +1306,7 @@ class Data(object):
             keep &= ~np.isnan(x)
 
         x = x[keep]
-        if weights is not None:
+        if w is not None:
             w = w[keep]
 
         if len(x) == 0:
@@ -1312,12 +1314,9 @@ class Data(object):
 
         if log:
             range = None
-            bins = np.logspace(np.log10(xmin), np.log10(xmax), self._viewer_state.hist_n_bin)
-        else:
-            range = [xmin, xmax]
-            bins = self._viewer_state.hist_n_bin
+            bins = np.logspace(np.log10(xmin), np.log10(xmax), bins + 1)
 
-        return np.histogram(x, range=range, bins=bins, weights=w)
+        return np.histogram(x, range=range, bins=bins, weights=w)[0]
 
 
 @contract(i=int, ndim=int)

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -24,7 +24,7 @@ from glue.core.visual import VisualAttributes
 from glue.core.coordinates import Coordinates
 from glue.core.contracts import contract
 from glue.config import settings
-from glue.utils import compute_statistic, unbroadcast, iterate_chunks
+from glue.utils import compute_statistic, unbroadcast, iterate_chunks, datetime64_to_mpl
 
 
 # Note: leave all the following imports for component and component_id since
@@ -1302,7 +1302,11 @@ class Data(object):
 
         keep = (x >= xmin) & (x <= xmax)
 
-        if x.dtype.kind != 'M':
+        if x.dtype.kind == 'M':
+            x = datetime64_to_mpl(x)
+            xmin = datetime64_to_mpl(xmin)
+            xmax = datetime64_to_mpl(xmax)
+        else:
             keep &= ~np.isnan(x)
 
         x = x[keep]
@@ -1315,6 +1319,8 @@ class Data(object):
         if log:
             range = None
             bins = np.logspace(np.log10(xmin), np.log10(xmax), bins + 1)
+        else:
+            range = (xmin, xmax)
 
         return np.histogram(x, range=range, bins=bins, weights=w)[0]
 

--- a/glue/plugins/exporters/plotly/export_plotly.py
+++ b/glue/plugins/exporters/plotly/export_plotly.py
@@ -187,7 +187,7 @@ def export_histogram(viewer):
         if not artist.visible:
             continue
         layer = artist.layer
-        x, y = _sanitize(artist.mpl_bins[:-1], artist.mpl_hist)
+        x, y = _sanitize(artist.mpl_hist_edges[:-1], artist.mpl_hist)
         trace = dict(
             name=layer.label,
             type='bar',

--- a/glue/viewers/histogram/layer_artist.py
+++ b/glue/viewers/histogram/layer_artist.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 import numpy as np
 
 from glue.core import Subset
-from glue.utils import defer_draw
+from glue.utils import defer_draw, datetime64_to_mpl
 
 from glue.viewers.histogram.state import HistogramLayerState
 from glue.viewers.histogram.python_export import python_export_histogram_layer
@@ -66,6 +66,9 @@ class HistogramLayerArtist(MatplotlibLayerArtist):
                                              bins=[self._viewer_state.hist_n_bin],
                                              log=[self._viewer_state.x_log],
                                              subset_state=subset_state)
+
+        if isinstance(range[0], np.datetime64):
+            range = [datetime64_to_mpl(range[0]), datetime64_to_mpl(range[1])]
 
         if self._viewer_state.x_log:
             hist_edges = np.logspace(np.log10(range[0]), np.log10(range[1]), self._viewer_state.hist_n_bin + 1)

--- a/glue/viewers/histogram/layer_artist.py
+++ b/glue/viewers/histogram/layer_artist.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 
+from glue.core import Subset
 from glue.utils import defer_draw
 
 from glue.viewers.histogram.state import HistogramLayerState
@@ -30,8 +31,7 @@ class HistogramLayerArtist(MatplotlibLayerArtist):
     def remove(self):
         super(HistogramLayerArtist, self).remove()
         self.mpl_hist_unscaled = np.array([])
-        self.mpl_hist = np.array([])
-        self.mpl_bins = np.array([])
+        self.mpl_hist_edges = np.array([])
 
     def reset_cache(self):
         self._last_viewer_state = {}
@@ -42,8 +42,15 @@ class HistogramLayerArtist(MatplotlibLayerArtist):
 
         self.remove()
 
+        if isinstance(self.layer, Subset):
+            data = self.layer.data
+            subset_state = self.layer.subset_state
+        else:
+            data = self.layer
+            subset_state = None
+
         try:
-            x = self.layer[self._viewer_state.x_att]
+            x_comp = data.get_component(self._viewer_state.x_att)
         except AttributeError:
             return
         except (IncompatibleAttribute, IndexError):
@@ -52,36 +59,32 @@ class HistogramLayerArtist(MatplotlibLayerArtist):
         else:
             self.enable()
 
-        keep = (x >= self._viewer_state.hist_x_min) & (x <= self._viewer_state.hist_x_max)
+        range = sorted((self._viewer_state.hist_x_min, self._viewer_state.hist_x_max))
 
-        if x.dtype.kind != 'M':
-            keep &= ~np.isnan(x)
+        hist_values = data.compute_histogram([self._viewer_state.x_att],
+                                             range=[range],
+                                             bins=[self._viewer_state.hist_n_bin],
+                                             log=[self._viewer_state.x_log],
+                                             subset_state=subset_state)
 
-        x = x[keep]
-
-        if len(x) == 0:
-            self.redraw()
-            return
-
-        # For histogram
-        xmin, xmax = sorted([self._viewer_state.hist_x_min, self._viewer_state.hist_x_max])
         if self._viewer_state.x_log:
-            range = None
-            bins = np.logspace(np.log10(xmin), np.log10(xmax), self._viewer_state.hist_n_bin)
+            hist_edges = np.logspace(np.log10(range[0]), np.log10(range[1]), self._viewer_state.hist_n_bin + 1)
         else:
-            range = [xmin, xmax]
-            bins = self._viewer_state.hist_n_bin
+            hist_edges = np.linspace(range[0], range[1], self._viewer_state.hist_n_bin + 1)
 
-        self.mpl_hist_unscaled, self.mpl_bins, self.mpl_artists = self.axes.hist(x, range=range, bins=bins)
+        self.mpl_artists = self.axes.bar(hist_edges[:-1], hist_values, align='edge', width=np.diff(hist_edges)).get_children()
+
+        self.mpl_hist_unscaled = hist_values
+        self.mpl_hist_edges = hist_edges
 
     @defer_draw
     def _scale_histogram(self):
 
-        if self.mpl_bins.size == 0 or self.mpl_hist_unscaled.sum() == 0:
+        if self.mpl_hist_edges.size == 0 or self.mpl_hist_unscaled.sum() == 0:
             return
 
         self.mpl_hist = self.mpl_hist_unscaled.astype(np.float)
-        dx = self.mpl_bins[1] - self.mpl_bins[0]
+        dx = self.mpl_hist_edges[1] - self.mpl_hist_edges[0]
 
         if self._viewer_state.cumulative:
             self.mpl_hist = self.mpl_hist.cumsum()

--- a/glue/viewers/histogram/qt/tests/test_data_viewer.py
+++ b/glue/viewers/histogram/qt/tests/test_data_viewer.py
@@ -192,37 +192,37 @@ class TestHistogramViewer(object):
         assert_allclose(self.viewer.state.y_max, 2.4)
 
         assert_allclose(self.viewer.layers[0].mpl_hist, [0, 1, 2, 1])
-        assert_allclose(self.viewer.layers[0].mpl_bins, [-5, -2.5, 0, 2.5, 5])
+        assert_allclose(self.viewer.layers[0].mpl_hist_edges, [-5, -2.5, 0, 2.5, 5])
 
         cid = self.data.visible_components[0]
         self.data_collection.new_subset_group('subset 1', cid < 2)
 
         assert_allclose(self.viewer.layers[1].mpl_hist, [0, 1, 1, 0])
-        assert_allclose(self.viewer.layers[1].mpl_bins, [-5, -2.5, 0, 2.5, 5])
+        assert_allclose(self.viewer.layers[1].mpl_hist_edges, [-5, -2.5, 0, 2.5, 5])
 
         viewer_state.normalize = True
 
         assert_allclose(self.viewer.state.y_max, 0.24)
         assert_allclose(self.viewer.layers[0].mpl_hist, [0, 0.1, 0.2, 0.1])
-        assert_allclose(self.viewer.layers[0].mpl_bins, [-5, -2.5, 0, 2.5, 5])
+        assert_allclose(self.viewer.layers[0].mpl_hist_edges, [-5, -2.5, 0, 2.5, 5])
         assert_allclose(self.viewer.layers[1].mpl_hist, [0, 0.2, 0.2, 0])
-        assert_allclose(self.viewer.layers[1].mpl_bins, [-5, -2.5, 0, 2.5, 5])
+        assert_allclose(self.viewer.layers[1].mpl_hist_edges, [-5, -2.5, 0, 2.5, 5])
 
         viewer_state.cumulative = True
 
         assert_allclose(self.viewer.state.y_max, 1.2)
         assert_allclose(self.viewer.layers[0].mpl_hist, [0, 0.25, 0.75, 1.0])
-        assert_allclose(self.viewer.layers[0].mpl_bins, [-5, -2.5, 0, 2.5, 5])
+        assert_allclose(self.viewer.layers[0].mpl_hist_edges, [-5, -2.5, 0, 2.5, 5])
         assert_allclose(self.viewer.layers[1].mpl_hist, [0, 0.5, 1.0, 1.0])
-        assert_allclose(self.viewer.layers[1].mpl_bins, [-5, -2.5, 0, 2.5, 5])
+        assert_allclose(self.viewer.layers[1].mpl_hist_edges, [-5, -2.5, 0, 2.5, 5])
 
         viewer_state.normalize = False
 
         assert_allclose(self.viewer.state.y_max, 4.8)
         assert_allclose(self.viewer.layers[0].mpl_hist, [0, 1, 3, 4])
-        assert_allclose(self.viewer.layers[0].mpl_bins, [-5, -2.5, 0, 2.5, 5])
+        assert_allclose(self.viewer.layers[0].mpl_hist_edges, [-5, -2.5, 0, 2.5, 5])
         assert_allclose(self.viewer.layers[1].mpl_hist, [0, 1, 2, 2])
-        assert_allclose(self.viewer.layers[1].mpl_bins, [-5, -2.5, 0, 2.5, 5])
+        assert_allclose(self.viewer.layers[1].mpl_hist_edges, [-5, -2.5, 0, 2.5, 5])
 
         viewer_state.cumulative = False
 
@@ -236,33 +236,33 @@ class TestHistogramViewer(object):
 
         assert_allclose(self.viewer.state.y_max, 2.4)
         assert_allclose(self.viewer.layers[0].mpl_hist, [2, 1, 1])
-        assert_allclose(self.viewer.layers[0].mpl_bins, [-0.5, 0.5, 1.5, 2.5])
+        assert_allclose(self.viewer.layers[0].mpl_hist_edges, [-0.5, 0.5, 1.5, 2.5])
         assert_allclose(self.viewer.layers[1].mpl_hist, [1, 0, 1])
-        assert_allclose(self.viewer.layers[1].mpl_bins, [-0.5, 0.5, 1.5, 2.5])
+        assert_allclose(self.viewer.layers[1].mpl_hist_edges, [-0.5, 0.5, 1.5, 2.5])
 
         viewer_state.normalize = True
 
         assert_allclose(self.viewer.state.y_max, 0.6)
         assert_allclose(self.viewer.layers[0].mpl_hist, [0.5, 0.25, 0.25])
-        assert_allclose(self.viewer.layers[0].mpl_bins, [-0.5, 0.5, 1.5, 2.5])
+        assert_allclose(self.viewer.layers[0].mpl_hist_edges, [-0.5, 0.5, 1.5, 2.5])
         assert_allclose(self.viewer.layers[1].mpl_hist, [0.5, 0, 0.5])
-        assert_allclose(self.viewer.layers[1].mpl_bins, [-0.5, 0.5, 1.5, 2.5])
+        assert_allclose(self.viewer.layers[1].mpl_hist_edges, [-0.5, 0.5, 1.5, 2.5])
 
         viewer_state.cumulative = True
 
         assert_allclose(self.viewer.state.y_max, 1.2)
         assert_allclose(self.viewer.layers[0].mpl_hist, [0.5, 0.75, 1])
-        assert_allclose(self.viewer.layers[0].mpl_bins, [-0.5, 0.5, 1.5, 2.5])
+        assert_allclose(self.viewer.layers[0].mpl_hist_edges, [-0.5, 0.5, 1.5, 2.5])
         assert_allclose(self.viewer.layers[1].mpl_hist, [0.5, 0.5, 1])
-        assert_allclose(self.viewer.layers[1].mpl_bins, [-0.5, 0.5, 1.5, 2.5])
+        assert_allclose(self.viewer.layers[1].mpl_hist_edges, [-0.5, 0.5, 1.5, 2.5])
 
         viewer_state.normalize = False
 
         assert_allclose(self.viewer.state.y_max, 4.8)
         assert_allclose(self.viewer.layers[0].mpl_hist, [2, 3, 4])
-        assert_allclose(self.viewer.layers[0].mpl_bins, [-0.5, 0.5, 1.5, 2.5])
+        assert_allclose(self.viewer.layers[0].mpl_hist_edges, [-0.5, 0.5, 1.5, 2.5])
         assert_allclose(self.viewer.layers[1].mpl_hist, [1, 1, 2])
-        assert_allclose(self.viewer.layers[1].mpl_bins, [-0.5, 0.5, 1.5, 2.5])
+        assert_allclose(self.viewer.layers[1].mpl_hist_edges, [-0.5, 0.5, 1.5, 2.5])
 
         # TODO: add tests for log
 


### PR DESCRIPTION
This is the first in a series of pull requests to try and move some of the basic computation to the Data object to enable a more abstract data interface in future.

This focuses on moving the computation of the 1D histogram to Data.