### PR TITLE
Fix profile computation for subsets

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -61,7 +61,7 @@ if ON_RTD:
 intersphinx_cache_limit = 10     # days to keep the cached inventories
 intersphinx_mapping = {
     'sphinx': ('http://www.sphinx-doc.org/en/latest/', None),
-    'python': ('https://docs.python.org/2.7', None),
+    'python': ('https://docs.python.org/3.6', None),
     'matplotlib': ('http://matplotlib.org', None),
     'numpy': ('https://docs.scipy.org/doc/numpy', None),
     'astropy': ('http://docs.astropy.org/en/stable/', None),

--- a/doc/customizing_guide/customization.rst
+++ b/doc/customizing_guide/customization.rst
@@ -335,12 +335,6 @@ This example then looks this the following once glue is loaded:
 .. image:: images/preferences.png
    :align: center
 
-Custom data viewer
-------------------
-
-For information on registering a custom data viewer, see
-:doc:`full_custom_qt_viewer`.
-
 .. _custom_fixed_layout:
 
 Custom fixed layout tab

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -1237,7 +1237,7 @@ class Data(object):
                 data = subset_state.to_array(self, cid)
                 mask = None
             else:
-                data = self[cid]
+                data = self[cid, view]
                 mask = subset_state.to_mask(self, view)
         else:
             data = self[cid, view]

--- a/glue/core/subset.py
+++ b/glue/core/subset.py
@@ -509,7 +509,7 @@ class SubsetState(object):
     @contract(data='isinstance(Data)', view='array_view')
     def to_mask(self, data, view=None):
         shp = view_shape(data.shape, view)
-        return np.zeros(shp, dtype=bool)
+        return broadcast_to(False, shp)
 
     @contract(returns='isinstance(SubsetState)')
     def copy(self):

--- a/glue/core/tests/test_data.py
+++ b/glue/core/tests/test_data.py
@@ -10,6 +10,7 @@ from astropy.utils import NumpyRNGContext
 
 from glue.external import six
 from glue import core
+from glue.utils import broadcast_to
 
 from ..component import Component, DerivedComponent, CategoricalComponent, DateTimeComponent
 from ..component_id import ComponentID
@@ -875,3 +876,23 @@ def test_compute_statistic_random_subset():
                                         subset_state=MaskSubsetState([0, 1, 0, 1, 1, 1, 0, 1, 0, 1],
                                                                      data.pixel_component_ids))
         assert_allclose(result, 4.75)
+
+
+def test_compute_statistic_empty_subset():
+
+    data = Data(x=np.empty((30, 20, 40)))
+
+    # A default subset state should be empty
+    subset_state = SubsetState()
+
+    result = data.compute_statistic('mean', data.id['x'], subset_state=subset_state)
+    assert_equal(result, np.nan)
+
+    result = data.compute_statistic('maximum', data.id['x'], subset_state=subset_state, axis=1)
+    assert_equal(result, broadcast_to(np.nan, (30, 40)))
+
+    result = data.compute_statistic('median', data.id['x'], subset_state=subset_state, axis=(1, 2))
+    assert_equal(result, broadcast_to(np.nan, (30)))
+
+    result = data.compute_statistic('sum', data.id['x'], subset_state=subset_state, axis=(0, 1, 2))
+    assert_equal(result, np.nan)

--- a/glue/utils/misc.py
+++ b/glue/utils/misc.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+import queue
 import string
 from functools import partial
 
@@ -10,7 +11,7 @@ from glue.external.six.moves import reduce
 
 __all__ = ['DeferredMethod', 'nonpartial', 'lookup_class', 'as_variable_name',
            'as_list', 'file_format', 'CallbackMixin', 'PropertySetMixin',
-           'Pointer', 'common_prefix']
+           'Pointer', 'common_prefix', 'queue_to_list']
 
 
 class DeferredMethod(object):
@@ -211,3 +212,15 @@ class Pointer(object):
         v = self.key.split('.')
         attr = reduce(getattr, [instance] + v[:-1])
         setattr(attr, v[-1], value)
+
+
+def queue_to_list(q):
+    """
+    Get all the values in a :class:`queue.Queue` object and return a list.
+    """
+    l = []
+    while True:
+        try:
+            l.append(q.get_nowait())
+        except queue.Empty:
+            return l

--- a/glue/utils/misc.py
+++ b/glue/utils/misc.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-import queue
+from glue.external.six.moves import queue
 import string
 from functools import partial
 

--- a/glue/viewers/common/qt/data_viewer.py
+++ b/glue/viewers/common/qt/data_viewer.py
@@ -5,6 +5,7 @@ from qtpy import QtWidgets
 from glue.core.qt.layer_artist_model import QtLayerArtistContainer, LayerArtistWidget
 from glue.utils.qt import set_cursor
 from glue.external import six
+from glue.core.qt.dialogs import warn
 from glue.utils.noconflict import classmaker
 from glue.config import viewer_tool
 from glue.viewers.common.qt.base_widget import BaseQtViewerWidget
@@ -112,6 +113,9 @@ class DataViewer(Viewer, BaseQtViewerWidget):
     @set_cursor(Qt.WaitCursor)
     def apply_roi(self, roi):
         pass
+
+    def warn(self, message, *args, **kwargs):
+        return warn(message, *args, **kwargs)
 
     def close(self, warn=True):
 

--- a/glue/viewers/common/viewer.py
+++ b/glue/viewers/common/viewer.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import os
+import warnings
 
 from glue.core.hub import HubListener
 from glue.core import Data, Subset
@@ -154,6 +155,10 @@ class Viewer(BaseViewer):
         for layer_artist in self._layer_artist_container:
             if layer_artist.layer not in layer_states:
                 self._layer_artist_container.remove(layer_artist)
+
+    def warn(self, message, *args, **kwargs):
+        warnings.warn(message)
+        return True
 
     def add_data(self, data):
 

--- a/glue/viewers/matplotlib/layer_artist.py
+++ b/glue/viewers/matplotlib/layer_artist.py
@@ -44,7 +44,8 @@ class MatplotlibLayerArtist(LayerArtist):
         than 500ms.
         """
         if QT_INSTALLED:
-            self._notify_start.start(delay)
+            if self._notify_start is not None:
+                self._notify_start.start(delay)
         else:
             self._notify_start_computation()
 
@@ -59,7 +60,8 @@ class MatplotlibLayerArtist(LayerArtist):
         operations). If the computation was never started, this does nothing.
         """
         if QT_INSTALLED:
-            self._notify_start.stop()
+            if self._notify_start is not None:
+                self._notify_start.stop()
         if self._notified_start:
             self.state.layer.hub.broadcast(ComputationEndedMessage(self))
             self._notified_start = False

--- a/glue/viewers/profile/layer_artist.py
+++ b/glue/viewers/profile/layer_artist.py
@@ -68,7 +68,8 @@ class ProfileLayerArtist(MatplotlibLayerArtist):
 
     def wait(self):
         if QT_INSTALLED:
-            self._worker.wait()
+            while self._worker.running:
+                time.sleep(1 / 25)
             from glue.utils.qt import get_qapp
             app = get_qapp()
             app.processEvents()
@@ -119,10 +120,11 @@ class ProfileLayerArtist(MatplotlibLayerArtist):
                 self._worker.running = True
                 self._worker.compute_start.emit()
                 self._calculate_profile_thread(reset=reset)
-                self._worker.running = False
             except Exception:
+                self._worker.running = False
                 self._worker.compute_error.emit(sys.exc_info())
             else:
+                self._worker.running = False
                 self._worker.compute_end.emit()
 
     @defer_draw

--- a/glue/viewers/profile/layer_artist.py
+++ b/glue/viewers/profile/layer_artist.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import sys
 import time
-import queue
+from glue.external.six.moves import queue
 
 import numpy as np
 
@@ -121,11 +121,11 @@ class ProfileLayerArtist(MatplotlibLayerArtist):
                 self._worker.compute_start.emit()
                 self._calculate_profile_thread(reset=reset)
             except Exception:
-                self._worker.running = False
                 self._worker.compute_error.emit(sys.exc_info())
-            else:
                 self._worker.running = False
+            else:
                 self._worker.compute_end.emit()
+                self._worker.running = False
 
     @defer_draw
     def _calculate_profile(self, reset=False):


### PR DESCRIPTION
There was a subtle bug that affected profile viewers - if a thread was stopped and restarted before it had actually stopped, the thread wasn't actually restarted and the subset shown didn't always reflect the latest actual subset. The profile thread for each layer now runs more like a daemon in that it runs continuously and listens for messages asking it to compute the profile. This also fixes other bugs that popped up while investigating this.