### PR TITLE
Avoid circular references when closing viewer

### DIFF
--- a/glue/core/layer_artist.py
+++ b/glue/core/layer_artist.py
@@ -18,6 +18,7 @@ from abc import ABCMeta, abstractmethod
 
 import numpy as np
 
+from glue.external.echo.callback_container import CallbackContainer
 from glue.external import six
 from glue.core.subset import Subset
 from glue.utils import Pointer, PropertySetMixin
@@ -252,8 +253,8 @@ class LayerArtistContainer(object):
 
     def __init__(self):
         self.artists = []
-        self.empty_callbacks = []
-        self.change_callbacks = []
+        self.empty_callbacks = CallbackContainer()
+        self.change_callbacks = CallbackContainer()
         self._ignore_callbacks = False
 
     def on_empty(self, func):
@@ -308,12 +309,8 @@ class LayerArtistContainer(object):
         """
         Remove all callbacks
         """
-        if six.PY2:
-            self.empty_callbacks[:] = []
-            self.change_callbacks[:] = []
-        else:
-            self.empty_callbacks.clear()
-            self.change_callbacks.clear()
+        self.empty_callbacks.clear()
+        self.change_callbacks.clear()
 
     def _notify(self):
         if self._ignore_callbacks:

--- a/glue/external/echo/callback_container.py
+++ b/glue/external/echo/callback_container.py
@@ -17,6 +17,9 @@ class CallbackContainer(object):
     def __init__(self):
         self.callbacks = []
 
+    def clear(self):
+        self.callbacks[:] = []
+
     def _wrap(self, value, priority=0):
         """
         Given a function/method, this will automatically wrap a method using

--- a/glue/viewers/common/qt/base_widget.py
+++ b/glue/viewers/common/qt/base_widget.py
@@ -234,7 +234,10 @@ class BaseQtViewerWidget(QtWidgets.QMainWindow):
         return str(self)
 
     def update_window_title(self):
-        self.setWindowTitle(self.window_title)
+        try:
+            self.setWindowTitle(self.window_title)
+        except RuntimeError:  # Avoid C/C++ errors when closing viewer
+            pass
 
     def set_status(self, message):
         sb = self.statusBar()

--- a/glue/viewers/common/qt/data_viewer.py
+++ b/glue/viewers/common/qt/data_viewer.py
@@ -103,7 +103,7 @@ class DataViewer(Viewer, BaseQtViewerWidget):
 
         # close window when last plot layer deleted
         if self._close_on_last_layer_removed:
-            self._layer_artist_container.on_empty(lambda: self.close(warn=False))
+            self._layer_artist_container.on_empty(self._close_nowarn)
         self._layer_artist_container.on_changed(self.update_window_title)
 
     @property
@@ -116,6 +116,9 @@ class DataViewer(Viewer, BaseQtViewerWidget):
 
     def warn(self, message, *args, **kwargs):
         return warn(message, *args, **kwargs)
+
+    def _close_nowarn(self):
+        return self.close(warn=False)
 
     def close(self, warn=True):
 


### PR DESCRIPTION
This gets rid of some residual circular references that persisted after closing a viewer