### PR TITLE
Compute histograms in a thread

### DIFF
--- a/glue/core/state_objects.py
+++ b/glue/core/state_objects.py
@@ -279,9 +279,9 @@ class StateAttributeLimitsHelper(StateAttributeCacheHelper):
     values_names = ('lower', 'upper')
     modifiers_names = ('log', 'percentile')
 
-    def __init__(self, state, attribute, random_subset=10000, margin=0, cache=None, **kwargs):
+    def __init__(self, state, attribute, random_subset=10000, margin=0, **kwargs):
 
-        super(StateAttributeLimitsHelper, self).__init__(state, attribute, cache=cache, **kwargs)
+        super(StateAttributeLimitsHelper, self).__init__(state, attribute, **kwargs)
 
         self.margin = margin
         self.random_subset = random_subset
@@ -398,14 +398,17 @@ class StateAttributeHistogramHelper(StateAttributeCacheHelper):
     values_names = ('lower', 'upper', 'n_bin')
     modifiers_names = ()
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, state, attribute, random_subset=10000, max_n_bin=30,
+                 default_n_bin=15, common_n_bin=None, **kwargs):
 
-        self._max_n_bin = kwargs.pop('max_n_bin', 30)
-        self._default_n_bin = kwargs.pop('default_n_bin', 15)
+        self._max_n_bin = max_n_bin
+        self._default_n_bin = default_n_bin
 
-        common_n_bin_att = kwargs.pop('common_n_bin', None)
+        common_n_bin_att = common_n_bin
 
-        super(StateAttributeHistogramHelper, self).__init__(*args, **kwargs)
+        super(StateAttributeHistogramHelper, self).__init__(state, attribute, **kwargs)
+
+        self.random_subset = random_subset
 
         if common_n_bin_att is not None:
             if getattr(self._state, common_n_bin_att):
@@ -461,8 +464,10 @@ class StateAttributeHistogramHelper(StateAttributeCacheHelper):
                 else:
                     n_bin = self._common_n_bin
 
-                lower = self.data.compute_statistic('minimum', cid=self.component_id, finite=True)
-                upper = self.data.compute_statistic('maximum', cid=self.component_id, finite=True)
+                lower = self.data.compute_statistic('minimum', cid=self.component_id,
+                                                    finite=True, random_subset=self.random_subset)
+                upper = self.data.compute_statistic('maximum', cid=self.component_id,
+                                                    finite=True, random_subset=self.random_subset)
 
                 if not isinstance(lower, np.datetime64) and np.isnan(lower):
                     lower, upper = 0, 1

--- a/glue/plugins/exporters/plotly/export_plotly.py
+++ b/glue/plugins/exporters/plotly/export_plotly.py
@@ -186,8 +186,10 @@ def export_histogram(viewer):
     for artist in viewer.layers:
         if not artist.visible:
             continue
+        artist.wait()
         layer = artist.layer
-        x, y = _sanitize(artist.mpl_hist_edges[:-1], artist.mpl_hist)
+        edges, hist = artist.state.histogram
+        x, y = _sanitize(edges[:-1], hist)
         trace = dict(
             name=layer.label,
             type='bar',
@@ -195,7 +197,7 @@ def export_histogram(viewer):
             x=x,
             y=y)
         traces.append(trace)
-        ymax = max(ymax, artist.mpl_hist.max())
+        ymax = max(ymax, hist.max())
 
     xlabel = att.label
     xmin, xmax = viewer.state.x_min, viewer.state.x_max

--- a/glue/plugins/exporters/plotly/tests/test_plotly.py
+++ b/glue/plugins/exporters/plotly/tests/test_plotly.py
@@ -115,6 +115,9 @@ class TestPlotly(object):
         viewer.state.hist_x_max = 10
         viewer.state.hist_n_bin = 20
 
+        for layer in viewer.layers:
+            layer.wait()
+
         args, kwargs = build_plotly_call(self.app)
 
         expected = dict(

--- a/glue/viewers/histogram/layer_artist.py
+++ b/glue/viewers/histogram/layer_artist.py
@@ -9,10 +9,11 @@ from matplotlib.patches import Rectangle
 
 from glue.utils import defer_draw
 
+from glue.core import Data
 from glue.viewers.histogram.state import HistogramLayerState
 from glue.viewers.histogram.python_export import python_export_histogram_layer
 from glue.viewers.matplotlib.layer_artist import MatplotlibLayerArtist
-from glue.core.exceptions import IncompatibleAttribute
+from glue.core.exceptions import IncompatibleAttribute, IncompatibleDataException
 
 try:
     import qtpy  # noqa
@@ -113,7 +114,12 @@ class HistogramLayerArtist(MatplotlibLayerArtist):
         self.notify_end_computation()
         self.redraw()
         if issubclass(exc[0], (IncompatibleAttribute, IndexError)):
-            self.disable_invalid_attributes(self._viewer_state.x_att)
+            if isinstance(self.state.layer, Data):
+                self.disable_invalid_attributes(self._viewer_state.x_att)
+            else:
+                self.disable_incompatible_subset()
+        elif issubclass(exc[0], IncompatibleDataException):
+            self.disable("Incompatible data")
 
     @defer_draw
     def _update_artists(self):

--- a/glue/viewers/histogram/layer_artist.py
+++ b/glue/viewers/histogram/layer_artist.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import sys
-import queue
+import time
 import warnings
 
 import numpy as np
@@ -42,6 +42,16 @@ class HistogramLayerArtist(MatplotlibLayerArtist):
 
         if QT_INSTALLED:
             self.setup_thread()
+
+    def wait(self):
+        if QT_INSTALLED:
+            # Wait 0.5 seconds to make sure that the computation has properly started
+            time.sleep(0.5)
+            while self._worker.running:
+                time.sleep(1 / 25)
+            from glue.utils.qt import get_qapp
+            app = get_qapp()
+            app.processEvents()
 
     def remove(self):
         super(HistogramLayerArtist, self).remove()

--- a/glue/viewers/histogram/layer_artist.py
+++ b/glue/viewers/histogram/layer_artist.py
@@ -210,7 +210,11 @@ class HistogramLayerArtist(MatplotlibLayerArtist):
             self.state._y_max *= 1.2
 
         if self._viewer_state.y_log:
-            self.state._y_min = mpl_hist[mpl_hist > 0].min() / 10
+            keep = mpl_hist > 0
+            if np.any(keep):
+                self.state._y_min = mpl_hist[mpl_hist > 0].min() / 10
+            else:
+                self.state._y_min = 0
         else:
             self.state._y_min = 0
 

--- a/glue/viewers/histogram/layer_artist.py
+++ b/glue/viewers/histogram/layer_artist.py
@@ -1,14 +1,47 @@
 from __future__ import absolute_import, division, print_function
 
+import sys
+import time
+import queue
 import numpy as np
+from matplotlib.patches import Rectangle
 
-from glue.core import Subset
-from glue.utils import defer_draw, datetime64_to_mpl
+from glue.utils import defer_draw, queue_to_list
 
 from glue.viewers.histogram.state import HistogramLayerState
 from glue.viewers.histogram.python_export import python_export_histogram_layer
 from glue.viewers.matplotlib.layer_artist import MatplotlibLayerArtist
 from glue.core.exceptions import IncompatibleAttribute
+
+try:
+    import qtpy  # noqa
+except Exception:
+    QT_INSTALLED = False
+else:
+    QT_INSTALLED = True
+
+if QT_INSTALLED:
+
+    # When using Qt, we make use of a thread that continuously listens for
+    # requests to update the histogram and we run these as needed. In future,
+    # we should add the ability to interrupt compute jobs if a newer compute
+    # job is requested.
+
+    from qtpy.QtCore import Signal, QThread
+
+    class ComputeWorker(QThread):
+
+        compute_start = Signal()
+        compute_end = Signal()
+        compute_error = Signal(object)
+
+        def __init__(self, function):
+            super(ComputeWorker, self).__init__()
+            self.function = function
+            self.running = False
+
+        def run(self):
+            self.function()
 
 
 class HistogramLayerArtist(MatplotlibLayerArtist):
@@ -28,80 +61,134 @@ class HistogramLayerArtist(MatplotlibLayerArtist):
 
         self.reset_cache()
 
+        if QT_INSTALLED:
+            self.setup_thread()
+
     def remove(self):
         super(HistogramLayerArtist, self).remove()
-        self.mpl_hist_unscaled = np.array([])
-        self.mpl_hist_edges = np.array([])
+        if QT_INSTALLED and self._worker is not None:
+            self._work_queue.put('stop')
+            self._worker.exit()
+            # Need to wait otherwise the thread will be destroyed while still
+            # running, causing a segmentation fault
+            self._worker.wait()
+            self._worker = None
+
+    @property
+    def is_computing(self):
+        if QT_INSTALLED:
+            return self._worker.running
 
     def reset_cache(self):
         self._last_viewer_state = {}
         self._last_layer_state = {}
 
+    def setup_thread(self):
+        self._worker = ComputeWorker(self._thread_loop)
+        self._worker.compute_end.connect(self._calculate_histogram_postthread)
+        self._worker.compute_error.connect(self._calculate_histogram_error)
+        self._worker.compute_start.connect(self.notify_start_computation)
+        self._work_queue = queue.Queue()
+        self._worker.start()
+
+    def _thread_loop(self):
+
+        error = None
+
+        while True:
+
+            time.sleep(1 / 25)
+
+            msgs = queue_to_list(self._work_queue)
+
+            if 'stop' in msgs:
+                return
+            elif len(msgs) == 0:
+                # We change this here rather than in the try...except below
+                # to avoid stopping and starting in quick succession.
+                if self._worker.running:
+                    self._worker.running = False
+                    if error is None:
+                        self._worker.compute_end.emit()
+                    else:
+                        self._worker.compute_error.emit(error)
+                        error = None
+                continue
+
+            # If any resets were requested, honor this
+            reset = any(msgs)
+
+            try:
+                self._worker.running = True
+                self._worker.compute_start.emit()
+                self._calculate_histogram_thread(reset=reset)
+            except Exception:
+                error = sys.exc_info()
+            else:
+                error = None
+
     @defer_draw
-    def _calculate_histogram(self):
-
-        self.remove()
-
-        if isinstance(self.layer, Subset):
-            data = self.layer.data
-            subset_state = self.layer.subset_state
+    def _calculate_histogram(self, reset=False):
+        if QT_INSTALLED:
+            print("HERE")
+            self._work_queue.put(reset)
         else:
-            data = self.layer
-            subset_state = None
+            try:
+                self.notify_start_computation()
+                self._calculate_histogram_thread(reset=reset)
+            except Exception:
+                self._calculate_histogram_error(sys.exc_info())
+            else:
+                self._calculate_histogram_postthread()
 
-        try:
-            x_comp = data.get_component(self._viewer_state.x_att)
-        except AttributeError:
-            return
-        except (IncompatibleAttribute, IndexError):
+    def _calculate_histogram_thread(self, reset=False):
+        if reset:
+            self.state.reset_cache()
+        self.state.update_histogram()
+
+    def _calculate_histogram_postthread(self):
+        self.notify_end_computation()
+        self._scale_histogram()
+        self._update_visual_attributes()
+
+    @defer_draw
+    def _calculate_histogram_error(self, exc):
+        self.notify_end_computation()
+        self.redraw()
+        if issubclass(exc[0], (IncompatibleAttribute, IndexError)):
             self.disable_invalid_attributes(self._viewer_state.x_att)
-            return
-        else:
-            self.enable()
-
-        range = sorted((self._viewer_state.hist_x_min, self._viewer_state.hist_x_max))
-
-        hist_values = data.compute_histogram([self._viewer_state.x_att],
-                                             range=[range],
-                                             bins=[self._viewer_state.hist_n_bin],
-                                             log=[self._viewer_state.x_log],
-                                             subset_state=subset_state)
-
-        if isinstance(range[0], np.datetime64):
-            range = [datetime64_to_mpl(range[0]), datetime64_to_mpl(range[1])]
-
-        if self._viewer_state.x_log:
-            hist_edges = np.logspace(np.log10(range[0]), np.log10(range[1]), self._viewer_state.hist_n_bin + 1)
-        else:
-            hist_edges = np.linspace(range[0], range[1], self._viewer_state.hist_n_bin + 1)
-
-        self.mpl_artists = self.axes.bar(hist_edges[:-1], hist_values, align='edge', width=np.diff(hist_edges)).get_children()
-
-        self.mpl_hist_unscaled = hist_values
-        self.mpl_hist_edges = hist_edges
 
     @defer_draw
     def _scale_histogram(self):
 
-        if self.mpl_hist_edges.size == 0 or self.mpl_hist_unscaled.sum() == 0:
+        print("HERE1")
+        mpl_hist_edges, mpl_hist = self.state.histogram
+        print("HERE2")
+
+        if mpl_hist_edges.size == 0 or mpl_hist.sum() == 0:
             return
 
-        self.mpl_hist = self.mpl_hist_unscaled.astype(np.float)
-        dx = self.mpl_hist_edges[1] - self.mpl_hist_edges[0]
+        if len(self.mpl_artists) > len(mpl_hist):
+            for artist in self.mpl_artists[len(mpl_hist):]:
+                artist.remove()
+            self.mpl_artists = self.mpl_artists[:len(mpl_hist)]
+        elif len(self.mpl_artists) < len(mpl_hist):
+            for i in range(len(mpl_hist) - len(self.mpl_artists)):
+                artist = Rectangle((0, 0), 0, 0)
+                self.mpl_artists.append(artist)
+                self.axes.add_artist(artist)
+            self._update_visual_attributes()
 
-        if self._viewer_state.cumulative:
-            self.mpl_hist = self.mpl_hist.cumsum()
-            if self._viewer_state.normalize:
-                self.mpl_hist /= self.mpl_hist.max()
-        elif self._viewer_state.normalize:
-            self.mpl_hist /= (self.mpl_hist.sum() * dx)
+        widths = np.diff(mpl_hist_edges)
 
         bottom = 0 if not self._viewer_state.y_log else 1e-100
 
-        for mpl_artist, y in zip(self.mpl_artists, self.mpl_hist):
+        for mpl_artist, x, y, dx in zip(self.mpl_artists, mpl_hist_edges[:-1], mpl_hist, widths):
+            mpl_artist.set_width(dx)
             mpl_artist.set_height(y)
-            x, y = mpl_artist.get_xy()
             mpl_artist.set_xy((x, bottom))
+
+        # TODO: move the following to state
 
         # We have to do the following to make sure that we reset the y_max as
         # needed. We can't simply reset based on the maximum for this layer
@@ -111,14 +198,14 @@ class HistogramLayerArtist(MatplotlibLayerArtist):
         #
         # because this would never allow y_max to get smaller.
 
-        self.state._y_max = self.mpl_hist.max()
+        self.state._y_max = mpl_hist.max()
         if self._viewer_state.y_log:
             self.state._y_max *= 2
         else:
             self.state._y_max *= 1.2
 
         if self._viewer_state.y_log:
-            self.state._y_min = self.mpl_hist[self.mpl_hist > 0].min() / 10
+            self.state._y_min = mpl_hist[mpl_hist > 0].min() / 10
         else:
             self.state._y_min = 0
 
@@ -178,17 +265,14 @@ class HistogramLayerArtist(MatplotlibLayerArtist):
         self._last_viewer_state.update(self._viewer_state.as_dict())
         self._last_layer_state.update(self.state.as_dict())
 
-        if force or any(prop in changed for prop in ('layer', 'x_att', 'hist_x_min', 'hist_x_max', 'hist_n_bin', 'x_log')):
-            self._calculate_histogram()
-            force = True  # make sure scaling and visual attributes are updated
-
-        if force or any(prop in changed for prop in ('y_log', 'normalize', 'cumulative')):
-            self._scale_histogram()
+        if force or any(prop in changed for prop in ('layer', 'x_att', 'hist_x_min', 'hist_x_max', 'hist_n_bin', 'x_log', 'y_log', 'normalize', 'cumulative')):
+            self._calculate_histogram(reset=force)
 
         if force or any(prop in changed for prop in ('alpha', 'color', 'zorder', 'visible')):
             self._update_visual_attributes()
 
     @defer_draw
     def update(self):
+        self.state.reset_cache()
         self._update_histogram(force=True)
         self.redraw()

--- a/glue/viewers/histogram/qt/tests/test_data_viewer.py
+++ b/glue/viewers/histogram/qt/tests/test_data_viewer.py
@@ -680,6 +680,8 @@ class TestHistogramViewer(object):
         viewer = ga.viewers[0][0]
         options = viewer.options_widget().ui
 
+        wait_for_layers(viewer)
+
         assert_equal(self.viewer.state.x_min, np.datetime64('1970-04-14', 'D'))
 
         assert options.valuetext_x_min.text() == '1970-04-14'

--- a/glue/viewers/histogram/qt/tests/test_data_viewer.py
+++ b/glue/viewers/histogram/qt/tests/test_data_viewer.py
@@ -27,6 +27,11 @@ from ..data_viewer import HistogramViewer
 DATA = os.path.join(os.path.dirname(__file__), 'data')
 
 
+def wait_for_layers(viewer):
+    for layer in viewer.layers:
+        layer.wait()
+
+
 class TestHistogramCommon(BaseTestMatplotlibDataViewer):
     def init_data(self):
         return Data(label='d1', x=[3.4, 2.3, -1.1, 0.3], y=['a', 'b', 'c', 'a'])
@@ -61,7 +66,7 @@ class TestHistogramViewer(object):
         # Check defaults when we add data
         self.viewer.add_data(self.data)
 
-        self.viewer.layers[0].wait()
+        wait_for_layers(self.viewer)
 
         assert combo_as_string(self.viewer.options_widget().ui.combosel_x_att) == 'Main components:x:y:Coordinate components:Pixel Axis 0 [x]:World 0'
 
@@ -87,7 +92,7 @@ class TestHistogramViewer(object):
 
         viewer_state.x_att = self.data.id['y']
 
-        self.viewer.layers[0].wait()
+        wait_for_layers(self.viewer)
 
         assert viewer_state.x_min == -0.5
         assert viewer_state.x_max == 2.5
@@ -193,7 +198,7 @@ class TestHistogramViewer(object):
         viewer_state.hist_x_max = 5
         viewer_state.hist_n_bin = 4
 
-        self.viewer.layers[0].wait()
+        wait_for_layers(self.viewer)
 
         assert_allclose(self.viewer.state.y_max, 2.4)
 
@@ -203,15 +208,14 @@ class TestHistogramViewer(object):
         cid = self.data.visible_components[0]
         self.data_collection.new_subset_group('subset 1', cid < 2)
 
-        self.viewer.layers[1].wait()
+        wait_for_layers(self.viewer)
 
         assert_allclose(self.viewer.layers[1].state.histogram[1], [0, 1, 1, 0])
         assert_allclose(self.viewer.layers[1].state.histogram[0], [-5, -2.5, 0, 2.5, 5])
 
         viewer_state.normalize = True
 
-        self.viewer.layers[0].wait()
-        self.viewer.layers[1].wait()
+        wait_for_layers(self.viewer)
 
         assert_allclose(self.viewer.state.y_max, 0.24)
         assert_allclose(self.viewer.layers[0].state.histogram[1], [0, 0.1, 0.2, 0.1])
@@ -221,8 +225,7 @@ class TestHistogramViewer(object):
 
         viewer_state.cumulative = True
 
-        self.viewer.layers[0].wait()
-        self.viewer.layers[1].wait()
+        wait_for_layers(self.viewer)
 
         assert_allclose(self.viewer.state.y_max, 1.2)
         assert_allclose(self.viewer.layers[0].state.histogram[1], [0, 0.25, 0.75, 1.0])
@@ -232,8 +235,7 @@ class TestHistogramViewer(object):
 
         viewer_state.normalize = False
 
-        self.viewer.layers[0].wait()
-        self.viewer.layers[1].wait()
+        wait_for_layers(self.viewer)
 
         assert_allclose(self.viewer.state.y_max, 4.8)
         assert_allclose(self.viewer.layers[0].state.histogram[1], [0, 1, 3, 4])
@@ -247,8 +249,7 @@ class TestHistogramViewer(object):
 
         viewer_state.x_att = self.data.id['y']
 
-        self.viewer.layers[0].wait()
-        self.viewer.layers[1].wait()
+        wait_for_layers(self.viewer)
 
         formatter = self.viewer.axes.xaxis.get_major_formatter()
         xlabels = [formatter.format_data(pos) for pos in range(3)]
@@ -262,8 +263,7 @@ class TestHistogramViewer(object):
 
         viewer_state.normalize = True
 
-        self.viewer.layers[0].wait()
-        self.viewer.layers[1].wait()
+        wait_for_layers(self.viewer)
 
         assert_allclose(self.viewer.state.y_max, 0.6)
         assert_allclose(self.viewer.layers[0].state.histogram[1], [0.5, 0.25, 0.25])
@@ -273,8 +273,7 @@ class TestHistogramViewer(object):
 
         viewer_state.cumulative = True
 
-        self.viewer.layers[0].wait()
-        self.viewer.layers[1].wait()
+        wait_for_layers(self.viewer)
 
         assert_allclose(self.viewer.state.y_max, 1.2)
         assert_allclose(self.viewer.layers[0].state.histogram[1], [0.5, 0.75, 1])
@@ -284,8 +283,7 @@ class TestHistogramViewer(object):
 
         viewer_state.normalize = False
 
-        self.viewer.layers[0].wait()
-        self.viewer.layers[1].wait()
+        wait_for_layers(self.viewer)
 
         assert_allclose(self.viewer.state.y_max, 4.8)
         assert_allclose(self.viewer.layers[0].state.histogram[1], [2, 3, 4])
@@ -314,8 +312,7 @@ class TestHistogramViewer(object):
 
         self.viewer.apply_roi(roi)
 
-        for layer in self.viewer.layers:
-            layer.wait()
+        wait_for_layers(self.viewer)
 
         assert len(self.viewer.layers) == 2
 
@@ -349,8 +346,7 @@ class TestHistogramViewer(object):
 
         self.viewer.apply_roi(roi)
 
-        for layer in self.viewer.layers:
-            layer.wait()
+        wait_for_layers(self.viewer)
 
         assert len(self.viewer.layers) == 2
 
@@ -423,24 +419,21 @@ class TestHistogramViewer(object):
         cid = self.data.visible_components[0]
         self.data_collection.new_subset_group('subset 3', cid < 3)
 
-        for layer in self.viewer.layers:
-            layer.wait()
+        wait_for_layers(self.viewer)
 
         assert_allclose(self.viewer.state.y_min, 0)
         assert_allclose(self.viewer.state.y_max, 1.2)
 
         viewer_state.x_att = self.data.id['z']
 
-        for layer in self.viewer.layers:
-            layer.wait()
+        wait_for_layers(self.viewer)
 
         assert_allclose(self.viewer.state.y_min, 0)
         assert_allclose(self.viewer.state.y_max, 2.4)
 
         viewer_state.normalize = True
 
-        for layer in self.viewer.layers:
-            layer.wait()
+        wait_for_layers(self.viewer)
 
         assert_allclose(self.viewer.state.y_min, 0)
         assert_allclose(self.viewer.state.y_max, 0.5325443786982249)
@@ -460,8 +453,7 @@ class TestHistogramViewer(object):
         viewer_state.hist_x_max = +10
         viewer_state.hist_n_bin = 5
 
-        for layer in self.viewer.layers:
-            layer.wait()
+        wait_for_layers(self.viewer)
 
         assert_allclose(self.viewer.layers[0].state.histogram[1], [0, 0, 3, 1, 0])
 
@@ -470,22 +462,19 @@ class TestHistogramViewer(object):
         viewer_state.hist_x_max = +10
         viewer_state.hist_n_bin = 5
 
-        for layer in self.viewer.layers:
-            layer.wait()
+        wait_for_layers(self.viewer)
 
         assert_allclose(self.viewer.layers[0].state.histogram[1], [0, 0, 2, 2, 0])
 
         viewer_state.x_att = self.data.id['y']
 
-        for layer in self.viewer.layers:
-            layer.wait()
+        wait_for_layers(self.viewer)
 
         assert_allclose(self.viewer.layers[0].state.histogram[1], [0, 0, 3, 1, 0])
 
         viewer_state.x_att = self.data.id['x']
 
-        for layer in self.viewer.layers:
-            layer.wait()
+        wait_for_layers(self.viewer)
 
         assert_allclose(self.viewer.layers[0].state.histogram[1], [0, 0, 2, 2, 0])
 
@@ -533,6 +522,7 @@ class TestHistogramViewer(object):
         assert dc[0].label == 'data'
 
         viewer1 = ga.viewers[0][0]
+        wait_for_layers(viewer1)
         assert len(viewer1.state.layers) == 2
         assert viewer1.state.x_att is dc[0].id['a']
         assert_allclose(viewer1.state.x_min, 0)
@@ -550,6 +540,7 @@ class TestHistogramViewer(object):
         assert not viewer1.state.normalize
 
         viewer2 = ga.viewers[0][1]
+        wait_for_layers(viewer2)
         assert viewer2.state.x_att is dc[0].id['b']
         assert_allclose(viewer2.state.x_min, 2)
         assert_allclose(viewer2.state.x_max, 16)
@@ -566,6 +557,7 @@ class TestHistogramViewer(object):
         assert not viewer2.state.normalize
 
         viewer3 = ga.viewers[0][2]
+        wait_for_layers(viewer3)
         assert viewer3.state.x_att is dc[0].id['a']
         assert_allclose(viewer3.state.x_min, 0)
         assert_allclose(viewer3.state.x_max, 9)
@@ -582,6 +574,7 @@ class TestHistogramViewer(object):
         assert viewer3.state.normalize
 
         viewer4 = ga.viewers[0][3]
+        wait_for_layers(viewer4)
         assert viewer4.state.x_att is dc[0].id['a']
         assert_allclose(viewer4.state.x_min, -1)
         assert_allclose(viewer4.state.x_max, 10)
@@ -649,6 +642,8 @@ class TestHistogramViewer(object):
         self.viewer.add_data(self.data)
         self.viewer.state.x_att = self.data.id['t1']
 
+        wait_for_layers(self.viewer)
+
         # Matplotlib deals with dates by converting them to the number of days
         # since 01-01-0001, so we can check that the limits are correctly
         # converted (and not 100 to 400)
@@ -657,6 +652,8 @@ class TestHistogramViewer(object):
         # Apply an ROI selection in plotting coordinates
         roi = XRangeROI(719313, 719513)
         self.viewer.apply_roi(roi)
+
+        wait_for_layers(self.viewer)
 
         # Check that the two middle elements are selected
         assert_equal(self.data.subsets[0].to_mask(), [0, 1, 1, 0])

--- a/glue/viewers/histogram/qt/tests/test_data_viewer.py
+++ b/glue/viewers/histogram/qt/tests/test_data_viewer.py
@@ -61,6 +61,8 @@ class TestHistogramViewer(object):
         # Check defaults when we add data
         self.viewer.add_data(self.data)
 
+        self.viewer.layers[0].wait()
+
         assert combo_as_string(self.viewer.options_widget().ui.combosel_x_att) == 'Main components:x:y:Coordinate components:Pixel Axis 0 [x]:World 0'
 
         assert viewer_state.x_att is self.data.id['x']
@@ -84,6 +86,8 @@ class TestHistogramViewer(object):
         # Change to categorical component and check new values
 
         viewer_state.x_att = self.data.id['y']
+
+        self.viewer.layers[0].wait()
 
         assert viewer_state.x_min == -0.5
         assert viewer_state.x_max == 2.5
@@ -189,40 +193,53 @@ class TestHistogramViewer(object):
         viewer_state.hist_x_max = 5
         viewer_state.hist_n_bin = 4
 
+        self.viewer.layers[0].wait()
+
         assert_allclose(self.viewer.state.y_max, 2.4)
 
-        assert_allclose(self.viewer.layers[0].mpl_hist, [0, 1, 2, 1])
-        assert_allclose(self.viewer.layers[0].mpl_hist_edges, [-5, -2.5, 0, 2.5, 5])
+        assert_allclose(self.viewer.layers[0].state.histogram[1], [0, 1, 2, 1])
+        assert_allclose(self.viewer.layers[0].state.histogram[0], [-5, -2.5, 0, 2.5, 5])
 
         cid = self.data.visible_components[0]
         self.data_collection.new_subset_group('subset 1', cid < 2)
 
-        assert_allclose(self.viewer.layers[1].mpl_hist, [0, 1, 1, 0])
-        assert_allclose(self.viewer.layers[1].mpl_hist_edges, [-5, -2.5, 0, 2.5, 5])
+        self.viewer.layers[1].wait()
+
+        assert_allclose(self.viewer.layers[1].state.histogram[1], [0, 1, 1, 0])
+        assert_allclose(self.viewer.layers[1].state.histogram[0], [-5, -2.5, 0, 2.5, 5])
 
         viewer_state.normalize = True
 
+        self.viewer.layers[0].wait()
+        self.viewer.layers[1].wait()
+
         assert_allclose(self.viewer.state.y_max, 0.24)
-        assert_allclose(self.viewer.layers[0].mpl_hist, [0, 0.1, 0.2, 0.1])
-        assert_allclose(self.viewer.layers[0].mpl_hist_edges, [-5, -2.5, 0, 2.5, 5])
-        assert_allclose(self.viewer.layers[1].mpl_hist, [0, 0.2, 0.2, 0])
-        assert_allclose(self.viewer.layers[1].mpl_hist_edges, [-5, -2.5, 0, 2.5, 5])
+        assert_allclose(self.viewer.layers[0].state.histogram[1], [0, 0.1, 0.2, 0.1])
+        assert_allclose(self.viewer.layers[0].state.histogram[0], [-5, -2.5, 0, 2.5, 5])
+        assert_allclose(self.viewer.layers[1].state.histogram[1], [0, 0.2, 0.2, 0])
+        assert_allclose(self.viewer.layers[1].state.histogram[0], [-5, -2.5, 0, 2.5, 5])
 
         viewer_state.cumulative = True
 
+        self.viewer.layers[0].wait()
+        self.viewer.layers[1].wait()
+
         assert_allclose(self.viewer.state.y_max, 1.2)
-        assert_allclose(self.viewer.layers[0].mpl_hist, [0, 0.25, 0.75, 1.0])
-        assert_allclose(self.viewer.layers[0].mpl_hist_edges, [-5, -2.5, 0, 2.5, 5])
-        assert_allclose(self.viewer.layers[1].mpl_hist, [0, 0.5, 1.0, 1.0])
-        assert_allclose(self.viewer.layers[1].mpl_hist_edges, [-5, -2.5, 0, 2.5, 5])
+        assert_allclose(self.viewer.layers[0].state.histogram[1], [0, 0.25, 0.75, 1.0])
+        assert_allclose(self.viewer.layers[0].state.histogram[0], [-5, -2.5, 0, 2.5, 5])
+        assert_allclose(self.viewer.layers[1].state.histogram[1], [0, 0.5, 1.0, 1.0])
+        assert_allclose(self.viewer.layers[1].state.histogram[0], [-5, -2.5, 0, 2.5, 5])
 
         viewer_state.normalize = False
 
+        self.viewer.layers[0].wait()
+        self.viewer.layers[1].wait()
+
         assert_allclose(self.viewer.state.y_max, 4.8)
-        assert_allclose(self.viewer.layers[0].mpl_hist, [0, 1, 3, 4])
-        assert_allclose(self.viewer.layers[0].mpl_hist_edges, [-5, -2.5, 0, 2.5, 5])
-        assert_allclose(self.viewer.layers[1].mpl_hist, [0, 1, 2, 2])
-        assert_allclose(self.viewer.layers[1].mpl_hist_edges, [-5, -2.5, 0, 2.5, 5])
+        assert_allclose(self.viewer.layers[0].state.histogram[1], [0, 1, 3, 4])
+        assert_allclose(self.viewer.layers[0].state.histogram[0], [-5, -2.5, 0, 2.5, 5])
+        assert_allclose(self.viewer.layers[1].state.histogram[1], [0, 1, 2, 2])
+        assert_allclose(self.viewer.layers[1].state.histogram[0], [-5, -2.5, 0, 2.5, 5])
 
         viewer_state.cumulative = False
 
@@ -230,39 +247,51 @@ class TestHistogramViewer(object):
 
         viewer_state.x_att = self.data.id['y']
 
+        self.viewer.layers[0].wait()
+        self.viewer.layers[1].wait()
+
         formatter = self.viewer.axes.xaxis.get_major_formatter()
         xlabels = [formatter.format_data(pos) for pos in range(3)]
         assert xlabels == ['a', 'b', 'c']
 
         assert_allclose(self.viewer.state.y_max, 2.4)
-        assert_allclose(self.viewer.layers[0].mpl_hist, [2, 1, 1])
-        assert_allclose(self.viewer.layers[0].mpl_hist_edges, [-0.5, 0.5, 1.5, 2.5])
-        assert_allclose(self.viewer.layers[1].mpl_hist, [1, 0, 1])
-        assert_allclose(self.viewer.layers[1].mpl_hist_edges, [-0.5, 0.5, 1.5, 2.5])
+        assert_allclose(self.viewer.layers[0].state.histogram[1], [2, 1, 1])
+        assert_allclose(self.viewer.layers[0].state.histogram[0], [-0.5, 0.5, 1.5, 2.5])
+        assert_allclose(self.viewer.layers[1].state.histogram[1], [1, 0, 1])
+        assert_allclose(self.viewer.layers[1].state.histogram[0], [-0.5, 0.5, 1.5, 2.5])
 
         viewer_state.normalize = True
 
+        self.viewer.layers[0].wait()
+        self.viewer.layers[1].wait()
+
         assert_allclose(self.viewer.state.y_max, 0.6)
-        assert_allclose(self.viewer.layers[0].mpl_hist, [0.5, 0.25, 0.25])
-        assert_allclose(self.viewer.layers[0].mpl_hist_edges, [-0.5, 0.5, 1.5, 2.5])
-        assert_allclose(self.viewer.layers[1].mpl_hist, [0.5, 0, 0.5])
-        assert_allclose(self.viewer.layers[1].mpl_hist_edges, [-0.5, 0.5, 1.5, 2.5])
+        assert_allclose(self.viewer.layers[0].state.histogram[1], [0.5, 0.25, 0.25])
+        assert_allclose(self.viewer.layers[0].state.histogram[0], [-0.5, 0.5, 1.5, 2.5])
+        assert_allclose(self.viewer.layers[1].state.histogram[1], [0.5, 0, 0.5])
+        assert_allclose(self.viewer.layers[1].state.histogram[0], [-0.5, 0.5, 1.5, 2.5])
 
         viewer_state.cumulative = True
 
+        self.viewer.layers[0].wait()
+        self.viewer.layers[1].wait()
+
         assert_allclose(self.viewer.state.y_max, 1.2)
-        assert_allclose(self.viewer.layers[0].mpl_hist, [0.5, 0.75, 1])
-        assert_allclose(self.viewer.layers[0].mpl_hist_edges, [-0.5, 0.5, 1.5, 2.5])
-        assert_allclose(self.viewer.layers[1].mpl_hist, [0.5, 0.5, 1])
-        assert_allclose(self.viewer.layers[1].mpl_hist_edges, [-0.5, 0.5, 1.5, 2.5])
+        assert_allclose(self.viewer.layers[0].state.histogram[1], [0.5, 0.75, 1])
+        assert_allclose(self.viewer.layers[0].state.histogram[0], [-0.5, 0.5, 1.5, 2.5])
+        assert_allclose(self.viewer.layers[1].state.histogram[1], [0.5, 0.5, 1])
+        assert_allclose(self.viewer.layers[1].state.histogram[0], [-0.5, 0.5, 1.5, 2.5])
 
         viewer_state.normalize = False
 
+        self.viewer.layers[0].wait()
+        self.viewer.layers[1].wait()
+
         assert_allclose(self.viewer.state.y_max, 4.8)
-        assert_allclose(self.viewer.layers[0].mpl_hist, [2, 3, 4])
-        assert_allclose(self.viewer.layers[0].mpl_hist_edges, [-0.5, 0.5, 1.5, 2.5])
-        assert_allclose(self.viewer.layers[1].mpl_hist, [1, 1, 2])
-        assert_allclose(self.viewer.layers[1].mpl_hist_edges, [-0.5, 0.5, 1.5, 2.5])
+        assert_allclose(self.viewer.layers[0].state.histogram[1], [2, 3, 4])
+        assert_allclose(self.viewer.layers[0].state.histogram[0], [-0.5, 0.5, 1.5, 2.5])
+        assert_allclose(self.viewer.layers[1].state.histogram[1], [1, 1, 2])
+        assert_allclose(self.viewer.layers[1].state.histogram[0], [-0.5, 0.5, 1.5, 2.5])
 
         # TODO: add tests for log
 
@@ -285,10 +314,13 @@ class TestHistogramViewer(object):
 
         self.viewer.apply_roi(roi)
 
+        for layer in self.viewer.layers:
+            layer.wait()
+
         assert len(self.viewer.layers) == 2
 
-        assert_allclose(self.viewer.layers[0].mpl_hist, [0, 1, 2, 1])
-        assert_allclose(self.viewer.layers[1].mpl_hist, [0, 1, 2, 0])
+        assert_allclose(self.viewer.layers[0].state.histogram[1], [0, 1, 2, 1])
+        assert_allclose(self.viewer.layers[1].state.histogram[1], [0, 1, 2, 0])
 
         assert_allclose(self.data.subsets[0].to_mask(), [0, 1, 1, 1])
 
@@ -317,10 +349,13 @@ class TestHistogramViewer(object):
 
         self.viewer.apply_roi(roi)
 
+        for layer in self.viewer.layers:
+            layer.wait()
+
         assert len(self.viewer.layers) == 2
 
-        assert_allclose(self.viewer.layers[0].mpl_hist, [2, 1, 1])
-        assert_allclose(self.viewer.layers[1].mpl_hist, [2, 1, 0])
+        assert_allclose(self.viewer.layers[0].state.histogram[1], [2, 1, 1])
+        assert_allclose(self.viewer.layers[1].state.histogram[1], [2, 1, 0])
 
         assert_allclose(self.data.subsets[0].to_mask(), [1, 1, 0, 1])
 
@@ -388,15 +423,24 @@ class TestHistogramViewer(object):
         cid = self.data.visible_components[0]
         self.data_collection.new_subset_group('subset 3', cid < 3)
 
+        for layer in self.viewer.layers:
+            layer.wait()
+
         assert_allclose(self.viewer.state.y_min, 0)
         assert_allclose(self.viewer.state.y_max, 1.2)
 
         viewer_state.x_att = self.data.id['z']
 
+        for layer in self.viewer.layers:
+            layer.wait()
+
         assert_allclose(self.viewer.state.y_min, 0)
         assert_allclose(self.viewer.state.y_max, 2.4)
 
         viewer_state.normalize = True
+
+        for layer in self.viewer.layers:
+            layer.wait()
 
         assert_allclose(self.viewer.state.y_min, 0)
         assert_allclose(self.viewer.state.y_max, 0.5325443786982249)
@@ -416,22 +460,34 @@ class TestHistogramViewer(object):
         viewer_state.hist_x_max = +10
         viewer_state.hist_n_bin = 5
 
-        assert_allclose(self.viewer.layers[0].mpl_hist, [0, 0, 3, 1, 0])
+        for layer in self.viewer.layers:
+            layer.wait()
+
+        assert_allclose(self.viewer.layers[0].state.histogram[1], [0, 0, 3, 1, 0])
 
         viewer_state.x_att = self.data.id['x']
         viewer_state.hist_x_min = -10
         viewer_state.hist_x_max = +10
         viewer_state.hist_n_bin = 5
 
-        assert_allclose(self.viewer.layers[0].mpl_hist, [0, 0, 2, 2, 0])
+        for layer in self.viewer.layers:
+            layer.wait()
+
+        assert_allclose(self.viewer.layers[0].state.histogram[1], [0, 0, 2, 2, 0])
 
         viewer_state.x_att = self.data.id['y']
 
-        assert_allclose(self.viewer.layers[0].mpl_hist, [0, 0, 3, 1, 0])
+        for layer in self.viewer.layers:
+            layer.wait()
+
+        assert_allclose(self.viewer.layers[0].state.histogram[1], [0, 0, 3, 1, 0])
 
         viewer_state.x_att = self.data.id['x']
 
-        assert_allclose(self.viewer.layers[0].mpl_hist, [0, 0, 2, 2, 0])
+        for layer in self.viewer.layers:
+            layer.wait()
+
+        assert_allclose(self.viewer.layers[0].state.histogram[1], [0, 0, 2, 2, 0])
 
     def test_component_replaced(self):
 

--- a/glue/viewers/histogram/state.py
+++ b/glue/viewers/histogram/state.py
@@ -11,7 +11,7 @@ from glue.viewers.matplotlib.state import (MatplotlibDataViewerState,
                                            DeferredDrawSelectionCallbackProperty as DDSCProperty)
 from glue.core.state_objects import (StateAttributeLimitsHelper,
                                      StateAttributeHistogramHelper)
-from glue.core.exceptions import IncompatibleAttribute
+from glue.core.exceptions import IncompatibleAttribute, IncompatibleDataException
 from glue.core.data_combo_helper import ComponentIDComboHelper
 from glue.utils import defer_draw, datetime64_to_mpl
 from glue.utils.decorators import avoid_circular
@@ -209,8 +209,10 @@ class HistogramLayerState(MatplotlibLayerState):
             self.viewer_state.add_callback('hist_n_bin', self.reset_cache, priority=100000)
             self._viewer_callbacks_set = True
 
-        # if self.viewer_state is None or self.viewer_state.x_att is None:
-        #     raise IncompatibleDataException()
+        if (self.viewer_state is None or self.viewer_state.x_att is None or
+            self.viewer_state.hist_x_min is None or self.viewer_state.hist_x_max is None or
+                self.viewer_state.hist_n_bin is None or self.viewer_state.x_log is None):
+            raise IncompatibleDataException()
 
         if isinstance(self.layer, Subset):
             data = self.layer.data

--- a/glue/viewers/histogram/state.py
+++ b/glue/viewers/histogram/state.py
@@ -172,7 +172,6 @@ class HistogramLayerState(MatplotlibLayerState):
     _histogram_cache = None
 
     def reset_cache(self, *args):
-        print("RESET CACHE")
         self._histogram_cache = None
 
     @property
@@ -185,7 +184,6 @@ class HistogramLayerState(MatplotlibLayerState):
 
     @property
     def histogram(self):
-        print('cache', self._histogram_cache)
         self.update_histogram()
         edges, unscaled = self._histogram_cache
         scaled = unscaled.astype(np.float)
@@ -241,5 +239,3 @@ class HistogramLayerState(MatplotlibLayerState):
                                      self._viewer_state.hist_n_bin + 1)
 
         self._histogram_cache = hist_edges, hist_values
-
-        print("CACHE", self._histogram_cache)

--- a/glue/viewers/histogram/tests/test_layer_artist.py
+++ b/glue/viewers/histogram/tests/test_layer_artist.py
@@ -44,6 +44,8 @@ class TestHistogramLayerArtist(object):
         self.layer_state = self.artist.state
         self.viewer_state.layers.append(self.layer_state)
 
+        self.artist.wait()
+
         self.call_counter = CallCounter()
         sys.setprofile(self.call_counter)
 
@@ -53,49 +55,62 @@ class TestHistogramLayerArtist(object):
     def test_recalc_on_state_changes(self):
 
         assert self.call_counter['_calculate_histogram'] == 0
-        assert self.call_counter['_scale_histogram'] == 0
+        assert self.call_counter['_update_artists'] == 0
 
         # attribute
         self.viewer_state.x_att = self.data.id['y']
+        self.artist.wait()
         assert self.call_counter['_calculate_histogram'] == 1
-        assert self.call_counter['_scale_histogram'] == 1
+        assert self.call_counter['_update_artists'] == 1
 
         # lo
         self.viewer_state.hist_x_min = -1
+        self.artist.wait()
         assert self.call_counter['_calculate_histogram'] == 2
-        assert self.call_counter['_scale_histogram'] == 2
+        assert self.call_counter['_update_artists'] == 2
 
         # hi
         self.viewer_state.hist_x_max = 5
+        self.artist.wait()
         assert self.call_counter['_calculate_histogram'] == 3
-        assert self.call_counter['_scale_histogram'] == 3
+        assert self.call_counter['_update_artists'] == 3
 
         # nbins
         self.viewer_state.hist_n_bin += 1
+        self.artist.wait()
         assert self.call_counter['_calculate_histogram'] == 4
-        assert self.call_counter['_scale_histogram'] == 4
+        assert self.call_counter['_update_artists'] == 4
 
         # xlog
         self.viewer_state.x_log ^= True
+        self.artist.wait()
         assert self.call_counter['_calculate_histogram'] == 5
-        assert self.call_counter['_scale_histogram'] == 5
+        assert self.call_counter['_update_artists'] == 5
+
+        # TODO: find a way to determine whether the histogram calculation is
+        # carried out since _calculate_histogram calls are no longer a good
+        # way to find out (we now rely on state cache)
 
         # ylog -- no call
         self.viewer_state.y_log ^= True
-        assert self.call_counter['_calculate_histogram'] == 5
-        assert self.call_counter['_scale_histogram'] == 6
+        self.artist.wait()
+        # assert self.call_counter['_calculate_histogram'] == 5
+        assert self.call_counter['_update_artists'] == 6
 
         # cumulative -- no call
         self.viewer_state.cumulative ^= True
-        assert self.call_counter['_calculate_histogram'] == 5
-        assert self.call_counter['_scale_histogram'] == 7
+        self.artist.wait()
+        # assert self.call_counter['_calculate_histogram'] == 5
+        assert self.call_counter['_update_artists'] == 7
 
         # normed -- no call
         self.viewer_state.normalize ^= True
-        assert self.call_counter['_calculate_histogram'] == 5
-        assert self.call_counter['_scale_histogram'] == 8
+        self.artist.wait()
+        # assert self.call_counter['_calculate_histogram'] == 5
+        assert self.call_counter['_update_artists'] == 8
 
         # subset style -- no call
         self.subset.style.color = '#00ff00'
-        assert self.call_counter['_calculate_histogram'] == 5
-        assert self.call_counter['_scale_histogram'] == 8
+        self.artist.wait()
+        # assert self.call_counter['_calculate_histogram'] == 5
+        assert self.call_counter['_update_artists'] == 8

--- a/glue/viewers/matplotlib/qt/compute_worker.py
+++ b/glue/viewers/matplotlib/qt/compute_worker.py
@@ -1,0 +1,64 @@
+from __future__ import absolute_import, division, print_function
+
+import sys
+import time
+
+from glue.external.six.moves import queue
+from glue.utils import queue_to_list
+from qtpy.QtCore import Signal, QThread
+
+
+# For some viewers, we make use of a thread that continuously listens for
+# requests to update the profile and we run these as needed. In future,
+# we should add the ability to interrupt compute jobs if a newer compute
+# job is requested.
+
+
+class ComputeWorker(QThread):
+
+    compute_start = Signal()
+    compute_end = Signal()
+    compute_error = Signal(object)
+
+    def __init__(self, function):
+        super(ComputeWorker, self).__init__()
+        self.function = function
+        self.running = False
+        self.work_queue = queue.Queue()
+
+    def run(self):
+
+        error = None
+
+        while True:
+
+            time.sleep(1 / 25)
+
+            msgs = queue_to_list(self.work_queue)
+
+            if 'stop' in msgs:
+                return
+
+            elif len(msgs) == 0:
+                # We change this here rather than in the try...except below
+                # to avoid stopping and starting in quick succession.
+                if self.running:
+                    self.running = False
+                    if error is None:
+                        self.compute_end.emit()
+                    else:
+                        self.compute_error.emit(error)
+                        error = None
+                continue
+
+            # If any resets were requested, honor this
+            reset = any(msgs)
+
+            try:
+                self.running = True
+                self.compute_start.emit()
+                self.function(reset=reset)
+            except Exception:
+                error = sys.exc_info()
+            else:
+                error = None

--- a/glue/viewers/matplotlib/qt/data_viewer.py
+++ b/glue/viewers/matplotlib/qt/data_viewer.py
@@ -133,9 +133,9 @@ class MatplotlibDataViewer(DataViewer):
         # active, then we start the timer but we then return straight away.
         # This is to avoid showing the 'Computing' message straight away in the
         # case of reasonably fast operations.
-        if (isinstance(message, ComputationStartedMessage) and
-                not self._monitor_computation.isActive()):
-            self._monitor_computation.start()
+        if isinstance(message, ComputationStartedMessage):
+            if not self._monitor_computation.isActive():
+                self._monitor_computation.start()
             return
 
         for layer_artist in self.layers:

--- a/glue/viewers/matplotlib/qt/data_viewer.py
+++ b/glue/viewers/matplotlib/qt/data_viewer.py
@@ -219,10 +219,24 @@ class MatplotlibDataViewer(DataViewer):
 
     @avoid_circular
     def limits_to_mpl(self, *args):
+
         if self.state.x_min is not None and self.state.x_max is not None:
-            self.axes.set_xlim(self.state.x_min, self.state.x_max)
+            x_min, x_max = self.state.x_min, self.state.x_max
+            if self.state.x_log:
+                if self.state.x_max <= 0:
+                    x_min, x_max = 0.1, 1
+                elif self.state.x_min <= 0:
+                    x_min = x_max / 10
+            self.axes.set_xlim(x_min, x_max)
+
         if self.state.y_min is not None and self.state.y_max is not None:
-            self.axes.set_ylim(self.state.y_min, self.state.y_max)
+            y_min, y_max = self.state.y_min, self.state.y_max
+            if self.state.y_log:
+                if self.state.y_max <= 0:
+                    y_min, y_max = 0.1, 1
+                elif self.state.y_min <= 0:
+                    y_min = y_max / 10
+            self.axes.set_ylim(y_min, y_max)
 
         if self.state.aspect == 'equal':
 

--- a/glue/viewers/matplotlib/qt/data_viewer.py
+++ b/glue/viewers/matplotlib/qt/data_viewer.py
@@ -178,10 +178,12 @@ class MatplotlibDataViewer(DataViewer):
 
     def update_x_ticklabel(self, *event):
         self.axes.tick_params(axis='x', labelsize=self.state.x_ticklabel_size)
+        self.axes.xaxis.get_offset_text().set_fontsize(self.state.x_ticklabel_size)
         self.redraw()
 
     def update_y_ticklabel(self, *event):
         self.axes.tick_params(axis='y', labelsize=self.state.y_ticklabel_size)
+        self.axes.yaxis.get_offset_text().set_fontsize(self.state.y_ticklabel_size)
         self.redraw()
 
     def redraw(self):

--- a/glue/viewers/profile/layer_artist.py
+++ b/glue/viewers/profile/layer_artist.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from glue.external.six.moves import queue
 from glue.core import Data
-from glue.utils import defer_draw, nanmin, nanmax, queue_to_list
+from glue.utils import defer_draw, nanmin, nanmax
 from glue.viewers.profile.state import ProfileLayerState
 from glue.viewers.matplotlib.layer_artist import MatplotlibLayerArtist
 from glue.core.exceptions import IncompatibleAttribute, IncompatibleDataException
@@ -19,29 +19,7 @@ except Exception:
     QT_INSTALLED = False
 else:
     QT_INSTALLED = True
-
-if QT_INSTALLED:
-
-    # When using Qt, we make use of a thread that continuously listens for
-    # requests to update the profile and we run these as needed. In future,
-    # we should add the ability to interrupt compute jobs if a newer compute
-    # job is requested.
-
-    from qtpy.QtCore import Signal, QThread
-
-    class ComputeWorker(QThread):
-
-        compute_start = Signal()
-        compute_end = Signal()
-        compute_error = Signal(object)
-
-        def __init__(self, function):
-            super(ComputeWorker, self).__init__()
-            self.function = function
-            self.running = False
-
-        def run(self):
-            self.function()
+    from glue.viewers.matplotlib.qt.compute_worker import ComputeWorker
 
 
 class ProfileLayerArtist(MatplotlibLayerArtist):
@@ -80,7 +58,7 @@ class ProfileLayerArtist(MatplotlibLayerArtist):
     def remove(self):
         super(ProfileLayerArtist, self).remove()
         if QT_INSTALLED and self._worker is not None:
-            self._work_queue.put('stop')
+            self._worker.work_queue.put('stop')
             self._worker.exit()
             # Need to wait otherwise the thread will be destroyed while still
             # running, causing a segmentation fault
@@ -97,53 +75,17 @@ class ProfileLayerArtist(MatplotlibLayerArtist):
         self._last_layer_state = {}
 
     def setup_thread(self):
-        self._worker = ComputeWorker(self._thread_loop)
+        self._worker = ComputeWorker(self._calculate_profile_thread)
         self._worker.compute_end.connect(self._calculate_profile_postthread)
         self._worker.compute_error.connect(self._calculate_profile_error)
         self._worker.compute_start.connect(self.notify_start_computation)
-        self._work_queue = queue.Queue()
+        self._worker.work_queue = queue.Queue()
         self._worker.start()
-
-    def _thread_loop(self):
-
-        error = None
-
-        while True:
-
-            time.sleep(1 / 25)
-
-            msgs = queue_to_list(self._work_queue)
-
-            if 'stop' in msgs:
-                return
-            elif len(msgs) == 0:
-                # We change this here rather than in the try...except below
-                # to avoid stopping and starting in quick succession.
-                if self._worker.running:
-                    self._worker.running = False
-                    if error is None:
-                        self._worker.compute_end.emit()
-                    else:
-                        self._worker.compute_error.emit(error)
-                        error = None
-                continue
-
-            # If any resets were requested, honor this
-            reset = any(msgs)
-
-            try:
-                self._worker.running = True
-                self._worker.compute_start.emit()
-                self._calculate_profile_thread(reset=reset)
-            except Exception:
-                error = sys.exc_info()
-            else:
-                error = None
 
     @defer_draw
     def _calculate_profile(self, reset=False):
         if QT_INSTALLED:
-            self._work_queue.put(reset)
+            self._worker.work_queue.put(reset)
         else:
             try:
                 self.notify_start_computation()


### PR DESCRIPTION
This extends the work that was done for the profile viewer. It may be possible to factor out some of the code into a common matplotlib layer artist for viewers that use threads.