### PR TITLE
Make sure we clean up things in viewers when closing viewers via the GUI

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,10 @@ v0.14.0 (unreleased)
 
 * Moved calculation of histograms to Data.compute_histogram. [#1739]
 
+* Fixed an issue that caused residual references to viewers
+  after they were closed if they were accessed through the
+  IPython console. [#1770]
+
 v0.13.4 (unreleased)
 --------------------
 

--- a/glue/app/qt/terminal.py
+++ b/glue/app/qt/terminal.py
@@ -19,6 +19,8 @@ from qtpy import QtWidgets
 
 from IPython import get_ipython
 
+from IPython.core.interactiveshell import InteractiveShell
+
 from ipykernel.inprocess.ipkernel import InProcessInteractiveShell
 from ipykernel.connect import get_connection_file
 
@@ -29,6 +31,16 @@ from qtconsole.client import QtKernelClient
 from glue.app.qt.mdi_area import GlueMdiSubWindow
 from glue.utils import as_variable_name
 from glue.utils.qt import get_qapp
+
+# We need to do the following to make sure that the outputs in the IPython
+# terminal don't get cached. This is because if a user does e.g.
+#
+# In  [1]: viewer
+# Out [1]: <HistogramViewer...>
+#
+# then there will be a remaining reference to the viewer in the IPython
+# namespace.
+InteractiveShell.cache_size.default_value = 0
 
 kernel_manager = None
 kernel_client = None

--- a/glue/viewers/common/qt/data_viewer.py
+++ b/glue/viewers/common/qt/data_viewer.py
@@ -120,12 +120,9 @@ class DataViewer(Viewer, BaseQtViewerWidget):
     def _close_nowarn(self):
         return self.close(warn=False)
 
-    def close(self, warn=True):
-
-        BaseQtViewerWidget.close(self, warn=warn)
-
-        Viewer.close(self)
-
+    def closeEvent(self, event):
+        super(DataViewer, self).closeEvent(event)
+        Viewer.cleanup(self)
         # We tell the toolbar to do cleanup to make sure we get rid of any
         # circular references
         if self.toolbar:

--- a/glue/viewers/common/qt/toolbar.py
+++ b/glue/viewers/common/qt/toolbar.py
@@ -213,5 +213,7 @@ class BasicToolbar(QtWidgets.QToolBar):
         # We need to make sure we set _default_mouse_mode to None otherwise
         # we keep a reference to the viewer (parent) inside the mouse mode,
         # creating a circular reference.
-        self._default_mouse_mode = None
+        if self._default_mouse_mode is not None:
+            self._default_mouse_mode.deactivate()
+            self._default_mouse_mode = None
         self.active_tool = None

--- a/glue/viewers/common/viewer.py
+++ b/glue/viewers/common/viewer.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import, division, print_function
 import os
 import warnings
 
+from IPython import get_ipython
+
 from glue.core.hub import HubListener
 from glue.core import Data, Subset
 from glue.core import command
@@ -348,10 +350,20 @@ class Viewer(BaseViewer):
         return viewer
 
     def cleanup(self):
+
         if self._hub is not None:
             self.unregister(self._hub)
+
         self._layer_artist_container.clear_callbacks()
         self._layer_artist_container.clear()
+
+        # Remove any references to the viewer in the IPython namespace. We use
+        # list() here to force an explicit copy since we are modifying the
+        # dictionary in-place
+        shell = get_ipython()
+        for key in list(shell.user_ns):
+            if shell.user_ns[key] is self:
+                shell.user_ns.pop(key)
 
     def remove_layer(self, layer):
         self._layer_artist_container.pop(layer)

--- a/glue/viewers/common/viewer.py
+++ b/glue/viewers/common/viewer.py
@@ -347,7 +347,7 @@ class Viewer(BaseViewer):
 
         return viewer
 
-    def close(self):
+    def cleanup(self):
         if self._hub is not None:
             self.unregister(self._hub)
         self._layer_artist_container.clear_callbacks()


### PR DESCRIPTION
This bypasses the ``close`` method so we need to do this in the ``closeEvent`` instead.