### PR TITLE
Only use threads for profiles and histograms above a certain data size

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,8 +38,9 @@ v0.14.0 (unreleased)
   can access the indices with ``Data[name].codes`` and the unique categories
   with ``Data[name].categories``.  [#1784]
 
-* Compute profiles asynchronously to avoid holding up the UI,
-  and in chunks to avoid excessive memory usage. [#1736]
+* Compute profiles and histograms asynchronously when dataset is large
+  to avoid holding up the UI, and compute profiles in chunks to avoid
+  excessive memory usage. [#1736, #1764]
 
 * Improved naming of components when merging datasets. [#1249]
 

--- a/glue/viewers/histogram/layer_artist.py
+++ b/glue/viewers/histogram/layer_artist.py
@@ -82,7 +82,7 @@ class HistogramLayerArtist(MatplotlibLayerArtist):
 
     @defer_draw
     def _calculate_histogram(self, reset=False):
-        if QT_INSTALLED:
+        if self.state.layer is not None and self.state.layer.size > 1e7 and QT_INSTALLED:
             self._worker.work_queue.put(reset)
         else:
             try:

--- a/glue/viewers/histogram/qt/tests/test_data_viewer.py
+++ b/glue/viewers/histogram/qt/tests/test_data_viewer.py
@@ -27,11 +27,6 @@ from ..data_viewer import HistogramViewer
 DATA = os.path.join(os.path.dirname(__file__), 'data')
 
 
-def wait_for_layers(viewer):
-    for layer in viewer.layers:
-        layer.wait()
-
-
 class TestHistogramCommon(BaseTestMatplotlibDataViewer):
     def init_data(self):
         return Data(label='d1', x=[3.4, 2.3, -1.1, 0.3], y=['a', 'b', 'c', 'a'])
@@ -66,7 +61,6 @@ class TestHistogramViewer(object):
         # Check defaults when we add data
         self.viewer.add_data(self.data)
 
-        wait_for_layers(self.viewer)
 
         assert combo_as_string(self.viewer.options_widget().ui.combosel_x_att) == 'Main components:x:y:Coordinate components:Pixel Axis 0 [x]:World 0'
 
@@ -92,7 +86,6 @@ class TestHistogramViewer(object):
 
         viewer_state.x_att = self.data.id['y']
 
-        wait_for_layers(self.viewer)
 
         assert viewer_state.x_min == -0.5
         assert viewer_state.x_max == 2.5
@@ -198,8 +191,6 @@ class TestHistogramViewer(object):
         viewer_state.hist_x_max = 5
         viewer_state.hist_n_bin = 4
 
-        wait_for_layers(self.viewer)
-
         assert_allclose(self.viewer.state.y_max, 2.4)
 
         assert_allclose(self.viewer.layers[0].state.histogram[1], [0, 1, 2, 1])
@@ -208,14 +199,10 @@ class TestHistogramViewer(object):
         cid = self.data.visible_components[0]
         self.data_collection.new_subset_group('subset 1', cid < 2)
 
-        wait_for_layers(self.viewer)
-
         assert_allclose(self.viewer.layers[1].state.histogram[1], [0, 1, 1, 0])
         assert_allclose(self.viewer.layers[1].state.histogram[0], [-5, -2.5, 0, 2.5, 5])
 
         viewer_state.normalize = True
-
-        wait_for_layers(self.viewer)
 
         assert_allclose(self.viewer.state.y_max, 0.24)
         assert_allclose(self.viewer.layers[0].state.histogram[1], [0, 0.1, 0.2, 0.1])
@@ -225,8 +212,6 @@ class TestHistogramViewer(object):
 
         viewer_state.cumulative = True
 
-        wait_for_layers(self.viewer)
-
         assert_allclose(self.viewer.state.y_max, 1.2)
         assert_allclose(self.viewer.layers[0].state.histogram[1], [0, 0.25, 0.75, 1.0])
         assert_allclose(self.viewer.layers[0].state.histogram[0], [-5, -2.5, 0, 2.5, 5])
@@ -234,8 +219,6 @@ class TestHistogramViewer(object):
         assert_allclose(self.viewer.layers[1].state.histogram[0], [-5, -2.5, 0, 2.5, 5])
 
         viewer_state.normalize = False
-
-        wait_for_layers(self.viewer)
 
         assert_allclose(self.viewer.state.y_max, 4.8)
         assert_allclose(self.viewer.layers[0].state.histogram[1], [0, 1, 3, 4])
@@ -249,8 +232,6 @@ class TestHistogramViewer(object):
 
         viewer_state.x_att = self.data.id['y']
 
-        wait_for_layers(self.viewer)
-
         formatter = self.viewer.axes.xaxis.get_major_formatter()
         xlabels = [formatter.format_data(pos) for pos in range(3)]
         assert xlabels == ['a', 'b', 'c']
@@ -263,8 +244,6 @@ class TestHistogramViewer(object):
 
         viewer_state.normalize = True
 
-        wait_for_layers(self.viewer)
-
         assert_allclose(self.viewer.state.y_max, 0.6)
         assert_allclose(self.viewer.layers[0].state.histogram[1], [0.5, 0.25, 0.25])
         assert_allclose(self.viewer.layers[0].state.histogram[0], [-0.5, 0.5, 1.5, 2.5])
@@ -273,8 +252,6 @@ class TestHistogramViewer(object):
 
         viewer_state.cumulative = True
 
-        wait_for_layers(self.viewer)
-
         assert_allclose(self.viewer.state.y_max, 1.2)
         assert_allclose(self.viewer.layers[0].state.histogram[1], [0.5, 0.75, 1])
         assert_allclose(self.viewer.layers[0].state.histogram[0], [-0.5, 0.5, 1.5, 2.5])
@@ -282,8 +259,6 @@ class TestHistogramViewer(object):
         assert_allclose(self.viewer.layers[1].state.histogram[0], [-0.5, 0.5, 1.5, 2.5])
 
         viewer_state.normalize = False
-
-        wait_for_layers(self.viewer)
 
         assert_allclose(self.viewer.state.y_max, 4.8)
         assert_allclose(self.viewer.layers[0].state.histogram[1], [2, 3, 4])
@@ -311,8 +286,6 @@ class TestHistogramViewer(object):
         assert len(self.viewer.layers) == 1
 
         self.viewer.apply_roi(roi)
-
-        wait_for_layers(self.viewer)
 
         assert len(self.viewer.layers) == 2
 
@@ -345,8 +318,6 @@ class TestHistogramViewer(object):
         assert len(self.viewer.layers) == 1
 
         self.viewer.apply_roi(roi)
-
-        wait_for_layers(self.viewer)
 
         assert len(self.viewer.layers) == 2
 
@@ -419,21 +390,15 @@ class TestHistogramViewer(object):
         cid = self.data.visible_components[0]
         self.data_collection.new_subset_group('subset 3', cid < 3)
 
-        wait_for_layers(self.viewer)
-
         assert_allclose(self.viewer.state.y_min, 0)
         assert_allclose(self.viewer.state.y_max, 1.2)
 
         viewer_state.x_att = self.data.id['z']
 
-        wait_for_layers(self.viewer)
-
         assert_allclose(self.viewer.state.y_min, 0)
         assert_allclose(self.viewer.state.y_max, 2.4)
 
         viewer_state.normalize = True
-
-        wait_for_layers(self.viewer)
 
         assert_allclose(self.viewer.state.y_min, 0)
         assert_allclose(self.viewer.state.y_max, 0.5325443786982249)
@@ -453,8 +418,6 @@ class TestHistogramViewer(object):
         viewer_state.hist_x_max = +10
         viewer_state.hist_n_bin = 5
 
-        wait_for_layers(self.viewer)
-
         assert_allclose(self.viewer.layers[0].state.histogram[1], [0, 0, 3, 1, 0])
 
         viewer_state.x_att = self.data.id['x']
@@ -462,19 +425,13 @@ class TestHistogramViewer(object):
         viewer_state.hist_x_max = +10
         viewer_state.hist_n_bin = 5
 
-        wait_for_layers(self.viewer)
-
         assert_allclose(self.viewer.layers[0].state.histogram[1], [0, 0, 2, 2, 0])
 
         viewer_state.x_att = self.data.id['y']
 
-        wait_for_layers(self.viewer)
-
         assert_allclose(self.viewer.layers[0].state.histogram[1], [0, 0, 3, 1, 0])
 
         viewer_state.x_att = self.data.id['x']
-
-        wait_for_layers(self.viewer)
 
         assert_allclose(self.viewer.layers[0].state.histogram[1], [0, 0, 2, 2, 0])
 
@@ -522,7 +479,6 @@ class TestHistogramViewer(object):
         assert dc[0].label == 'data'
 
         viewer1 = ga.viewers[0][0]
-        wait_for_layers(viewer1)
         assert len(viewer1.state.layers) == 2
         assert viewer1.state.x_att is dc[0].id['a']
         assert_allclose(viewer1.state.x_min, 0)
@@ -540,7 +496,6 @@ class TestHistogramViewer(object):
         assert not viewer1.state.normalize
 
         viewer2 = ga.viewers[0][1]
-        wait_for_layers(viewer2)
         assert viewer2.state.x_att is dc[0].id['b']
         assert_allclose(viewer2.state.x_min, 2)
         assert_allclose(viewer2.state.x_max, 16)
@@ -557,7 +512,6 @@ class TestHistogramViewer(object):
         assert not viewer2.state.normalize
 
         viewer3 = ga.viewers[0][2]
-        wait_for_layers(viewer3)
         assert viewer3.state.x_att is dc[0].id['a']
         assert_allclose(viewer3.state.x_min, 0)
         assert_allclose(viewer3.state.x_max, 9)
@@ -574,7 +528,6 @@ class TestHistogramViewer(object):
         assert viewer3.state.normalize
 
         viewer4 = ga.viewers[0][3]
-        wait_for_layers(viewer4)
         assert viewer4.state.x_att is dc[0].id['a']
         assert_allclose(viewer4.state.x_min, -1)
         assert_allclose(viewer4.state.x_max, 10)
@@ -642,8 +595,6 @@ class TestHistogramViewer(object):
         self.viewer.add_data(self.data)
         self.viewer.state.x_att = self.data.id['t1']
 
-        wait_for_layers(self.viewer)
-
         # Matplotlib deals with dates by converting them to the number of days
         # since 01-01-0001, so we can check that the limits are correctly
         # converted (and not 100 to 400)
@@ -653,7 +604,6 @@ class TestHistogramViewer(object):
         roi = XRangeROI(719313, 719513)
         self.viewer.apply_roi(roi)
 
-        wait_for_layers(self.viewer)
 
         # Check that the two middle elements are selected
         assert_equal(self.data.subsets[0].to_mask(), [0, 1, 1, 0])
@@ -679,8 +629,6 @@ class TestHistogramViewer(object):
         ga = state.object('__main__')
         viewer = ga.viewers[0][0]
         options = viewer.options_widget().ui
-
-        wait_for_layers(viewer)
 
         assert_equal(self.viewer.state.x_min, np.datetime64('1970-04-14', 'D'))
 

--- a/glue/viewers/histogram/qt/tests/test_data_viewer.py
+++ b/glue/viewers/histogram/qt/tests/test_data_viewer.py
@@ -61,7 +61,6 @@ class TestHistogramViewer(object):
         # Check defaults when we add data
         self.viewer.add_data(self.data)
 
-
         assert combo_as_string(self.viewer.options_widget().ui.combosel_x_att) == 'Main components:x:y:Coordinate components:Pixel Axis 0 [x]:World 0'
 
         assert viewer_state.x_att is self.data.id['x']
@@ -85,7 +84,6 @@ class TestHistogramViewer(object):
         # Change to categorical component and check new values
 
         viewer_state.x_att = self.data.id['y']
-
 
         assert viewer_state.x_min == -0.5
         assert viewer_state.x_max == 2.5
@@ -603,7 +601,6 @@ class TestHistogramViewer(object):
         # Apply an ROI selection in plotting coordinates
         roi = XRangeROI(719313, 719513)
         self.viewer.apply_roi(roi)
-
 
         # Check that the two middle elements are selected
         assert_equal(self.data.subsets[0].to_mask(), [0, 1, 1, 0])

--- a/glue/viewers/histogram/tests/test_layer_artist.py
+++ b/glue/viewers/histogram/tests/test_layer_artist.py
@@ -44,8 +44,6 @@ class TestHistogramLayerArtist(object):
         self.layer_state = self.artist.state
         self.viewer_state.layers.append(self.layer_state)
 
-        self.artist.wait()
-
         self.call_counter = CallCounter()
         sys.setprofile(self.call_counter)
 
@@ -59,31 +57,26 @@ class TestHistogramLayerArtist(object):
 
         # attribute
         self.viewer_state.x_att = self.data.id['y']
-        self.artist.wait()
         assert self.call_counter['_calculate_histogram'] == 1
         assert self.call_counter['_update_artists'] == 1
 
         # lo
         self.viewer_state.hist_x_min = -1
-        self.artist.wait()
         assert self.call_counter['_calculate_histogram'] == 2
         assert self.call_counter['_update_artists'] == 2
 
         # hi
         self.viewer_state.hist_x_max = 5
-        self.artist.wait()
         assert self.call_counter['_calculate_histogram'] == 3
         assert self.call_counter['_update_artists'] == 3
 
         # nbins
         self.viewer_state.hist_n_bin += 1
-        self.artist.wait()
         assert self.call_counter['_calculate_histogram'] == 4
         assert self.call_counter['_update_artists'] == 4
 
         # xlog
         self.viewer_state.x_log ^= True
-        self.artist.wait()
         assert self.call_counter['_calculate_histogram'] == 5
         assert self.call_counter['_update_artists'] == 5
 
@@ -93,24 +86,20 @@ class TestHistogramLayerArtist(object):
 
         # ylog -- no call
         self.viewer_state.y_log ^= True
-        self.artist.wait()
         # assert self.call_counter['_calculate_histogram'] == 5
         assert self.call_counter['_update_artists'] == 6
 
         # cumulative -- no call
         self.viewer_state.cumulative ^= True
-        self.artist.wait()
         # assert self.call_counter['_calculate_histogram'] == 5
         assert self.call_counter['_update_artists'] == 7
 
         # normed -- no call
         self.viewer_state.normalize ^= True
-        self.artist.wait()
         # assert self.call_counter['_calculate_histogram'] == 5
         assert self.call_counter['_update_artists'] == 8
 
         # subset style -- no call
         self.subset.style.color = '#00ff00'
-        self.artist.wait()
         # assert self.call_counter['_calculate_histogram'] == 5
         assert self.call_counter['_update_artists'] == 8

--- a/glue/viewers/profile/layer_artist.py
+++ b/glue/viewers/profile/layer_artist.py
@@ -84,7 +84,7 @@ class ProfileLayerArtist(MatplotlibLayerArtist):
 
     @defer_draw
     def _calculate_profile(self, reset=False):
-        if QT_INSTALLED:
+        if self.state.layer is not None and self.state.layer.size > 1e7 and QT_INSTALLED:
             self._worker.work_queue.put(reset)
         else:
             try:

--- a/glue/viewers/profile/qt/tests/test_data_viewer.py
+++ b/glue/viewers/profile/qt/tests/test_data_viewer.py
@@ -64,7 +64,6 @@ class TestProfileViewer(object):
         self.viewer.state.function = 'mean'
         assert len(self.viewer.layers) == 1
         layer_artist = self.viewer.layers[0]
-        layer_artist.wait()
         assert_allclose(layer_artist.state.profile[0], [0, 2, 4])
         assert_allclose(layer_artist.state.profile[1], [3.5, 11.5, 19.5])
 
@@ -73,8 +72,6 @@ class TestProfileViewer(object):
         data2 = Data(y=np.random.random((3, 4, 2)))
         self.data_collection.append(data2)
         self.viewer.add_data(data2)
-        for layer in self.viewer.layers:
-            layer.wait()
         assert len(self.viewer.layers) == 2
         assert self.viewer.layers[0].enabled
         assert not self.viewer.layers[1].enabled
@@ -109,16 +106,10 @@ class TestProfileViewer(object):
         self.viewer.add_data(self.data)
         self.viewer.add_data(data2)
 
-        for layer in self.viewer.layers:
-            layer.wait()
-
         assert self.viewer.layers[0].enabled
         assert not self.viewer.layers[1].enabled
 
         self.data_collection.add_link(ComponentLink([data2.world_component_ids[1]], self.data.world_component_ids[0], using=lambda x: 2 * x))
-
-        for layer in self.viewer.layers:
-            layer.wait()
 
         assert self.viewer.layers[0].enabled
         assert self.viewer.layers[1].enabled


### PR DESCRIPTION
This should help avoid race conditions, and issues when running tests