### PR TITLE
Deprecate primary_components and visible_components

### DIFF
--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -4,6 +4,8 @@ from collections import OrderedDict
 
 import abc
 import uuid
+import warnings
+
 import numpy as np
 import pandas as pd
 
@@ -129,10 +131,6 @@ class BaseData(object):
     @property
     def derived_components(self):
         return []
-
-    @property
-    def visible_components(self):
-        return self.main_components
 
     def find_component_id(self, label):
         """
@@ -991,15 +989,6 @@ class Data(BaseCartesianData):
         return list(self._externally_derivable_components.keys())
 
     @property
-    def visible_components(self):
-        """All :class:`ComponentIDs <glue.core.component_id.ComponentID>` in the Data that aren't coordinate.
-
-        :rtype: list
-        """
-        return [cid for cid, comp in self._components.items()
-                if not isinstance(comp, CoordinateComponent) and cid.parent is self]
-
-    @property
     def coordinate_components(self):
         """The ComponentIDs associated with a :class:`~glue.core.component.CoordinateComponent`
 
@@ -1012,17 +1001,6 @@ class Data(BaseCartesianData):
     def main_components(self):
         return [c for c in self.component_ids() if
                 not isinstance(self._components[c], (DerivedComponent, CoordinateComponent))]
-
-    @property
-    def primary_components(self):
-        """
-        The ComponentIDs not associated with a :class:`~glue.core.component.DerivedComponent`
-
-        This property is deprecated.
-        """
-        warnings.warn('primary_components is deprecated', UserWarning)
-        return [c for c in self.component_ids() if
-                not isinstance(self._components[c], DerivedComponent)]
 
     @property
     def derived_components(self):
@@ -1587,6 +1565,29 @@ class Data(BaseCartesianData):
             range = (xmin, xmax)
 
         return np.histogram(x, range=range, bins=bins, weights=w)[0]
+
+    # DEPRECATED
+
+    @property
+    def primary_components(self):
+        """
+        The ComponentIDs not associated with a :class:`~glue.core.component.DerivedComponent`
+
+        This property is deprecated.
+        """
+        warnings.warn('Data.primary_components is deprecated', UserWarning)
+        return [c for c in self.component_ids() if
+                not isinstance(self._components[c], DerivedComponent)]
+
+    @property
+    def visible_components(self):
+        """All :class:`ComponentIDs <glue.core.component_id.ComponentID>` in the Data that aren't coordinates.
+
+        This property is deprecated.
+        """
+        warnings.warn('Data.visible_components is deprecated', UserWarning)
+        return [cid for cid, comp in self._components.items()
+                if not isinstance(comp, CoordinateComponent) and cid.parent is self]
 
 
 @contract(i=int, ndim=int)

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -131,10 +131,6 @@ class BaseData(object):
         return []
 
     @property
-    def primary_components(self):
-        return [cid for cid in self.components if cid not in self.derived_components]
-
-    @property
     def visible_components(self):
         return self.main_components
 
@@ -1019,10 +1015,12 @@ class Data(BaseCartesianData):
 
     @property
     def primary_components(self):
-        """The ComponentIDs not associated with a :class:`~glue.core.component.DerivedComponent`
-
-        :rtype: list
         """
+        The ComponentIDs not associated with a :class:`~glue.core.component.DerivedComponent`
+
+        This property is deprecated.
+        """
+        warnings.warn('primary_components is deprecated', UserWarning)
         return [c for c in self.component_ids() if
                 not isinstance(self._components[c], DerivedComponent)]
 
@@ -1064,7 +1062,7 @@ class Data(BaseCartesianData):
             one takes precedence.
         """
 
-        for cid_set in (self.primary_components, self.derived_components, self.coordinate_components, list(self._externally_derivable_components)):
+        for cid_set in (self.main_components, self.derived_components, self.coordinate_components, list(self._externally_derivable_components)):
 
             result = []
             for cid in cid_set:

--- a/glue/core/data_collection.py
+++ b/glue/core/data_collection.py
@@ -309,7 +309,7 @@ class DataCollection(HubListener):
         # dataset
 
         from collections import Counter
-        clabel_count = Counter([c.label for d in data for c in d.visible_components])
+        clabel_count = Counter([c.label for d in data for c in d.main_components + d.derived_components])
 
         for d in data:
 

--- a/glue/core/data_combo_helper.py
+++ b/glue/core/data_combo_helper.py
@@ -345,11 +345,10 @@ class ComponentIDComboHelper(ComboHelper):
                     choices.append(ChoiceSeparator(data.label))
 
             cids = [ChoiceSeparator('Main components')]
-            for cid in data.primary_components:
-                if cid not in data.coordinate_components:
-                    if ((data.get_kind(cid) in ('numerical', 'datetime') and self.numeric) or
-                            (data.get_kind(cid) == 'categorical' and self.categorical)):
-                        cids.append(cid)
+            for cid in data.main_components:
+                if ((data.get_kind(cid) in ('numerical', 'datetime') and self.numeric) or
+                        (data.get_kind(cid) == 'categorical' and self.categorical)):
+                    cids.append(cid)
             if len(cids) > 1:
                 if self.pixel_coord or self.world_coord or (self.derived and len(derived_components) > 0):
                     choices += cids

--- a/glue/core/data_exporters/astropy_table.py
+++ b/glue/core/data_exporters/astropy_table.py
@@ -19,7 +19,7 @@ def data_to_astropy_table(data, components=None):
     from astropy.table import Table
 
     table = Table()
-    for cid in data.visible_components:
+    for cid in data.main_components + data.derived_components:
 
         if components is not None and cid not in components:
             continue

--- a/glue/core/data_exporters/gridded_fits.py
+++ b/glue/core/data_exporters/gridded_fits.py
@@ -54,7 +54,7 @@ def fits_writer(filename, data, components=None):
 
     hdus = fits.HDUList()
 
-    for cid in data.visible_components:
+    for cid in data.main_components + data.derived_components:
 
         if components is not None and cid not in components:
             continue

--- a/glue/core/data_exporters/hdf5.py
+++ b/glue/core/data_exporters/hdf5.py
@@ -34,7 +34,7 @@ def hdf5_writer(filename, data, components=None):
 
     f = File(filename, 'w')
 
-    for cid in data.visible_components:
+    for cid in data.main_components + data.derived_components:
 
         if components is not None and cid not in components:
             continue

--- a/glue/core/data_factories/helpers.py
+++ b/glue/core/data_factories/helpers.py
@@ -260,17 +260,18 @@ def load_data(path, factory=None, **kwargs):
             # We just follow the order in which the components are now loaded,
             # which is coordinate components first, followed by all other
             # components
-            for cid in item.primary_components:
+            for cid in item.coordinate_components + item.main_components:
                 log.log(item.get_component(cid))
         else:
             # In this case the first component was the first one that is not a
             # coordinate component, followed by the coordinate components,
             # followed by the remaining components.
-            cid = item.primary_components[item.ndim * 2]
+            cid = item.main_components[0]
             log.log(item.get_component(cid))
-            for icid, cid in enumerate(item.primary_components):
-                if icid != item.ndim * 2:
-                    log.log(item.get_component(cid))
+            for icid, cid in enumerate(item.coordinate_components):
+                log.log(item.get_component(cid))
+            for icid, cid in enumerate(item.main_components[1:]):
+                log.log(item.get_component(cid))
 
     if len(d) == 1:
         # unpack single-length lists for user convenience

--- a/glue/core/link_manager.py
+++ b/glue/core/link_manager.py
@@ -67,7 +67,7 @@ def discover_links(data, links):
     # TODO: try to add shortest paths first -- should
     # prevent lots of repeated checking
 
-    cids = set(data.main_components) + set(self.coordinate_components)
+    cids = set(data.main_components + data.coordinate_components)
     cid_links = {}
     depth = {}
     for cid in cids:

--- a/glue/core/link_manager.py
+++ b/glue/core/link_manager.py
@@ -67,7 +67,7 @@ def discover_links(data, links):
     # TODO: try to add shortest paths first -- should
     # prevent lots of repeated checking
 
-    cids = set(data.primary_components)
+    cids = set(data.main_components) + set(self.coordinate_components)
     cid_links = {}
     depth = {}
     for cid in cids:

--- a/glue/core/subset.py
+++ b/glue/core/subset.py
@@ -457,12 +457,8 @@ class Subset(object):
         return self.data.derived_components
 
     @property
-    def primary_components(self):
-        return self.data.primary_components
-
-    @property
-    def visible_components(self):
-        return self.data.visible_components
+    def main_components(self):
+        return self.data.main_components
 
     @property
     def pixel_component_ids(self):
@@ -487,6 +483,16 @@ class Subset(object):
     @property
     def hub(self):
         return self.data.hub
+
+    # DEPRECATED (warnings raised in Data)
+
+    @property
+    def primary_components(self):
+        return self.data.primary_components
+
+    @property
+    def visible_components(self):
+        return self.data.visible_components
 
 
 class SubsetState(object):

--- a/glue/core/tests/test_data.py
+++ b/glue/core/tests/test_data.py
@@ -142,7 +142,7 @@ class TestData(object):
         labels = 'asldfkjaAREGWoibasiwnsldkgajsldkgslkg'
         for label in labels:
             data.add_component(comp, label)
-        ids = data.visible_components
+        ids = data.main_components
         assert [cid.label for cid in ids] == list(labels)
 
     def test_broadcast(self):
@@ -617,7 +617,7 @@ def test_foreign_pixel_components_not_in_visible():
     dc.add_link(LinkSame(d1.world_component_ids[0],
                          d2.world_component_ids[0]))
 
-    assert d2.pixel_component_ids[0] not in d1.visible_components
+    assert d2.pixel_component_ids[0] not in d1.main_components
     np.testing.assert_array_equal(d1[d2.pixel_component_ids[0]], [0])
 
 
@@ -682,7 +682,7 @@ def test_update_values_from_data():
     assert d1b in d1.components
     assert d2b not in d1.components
     assert d2c not in d1.components
-    assert [cid.label for cid in d1.visible_components] == ['b', 'c']
+    assert [cid.label for cid in d1.main_components] == ['b', 'c']
     assert d1.shape == (4,)
 
 
@@ -723,7 +723,7 @@ def test_update_values_from_data_order():
 
     d2.update_values_from_data(d1)
 
-    assert [cid.label for cid in d2.visible_components] == ['j', 'a', 'c', 'b', 'f']
+    assert [cid.label for cid in d2.main_components] == ['j', 'a', 'c', 'b', 'f']
 
 
 def test_find_component_id_with_cid():

--- a/glue/core/tests/test_data.py
+++ b/glue/core/tests/test_data.py
@@ -165,19 +165,16 @@ class TestData(object):
         assert exc.value.args[0] == ("Data has already been assigned "
                                      "to a different hub")
 
-    def test_primary_components(self):
+    def test_main_components(self):
         compid = ComponentID('virtual')
         link = MagicMock(spec_set=ComponentLink)
         comp = DerivedComponent(self.data, link)
 
         self.data.add_component(comp, compid)
 
-        pricomps = self.data.primary_components
-        print(self.comp_id, compid, pricomps)
-        print(self.comp_id in pricomps)
-        print(compid not in pricomps)
-        assert self.comp_id in pricomps
-        assert compid not in pricomps
+        main_comps = self.data.main_components
+        assert self.comp_id in main_comps
+        assert compid not in main_comps
 
     def test_add_component_invalid_component(self):
         comp = Component(np.array([1]))

--- a/glue/core/tests/test_state_objects.py
+++ b/glue/core/tests/test_state_objects.py
@@ -74,8 +74,8 @@ class TestStateAttributeLimitsHelper():
         self.state.data = self.data
         self.state.comp = self.data.id['x']
 
-        self.x_id = self.data.visible_components[0]
-        self.y_id = self.data.visible_components[1]
+        self.x_id = self.data.main_components[0]
+        self.y_id = self.data.main_components[1]
 
     def test_minmax(self):
         assert self.helper.lower == -100
@@ -178,8 +178,8 @@ class TestStateAttributeSingleValueHelper():
 
         self.state.comp = self.data.id['x']
 
-        self.x_id = self.data.visible_components[0]
-        self.y_id = self.data.visible_components[1]
+        self.x_id = self.data.main_components[0]
+        self.y_id = self.data.main_components[1]
 
     def test_value(self):
         assert self.helper.value == -35.

--- a/glue/core/tests/test_subset.py
+++ b/glue/core/tests/test_subset.py
@@ -680,9 +680,8 @@ def test_inherited_properties():
 
     assert sub.component_ids() == d.component_ids()
     assert sub.components == d.components
+    assert sub.main_components == d.main_components
     assert sub.derived_components == d.derived_components
-    assert sub.primary_components == d.primary_components
-    assert sub.visible_components == d.visible_components
     assert sub.pixel_component_ids == d.pixel_component_ids
     assert sub.world_component_ids == d.world_component_ids
 

--- a/glue/dialogs/common/qt/component_selector.py
+++ b/glue/dialogs/common/qt/component_selector.py
@@ -91,15 +91,14 @@ class ComponentSelector(QtWidgets.QWidget):
                 c_list.addItem(item)
                 c_list.set_data(item, c)
 
-        if len(set(data.primary_components) - set(data.coordinate_components)) > 0:
+        if len(data.main_components) > 0:
             item = QtWidgets.QListWidgetItem('Main components')
             item.setFlags(item.flags() & ~Qt.ItemIsEnabled)
             c_list.addItem(item)
-            for c in data.primary_components:
-                if c not in data.coordinate_components:
-                    item = QtWidgets.QListWidgetItem(c.label)
-                    c_list.addItem(item)
-                    c_list.set_data(item, c)
+            for c in data.main_components:
+                item = QtWidgets.QListWidgetItem(c.label)
+                c_list.addItem(item)
+                c_list.set_data(item, c)
 
         if len(set(data.derived_components) & set(data.visible_components)) > 0:
             item = QtWidgets.QListWidgetItem('Derived components')

--- a/glue/dialogs/common/qt/component_selector.py
+++ b/glue/dialogs/common/qt/component_selector.py
@@ -100,7 +100,7 @@ class ComponentSelector(QtWidgets.QWidget):
                 c_list.addItem(item)
                 c_list.set_data(item, c)
 
-        if len(set(data.derived_components) & set(data.visible_components)) > 0:
+        if len(data.derived_components) > 0:
             item = QtWidgets.QListWidgetItem('Derived components')
             item.setFlags(item.flags() & ~Qt.ItemIsEnabled)
             c_list.addItem(item)

--- a/glue/dialogs/component_arithmetic/qt/equation_editor.py
+++ b/glue/dialogs/component_arithmetic/qt/equation_editor.py
@@ -125,7 +125,7 @@ class EquationEditorDialog(QtWidgets.QDialog):
             self.references = references
         elif data is not None:
             self.references = OrderedDict()
-            for cid in data.primary_components:
+            for cid in data.main_components:
                 self.references[cid.label] = cid
 
         example = sorted(self.references, key=len)[0]

--- a/glue/dialogs/component_arithmetic/qt/equation_editor.py
+++ b/glue/dialogs/component_arithmetic/qt/equation_editor.py
@@ -125,7 +125,7 @@ class EquationEditorDialog(QtWidgets.QDialog):
             self.references = references
         elif data is not None:
             self.references = OrderedDict()
-            for cid in data.main_components:
+            for cid in data.coordinate_components + data.main_components:
                 self.references[cid.label] = cid
 
         example = sorted(self.references, key=len)[0]

--- a/glue/viewers/histogram/qt/tests/test_data_viewer.py
+++ b/glue/viewers/histogram/qt/tests/test_data_viewer.py
@@ -205,7 +205,7 @@ class TestHistogramViewer(object):
         assert_allclose(self.viewer.layers[0].state.histogram[1], [0, 1, 2, 1])
         assert_allclose(self.viewer.layers[0].state.histogram[0], [-5, -2.5, 0, 2.5, 5])
 
-        cid = self.data.visible_components[0]
+        cid = self.data.main_components[0]
         self.data_collection.new_subset_group('subset 1', cid < 2)
 
         wait_for_layers(self.viewer)
@@ -410,13 +410,13 @@ class TestHistogramViewer(object):
 
         viewer_state.x_att = self.data.id['x']
 
-        cid = self.data.visible_components[0]
+        cid = self.data.main_components[0]
         self.data_collection.new_subset_group('subset 1', cid < 1)
 
-        cid = self.data.visible_components[0]
+        cid = self.data.main_components[0]
         self.data_collection.new_subset_group('subset 2', cid < 2)
 
-        cid = self.data.visible_components[0]
+        cid = self.data.main_components[0]
         self.data_collection.new_subset_group('subset 3', cid < 3)
 
         wait_for_layers(self.viewer)

--- a/glue/viewers/image/state.py
+++ b/glue/viewers/image/state.py
@@ -681,7 +681,7 @@ class ImageLayerState(BaseImageLayerState):
     def _update_attribute(self, *args):
         if self.layer is not None:
             self.attribute_att_helper.set_multiple_data([self.layer])
-            self.attribute = self.layer.visible_components[0]
+            self.attribute = self.layer.main_components[0]
 
     def _update_priority(self, name):
         if name == 'layer':

--- a/glue/viewers/matplotlib/qt/tests/test_data_viewer.py
+++ b/glue/viewers/matplotlib/qt/tests/test_data_viewer.py
@@ -65,7 +65,7 @@ class BaseTestMatplotlibDataViewer(object):
         self.viewer.register_to_hub(self.hub)
 
     def init_subset(self):
-        cid = self.data.visible_components[0]
+        cid = self.data.main_components[0]
         self.data_collection.new_subset_group('subset 1', cid > 0)
 
     @property
@@ -191,7 +191,7 @@ class BaseTestMatplotlibDataViewer(object):
         count_before = self.draw_count
 
         # Change the subset
-        cid = self.data.visible_components[0]
+        cid = self.data.main_components[0]
         self.data.subsets[0].subset_state = cid > 1
 
         # Make sure the figure has been redrawn
@@ -535,7 +535,7 @@ class BaseTestMatplotlibDataViewer(object):
         assert self.draw_count == 1
         data = Data(label=self.data.label)
         data.coords = self.data.coords
-        for cid in self.data.visible_components:
+        for cid in self.data.main_components:
             if self.data.get_kind(cid) == 'numerical':
                 data.add_component(self.data[cid] * 2, cid.label)
             else:

--- a/glue/viewers/table/qt/data_viewer.py
+++ b/glue/viewers/table/qt/data_viewer.py
@@ -34,7 +34,7 @@ class DataTableModel(QtCore.QAbstractTableModel):
             raise ValueError("Can only use Table widget for 1D data")
         self._table_viewer = table_viewer
         self._data = table_viewer.data
-        self.show_hidden = False
+        self.show_coords = False
         self.order = np.arange(self._data.shape[0])
 
     def data_changed(self):
@@ -45,10 +45,10 @@ class DataTableModel(QtCore.QAbstractTableModel):
 
     @property
     def columns(self):
-        if self.show_hidden:
+        if self.show_coords:
             return self._data.components
         else:
-            return self._data.visible_components
+            return self._data.main_components + self._data.derived_components
 
     def columnCount(self, index=None):
         return len(self.columns)

--- a/glue/viewers/table/qt/tests/test_data_viewer.py
+++ b/glue/viewers/table/qt/tests/test_data_viewer.py
@@ -26,11 +26,11 @@ class TestDataTableModel():
         assert self.model.columnCount() == 2
 
     def test_column_count_hidden(self):
-        self.model.show_hidden = True
+        self.model.show_coords = True
         assert self.model.columnCount() == 4
 
     def test_header_data(self):
-        for i, c in enumerate(self.data.visible_components):
+        for i, c in enumerate(self.data.main_components):
             result = self.model.headerData(i, Qt.Horizontal, Qt.DisplayRole)
             assert result == c.label
 
@@ -42,7 +42,7 @@ class TestDataTableModel():
         assert self.model.rowCount() == 4
 
     def test_data(self):
-        for i, c in enumerate(self.data.visible_components):
+        for i, c in enumerate(self.data.main_components):
             for j in range(self.data.size):
                 idx = self.model.index(j, i)
                 result = self.model.data(idx, Qt.DisplayRole)
@@ -52,7 +52,7 @@ class TestDataTableModel():
     def test_data_2d(self):
         self.data = Data(x=[[1, 2], [3, 4]], y=[[2, 3], [4, 5]])
         self.model = DataTableModel(self.data)
-        for i, c in enumerate(self.data.visible_components):
+        for i, c in enumerate(self.data.main_components):
             for j in range(self.data.size):
                 idx = self.model.index(j, i)
                 result = self.model.data(idx, Qt.DisplayRole)


### PR DESCRIPTION
There is a lot of duplication/overlap in the various component list properties, so deprecating two old ones that don't really make so much sense anymore.