### PR TITLE
Import WebEngine/WebKit before starting QApplication

### DIFF
--- a/glue/utils/qt/app.py
+++ b/glue/utils/qt/app.py
@@ -16,6 +16,13 @@ def get_qapp(icon_path=None):
 
     if qapp is None:
 
+        # Some Qt modules are picky in terms of being imported before the
+        # application is set up, so we import them here.
+        try:
+            from qtpy import QtWebEngineWidgets  # noqa
+        except ImportError:  # Not all PyQt installations have this module
+            pass
+
         qapp = QtWidgets.QApplication([''])
         qapp.setQuitOnLastWindowClosed(True)
 


### PR DESCRIPTION
This is to avoid an error if imported by plugins after QApplication has been started