### PR TITLE
Fix slicing of categorical_ndarray

### DIFF
--- a/glue/utils/array.py
+++ b/glue/utils/array.py
@@ -507,11 +507,18 @@ class categorical_ndarray(np.ndarray):
             result.categories = categories
         return result
 
+    def __array_finalize__(self, obj):
+        if isinstance(obj, categorical_ndarray):
+            self.categories = obj.categories
+
     def _update_categories_and_codes(self):
-        self._categories, self._codes = unique(self)
-        self._categories.setflags(write=False)
-        self._codes = self._codes.astype(float)
-        self._codes.setflags(write=False)
+        if hasattr(self, '_categories'):
+            self._codes = index_lookup(self, self._categories)
+        else:
+            self._categories, self._codes = unique(self)
+            self._categories.setflags(write=False)
+            self._codes = self._codes.astype(float)
+            self._codes.setflags(write=False)
 
     @property
     def categories(self):
@@ -522,7 +529,6 @@ class categorical_ndarray(np.ndarray):
     @categories.setter
     def categories(self, value):
         self._categories = value
-        self._codes = index_lookup(self, value)
 
     @property
     def codes(self):

--- a/glue/utils/tests/test_array.py
+++ b/glue/utils/tests/test_array.py
@@ -323,3 +323,16 @@ def test_categorical_ndarray():
 
     array.jitter(method=None)
     assert_equal(array.codes, [1, 0, np.nan, 0, 0, 1])
+
+
+def test_categorical_ndarray_slicing():
+
+    array = categorical_ndarray(['a', 'b', 'c', 'b', 'b', 'a'])
+    assert_equal(array, ['a', 'b', 'c', 'b', 'b', 'a'])
+    assert_equal(array.codes, [0, 1, 2, 1, 1, 0])
+    assert_equal(array.categories, ['a', 'b', 'c'])
+
+    subset = array[1:5]
+    assert_equal(subset, ['b', 'c', 'b', 'b'])
+    assert_equal(subset.codes, [1, 2, 1, 1])
+    assert_equal(subset.categories, ['a', 'b', 'c'])


### PR DESCRIPTION
Prior to this fix, codes were re-computed after slicing/masking, which meant that subsets didn't have the correct codes.

Fixes https://github.com/glue-viz/glue/issues/1790