### PR TITLE
Fixes related to Export Data dialog

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -56,6 +56,11 @@ v0.13.4 (unreleased)
 * Improve performance when updating links and changing attributes
   on subsets. [#1716]
 
+* Fix errors that happened when clicking on the 'Export Data' and
+  'Define arithmetic attributes' buttons when no data was present,
+  and fixed Qt errors that happened if the data collection changed
+  after the 'Export Data' dialog was opened. [#1795]
+
 * Fixed parsing of AVM meta-data from images. [#1732]
 
 v0.13.3 (unreleased)

--- a/glue/app/qt/application.py
+++ b/glue/app/qt/application.py
@@ -363,7 +363,6 @@ class GlueApplication(Application, QtWidgets.QMainWindow):
         self._button_link_data.setIcon(get_icon('glue_link'))
         self._button_link_data.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
         self._button_link_data.clicked.connect(self._set_up_links)
-        self._on_data_collection_change()
 
         self._data_toolbar.addWidget(self._button_link_data)
 
@@ -409,6 +408,8 @@ class GlueApplication(Application, QtWidgets.QMainWindow):
 
         self.addToolBar(self._data_toolbar)
 
+        self._on_data_collection_change()
+
         # Selection mode toolbar
 
         tbar = EditSubsetModeToolBar(parent=self)
@@ -452,7 +453,9 @@ class GlueApplication(Application, QtWidgets.QMainWindow):
         self._hub.subscribe(self, DataCollectionMessage, handler=self._on_data_collection_change)
 
     def _on_data_collection_change(self, *event):
+        self._button_save_data.setEnabled(len(self.data_collection) > 0)
         self._button_link_data.setEnabled(len(self.data_collection) > 1)
+        self._button_edit_components.setEnabled(len(self.data_collection) > 0)
 
     def keyPressEvent(self, event):
         if self.current_tab.activeSubWindow() and self.current_tab.activeSubWindow().widget():

--- a/glue/app/qt/save_data.py
+++ b/glue/app/qt/save_data.py
@@ -80,7 +80,7 @@ class SaveDataDialog(QDialog):
 
         self.ui = load_ui('save_data.ui', parent=self,
                           directory=os.path.dirname(__file__))
-        autoconnect_callbacks_to_qt(self.state, self)
+        autoconnect_callbacks_to_qt(self.state, self.ui)
 
         self.ui.button_cancel.clicked.connect(self.reject)
         self.ui.button_ok.clicked.connect(self.accept)

--- a/glue/core/data_combo_helper.py
+++ b/glue/core/data_combo_helper.py
@@ -374,18 +374,18 @@ class ComponentIDComboHelper(ComboHelper):
         self.choices = choices
 
     def _filter_msg(self, msg):
-        return msg.data in self._data or msg.sender in self._data_collection
+        return msg.sender in self._data
 
     def register_to_hub(self, hub):
         hub.subscribe(self, DataRenameComponentMessage,
                       handler=self._on_rename,
-                      filter=lambda msg: msg.sender in self._data)
+                      filter=self._filter_msg)
         hub.subscribe(self, DataReorderComponentMessage,
                       handler=self.refresh,
-                      filter=lambda msg: msg.sender in self._data)
+                      filter=self._filter_msg)
         hub.subscribe(self, ComponentsChangedMessage,
                       handler=self.refresh,
-                      filter=lambda msg: msg.sender in self._data)
+                      filter=self._filter_msg)
         if self._data_collection is not None:
             hub.subscribe(self, DataCollectionDeleteMessage,
                           handler=self._remove_data)
@@ -535,16 +535,22 @@ class ManualDataComboHelper(BaseDataComboHelper):
         self._datasets.remove(data)
         self.refresh()
 
+    def _remove_data_msg(self, msg):
+        self.remove_data(msg.data)
+
+    def _filter_msg(self, msg):
+        return msg.sender in self._datasets
+
     def register_to_hub(self, hub):
 
         super(ManualDataComboHelper, self).register_to_hub(hub)
 
         hub.subscribe(self, DataUpdateMessage,
                       handler=self._on_data_update,
-                      filter=lambda msg: msg.sender in self._datasets)
+                      filter=self._filter_msg)
         hub.subscribe(self, DataCollectionDeleteMessage,
-                      handler=lambda msg: self.remove_data(msg.data),
-                      filter=lambda msg: msg.sender is self._data_collection)
+                      handler=self._remove_data_msg,
+                      filter=self._filter_msg)
 
 
 class DataCollectionComboHelper(BaseDataComboHelper):
@@ -571,14 +577,17 @@ class DataCollectionComboHelper(BaseDataComboHelper):
 
         self.refresh()
 
+    def _filter_msg(self, msg):
+        return msg.sender in self._datasets
+
     def register_to_hub(self, hub):
         super(DataCollectionComboHelper, self).register_to_hub(hub)
         hub.subscribe(self, DataUpdateMessage,
                       handler=self._on_data_update,
-                      filter=lambda msg: msg.sender in self._datasets)
+                      filter=self._filter_msg)
         hub.subscribe(self, DataCollectionAddMessage,
                       handler=self.refresh,
-                      filter=lambda msg: msg.sender is self._datasets)
+                      filter=self._filter_msg)
         hub.subscribe(self, DataCollectionDeleteMessage,
                       handler=self.refresh,
-                      filter=lambda msg: msg.sender is self._datasets)
+                      filter=self._filter_msg)

--- a/glue/core/data_combo_helper.py
+++ b/glue/core/data_combo_helper.py
@@ -541,6 +541,9 @@ class ManualDataComboHelper(BaseDataComboHelper):
     def _filter_msg(self, msg):
         return msg.sender in self._datasets
 
+    def _filter_msg_dc(self, msg):
+        return msg.sender is self._data_collection
+
     def register_to_hub(self, hub):
 
         super(ManualDataComboHelper, self).register_to_hub(hub)
@@ -550,7 +553,7 @@ class ManualDataComboHelper(BaseDataComboHelper):
                       filter=self._filter_msg)
         hub.subscribe(self, DataCollectionDeleteMessage,
                       handler=self._remove_data_msg,
-                      filter=self._filter_msg)
+                      filter=self._filter_msg_dc)
 
 
 class DataCollectionComboHelper(BaseDataComboHelper):
@@ -577,17 +580,20 @@ class DataCollectionComboHelper(BaseDataComboHelper):
 
         self.refresh()
 
-    def _filter_msg(self, msg):
+    def _filter_msg_in(self, msg):
         return msg.sender in self._datasets
+
+    def _filter_msg_is(self, msg):
+        return msg.sender is self._datasets
 
     def register_to_hub(self, hub):
         super(DataCollectionComboHelper, self).register_to_hub(hub)
         hub.subscribe(self, DataUpdateMessage,
                       handler=self._on_data_update,
-                      filter=self._filter_msg)
+                      filter=self._filter_msg_in)
         hub.subscribe(self, DataCollectionAddMessage,
                       handler=self.refresh,
-                      filter=self._filter_msg)
+                      filter=self._filter_msg_is)
         hub.subscribe(self, DataCollectionDeleteMessage,
                       handler=self.refresh,
-                      filter=self._filter_msg)
+                      filter=self._filter_msg_is)

--- a/glue/external/echo/core.py
+++ b/glue/external/echo/core.py
@@ -188,6 +188,16 @@ class CallbackProperty(object):
         else:
             raise ValueError("Callback function not found: %s" % func)
 
+    def clear_callbacks(self, instance):
+        """
+        Remove all callbacks on this property.
+        """
+        for cb in [self._callbacks, self._2arg_callbacks]:
+            if instance in cb:
+                cb[instance].clear()
+        if instance in self._disabled:
+            self._disabled.pop(instance)
+
 
 class HasCallbackProperties(object):
     """
@@ -345,6 +355,14 @@ class HasCallbackProperties(object):
 
     def callback_properties(self):
         return [name for name in dir(self) if self.is_callback_property(name)]
+
+    def clear_callbacks(self):
+        """
+        Remove all global and property-specific callbacks.
+        """
+        self._global_callbacks.clear()
+        for name, prop in self.iter_callback_properties():
+            prop.clear_callbacks(self)
 
 
 def add_callback(instance, prop, callback, echo_old=False, priority=0):


### PR DESCRIPTION
This fixes issues when opening the 'Export Data' dialog when no data is present, and also when it is opened and the data collection is subsequently changed (which caused Qt errors due to circular references)