### PR TITLE
Fix default dataset in arithmetic and rename/reorder dialogs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -60,6 +60,9 @@ v0.13.4 (unreleased)
 
 * Always returned to last used folder when opening/saving files. [#1794]
 
+* Show correct dataset when using control-click to select to add
+  arithmetic attributes or rename/reorder components. [#1802]
+
 * Improve performance when updating links and changing attributes
   on subsets. [#1716]
 

--- a/glue/app/qt/application.py
+++ b/glue/app/qt/application.py
@@ -22,6 +22,7 @@ from glue.utils.qt import get_qapp
 from glue.app.qt.actions import action
 from glue.dialogs.data_wizard.qt import data_wizard
 from glue.dialogs.link_editor.qt import LinkEditor
+from glue.dialogs.component_arithmetic.qt import ArithmeticEditorWidget
 from glue.app.qt.edit_subset_mode_toolbar import EditSubsetModeToolBar
 from glue.app.qt.mdi_area import GlueMdiArea
 from glue.app.qt.layer_tree_widget import PlotAction, LayerTreeWidget
@@ -385,7 +386,7 @@ class GlueApplication(Application, QtWidgets.QMainWindow):
         self._button_edit_components.setText("Arithmetic attributes")
         self._button_edit_components.setIcon(get_icon('arithmetic'))
         self._button_edit_components.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
-        self._button_edit_components.clicked.connect(nonpartial(self._layer_widget._create_component))
+        self._button_edit_components.clicked.connect(self._artihmetic_dialog)
 
         self._data_toolbar.addWidget(self._button_edit_components)
 
@@ -443,6 +444,10 @@ class GlueApplication(Application, QtWidgets.QMainWindow):
         self._log.hide()
 
         self._hub.subscribe(self, DataCollectionMessage, handler=self._on_data_collection_change)
+
+    def _artihmetic_dialog(self, *event):
+        dialog = ArithmeticEditorWidget(self.data_collection)
+        dialog.exec_()
 
     def _on_data_collection_change(self, *event):
         self._button_save_data.setEnabled(len(self.data_collection) > 0)

--- a/glue/app/qt/layer_tree_widget.py
+++ b/glue/app/qt/layer_tree_widget.py
@@ -16,7 +16,6 @@ from glue.config import layer_action
 from glue import core
 from glue.dialogs.link_editor.qt import LinkEditor
 from glue.icons.qt import get_icon
-from glue.app.qt.actions import action
 from glue.dialogs.component_arithmetic.qt import ArithmeticEditorWidget
 from glue.dialogs.component_manager.qt import ComponentManagerWidget
 from glue.dialogs.subset_facet.qt import SubsetFacet
@@ -256,6 +255,40 @@ class ExportDataAction(LayerAction):
         data = self.selected_layers()[0]
         from glue.core.data_exporters.qt.dialog import export_data
         export_data(data)
+
+
+class ArithmeticAction(LayerAction):
+
+    _title = "Add/edit arithmetic attributes"
+    _tooltip = "Add/edit attributes derived from existing ones"
+
+    def _can_trigger(self):
+        return self.single_selection_data()
+
+    def _do_action(self):
+        assert self._can_trigger()
+        data = self.selected_layers()[0]
+        print(data.label)
+        dialog = ArithmeticEditorWidget(self._layer_tree.data_collection,
+                                        initial_data=data)
+        dialog.exec_()
+
+
+class ManageComponentsAction(LayerAction):
+
+    _title = "Reorder/rename data attributes"
+    _tooltip = "Reorder/rename data attributes"
+
+    def _can_trigger(self):
+        return self.single_selection_data()
+
+    def _do_action(self):
+        assert self._can_trigger()
+        data = self.selected_layers()[0]
+        print(data.label)
+        dialog = ComponentManagerWidget(self._layer_tree.data_collection,
+                                        initial_data=data)
+        dialog.exec_()
 
 
 class ExportSubsetAction(ExportDataAction):
@@ -549,14 +582,6 @@ class LayerTreeWidget(QtWidgets.QMainWindow, HubListener):
         mode = self.session.edit_subset_mode
         mode.edit_subset = [s for s in self.selected_layers() if isinstance(s, core.SubsetGroup)]
 
-    def _create_component(self):
-        dialog = ArithmeticEditorWidget(self.data_collection)
-        dialog.exec_()
-
-    def _manage_components(self):
-        dialog = ComponentManagerWidget(self.data_collection)
-        dialog.exec_()
-
     def _create_actions(self):
         tree = self.ui.layerTree
 
@@ -582,22 +607,8 @@ class LayerTreeWidget(QtWidgets.QMainWindow, HubListener):
         self._actions['merge'] = MergeAction(self)
         self._actions['maskify'] = MaskifySubsetAction(self)
         self._actions['link'] = LinkAction(self)
-
-        sep = QtWidgets.QAction("", tree)
-        sep.setSeparator(True)
-        tree.addAction(sep)
-
-        a = action("Add/edit arithmetic attributes", self,
-                   tip="Add/edit attributes derived from existing ones")
-        tree.addAction(a)
-        a.triggered.connect(nonpartial(self._create_component))
-        self._actions['new_component'] = a
-
-        a = action("Reorder/rename data attributes", self,
-                   tip="Reorder/rename data attributes")
-        tree.addAction(a)
-        a.triggered.connect(nonpartial(self._manage_components))
-        self._actions['manage_components'] = a
+        self._actions['new_component'] = ArithmeticAction(self)
+        self._actions['manage_components'] = ManageComponentsAction(self)
 
         # Add user-defined layer actions. Note that _asdict is actually a public
         # method, but just has an underscore to prevent conflict with

--- a/glue/dialogs/component_arithmetic/qt/component_arithmetic.py
+++ b/glue/dialogs/component_arithmetic/qt/component_arithmetic.py
@@ -22,7 +22,7 @@ class ArithmeticEditorWidget(QtWidgets.QDialog):
 
     data = SelectionCallbackProperty()
 
-    def __init__(self, data_collection=None, parent=None):
+    def __init__(self, data_collection=None, initial_data=None, parent=None):
 
         super(ArithmeticEditorWidget, self).__init__(parent=parent)
 
@@ -67,7 +67,11 @@ class ArithmeticEditorWidget(QtWidgets.QDialog):
         ArithmeticEditorWidget.data.set_display_func(self, lambda x: x.label)
         connect_combo_selection(self, 'data', self.ui.combosel_data)
 
-        self.ui.combosel_data.setCurrentIndex(0)
+        if initial_data is None:
+            self.ui.combosel_data.setCurrentIndex(0)
+        else:
+            self.data = initial_data
+
         self.ui.combosel_data.currentIndexChanged.connect(self._update_component_lists)
         self._update_component_lists()
 

--- a/glue/dialogs/component_manager/qt/component_manager.py
+++ b/glue/dialogs/component_manager/qt/component_manager.py
@@ -17,7 +17,7 @@ class ComponentManagerWidget(QtWidgets.QDialog):
 
     data = SelectionCallbackProperty()
 
-    def __init__(self, data_collection=None, parent=None):
+    def __init__(self, data_collection=None, initial_data=None, parent=None):
 
         super(ComponentManagerWidget, self).__init__(parent=parent)
 
@@ -55,7 +55,11 @@ class ComponentManagerWidget(QtWidgets.QDialog):
         ComponentManagerWidget.data.set_display_func(self, lambda x: x.label)
         connect_combo_selection(self, 'data', self.ui.combosel_data)
 
-        self.ui.combosel_data.setCurrentIndex(0)
+        if initial_data is None:
+            self.ui.combosel_data.setCurrentIndex(0)
+        else:
+            self.data = initial_data
+
         self.ui.combosel_data.currentIndexChanged.connect(self._update_component_lists)
         self._update_component_lists()
 


### PR DESCRIPTION
Make it so that when control-clicking on datasets to open the dialogs to create arithmetic attributes or rename/reorder components, the selected dataset is shown

Fixes https://github.com/glue-viz/glue/issues/1725