### PR TITLE
Use fast-histogram instead of np.histogram

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,9 @@ v0.14.0 (unreleased)
 
 * Deprecated ``Data.visible_components`` and ``Data.primary_components``. [#1788]
 
+* Speed up histogram calculations by using the fast-histogram package instead of
+  np.histogram. [#1806]
+
 * In the case of categorical attributes, ``Data[name]`` now returns a
   ``categorical_ndarray`` object rather than the indices of the categories. You
   can access the indices with ``Data[name].codes`` and the unique categories

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -9,6 +9,8 @@ import warnings
 import numpy as np
 import pandas as pd
 
+from fast_histogram import histogram1d
+
 from glue.external import six
 from glue.core.message import (DataUpdateMessage, DataRemoveComponentMessage,
                                DataAddComponentMessage, NumericalDataChangedMessage,
@@ -1559,12 +1561,17 @@ class Data(BaseCartesianData):
             return np.zeros(bins)
 
         if log:
-            range = None
-            bins = np.logspace(np.log10(xmin), np.log10(xmax), bins + 1)
-        else:
-            range = (xmin, xmax)
+            xmin = np.log10(xmin)
+            xmax = np.log10(xmax)
+            x = np.log10(x)
 
-        return np.histogram(x, range=range, bins=bins, weights=w)[0]
+        # By default fast-histogram drops values that are exactly xmax, so we
+        # increase xmax very slightly to make sure that this doesn't happen
+        xmax += 10 * np.spacing(xmax)
+
+        range = (xmin, xmax)
+
+        return histogram1d(x, range=range, bins=bins, weights=w)
 
     # DEPRECATED
 

--- a/glue/viewers/histogram/qt/tests/test_data_viewer.py
+++ b/glue/viewers/histogram/qt/tests/test_data_viewer.py
@@ -412,14 +412,14 @@ class TestHistogramViewer(object):
         self.viewer.add_data(self.data)
 
         viewer_state.x_att = self.data.id['y']
-        viewer_state.hist_x_min = -10
+        viewer_state.hist_x_min = -10.1
         viewer_state.hist_x_max = +10
         viewer_state.hist_n_bin = 5
 
         assert_allclose(self.viewer.layers[0].state.histogram[1], [0, 0, 3, 1, 0])
 
         viewer_state.x_att = self.data.id['x']
-        viewer_state.hist_x_min = -10
+        viewer_state.hist_x_min = -10.1
         viewer_state.hist_x_max = +10
         viewer_state.hist_n_bin = 5
 


### PR DESCRIPTION
Closes https://github.com/glue-viz/glue/issues/1462
Closes https://github.com/glue-viz/glue/issues/1701 (which was related to np.histogram)
