### PR TITLE
Don't add Data when adding Subset to a viewer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,10 @@ v0.14.0 (unreleased)
 
   - ``glue.viewers.common.qt.DataViewerWithState`` is now deprecated.
 
+* Make it so that adding a subset to a viewer no longer adds the
+  associated data, since in some cases the viewer can handle the
+  subset size, but not the full data. [#1807]
+
 * Defined a new abstract base class for all datasets, ``BaseData``,
   and a base class ``BaseCartesianData``,
   which can be used to implement interfaces to datasets that may be

--- a/glue/app/qt/mdi_area.py
+++ b/glue/app/qt/mdi_area.py
@@ -52,9 +52,7 @@ class GlueMdiArea(QtWidgets.QMdiArea):
             application = self._application()
             if application is None:
                 return
-            if isinstance(layer, core.subset.Subset):
-                application.choose_new_data_viewer(layer.data)
-            elif isinstance(layer, core.data.BaseData):
+            if isinstance(layer, (core.data.BaseData, core.subset.Subset)):
                 application.choose_new_data_viewer(layer)
             else:
                 raise TypeError("Expected a Data or Subset, got {0}".format(type(layer)))

--- a/glue/core/application_base.py
+++ b/glue/core/application_base.py
@@ -4,6 +4,7 @@ import os
 import traceback
 from functools import wraps
 
+from glue.core.data import Data, Subset
 from glue.external.six import string_types
 from glue.core.session import Session
 from glue.core.hub import HubListener
@@ -80,9 +81,14 @@ class Application(HubListener):
         c = viewer_class(self._session)
         c.register_to_hub(self._session.hub)
 
-        if data and not c.add_data(data):
-            c.close(warn=False)
-            return
+        if data is not None:
+            if isinstance(data, Data):
+                result = c.add_data(data)
+            elif isinstance(data, Subset):
+                result = c.add_subset(data)
+            if not result:
+                c.close(warn=False)
+                return
 
         self.add_widget(c)
         c.show()

--- a/glue/viewers/common/viewer.py
+++ b/glue/viewers/common/viewer.py
@@ -218,12 +218,6 @@ class Viewer(BaseViewer):
         if not self.allow_duplicate_subset and subset in self._layer_artist_container:
             return True
 
-        # Make sure we add the data first if it doesn't already exist in viewer.
-        # This will then auto add the subsets so can just return.
-        if subset.data not in self._layer_artist_container:
-            self.add_data(subset.data)
-            return
-
         # Create scatter layer artist and add to container
         layer = self.get_subset_layer_artist(subset)
         self._layer_artist_container.append(layer)

--- a/glue/viewers/matplotlib/qt/data_viewer.py
+++ b/glue/viewers/matplotlib/qt/data_viewer.py
@@ -158,12 +158,6 @@ class MatplotlibDataViewer(DataViewer):
         # If we get here, the computation has stopped so we can stop the timer
         self._monitor_computation.stop()
 
-    def add_data(self, *args, **kwargs):
-        return super(MatplotlibDataViewer, self).add_data(*args, **kwargs)
-
-    def add_subset(self, *args, **kwargs):
-        return super(MatplotlibDataViewer, self).add_subset(*args, **kwargs)
-
     def update_x_axislabel(self, *event):
         self.axes.set_xlabel(self.state.x_axislabel,
                              weight=self.state.x_axislabel_weight,

--- a/glue/viewers/matplotlib/qt/tests/test_data_viewer.py
+++ b/glue/viewers/matplotlib/qt/tests/test_data_viewer.py
@@ -123,21 +123,6 @@ class BaseTestMatplotlibDataViewer(object):
         assert self.viewer.state.layers[0].layer is self.data
         assert self.viewer.state.layers[1].layer is self.data.subsets[0]
 
-    def test_adding_subset_adds_data(self):
-
-        # TODO: in future consider whether we want to deprecate this behavior
-
-        self.init_subset()
-        self.viewer.add_subset(self.data.subsets[0])
-
-        assert len(self.viewer.layers) == 2
-        assert self.viewer.layers[0].layer is self.data
-        assert self.viewer.layers[1].layer is self.data.subsets[0]
-
-        assert len(self.viewer.state.layers) == 2
-        assert self.viewer.state.layers[0].layer is self.data
-        assert self.viewer.state.layers[1].layer is self.data.subsets[0]
-
     def test_add_data_then_subset(self):
 
         # Make sure that if a subset is created in a dataset that has already


### PR DESCRIPTION
This behavior doesn't actually make sense because if a user dragged a subset explicitly they probably really meant that - not to add the data. Adding the data and subsets can be done by dragging the data onto a viewer.