### PR TITLE
Don't import QtWebEngineWidgets by default before starting QApplication

### DIFF
--- a/glue/utils/qt/app.py
+++ b/glue/utils/qt/app.py
@@ -16,12 +16,11 @@ def get_qapp(icon_path=None):
 
     if qapp is None:
 
-        # Some Qt modules are picky in terms of being imported before the
-        # application is set up, so we import them here.
-        try:
-            from qtpy import QtWebEngineWidgets  # noqa
-        except ImportError:  # Not all PyQt installations have this module
-            pass
+        # NOTE: plugins that need WebEngine may complain that QtWebEngineWidgets
+        # needs to be imported before QApplication is constructed, but this can
+        # cause segmentation faults to crop up under certain conditions, so we
+        # don't do it here and instead ask that the plugins do it in their
+        # main __init__.py (which should get executed before glue is launched).
 
         qapp = QtWidgets.QApplication([''])
         qapp.setQuitOnLastWindowClosed(True)


### PR DESCRIPTION
This tries to revert https://github.com/glue-viz/glue/pull/1789, which is responsible for segmentation faults over at the 3D viewer CI.

Importing QtWebEngineWidgets will be left up to the plugins as it is flakey and we don't want to always do it by default (it can cause segmentation faults under certain circumstances)