### PR TITLE
Fix HDF5 reader for string columns

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -74,6 +74,8 @@ v0.14.0 (unreleased)
 v0.13.4 (unreleased)
 --------------------
 
+* Fix HDF5 reader for string columns. [#1840]
+
 * Fix visual bug in link editor in advanced mode when resizing window. [#1837]
 
 * Fixed a bug that caused custom data importers to no longer work. [#1813]

--- a/glue/core/data_factories/hdf5.py
+++ b/glue/core/data_factories/hdf5.py
@@ -40,7 +40,7 @@ def extract_hdf5_datasets(filename, memmap=True):
     def visitor(name, item):
         if isinstance(item, h5py.Dataset):
             full_path = item.name
-            if item.dtype.kind in ('f', 'i'):
+            if item.dtype.kind in ('f', 'i', 'S'):
                 offset = item.id.get_offset()
                 # If an offset is available, the data is contiguous and we can
                 # use memory mapping for efficiency.

--- a/glue/core/util.py
+++ b/glue/core/util.py
@@ -327,7 +327,11 @@ def tick_linker(all_categories, pos, *args):
     else:
         try:
             pos = np.round(pos)
-            return all_categories[int(pos)]
+            label = all_categories[int(pos)]
+            if isinstance(label, bytes):
+                return label.decode('ascii')
+            else:
+                return label
         except IndexError:
             return ''
 


### PR DESCRIPTION
Note: The strings show up as byte strings in plots (with the ``b`` prefix) so we may want to consider fixing that.