### PR TITLE
Refactor Matplotlib-based viewers to make code re-usable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -71,6 +71,9 @@ v0.14.0 (unreleased)
 
 * Don't show layer edit options if layer is not visible. [#1805]
 
+* Make the Matplotlib viewer code that doesn't depend on Qt accessible
+  to non-Qt frontends. [#1841]
+
 v0.13.4 (unreleased)
 --------------------
 

--- a/glue/app/qt/tests/test_application.py
+++ b/glue/app/qt/tests/test_application.py
@@ -228,11 +228,9 @@ class TestGlueApplication(object):
         m = QtCore.QMimeData()
         m.setUrls([QtCore.QUrl('test.glu'), QtCore.QUrl('test.fits')])
         e.mimeData.return_value = m
-        with patch('qtpy.QtWidgets.QMessageBox') as mb:
+        with pytest.raises(Exception) as exc:
             self.app.dropEvent(e)
-            assert mb.call_count == 1
-            assert "When dragging and dropping files" in mb.call_args[0][2]
-            mb.reset_mock()
+        assert exc.value.args[0].startswith("When dragging and dropping files")
 
         load_data.reset_mock()
 

--- a/glue/utils/qt/decorators.py
+++ b/glue/utils/qt/decorators.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+import os
 import sys
 import traceback
 from contextlib import contextmanager
@@ -51,6 +52,11 @@ def messagebox_on_error(msg, sep='\n'):
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
+
+            # If we are in glue testing mode, don't show GUI errors
+            if os.environ.get("GLUE_TESTING") == 'True':
+                return func(*args, **kwargs)
+
             try:
                 return func(*args, **kwargs)
             except Exception as e:

--- a/glue/utils/qt/tests/test_decorators.py
+++ b/glue/utils/qt/tests/test_decorators.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+import os
 from mock import patch
 
 from ..decorators import messagebox_on_error
@@ -7,9 +8,13 @@ from ..decorators import messagebox_on_error
 
 def test_messagebox_on_error():
 
+    os.environ['GLUE_TESTING'] = 'False'
+
     @messagebox_on_error('an error occurred')
     def failing_function():
         raise ValueError("Dialog failure")
 
     with patch('qtpy.QtWidgets.QMessageBox.exec_'):
         failing_function()
+
+    os.environ['GLUE_TESTING'] = 'True'

--- a/glue/viewers/common/qt/data_viewer.py
+++ b/glue/viewers/common/qt/data_viewer.py
@@ -232,8 +232,8 @@ class DataViewer(Viewer, BaseQtViewerWidget):
 
     @messagebox_on_error("Failed to add data")
     def add_data(self, data):
-        super(DataViewer, self).add_data(data)
+        return super(DataViewer, self).add_data(data)
 
     @messagebox_on_error("Failed to add subset")
-    def add_subset(self, data):
-        super(DataViewer, self).add_subset(data)
+    def add_subset(self, subset):
+        return super(DataViewer, self).add_subset(subset)

--- a/glue/viewers/common/qt/data_viewer.py
+++ b/glue/viewers/common/qt/data_viewer.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 from qtpy.QtCore import Qt
 from qtpy import QtWidgets
 from glue.core.qt.layer_artist_model import QtLayerArtistContainer, LayerArtistWidget
-from glue.utils.qt import set_cursor
+from glue.utils.qt import set_cursor, messagebox_on_error
 from glue.external import six
 from glue.core.qt.dialogs import warn
 from glue.utils.noconflict import classmaker
@@ -229,3 +229,11 @@ class DataViewer(Viewer, BaseQtViewerWidget):
         viewer.move(x=x, y=y)
 
         return viewer
+
+    @messagebox_on_error("Failed to add data")
+    def add_data(self, data):
+        super(DataViewer, self).add_data(data)
+
+    @messagebox_on_error("Failed to add subset")
+    def add_subset(self, data):
+        super(DataViewer, self).add_subset(data)

--- a/glue/viewers/common/viewer.py
+++ b/glue/viewers/common/viewer.py
@@ -15,6 +15,7 @@ from glue.core import message as msg
 from glue.core.exceptions import IncompatibleDataException
 from glue.core.state import lookup_class_with_patches
 from glue.external.echo import delay_callback
+from glue.core.layer_artist import LayerArtistContainer
 
 from glue.viewers.common.state import ViewerState
 
@@ -112,7 +113,7 @@ class Viewer(BaseViewer):
     """
 
     # The LayerArtistContainer class/subclass to use
-    _layer_artist_container_cls = None
+    _layer_artist_container_cls = LayerArtistContainer
 
     # The state class/subclass to use
     _state_cls = ViewerState

--- a/glue/viewers/common/viewer.py
+++ b/glue/viewers/common/viewer.py
@@ -58,7 +58,7 @@ class BaseViewer(HubListener):
     def add_data(self, data):
         raise NotImplementedError()
 
-    def add_subset(self, data):
+    def add_subset(self, subset):
         raise NotImplementedError()
 
     def __str__(self):

--- a/glue/viewers/histogram/qt/data_viewer.py
+++ b/glue/viewers/histogram/qt/data_viewer.py
@@ -1,27 +1,26 @@
 from __future__ import absolute_import, division, print_function
 
-from glue.core.util import update_ticks
-from glue.core.roi import RangeROI
-from glue.core.subset import roi_to_subset_state
-from glue.utils import mpl_to_datetime64, defer_draw, decorate_all_methods
-
+from glue.utils import defer_draw, decorate_all_methods
 from glue.viewers.matplotlib.qt.data_viewer import MatplotlibDataViewer
 from glue.viewers.histogram.qt.layer_style_editor import HistogramLayerStyleEditor
-from glue.viewers.histogram.layer_artist import HistogramLayerArtist
 from glue.viewers.histogram.qt.options_widget import HistogramOptionsWidget
+from glue.viewers.histogram.layer_artist import HistogramLayerArtist
 from glue.viewers.histogram.state import HistogramViewerState
-from glue.viewers.histogram.compat import update_histogram_viewer_state
+
+from glue.viewers.histogram.viewer import MatplotlibHistogramMixin
 
 __all__ = ['HistogramViewer']
 
 
 @decorate_all_methods(defer_draw)
-class HistogramViewer(MatplotlibDataViewer):
+class HistogramViewer(MatplotlibHistogramMixin, MatplotlibDataViewer):
 
     LABEL = '1D Histogram'
+
     _layer_style_widget_cls = HistogramLayerStyleEditor
-    _state_cls = HistogramViewerState
     _options_cls = HistogramOptionsWidget
+
+    _state_cls = HistogramViewerState
     _data_artist_cls = HistogramLayerArtist
     _subset_artist_cls = HistogramLayerArtist
 
@@ -30,65 +29,5 @@ class HistogramViewer(MatplotlibDataViewer):
     tools = ['select:xrange']
 
     def __init__(self, session, parent=None, state=None):
-        super(HistogramViewer, self).__init__(session, parent, state=state)
-        self.state.add_callback('x_att', self._update_axes)
-        self.state.add_callback('x_log', self._update_axes)
-        self.state.add_callback('normalize', self._update_axes)
-
-    def _update_axes(self, *args):
-
-        if self.state.x_att is not None:
-
-            # Update ticks, which sets the labels to categories if components are categorical
-            update_ticks(self.axes, 'x', self.state.x_kinds, self.state.x_log, self.state.x_categories)
-
-            if self.state.x_log:
-                self.state.x_axislabel = 'Log ' + self.state.x_att.label
-            else:
-                self.state.x_axislabel = self.state.x_att.label
-
-        if self.state.normalize:
-            self.state.y_axislabel = 'Normalized number'
-        else:
-            self.state.y_axislabel = 'Number'
-
-        self.axes.figure.canvas.draw()
-
-    @defer_draw
-    def apply_roi(self, roi, override_mode=None):
-
-        # Force redraw to get rid of ROI. We do this because applying the
-        # subset state below might end up not having an effect on the viewer,
-        # for example there may not be any layers, or the active subset may not
-        # be one of the layers. So we just explicitly redraw here to make sure
-        # a redraw will happen after this method is called.
-        self.redraw()
-
-        if len(self.layers) == 0:
-            return
-
-        x_date = 'datetime' in self.state.x_kinds
-
-        if x_date:
-            roi = roi.transformed(xfunc=mpl_to_datetime64 if x_date else None)
-
-        bins = self.state.bins
-
-        x = roi.to_polygon()[0]
-        lo, hi = min(x), max(x)
-
-        if lo >= bins.min():
-            lo = bins[bins <= lo].max()
-        if hi <= bins.max():
-            hi = bins[bins >= hi].min()
-
-        roi_new = RangeROI(min=lo, max=hi, orientation='x')
-
-        subset_state = roi_to_subset_state(roi_new, x_att=self.state.x_att,
-                                           x_categories=self.state.x_categories)
-
-        self.apply_subset_state(subset_state, override_mode=override_mode)
-
-    @staticmethod
-    def update_viewer_state(rec, context):
-        return update_histogram_viewer_state(rec, context)
+        super(HistogramViewer, self).__init__(session, parent=parent, state=state)
+        MatplotlibHistogramMixin.setup_callbacks(self)

--- a/glue/viewers/histogram/viewer.py
+++ b/glue/viewers/histogram/viewer.py
@@ -10,7 +10,7 @@ from glue.viewers.histogram.compat import update_histogram_viewer_state
 __all__ = ['MatplotlibHistogramMixin']
 
 
-class MatplotlibHistogramMixin:
+class MatplotlibHistogramMixin(object):
 
     def setup_callbacks(self):
         self.state.add_callback('x_att', self._update_axes)

--- a/glue/viewers/histogram/viewer.py
+++ b/glue/viewers/histogram/viewer.py
@@ -1,0 +1,75 @@
+from __future__ import absolute_import, division, print_function
+
+from glue.core.util import update_ticks
+from glue.core.roi import RangeROI
+from glue.core.subset import roi_to_subset_state
+from glue.utils import mpl_to_datetime64
+
+from glue.viewers.histogram.compat import update_histogram_viewer_state
+
+__all__ = ['MatplotlibHistogramMixin']
+
+
+class MatplotlibHistogramMixin:
+
+    def setup_callbacks(self):
+        self.state.add_callback('x_att', self._update_axes)
+        self.state.add_callback('x_log', self._update_axes)
+        self.state.add_callback('normalize', self._update_axes)
+
+    def _update_axes(self, *args):
+
+        if self.state.x_att is not None:
+
+            # Update ticks, which sets the labels to categories if components are categorical
+            update_ticks(self.axes, 'x', self.state.x_kinds, self.state.x_log, self.state.x_categories)
+
+            if self.state.x_log:
+                self.state.x_axislabel = 'Log ' + self.state.x_att.label
+            else:
+                self.state.x_axislabel = self.state.x_att.label
+
+        if self.state.normalize:
+            self.state.y_axislabel = 'Normalized number'
+        else:
+            self.state.y_axislabel = 'Number'
+
+        self.axes.figure.canvas.draw()
+
+    def apply_roi(self, roi, override_mode=None):
+
+        # Force redraw to get rid of ROI. We do this because applying the
+        # subset state below might end up not having an effect on the viewer,
+        # for example there may not be any layers, or the active subset may not
+        # be one of the layers. So we just explicitly redraw here to make sure
+        # a redraw will happen after this method is called.
+        self.redraw()
+
+        if len(self.layers) == 0:
+            return
+
+        x_date = 'datetime' in self.state.x_kinds
+
+        if x_date:
+            roi = roi.transformed(xfunc=mpl_to_datetime64 if x_date else None)
+
+        bins = self.state.bins
+
+        x = roi.to_polygon()[0]
+        lo, hi = min(x), max(x)
+
+        if lo >= bins.min():
+            lo = bins[bins <= lo].max()
+        if hi <= bins.max():
+            hi = bins[bins >= hi].min()
+
+        roi_new = RangeROI(min=lo, max=hi, orientation='x')
+
+        subset_state = roi_to_subset_state(roi_new, x_att=self.state.x_att,
+                                           x_categories=self.state.x_categories)
+
+        self.apply_subset_state(subset_state, override_mode=override_mode)
+
+    @staticmethod
+    def update_viewer_state(rec, context):
+        return update_histogram_viewer_state(rec, context)

--- a/glue/viewers/image/layer_artist.py
+++ b/glue/viewers/image/layer_artist.py
@@ -247,7 +247,7 @@ class ImageSubsetArray(object):
             self.layer_artist.disable_incompatible_subset()
             return broadcast_to(np.nan, self.shape)
         else:
-            self.layer_artist.enable()
+            self.layer_artist.enable(redraw=False)
 
         r, g, b = color2rgb(self.layer_state.color)
         mask = np.dstack((r * mask, g * mask, b * mask, mask * .5))
@@ -306,10 +306,9 @@ class ImageSubsetLayerArtist(BaseImageLayerArtist):
             self._line_x.set_visible(False)
             self._line_y.set_visible(False)
         self.image_artist.invalidate_cache()
-        self.redraw()  # forces subset to be recomputed
 
     @defer_draw
-    def _update_visual_attributes(self):
+    def _update_visual_attributes(self, redraw=True):
 
         if not self.enabled:
             return
@@ -327,7 +326,8 @@ class ImageSubsetLayerArtist(BaseImageLayerArtist):
                 artist.set_alpha(self.state.alpha * 0.5)
             artist.set_zorder(self.state.zorder)
 
-        self.redraw()
+        if redraw:
+            self.redraw()
 
     def _update_image(self, force=False, **kwargs):
 
@@ -368,14 +368,14 @@ class ImageSubsetLayerArtist(BaseImageLayerArtist):
         super(ImageSubsetLayerArtist, self).remove()
         self.image_artist.invalidate_cache()
 
-    def enable(self):
+    def enable(self, redraw=True):
         super(ImageSubsetLayerArtist, self).enable()
         # We need to now ensure that image_artist, which may have been marked
         # as not being visible when the layer was cleared is made visible
         # again.
         if hasattr(self, 'image_artist'):
             self.image_artist.invalidate_cache()
-            self._update_visual_attributes()
+            self._update_visual_attributes(redraw=redraw)
 
     @defer_draw
     def update(self, *event):

--- a/glue/viewers/image/qt/data_viewer.py
+++ b/glue/viewers/image/qt/data_viewer.py
@@ -46,3 +46,9 @@ class ImageViewer(MatplotlibImageMixin, MatplotlibDataViewer):
     def __init__(self, session, parent=None, state=None):
         MatplotlibDataViewer.__init__(self, session, wcs=True, parent=parent, state=state)
         MatplotlibImageMixin.setup_callbacks(self)
+
+    def closeEvent(self, *args):
+        super(ImageViewer, self).closeEvent(*args)
+        if self.axes._composite_image is not None:
+            self.axes._composite_image.remove()
+            self.axes._composite_image = None

--- a/glue/viewers/image/qt/data_viewer.py
+++ b/glue/viewers/image/qt/data_viewer.py
@@ -1,14 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-import os
-
-from astropy.wcs import WCS
-
-from qtpy.QtWidgets import QMessageBox
-
-from glue.core.subset import roi_to_subset_state
-from glue.core.coordinates import Coordinates
-
 from glue.viewers.matplotlib.qt.data_viewer import MatplotlibDataViewer
 from glue.viewers.scatter.qt.layer_style_editor import ScatterLayerStyleEditor
 from glue.viewers.scatter.layer_artist import ScatterLayerArtist
@@ -18,41 +9,20 @@ from glue.viewers.image.layer_artist import ImageLayerArtist, ImageSubsetLayerAr
 from glue.viewers.image.qt.options_widget import ImageOptionsWidget
 from glue.viewers.image.qt.mouse_mode import RoiClickAndDragMode
 from glue.viewers.image.state import ImageViewerState
-from glue.viewers.image.compat import update_image_viewer_state
 from glue.utils import defer_draw, decorate_all_methods
-
-from glue.external.modest_image import imshow
-from glue.viewers.image.composite_array import CompositeArray
 
 # Import the mouse mode to make sure it gets registered
 from glue.viewers.image.qt.contrast_mouse_mode import ContrastBiasMode  # noqa
 from glue.viewers.image.qt.profile_viewer_tool import ProfileViewerTool  # noqa
 from glue.viewers.image.qt.pixel_selection_mode import PixelSelectionTool  # noqa
 
+from glue.viewers.image.viewer import MatplotlibImageMixin
+
 __all__ = ['ImageViewer']
 
 
-def get_identity_wcs(naxis):
-
-    wcs = WCS(naxis=naxis)
-    wcs.wcs.ctype = ['X'] * naxis
-    wcs.wcs.crval = [0.] * naxis
-    wcs.wcs.crpix = [1.] * naxis
-    wcs.wcs.cdelt = [1.] * naxis
-
-    return wcs
-
-
-EXTRA_FOOTER = """
-# Set tick label size - for now tick_params (called lower down) doesn't work
-# properly, but these lines won't be needed in future.
-ax.coords[{x_att_axis}].set_ticklabel(size={x_ticklabel_size})
-ax.coords[{y_att_axis}].set_ticklabel(size={y_ticklabel_size})
-""".strip()
-
-
 @decorate_all_methods(defer_draw)
-class ImageViewer(MatplotlibDataViewer):
+class ImageViewer(MatplotlibImageMixin, MatplotlibDataViewer):
 
     LABEL = '2D Image'
     _default_mouse_mode_cls = RoiClickAndDragMode
@@ -74,222 +44,5 @@ class ImageViewer(MatplotlibDataViewer):
              'profile-viewer']
 
     def __init__(self, session, parent=None, state=None):
-        self._wcs_set = False
-        self._changing_slice_requires_wcs_update = None
-        super(ImageViewer, self).__init__(session, parent=parent, wcs=True, state=state)
-        self.axes.set_adjustable('datalim')
-        self.state.add_callback('x_att', self._set_wcs)
-        self.state.add_callback('y_att', self._set_wcs)
-        self.state.add_callback('slices', self._on_slice_change)
-        self.state.add_callback('reference_data', self._set_wcs)
-        self.axes._composite = CompositeArray()
-        self.axes._composite_image = imshow(self.axes, self.axes._composite,
-                                            origin='lower', interpolation='nearest')
-        self._set_wcs()
-
-    def update_x_ticklabel(self, *event):
-        # We need to overload this here for WCSAxes
-        if self._wcs_set and self.state.x_att is not None:
-            axis = self.state.reference_data.ndim - self.state.x_att.axis - 1
-        else:
-            axis = 0
-        self.axes.coords[axis].set_ticklabel(size=self.state.x_ticklabel_size)
-        self.redraw()
-
-    def update_y_ticklabel(self, *event):
-        # We need to overload this here for WCSAxes
-        if self._wcs_set and self.state.y_att is not None:
-            axis = self.state.reference_data.ndim - self.state.y_att.axis - 1
-        else:
-            axis = 1
-        self.axes.coords[axis].set_ticklabel(size=self.state.y_ticklabel_size)
-        self.redraw()
-
-    def closeEvent(self, *args):
-        super(ImageViewer, self).closeEvent(*args)
-        if self.axes._composite_image is not None:
-            self.axes._composite_image.remove()
-            self.axes._composite_image = None
-
-    def _update_axes(self, *args):
-
-        if self.state.x_att_world is not None:
-            self.state.x_axislabel = self.state.x_att_world.label
-
-        if self.state.y_att_world is not None:
-            self.state.y_axislabel = self.state.y_att_world.label
-
-        self.axes.figure.canvas.draw()
-
-    def add_data(self, data):
-        result = super(ImageViewer, self).add_data(data)
-        # If this is the first layer (or the first after all layers were)
-        # removed, set the WCS for the axes.
-        if len(self.layers) == 1:
-            self._set_wcs()
-        return result
-
-    def _on_slice_change(self, event=None):
-        if self._changing_slice_requires_wcs_update:
-            self._set_wcs(event=event, relim=False)
-
-    def _set_wcs(self, event=None, relim=True):
-
-        if self.state.x_att is None or self.state.y_att is None or self.state.reference_data is None:
-            return
-
-        ref_coords = getattr(self.state.reference_data, 'coords', None)
-
-        if hasattr(ref_coords, 'wcs'):
-            self.axes.reset_wcs(slices=self.state.wcsaxes_slice, wcs=ref_coords.wcs)
-        elif hasattr(ref_coords, 'wcsaxes_dict'):
-            self.axes.reset_wcs(slices=self.state.wcsaxes_slice, **ref_coords.wcsaxes_dict)
-        else:
-            self.axes.reset_wcs(slices=self.state.wcsaxes_slice,
-                                wcs=get_identity_wcs(self.state.reference_data.ndim))
-
-        # Reset the axis labels to match the fact that the new axes have no labels
-        self.state.x_axislabel = ''
-        self.state.y_axislabel = ''
-
-        self._update_appearance_from_settings()
-        self._update_axes()
-
-        self.update_x_ticklabel()
-        self.update_y_ticklabel()
-
-        if relim:
-            self.state.reset_limits()
-
-        # Determine whether changing slices requires changing the WCS
-        if ref_coords is None or type(ref_coords) == Coordinates:
-            self._changing_slice_requires_wcs_update = False
-        else:
-            ix = self.state.x_att.axis
-            iy = self.state.y_att.axis
-            x_dep = list(ref_coords.dependent_axes(ix))
-            y_dep = list(ref_coords.dependent_axes(iy))
-            if ix in x_dep:
-                x_dep.remove(ix)
-            if iy in x_dep:
-                x_dep.remove(iy)
-            if ix in y_dep:
-                y_dep.remove(ix)
-            if iy in y_dep:
-                y_dep.remove(iy)
-            self._changing_slice_requires_wcs_update = bool(x_dep or y_dep)
-
-        self._wcs_set = True
-
-    @defer_draw
-    def apply_roi(self, roi, override_mode=None):
-
-        # Force redraw to get rid of ROI. We do this because applying the
-        # subset state below might end up not having an effect on the viewer,
-        # for example there may not be any layers, or the active subset may not
-        # be one of the layers. So we just explicitly redraw here to make sure
-        # a redraw will happen after this method is called.
-        self.redraw()
-
-        if len(self.layers) == 0:
-            return
-
-        if self.state.x_att is None or self.state.y_att is None or self.state.reference_data is None:
-            return
-
-        subset_state = roi_to_subset_state(roi,
-                                           x_att=self.state.x_att,
-                                           y_att=self.state.y_att)
-
-        self.apply_subset_state(subset_state, override_mode=override_mode)
-
-    def _scatter_artist(self, axes, state, layer=None, layer_state=None):
-        if len(self._layer_artist_container) == 0:
-            QMessageBox.critical(self, "Error", "Can only add a scatter plot "
-                                 "overlay once an image is present",
-                                 buttons=QMessageBox.Ok)
-            return None
-        return ScatterLayerArtist(axes, state, layer=layer, layer_state=None)
-
-    def get_data_layer_artist(self, layer=None, layer_state=None):
-        if layer.ndim == 1:
-            cls = self._scatter_artist
-        else:
-            cls = ImageLayerArtist
-        return self.get_layer_artist(cls, layer=layer, layer_state=layer_state)
-
-    def get_subset_layer_artist(self, layer=None, layer_state=None):
-        if layer.ndim == 1:
-            cls = self._scatter_artist
-        else:
-            cls = ImageSubsetLayerArtist
-        return self.get_layer_artist(cls, layer=layer, layer_state=layer_state)
-
-    @staticmethod
-    def update_viewer_state(rec, context):
-        return update_image_viewer_state(rec, context)
-
-    def show_crosshairs(self, x, y):
-
-        if getattr(self, '_crosshairs', None) is not None:
-            self._crosshairs.remove()
-
-        self._crosshairs, = self.axes.plot([x], [y], '+', ms=12,
-                                           mfc='none', mec='#d32d26',
-                                           mew=1, zorder=100)
-
-        self.axes.figure.canvas.draw()
-
-    def hide_crosshairs(self):
-        if getattr(self, '_crosshairs', None) is not None:
-            self._crosshairs.remove()
-            self._crosshairs = None
-            self.axes.figure.canvas.draw()
-
-    def update_aspect(self, aspect=None):
-        super(ImageViewer, self).update_aspect(aspect=aspect)
-        if self.state.reference_data is not None and self.state.x_att is not None and self.state.y_att is not None:
-            nx = self.state.reference_data.shape[self.state.x_att.axis]
-            ny = self.state.reference_data.shape[self.state.y_att.axis]
-            self.axes.set_xlim(-0.5, nx - 0.5)
-            self.axes.set_ylim(-0.5, ny - 0.5)
-            self.axes.figure.canvas.draw()
-
-    def _script_header(self):
-
-        imports = []
-        imports.append('import matplotlib.pyplot as plt')
-        imports.append('from glue.viewers.matplotlib.mpl_axes import init_mpl')
-        imports.append('from glue.viewers.image.composite_array import CompositeArray')
-        imports.append('from glue.external.modest_image import imshow')
-
-        script = ""
-        script += "fig, ax = init_mpl(wcs=True)\n"
-        script += "ax.set_aspect('{0}')\n".format(self.state.aspect)
-
-        script += '\ncomposite = CompositeArray()\n'
-        script += "image = imshow(ax, composite, origin='lower', interpolation='nearest', aspect='{0}')\n\n".format(self.state.aspect)
-
-        dindex = self.session.data_collection.index(self.state.reference_data)
-
-        script += "ref_data = data_collection[{0}]\n".format(dindex)
-
-        ref_coords = self.state.reference_data.coords
-
-        if hasattr(ref_coords, 'wcs'):
-            script += "ax.reset_wcs(slices={0}, wcs=ref_data.coords.wcs)\n".format(self.state.wcsaxes_slice)
-        elif hasattr(ref_coords, 'wcsaxes_dict'):
-            raise NotImplementedError()
-        else:
-            imports.append('from glue.viewers.image.qt.data_viewer import get_identity_wcs')
-            script += "ax.reset_wcs(slices={0}, wcs=get_identity_wcs(ref_data.ndim))\n".format(self.state.wcsaxes_slice)
-
-        return imports, script
-
-    def _script_footer(self):
-        imports, script = super(ImageViewer, self)._script_footer()
-        options = dict(x_att_axis=0 if self.state.x_att is None else self.state.reference_data.ndim - self.state.x_att.axis - 1,
-                       y_att_axis=1 if self.state.y_att is None else self.state.reference_data.ndim - self.state.y_att.axis - 1,
-                       x_ticklabel_size=self.state.x_ticklabel_size,
-                       y_ticklabel_size=self.state.y_ticklabel_size)
-        return [], EXTRA_FOOTER.format(**options) + os.linesep * 2 + script
+        MatplotlibDataViewer.__init__(self, session, wcs=True, parent=parent, state=state)
+        MatplotlibImageMixin.setup_callbacks(self)

--- a/glue/viewers/image/viewer.py
+++ b/glue/viewers/image/viewer.py
@@ -239,7 +239,7 @@ class MatplotlibImageMixin:
         elif hasattr(ref_coords, 'wcsaxes_dict'):
             raise NotImplementedError()
         else:
-            imports.append('from glue.viewers.image.qt.data_viewer import get_identity_wcs')
+            imports.append('from glue.viewers.image.viewer import get_identity_wcs')
             script += "ax.reset_wcs(slices={0}, wcs=get_identity_wcs(ref_data.ndim))\n".format(self.state.wcsaxes_slice)
 
         return imports, script

--- a/glue/viewers/image/viewer.py
+++ b/glue/viewers/image/viewer.py
@@ -1,0 +1,253 @@
+from __future__ import absolute_import, division, print_function
+
+import os
+
+from astropy.wcs import WCS
+
+from glue.core.subset import roi_to_subset_state
+from glue.core.coordinates import Coordinates
+
+from glue.viewers.scatter.layer_artist import ScatterLayerArtist
+from glue.viewers.image.layer_artist import ImageLayerArtist, ImageSubsetLayerArtist
+from glue.viewers.image.compat import update_image_viewer_state
+
+from glue.external.modest_image import imshow
+from glue.viewers.image.composite_array import CompositeArray
+
+__all__ = ['MatplotlibImageMixin']
+
+
+def get_identity_wcs(naxis):
+
+    wcs = WCS(naxis=naxis)
+    wcs.wcs.ctype = ['X'] * naxis
+    wcs.wcs.crval = [0.] * naxis
+    wcs.wcs.crpix = [1.] * naxis
+    wcs.wcs.cdelt = [1.] * naxis
+
+    return wcs
+
+
+EXTRA_FOOTER = """
+# Set tick label size - for now tick_params (called lower down) doesn't work
+# properly, but these lines won't be needed in future.
+ax.coords[{x_att_axis}].set_ticklabel(size={x_ticklabel_size})
+ax.coords[{y_att_axis}].set_ticklabel(size={y_ticklabel_size})
+""".strip()
+
+
+class MatplotlibImageMixin:
+
+    def setup_callbacks(self):
+        self._wcs_set = False
+        self._changing_slice_requires_wcs_update = None
+        self.axes.set_adjustable('datalim')
+        self.state.add_callback('x_att', self._set_wcs)
+        self.state.add_callback('y_att', self._set_wcs)
+        self.state.add_callback('slices', self._on_slice_change)
+        self.state.add_callback('reference_data', self._set_wcs)
+        self.axes._composite = CompositeArray()
+        self.axes._composite_image = imshow(self.axes, self.axes._composite,
+                                            origin='lower', interpolation='nearest')
+        self._set_wcs()
+
+    def update_x_ticklabel(self, *event):
+        # We need to overload this here for WCSAxes
+        if hasattr(self, '_wcs_set') and self._wcs_set and self.state.x_att is not None:
+            axis = self.state.reference_data.ndim - self.state.x_att.axis - 1
+        else:
+            axis = 0
+        self.axes.coords[axis].set_ticklabel(size=self.state.x_ticklabel_size)
+        self.redraw()
+
+    def update_y_ticklabel(self, *event):
+        # We need to overload this here for WCSAxes
+        if hasattr(self, '_wcs_set') and self._wcs_set and self.state.y_att is not None:
+            axis = self.state.reference_data.ndim - self.state.y_att.axis - 1
+        else:
+            axis = 1
+        self.axes.coords[axis].set_ticklabel(size=self.state.y_ticklabel_size)
+        self.redraw()
+
+    def _update_axes(self, *args):
+
+        if self.state.x_att_world is not None:
+            self.state.x_axislabel = self.state.x_att_world.label
+
+        if self.state.y_att_world is not None:
+            self.state.y_axislabel = self.state.y_att_world.label
+
+        self.axes.figure.canvas.draw()
+
+    def add_data(self, data):
+        result = super(MatplotlibImageMixin, self).add_data(data)
+        # If this is the first layer (or the first after all layers were)
+        # removed, set the WCS for the axes.
+        if len(self.layers) == 1:
+            self._set_wcs()
+        return result
+
+    def _on_slice_change(self, event=None):
+        if self._changing_slice_requires_wcs_update:
+            self._set_wcs(event=event, relim=False)
+
+    def _set_wcs(self, event=None, relim=True):
+
+        if self.state.x_att is None or self.state.y_att is None or self.state.reference_data is None:
+            return
+
+        ref_coords = getattr(self.state.reference_data, 'coords', None)
+
+        if hasattr(ref_coords, 'wcs'):
+            self.axes.reset_wcs(slices=self.state.wcsaxes_slice, wcs=ref_coords.wcs)
+        elif hasattr(ref_coords, 'wcsaxes_dict'):
+            self.axes.reset_wcs(slices=self.state.wcsaxes_slice, **ref_coords.wcsaxes_dict)
+        else:
+            self.axes.reset_wcs(slices=self.state.wcsaxes_slice,
+                                wcs=get_identity_wcs(self.state.reference_data.ndim))
+
+        # Reset the axis labels to match the fact that the new axes have no labels
+        self.state.x_axislabel = ''
+        self.state.y_axislabel = ''
+
+        self._update_appearance_from_settings()
+        self._update_axes()
+
+        self.update_x_ticklabel()
+        self.update_y_ticklabel()
+
+        if relim:
+            self.state.reset_limits()
+
+        # Determine whether changing slices requires changing the WCS
+        if ref_coords is None or type(ref_coords) == Coordinates:
+            self._changing_slice_requires_wcs_update = False
+        else:
+            ix = self.state.x_att.axis
+            iy = self.state.y_att.axis
+            x_dep = list(ref_coords.dependent_axes(ix))
+            y_dep = list(ref_coords.dependent_axes(iy))
+            if ix in x_dep:
+                x_dep.remove(ix)
+            if iy in x_dep:
+                x_dep.remove(iy)
+            if ix in y_dep:
+                y_dep.remove(ix)
+            if iy in y_dep:
+                y_dep.remove(iy)
+            self._changing_slice_requires_wcs_update = bool(x_dep or y_dep)
+
+        self._wcs_set = True
+
+    def apply_roi(self, roi, override_mode=None):
+
+        # Force redraw to get rid of ROI. We do this because applying the
+        # subset state below might end up not having an effect on the viewer,
+        # for example there may not be any layers, or the active subset may not
+        # be one of the layers. So we just explicitly redraw here to make sure
+        # a redraw will happen after this method is called.
+        self.redraw()
+
+        if len(self.layers) == 0:
+            return
+
+        if self.state.x_att is None or self.state.y_att is None or self.state.reference_data is None:
+            return
+
+        subset_state = roi_to_subset_state(roi,
+                                           x_att=self.state.x_att,
+                                           y_att=self.state.y_att)
+
+        self.apply_subset_state(subset_state, override_mode=override_mode)
+
+    def _scatter_artist(self, axes, state, layer=None, layer_state=None):
+        if len(self._layer_artist_container) == 0:
+            # FIXME: re-instate this error
+            # QMessageBox.critical(self, "Error", "Can only add a scatter plot "
+            #                      "overlay once an image is present",
+            #                      buttons=QMessageBox.Ok)
+            return None
+        return ScatterLayerArtist(axes, state, layer=layer, layer_state=None)
+
+    def get_data_layer_artist(self, layer=None, layer_state=None):
+        if layer.ndim == 1:
+            cls = self._scatter_artist
+        else:
+            cls = ImageLayerArtist
+        return self.get_layer_artist(cls, layer=layer, layer_state=layer_state)
+
+    def get_subset_layer_artist(self, layer=None, layer_state=None):
+        if layer.ndim == 1:
+            cls = self._scatter_artist
+        else:
+            cls = ImageSubsetLayerArtist
+        return self.get_layer_artist(cls, layer=layer, layer_state=layer_state)
+
+    @staticmethod
+    def update_viewer_state(rec, context):
+        return update_image_viewer_state(rec, context)
+
+    def show_crosshairs(self, x, y):
+
+        if getattr(self, '_crosshairs', None) is not None:
+            self._crosshairs.remove()
+
+        self._crosshairs, = self.axes.plot([x], [y], '+', ms=12,
+                                           mfc='none', mec='#d32d26',
+                                           mew=1, zorder=100)
+
+        self.axes.figure.canvas.draw()
+
+    def hide_crosshairs(self):
+        if getattr(self, '_crosshairs', None) is not None:
+            self._crosshairs.remove()
+            self._crosshairs = None
+            self.axes.figure.canvas.draw()
+
+    def update_aspect(self, aspect=None):
+        super(MatplotlibImageMixin, self).update_aspect(aspect=aspect)
+        if self.state.reference_data is not None and self.state.x_att is not None and self.state.y_att is not None:
+            nx = self.state.reference_data.shape[self.state.x_att.axis]
+            ny = self.state.reference_data.shape[self.state.y_att.axis]
+            self.axes.set_xlim(-0.5, nx - 0.5)
+            self.axes.set_ylim(-0.5, ny - 0.5)
+            self.axes.figure.canvas.draw()
+
+    def _script_header(self):
+
+        imports = []
+        imports.append('import matplotlib.pyplot as plt')
+        imports.append('from glue.viewers.matplotlib.mpl_axes import init_mpl')
+        imports.append('from glue.viewers.image.composite_array import CompositeArray')
+        imports.append('from glue.external.modest_image import imshow')
+
+        script = ""
+        script += "fig, ax = init_mpl(wcs=True)\n"
+        script += "ax.set_aspect('{0}')\n".format(self.state.aspect)
+
+        script += '\ncomposite = CompositeArray()\n'
+        script += "image = imshow(ax, composite, origin='lower', interpolation='nearest', aspect='{0}')\n\n".format(self.state.aspect)
+
+        dindex = self.session.data_collection.index(self.state.reference_data)
+
+        script += "ref_data = data_collection[{0}]\n".format(dindex)
+
+        ref_coords = self.state.reference_data.coords
+
+        if hasattr(ref_coords, 'wcs'):
+            script += "ax.reset_wcs(slices={0}, wcs=ref_data.coords.wcs)\n".format(self.state.wcsaxes_slice)
+        elif hasattr(ref_coords, 'wcsaxes_dict'):
+            raise NotImplementedError()
+        else:
+            imports.append('from glue.viewers.image.qt.data_viewer import get_identity_wcs')
+            script += "ax.reset_wcs(slices={0}, wcs=get_identity_wcs(ref_data.ndim))\n".format(self.state.wcsaxes_slice)
+
+        return imports, script
+
+    def _script_footer(self):
+        imports, script = super(MatplotlibImageMixin, self)._script_footer()
+        options = dict(x_att_axis=0 if self.state.x_att is None else self.state.reference_data.ndim - self.state.x_att.axis - 1,
+                       y_att_axis=1 if self.state.y_att is None else self.state.reference_data.ndim - self.state.y_att.axis - 1,
+                       x_ticklabel_size=self.state.x_ticklabel_size,
+                       y_ticklabel_size=self.state.y_ticklabel_size)
+        return [], EXTRA_FOOTER.format(**options) + os.linesep * 2 + script

--- a/glue/viewers/image/viewer.py
+++ b/glue/viewers/image/viewer.py
@@ -36,7 +36,7 @@ ax.coords[{y_att_axis}].set_ticklabel(size={y_ticklabel_size})
 """.strip()
 
 
-class MatplotlibImageMixin:
+class MatplotlibImageMixin(object):
 
     def setup_callbacks(self):
         self._wcs_set = False

--- a/glue/viewers/image/viewer.py
+++ b/glue/viewers/image/viewer.py
@@ -162,11 +162,7 @@ class MatplotlibImageMixin:
 
     def _scatter_artist(self, axes, state, layer=None, layer_state=None):
         if len(self._layer_artist_container) == 0:
-            # FIXME: re-instate this error
-            # QMessageBox.critical(self, "Error", "Can only add a scatter plot "
-            #                      "overlay once an image is present",
-            #                      buttons=QMessageBox.Ok)
-            return None
+            raise Exception("Can only add a scatter plot overlay once an image is present")
         return ScatterLayerArtist(axes, state, layer=layer, layer_state=None)
 
     def get_data_layer_artist(self, layer=None, layer_state=None):

--- a/glue/viewers/matplotlib/qt/data_viewer.py
+++ b/glue/viewers/matplotlib/qt/data_viewer.py
@@ -1,55 +1,23 @@
 from __future__ import absolute_import, division, print_function
 
-import numpy as np
 from qtpy.QtCore import QTimer
-
-from matplotlib.patches import Rectangle
 
 from glue.core.message import ComputationStartedMessage
 from glue.viewers.common.qt.data_viewer import DataViewer
 from glue.viewers.matplotlib.qt.widget import MplWidget
-from glue.viewers.matplotlib.mpl_axes import init_mpl, update_appearance_from_settings
-from glue.external.echo import delay_callback
-from glue.utils import defer_draw, mpl_to_datetime64, avoid_circular, decorate_all_methods
+from glue.viewers.matplotlib.mpl_axes import init_mpl
+from glue.utils import defer_draw, decorate_all_methods
 from glue.viewers.matplotlib.state import MatplotlibDataViewerState
+from glue.viewers.matplotlib.viewer import MatplotlibViewerMixin
 
 # The following import is required to register the viewer tools
 from glue.viewers.matplotlib.qt import toolbar  # noqa
 
 __all__ = ['MatplotlibDataViewer']
 
-SCRIPT_HEADER = """
-fig = plt.figure()
-ax = fig.add_subplot(1, 1, 1, aspect='{aspect}')
-""".strip()
-
-SCRIPT_FOOTER = """
-# Set limits
-ax.set_xlim({x_min}, {x_max})
-ax.set_ylim({y_min}, {y_max})
-
-# Set scale (log or linear)
-ax.set_xscale('{x_log_str}')
-ax.set_yscale('{y_log_str}')
-
-# Set axis label properties
-ax.set_xlabel('{x_axislabel}', weight='{x_axislabel_weight}', size={x_axislabel_size})
-ax.set_ylabel('{y_axislabel}', weight='{y_axislabel_weight}', size={y_axislabel_size})
-
-# Set tick label properties
-ax.tick_params('x', labelsize={x_ticklabel_size})
-ax.tick_params('y', labelsize={x_ticklabel_size})
-
-# Save figure
-fig.savefig('glue_plot.png')
-plt.close(fig)
-""".strip()
-
-ZORDER_MAX = 100000
-
 
 @decorate_all_methods(defer_draw)
-class MatplotlibDataViewer(DataViewer):
+class MatplotlibDataViewer(MatplotlibViewerMixin, DataViewer):
 
     _state_cls = MatplotlibDataViewerState
 
@@ -67,58 +35,9 @@ class MatplotlibDataViewer(DataViewer):
         # TODO: shouldn't have to do this
         self.central_widget = self.mpl_widget
 
-        self.figure, self._axes = init_mpl(self.mpl_widget.canvas.fig, wcs=wcs)
+        self.figure, self.axes = init_mpl(self.mpl_widget.canvas.fig, wcs=wcs)
 
-        for spine in self._axes.spines.values():
-            spine.set_zorder(ZORDER_MAX)
-
-        self.loading_rectangle = Rectangle((0, 0), 1, 1, color='0.9', alpha=0.9,
-                                           zorder=ZORDER_MAX - 1, transform=self.axes.transAxes)
-        self.loading_rectangle.set_visible(False)
-        self.axes.add_patch(self.loading_rectangle)
-
-        self.loading_text = self.axes.text(0.4, 0.5, 'Computing', color='k',
-                                           zorder=self.loading_rectangle.get_zorder() + 1,
-                                           ha='left', va='center',
-                                           transform=self.axes.transAxes)
-        self.loading_text.set_visible(False)
-
-        self.state.add_callback('aspect', self.update_aspect)
-
-        self.update_aspect()
-
-        self.state.add_callback('x_min', self.limits_to_mpl)
-        self.state.add_callback('x_max', self.limits_to_mpl)
-        self.state.add_callback('y_min', self.limits_to_mpl)
-        self.state.add_callback('y_max', self.limits_to_mpl)
-
-        self.limits_to_mpl()
-
-        self.state.add_callback('x_log', self.update_x_log, priority=1000)
-        self.state.add_callback('y_log', self.update_y_log, priority=1000)
-
-        self.update_x_log()
-
-        self.axes.callbacks.connect('xlim_changed', self.limits_from_mpl)
-        self.axes.callbacks.connect('ylim_changed', self.limits_from_mpl)
-
-        self.axes.set_autoscale_on(False)
-
-        self.state.add_callback('x_axislabel', self.update_x_axislabel)
-        self.state.add_callback('x_axislabel_weight', self.update_x_axislabel)
-        self.state.add_callback('x_axislabel_size', self.update_x_axislabel)
-
-        self.state.add_callback('y_axislabel', self.update_y_axislabel)
-        self.state.add_callback('y_axislabel_weight', self.update_y_axislabel)
-        self.state.add_callback('y_axislabel_size', self.update_y_axislabel)
-
-        self.state.add_callback('x_ticklabel_size', self.update_x_ticklabel)
-        self.state.add_callback('y_ticklabel_size', self.update_y_ticklabel)
-
-        self.update_x_axislabel()
-        self.update_y_axislabel()
-        self.update_x_ticklabel()
-        self.update_y_ticklabel()
+        MatplotlibViewerMixin.setup_callbacks(self)
 
         self.central_widget.resize(600, 400)
         self.resize(self.central_widget.size())
@@ -157,127 +76,3 @@ class MatplotlibDataViewer(DataViewer):
 
         # If we get here, the computation has stopped so we can stop the timer
         self._monitor_computation.stop()
-
-    def update_x_axislabel(self, *event):
-        self.axes.set_xlabel(self.state.x_axislabel,
-                             weight=self.state.x_axislabel_weight,
-                             size=self.state.x_axislabel_size)
-        self.redraw()
-
-    def update_y_axislabel(self, *event):
-        self.axes.set_ylabel(self.state.y_axislabel,
-                             weight=self.state.y_axislabel_weight,
-                             size=self.state.y_axislabel_size)
-        self.redraw()
-
-    def update_x_ticklabel(self, *event):
-        self.axes.tick_params(axis='x', labelsize=self.state.x_ticklabel_size)
-        self.axes.xaxis.get_offset_text().set_fontsize(self.state.x_ticklabel_size)
-        self.redraw()
-
-    def update_y_ticklabel(self, *event):
-        self.axes.tick_params(axis='y', labelsize=self.state.y_ticklabel_size)
-        self.axes.yaxis.get_offset_text().set_fontsize(self.state.y_ticklabel_size)
-        self.redraw()
-
-    def redraw(self):
-        self.figure.canvas.draw()
-
-    def update_x_log(self, *args):
-        self.axes.set_xscale('log' if self.state.x_log else 'linear')
-        self.redraw()
-
-    def update_y_log(self, *args):
-        self.axes.set_yscale('log' if self.state.y_log else 'linear')
-        self.redraw()
-
-    def update_aspect(self, aspect=None):
-        self.axes.set_aspect(self.state.aspect, adjustable='datalim')
-
-    @avoid_circular
-    def limits_from_mpl(self, *args):
-
-        with delay_callback(self.state, 'x_min', 'x_max', 'y_min', 'y_max'):
-
-            if isinstance(self.state.x_min, np.datetime64):
-                x_min, x_max = [mpl_to_datetime64(x) for x in self.axes.get_xlim()]
-            else:
-                x_min, x_max = self.axes.get_xlim()
-
-            self.state.x_min, self.state.x_max = x_min, x_max
-
-            if isinstance(self.state.y_min, np.datetime64):
-                y_min, y_max = [mpl_to_datetime64(y) for y in self.axes.get_ylim()]
-            else:
-                y_min, y_max = self.axes.get_ylim()
-
-            self.state.y_min, self.state.y_max = y_min, y_max
-
-    @avoid_circular
-    def limits_to_mpl(self, *args):
-
-        if self.state.x_min is not None and self.state.x_max is not None:
-            x_min, x_max = self.state.x_min, self.state.x_max
-            if self.state.x_log:
-                if self.state.x_max <= 0:
-                    x_min, x_max = 0.1, 1
-                elif self.state.x_min <= 0:
-                    x_min = x_max / 10
-            self.axes.set_xlim(x_min, x_max)
-
-        if self.state.y_min is not None and self.state.y_max is not None:
-            y_min, y_max = self.state.y_min, self.state.y_max
-            if self.state.y_log:
-                if self.state.y_max <= 0:
-                    y_min, y_max = 0.1, 1
-                elif self.state.y_min <= 0:
-                    y_min = y_max / 10
-            self.axes.set_ylim(y_min, y_max)
-
-        if self.state.aspect == 'equal':
-
-            # FIXME: for a reason I don't quite understand, dataLim doesn't
-            # get updated immediately here, which means that there are then
-            # issues in the first draw of the image (the limits are such that
-            # only part of the image is shown). We just set dataLim manually
-            # to avoid this issue.
-            self.axes.dataLim.intervalx = self.axes.get_xlim()
-            self.axes.dataLim.intervaly = self.axes.get_ylim()
-
-            # We then force the aspect to be computed straight away
-            self.axes.apply_aspect()
-
-            # And propagate any changes back to the state since we have the
-            # @avoid_circular decorator
-            with delay_callback(self.state, 'x_min', 'x_max', 'y_min', 'y_max'):
-                # TODO: fix case with datetime64 here
-                self.state.x_min, self.state.x_max = self.axes.get_xlim()
-                self.state.y_min, self.state.y_max = self.axes.get_ylim()
-
-        self.axes.figure.canvas.draw()
-
-    # TODO: shouldn't need this!
-    @property
-    def axes(self):
-        return self._axes
-
-    def _update_appearance_from_settings(self, message=None):
-        update_appearance_from_settings(self.axes)
-        self.redraw()
-
-    def get_layer_artist(self, cls, layer=None, layer_state=None):
-        return cls(self.axes, self.state, layer=layer, layer_state=layer_state)
-
-    def apply_roi(self, roi, override_mode=None):
-        """ This method must be implemented by subclasses """
-        raise NotImplementedError
-
-    def _script_header(self):
-        state_dict = self.state.as_dict()
-        return ['import matplotlib.pyplot as plt'], SCRIPT_HEADER.format(**state_dict)
-
-    def _script_footer(self):
-        state_dict = self.state.as_dict()
-        state_dict['x_log_str'] = 'log' if self.state.x_log else 'linear'
-        state_dict['y_log_str'] = 'log' if self.state.y_log else 'linear'
-        return [], SCRIPT_FOOTER.format(**state_dict)

--- a/glue/viewers/matplotlib/viewer.py
+++ b/glue/viewers/matplotlib/viewer.py
@@ -40,7 +40,7 @@ plt.close(fig)
 ZORDER_MAX = 100000
 
 
-class MatplotlibViewerMixin:
+class MatplotlibViewerMixin(object):
 
     def setup_callbacks(self):
 

--- a/glue/viewers/matplotlib/viewer.py
+++ b/glue/viewers/matplotlib/viewer.py
@@ -1,0 +1,218 @@
+from __future__ import absolute_import, division, print_function
+
+import numpy as np
+
+from matplotlib.patches import Rectangle
+
+from glue.viewers.matplotlib.mpl_axes import update_appearance_from_settings
+from glue.external.echo import delay_callback
+from glue.utils import mpl_to_datetime64, avoid_circular
+
+__all__ = ['MatplotlibViewerMixin']
+
+SCRIPT_HEADER = """
+fig = plt.figure()
+ax = fig.add_subplot(1, 1, 1, aspect='{aspect}')
+""".strip()
+
+SCRIPT_FOOTER = """
+# Set limits
+ax.set_xlim({x_min}, {x_max})
+ax.set_ylim({y_min}, {y_max})
+
+# Set scale (log or linear)
+ax.set_xscale('{x_log_str}')
+ax.set_yscale('{y_log_str}')
+
+# Set axis label properties
+ax.set_xlabel('{x_axislabel}', weight='{x_axislabel_weight}', size={x_axislabel_size})
+ax.set_ylabel('{y_axislabel}', weight='{y_axislabel_weight}', size={y_axislabel_size})
+
+# Set tick label properties
+ax.tick_params('x', labelsize={x_ticklabel_size})
+ax.tick_params('y', labelsize={x_ticklabel_size})
+
+# Save figure
+fig.savefig('glue_plot.png')
+plt.close(fig)
+""".strip()
+
+ZORDER_MAX = 100000
+
+
+class MatplotlibViewerMixin:
+
+    def setup_callbacks(self):
+
+        for spine in self.axes.spines.values():
+            spine.set_zorder(ZORDER_MAX)
+
+        self.loading_rectangle = Rectangle((0, 0), 1, 1, color='0.9', alpha=0.9,
+                                           zorder=ZORDER_MAX - 1, transform=self.axes.transAxes)
+        self.loading_rectangle.set_visible(False)
+        self.axes.add_patch(self.loading_rectangle)
+
+        self.loading_text = self.axes.text(0.4, 0.5, 'Computing', color='k',
+                                           zorder=self.loading_rectangle.get_zorder() + 1,
+                                           ha='left', va='center',
+                                           transform=self.axes.transAxes)
+        self.loading_text.set_visible(False)
+
+        self.state.add_callback('aspect', self.update_aspect)
+
+        self.update_aspect()
+
+        self.state.add_callback('x_min', self.limits_to_mpl)
+        self.state.add_callback('x_max', self.limits_to_mpl)
+        self.state.add_callback('y_min', self.limits_to_mpl)
+        self.state.add_callback('y_max', self.limits_to_mpl)
+
+        self.limits_to_mpl()
+
+        self.state.add_callback('x_log', self.update_x_log, priority=1000)
+        self.state.add_callback('y_log', self.update_y_log, priority=1000)
+
+        self.update_x_log()
+
+        self.axes.callbacks.connect('xlim_changed', self.limits_from_mpl)
+        self.axes.callbacks.connect('ylim_changed', self.limits_from_mpl)
+
+        self.axes.set_autoscale_on(False)
+
+        self.state.add_callback('x_axislabel', self.update_x_axislabel)
+        self.state.add_callback('x_axislabel_weight', self.update_x_axislabel)
+        self.state.add_callback('x_axislabel_size', self.update_x_axislabel)
+
+        self.state.add_callback('y_axislabel', self.update_y_axislabel)
+        self.state.add_callback('y_axislabel_weight', self.update_y_axislabel)
+        self.state.add_callback('y_axislabel_size', self.update_y_axislabel)
+
+        self.state.add_callback('x_ticklabel_size', self.update_x_ticklabel)
+        self.state.add_callback('y_ticklabel_size', self.update_y_ticklabel)
+
+        self.update_x_axislabel()
+        self.update_y_axislabel()
+        self.update_x_ticklabel()
+        self.update_y_ticklabel()
+
+    def _update_computation(self, message=None):
+        pass
+
+    def update_x_axislabel(self, *event):
+        self.axes.set_xlabel(self.state.x_axislabel,
+                             weight=self.state.x_axislabel_weight,
+                             size=self.state.x_axislabel_size)
+        self.redraw()
+
+    def update_y_axislabel(self, *event):
+        self.axes.set_ylabel(self.state.y_axislabel,
+                             weight=self.state.y_axislabel_weight,
+                             size=self.state.y_axislabel_size)
+        self.redraw()
+
+    def update_x_ticklabel(self, *event):
+        self.axes.tick_params(axis='x', labelsize=self.state.x_ticklabel_size)
+        self.axes.xaxis.get_offset_text().set_fontsize(self.state.x_ticklabel_size)
+        self.redraw()
+
+    def update_y_ticklabel(self, *event):
+        self.axes.tick_params(axis='y', labelsize=self.state.y_ticklabel_size)
+        self.axes.yaxis.get_offset_text().set_fontsize(self.state.y_ticklabel_size)
+        self.redraw()
+
+    def redraw(self):
+        self.figure.canvas.draw()
+
+    def update_x_log(self, *args):
+        self.axes.set_xscale('log' if self.state.x_log else 'linear')
+        self.redraw()
+
+    def update_y_log(self, *args):
+        self.axes.set_yscale('log' if self.state.y_log else 'linear')
+        self.redraw()
+
+    def update_aspect(self, aspect=None):
+        self.axes.set_aspect(self.state.aspect, adjustable='datalim')
+
+    @avoid_circular
+    def limits_from_mpl(self, *args):
+
+        with delay_callback(self.state, 'x_min', 'x_max', 'y_min', 'y_max'):
+
+            if isinstance(self.state.x_min, np.datetime64):
+                x_min, x_max = [mpl_to_datetime64(x) for x in self.axes.get_xlim()]
+            else:
+                x_min, x_max = self.axes.get_xlim()
+
+            self.state.x_min, self.state.x_max = x_min, x_max
+
+            if isinstance(self.state.y_min, np.datetime64):
+                y_min, y_max = [mpl_to_datetime64(y) for y in self.axes.get_ylim()]
+            else:
+                y_min, y_max = self.axes.get_ylim()
+
+            self.state.y_min, self.state.y_max = y_min, y_max
+
+    @avoid_circular
+    def limits_to_mpl(self, *args):
+
+        if self.state.x_min is not None and self.state.x_max is not None:
+            x_min, x_max = self.state.x_min, self.state.x_max
+            if self.state.x_log:
+                if self.state.x_max <= 0:
+                    x_min, x_max = 0.1, 1
+                elif self.state.x_min <= 0:
+                    x_min = x_max / 10
+            self.axes.set_xlim(x_min, x_max)
+
+        if self.state.y_min is not None and self.state.y_max is not None:
+            y_min, y_max = self.state.y_min, self.state.y_max
+            if self.state.y_log:
+                if self.state.y_max <= 0:
+                    y_min, y_max = 0.1, 1
+                elif self.state.y_min <= 0:
+                    y_min = y_max / 10
+            self.axes.set_ylim(y_min, y_max)
+
+        if self.state.aspect == 'equal':
+
+            # FIXME: for a reason I don't quite understand, dataLim doesn't
+            # get updated immediately here, which means that there are then
+            # issues in the first draw of the image (the limits are such that
+            # only part of the image is shown). We just set dataLim manually
+            # to avoid this issue.
+            self.axes.dataLim.intervalx = self.axes.get_xlim()
+            self.axes.dataLim.intervaly = self.axes.get_ylim()
+
+            # We then force the aspect to be computed straight away
+            self.axes.apply_aspect()
+
+            # And propagate any changes back to the state since we have the
+            # @avoid_circular decorator
+            with delay_callback(self.state, 'x_min', 'x_max', 'y_min', 'y_max'):
+                # TODO: fix case with datetime64 here
+                self.state.x_min, self.state.x_max = self.axes.get_xlim()
+                self.state.y_min, self.state.y_max = self.axes.get_ylim()
+
+        self.axes.figure.canvas.draw()
+
+    def _update_appearance_from_settings(self, message=None):
+        update_appearance_from_settings(self.axes)
+        self.redraw()
+
+    def get_layer_artist(self, cls, layer=None, layer_state=None):
+        return cls(self.axes, self.state, layer=layer, layer_state=layer_state)
+
+    def apply_roi(self, roi, override_mode=None):
+        """ This method must be implemented by subclasses """
+        raise NotImplementedError
+
+    def _script_header(self):
+        state_dict = self.state.as_dict()
+        return ['import matplotlib.pyplot as plt'], SCRIPT_HEADER.format(**state_dict)
+
+    def _script_footer(self):
+        state_dict = self.state.as_dict()
+        state_dict['x_log_str'] = 'log' if self.state.x_log else 'linear'
+        state_dict['y_log_str'] = 'log' if self.state.y_log else 'linear'
+        return [], SCRIPT_FOOTER.format(**state_dict)

--- a/glue/viewers/profile/qt/data_viewer.py
+++ b/glue/viewers/profile/qt/data_viewer.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-from glue.core.subset import roi_to_subset_state
 from glue.utils import defer_draw, decorate_all_methods
 
 from glue.viewers.matplotlib.qt.data_viewer import MatplotlibDataViewer
@@ -11,12 +10,13 @@ from glue.viewers.profile.state import ProfileViewerState
 
 from glue.viewers.common.qt import toolbar_mode  # noqa
 from glue.viewers.profile.qt.profile_tools import ProfileAnalysisTool  # noqa
+from glue.viewers.profile.viewer import MatplotlibProfileMixin
 
 __all__ = ['ProfileViewer']
 
 
 @decorate_all_methods(defer_draw)
-class ProfileViewer(MatplotlibDataViewer):
+class ProfileViewer(MatplotlibProfileMixin, MatplotlibDataViewer):
 
     LABEL = '1D Profile'
     _layer_style_widget_cls = ProfileLayerStyleEditor
@@ -32,34 +32,5 @@ class ProfileViewer(MatplotlibDataViewer):
     tools = ['select:xrange', 'profile-analysis']
 
     def __init__(self, session, parent=None, state=None):
-        super(ProfileViewer, self).__init__(session, parent, state=state)
-        self.state.add_callback('x_att', self._update_axes)
-        self.state.add_callback('normalize', self._update_axes)
-
-    def _update_axes(self, *args):
-
-        if self.state.x_att is not None:
-            self.state.x_axislabel = self.state.x_att.label
-
-        if self.state.normalize:
-            self.state.y_axislabel = 'Normalized data values'
-        else:
-            self.state.y_axislabel = 'Data values'
-
-        self.axes.figure.canvas.draw()
-
-    @defer_draw
-    def apply_roi(self, roi, override_mode=None):
-
-        # Force redraw to get rid of ROI. We do this because applying the
-        # subset state below might end up not having an effect on the viewer,
-        # for example there may not be any layers, or the active subset may not
-        # be one of the layers. So we just explicitly redraw here to make sure
-        # a redraw will happen after this method is called.
-        self.redraw()
-
-        if len(self.layers) == 0:
-            return
-
-        subset_state = roi_to_subset_state(roi, x_att=self.state.x_att)
-        self.apply_subset_state(subset_state, override_mode=override_mode)
+        MatplotlibDataViewer.__init__(self, session, parent=parent, state=state)
+        MatplotlibProfileMixin.setup_callbacks(self)

--- a/glue/viewers/profile/viewer.py
+++ b/glue/viewers/profile/viewer.py
@@ -5,7 +5,7 @@ from glue.core.subset import roi_to_subset_state
 __all__ = ['MatplotlibProfileMixin']
 
 
-class MatplotlibProfileMixin:
+class MatplotlibProfileMixin(object):
 
     def setup_callbacks(self):
         self.state.add_callback('x_att', self._update_axes)

--- a/glue/viewers/profile/viewer.py
+++ b/glue/viewers/profile/viewer.py
@@ -1,0 +1,42 @@
+from __future__ import absolute_import, division, print_function
+
+from glue.core.subset import roi_to_subset_state
+
+from glue.viewers.common.qt import toolbar_mode  # noqa
+from glue.viewers.profile.qt.profile_tools import ProfileAnalysisTool  # noqa
+
+__all__ = ['MatplotlibProfileMixin']
+
+
+class MatplotlibProfileMixin:
+
+    def setup_callbacks(self):
+        self.state.add_callback('x_att', self._update_axes)
+        self.state.add_callback('normalize', self._update_axes)
+
+    def _update_axes(self, *args):
+
+        if self.state.x_att is not None:
+            self.state.x_axislabel = self.state.x_att.label
+
+        if self.state.normalize:
+            self.state.y_axislabel = 'Normalized data values'
+        else:
+            self.state.y_axislabel = 'Data values'
+
+        self.axes.figure.canvas.draw()
+
+    def apply_roi(self, roi, override_mode=None):
+
+        # Force redraw to get rid of ROI. We do this because applying the
+        # subset state below might end up not having an effect on the viewer,
+        # for example there may not be any layers, or the active subset may not
+        # be one of the layers. So we just explicitly redraw here to make sure
+        # a redraw will happen after this method is called.
+        self.redraw()
+
+        if len(self.layers) == 0:
+            return
+
+        subset_state = roi_to_subset_state(roi, x_att=self.state.x_att)
+        self.apply_subset_state(subset_state, override_mode=override_mode)

--- a/glue/viewers/profile/viewer.py
+++ b/glue/viewers/profile/viewer.py
@@ -2,9 +2,6 @@ from __future__ import absolute_import, division, print_function
 
 from glue.core.subset import roi_to_subset_state
 
-from glue.viewers.common.qt import toolbar_mode  # noqa
-from glue.viewers.profile.qt.profile_tools import ProfileAnalysisTool  # noqa
-
 __all__ = ['MatplotlibProfileMixin']
 
 

--- a/glue/viewers/scatter/qt/data_viewer.py
+++ b/glue/viewers/scatter/qt/data_viewer.py
@@ -1,21 +1,19 @@
 from __future__ import absolute_import, division, print_function
 
-from glue.core.subset import roi_to_subset_state
-from glue.core.util import update_ticks
-
-from glue.utils import mpl_to_datetime64, defer_draw, decorate_all_methods
+from glue.utils import defer_draw, decorate_all_methods
 from glue.viewers.matplotlib.qt.data_viewer import MatplotlibDataViewer
 from glue.viewers.scatter.qt.layer_style_editor import ScatterLayerStyleEditor
 from glue.viewers.scatter.layer_artist import ScatterLayerArtist
 from glue.viewers.scatter.qt.options_widget import ScatterOptionsWidget
 from glue.viewers.scatter.state import ScatterViewerState
-from glue.viewers.scatter.compat import update_scatter_viewer_state
+
+from glue.viewers.scatter.viewer import MatplotlibScatterMixin
 
 __all__ = ['ScatterViewer']
 
 
 @decorate_all_methods(defer_draw)
-class ScatterViewer(MatplotlibDataViewer):
+class ScatterViewer(MatplotlibScatterMixin, MatplotlibDataViewer):
 
     LABEL = '2D Scatter'
     _layer_style_widget_cls = ScatterLayerStyleEditor
@@ -29,63 +27,5 @@ class ScatterViewer(MatplotlibDataViewer):
              'select:polygon']
 
     def __init__(self, session, parent=None, state=None):
-        super(ScatterViewer, self).__init__(session, parent, state=state)
-        self.state.add_callback('x_att', self._update_axes)
-        self.state.add_callback('y_att', self._update_axes)
-        self.state.add_callback('x_log', self._update_axes)
-        self.state.add_callback('y_log', self._update_axes)
-        self._update_axes()
-
-    def _update_axes(self, *args):
-
-        if self.state.x_att is not None:
-
-            # Update ticks, which sets the labels to categories if components are categorical
-            update_ticks(self.axes, 'x', self.state.x_kinds, self.state.x_log, self.state.x_categories)
-
-            if self.state.x_log:
-                self.state.x_axislabel = 'Log ' + self.state.x_att.label
-            else:
-                self.state.x_axislabel = self.state.x_att.label
-
-        if self.state.y_att is not None:
-
-            # Update ticks, which sets the labels to categories if components are categorical
-            update_ticks(self.axes, 'y', self.state.y_kinds, self.state.y_log, self.state.y_categories)
-
-            if self.state.y_log:
-                self.state.y_axislabel = 'Log ' + self.state.y_att.label
-            else:
-                self.state.y_axislabel = self.state.y_att.label
-
-        self.axes.figure.canvas.draw()
-
-    @defer_draw
-    def apply_roi(self, roi, override_mode=None):
-
-        # Force redraw to get rid of ROI. We do this because applying the
-        # subset state below might end up not having an effect on the viewer,
-        # for example there may not be any layers, or the active subset may not
-        # be one of the layers. So we just explicitly redraw here to make sure
-        # a redraw will happen after this method is called.
-        self.redraw()
-
-        if len(self.layers) == 0:
-            return
-
-        x_date = 'datetime' in self.state.x_kinds
-        y_date = 'datetime' in self.state.y_kinds
-
-        if x_date or y_date:
-            roi = roi.transformed(xfunc=mpl_to_datetime64 if x_date else None,
-                                  yfunc=mpl_to_datetime64 if y_date else None)
-
-        subset_state = roi_to_subset_state(roi,
-                                           x_att=self.state.x_att, x_categories=self.state.x_categories,
-                                           y_att=self.state.y_att, y_categories=self.state.y_categories)
-
-        self.apply_subset_state(subset_state, override_mode=override_mode)
-
-    @staticmethod
-    def update_viewer_state(rec, context):
-        return update_scatter_viewer_state(rec, context)
+        MatplotlibDataViewer.__init__(self, session, parent=parent, state=state)
+        MatplotlibScatterMixin.setup_callbacks(self)

--- a/glue/viewers/scatter/viewer.py
+++ b/glue/viewers/scatter/viewer.py
@@ -9,7 +9,7 @@ from glue.viewers.scatter.compat import update_scatter_viewer_state
 __all__ = ['MatplotlibScatterMixin']
 
 
-class MatplotlibScatterMixin:
+class MatplotlibScatterMixin(object):
 
     def setup_callbacks(self):
         self.state.add_callback('x_att', self._update_axes)

--- a/glue/viewers/scatter/viewer.py
+++ b/glue/viewers/scatter/viewer.py
@@ -1,0 +1,72 @@
+from __future__ import absolute_import, division, print_function
+
+from glue.core.subset import roi_to_subset_state
+from glue.core.util import update_ticks
+
+from glue.utils import mpl_to_datetime64
+from glue.viewers.scatter.compat import update_scatter_viewer_state
+
+__all__ = ['MatplotlibScatterMixin']
+
+
+class MatplotlibScatterMixin:
+
+    def setup_callbacks(self):
+        self.state.add_callback('x_att', self._update_axes)
+        self.state.add_callback('y_att', self._update_axes)
+        self.state.add_callback('x_log', self._update_axes)
+        self.state.add_callback('y_log', self._update_axes)
+        self._update_axes()
+
+    def _update_axes(self, *args):
+
+        if self.state.x_att is not None:
+
+            # Update ticks, which sets the labels to categories if components are categorical
+            update_ticks(self.axes, 'x', self.state.x_kinds, self.state.x_log, self.state.x_categories)
+
+            if self.state.x_log:
+                self.state.x_axislabel = 'Log ' + self.state.x_att.label
+            else:
+                self.state.x_axislabel = self.state.x_att.label
+
+        if self.state.y_att is not None:
+
+            # Update ticks, which sets the labels to categories if components are categorical
+            update_ticks(self.axes, 'y', self.state.y_kinds, self.state.y_log, self.state.y_categories)
+
+            if self.state.y_log:
+                self.state.y_axislabel = 'Log ' + self.state.y_att.label
+            else:
+                self.state.y_axislabel = self.state.y_att.label
+
+        self.axes.figure.canvas.draw()
+
+    def apply_roi(self, roi, override_mode=None):
+
+        # Force redraw to get rid of ROI. We do this because applying the
+        # subset state below might end up not having an effect on the viewer,
+        # for example there may not be any layers, or the active subset may not
+        # be one of the layers. So we just explicitly redraw here to make sure
+        # a redraw will happen after this method is called.
+        self.redraw()
+
+        if len(self.layers) == 0:
+            return
+
+        x_date = 'datetime' in self.state.x_kinds
+        y_date = 'datetime' in self.state.y_kinds
+
+        if x_date or y_date:
+            roi = roi.transformed(xfunc=mpl_to_datetime64 if x_date else None,
+                                  yfunc=mpl_to_datetime64 if y_date else None)
+
+        subset_state = roi_to_subset_state(roi,
+                                           x_att=self.state.x_att, x_categories=self.state.x_categories,
+                                           y_att=self.state.y_att, y_categories=self.state.y_categories)
+
+        self.apply_subset_state(subset_state, override_mode=override_mode)
+
+    @staticmethod
+    def update_viewer_state(rec, context):
+        return update_scatter_viewer_state(rec, context)


### PR DESCRIPTION
This splits out code for the Matplotlib viewers that doesn't depend on Qt into mixin classes that can then be re-used for e.g. the Jupyter viewers. The diff looks large, but most of this is just moving code to a different file.