### PR TITLE
Use compute_histogram for scatter density

### DIFF
--- a/glue/core/application_base.py
+++ b/glue/core/application_base.py
@@ -232,7 +232,10 @@ class Application(HubListener):
         datasets = []
 
         for path in args:
-            datasets.append(load_data(path))
+            if isinstance(path, BaseData):
+                datasets.append(path)
+            else:
+                datasets.append(load_data(path))
 
         links = kwargs.pop('links', None)
 

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -1547,7 +1547,8 @@ class Data(BaseCartesianData):
                 w = w[mask]
 
         if ndim == 1:
-            xmin, xmax = sorted(range)
+            xmin, xmax = range[0]
+            xmin, xmax = sorted((xmin, xmax))
             keep = (x >= xmin) & (x <= xmax)
         else:
             (xmin, xmax), (ymin, ymax) = range
@@ -1600,7 +1601,8 @@ class Data(BaseCartesianData):
 
         if ndim == 1:
             range = (xmin, xmax)
-            return histogram1d(x, range=range, bins=bins, weights=w)
+            print(x, range, bins, w)
+            return histogram1d(x, range=range, bins=bins[0], weights=w)
         elif ndim > 1:
             range = [(xmin, xmax), (ymin, ymax)]
             return histogram2d(x, y, range=range, bins=bins, weights=w)

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -9,7 +9,7 @@ import warnings
 import numpy as np
 import pandas as pd
 
-from fast_histogram import histogram1d
+from fast_histogram import histogram1d, histogram2d
 
 from glue.external import six
 from glue.core.message import (DataUpdateMessage, DataRemoveComponentMessage,
@@ -1517,61 +1517,139 @@ class Data(BaseCartesianData):
             the subset state.
         """
 
-        if len(cids) > 1:
+        if len(cids) > 2:
             raise NotImplementedError()
-        else:
+
+        ndim = len(cids)
+
+        if ndim == 1:
+
             cid = cids[0]
             range = range[0]
             bins = bins[0]
             log = log[0]
 
-        x = self.get_data(cid)
-        if isinstance(x, categorical_ndarray):
-            x = x.codes
+            x = self.get_data(cid)
+            if isinstance(x, categorical_ndarray):
+                x = x.codes
 
-        if weights is not None:
-            w = self.get_data(weights)
-            if isinstance(w, categorical_ndarray):
-                w = w.codes
-        else:
-            w = None
+            if weights is not None:
+                w = self.get_data(weights)
+                if isinstance(w, categorical_ndarray):
+                    w = w.codes
+            else:
+                w = None
 
-        if subset_state is not None:
-            mask = subset_state.to_mask(self)
-            x = x[mask]
+            if subset_state is not None:
+                mask = subset_state.to_mask(self)
+                x = x[mask]
+                if w is not None:
+                    w = w[mask]
+
+            xmin, xmax = sorted(range)
+
+            keep = (x >= xmin) & (x <= xmax)
+
+            if x.dtype.kind == 'M':
+                x = datetime64_to_mpl(x)
+                xmin = datetime64_to_mpl(xmin)
+                xmax = datetime64_to_mpl(xmax)
+            else:
+                keep &= ~np.isnan(x)
+
+            x = x[keep]
             if w is not None:
-                w = w[mask]
+                w = w[keep]
 
-        xmin, xmax = sorted(range)
+            if len(x) == 0:
+                return np.zeros(bins)
 
-        keep = (x >= xmin) & (x <= xmax)
+            if log:
+                xmin = np.log10(xmin)
+                xmax = np.log10(xmax)
+                x = np.log10(x)
 
-        if x.dtype.kind == 'M':
-            x = datetime64_to_mpl(x)
-            xmin = datetime64_to_mpl(xmin)
-            xmax = datetime64_to_mpl(xmax)
+            # By default fast-histogram drops values that are exactly xmax, so we
+            # increase xmax very slightly to make sure that this doesn't happen
+            xmax += 10 * np.spacing(xmax)
+
+            range = (xmin, xmax)
+
+            return histogram1d(x, range=range, bins=bins, weights=w)
+
         else:
-            keep &= ~np.isnan(x)
 
-        x = x[keep]
-        if w is not None:
-            w = w[keep]
+            x = self.get_data(cids[0])
+            if isinstance(x, categorical_ndarray):
+                x = x.codes
 
-        if len(x) == 0:
-            return np.zeros(bins)
+            y = self.get_data(cids[1])
+            if isinstance(y, categorical_ndarray):
+                y = y.codes
 
-        if log:
-            xmin = np.log10(xmin)
-            xmax = np.log10(xmax)
-            x = np.log10(x)
+            if weights is not None:
+                w = self.get_data(weights)
+                if isinstance(w, categorical_ndarray):
+                    w = w.codes
+            else:
+                w = None
 
-        # By default fast-histogram drops values that are exactly xmax, so we
-        # increase xmax very slightly to make sure that this doesn't happen
-        xmax += 10 * np.spacing(xmax)
+            if subset_state is not None:
+                mask = subset_state.to_mask(self)
+                x = x[mask]
+                y = y[mask]
+                if w is not None:
+                    w = w[mask]
 
-        range = (xmin, xmax)
+            (xmin, xmax), (ymin, ymax) = range
+            xmin, xmax = sorted((xmin, xmax))
+            ymin, ymax = sorted((ymin, ymax))
 
-        return histogram1d(x, range=range, bins=bins, weights=w)
+            keep = (x >= xmin) & (x <= xmax) & (y >= ymin) & (y <= ymax)
+
+            if x.dtype.kind == 'M':
+                x = datetime64_to_mpl(x)
+                xmin = datetime64_to_mpl(xmin)
+                xmax = datetime64_to_mpl(xmax)
+            else:
+                keep &= ~np.isnan(x)
+
+            if y.dtype.kind == 'M':
+                y = datetime64_to_mpl(y)
+                ymin = datetime64_to_mpl(ymin)
+                ymax = datetime64_to_mpl(ymax)
+            else:
+                keep &= ~np.isnan(y)
+
+            x = x[keep]
+            y = y[keep]
+            if w is not None:
+                w = w[keep]
+
+            if len(x) == 0:
+                return np.zeros(bins)
+
+            if len(y) == 0:
+                return np.zeros(bins)
+
+            if log is not None and log[0]:
+                xmin = np.log10(xmin)
+                xmax = np.log10(xmax)
+                x = np.log10(x)
+
+            if log is not None and log[1]:
+                ymin = np.log10(ymin)
+                ymax = np.log10(ymax)
+                y = np.log10(y)
+
+            # By default fast-histogram drops values that are exactly xmax, so we
+            # increase xmax very slightly to make sure that this doesn't happen
+            xmax += 10 * np.spacing(xmax)
+            ymax += 10 * np.spacing(ymax)
+
+            range = [(xmin, xmax), (ymin, ymax)]
+
+            return histogram2d(x, y, range=range, bins=bins, weights=w)
 
     # DEPRECATED
 

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -1601,7 +1601,6 @@ class Data(BaseCartesianData):
 
         if ndim == 1:
             range = (xmin, xmax)
-            print(x, range, bins, w)
             return histogram1d(x, range=range, bins=bins[0], weights=w)
         elif ndim > 1:
             range = [(xmin, xmax), (ymin, ymax)]

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -1593,13 +1593,15 @@ class Data(BaseCartesianData):
             y = np.log10(y)
 
         # By default fast-histogram drops values that are exactly xmax, so we
-        # increase xmax very slightly to make sure that this doesn't happen
-        xmax += 10 * np.spacing(xmax)
+        # increase xmax very slightly to make sure that this doesn't happen, to
+        # be consistent with np.histogram.
+        if ndim == 1:
+            xmax += 10 * np.spacing(xmax)
+
         if ndim == 1:
             range = (xmin, xmax)
             return histogram1d(x, range=range, bins=bins, weights=w)
         elif ndim > 1:
-            ymax += 10 * np.spacing(ymax)
             range = [(xmin, xmax), (ymin, ymax)]
             return histogram2d(x, y, range=range, bins=bins, weights=w)
 

--- a/glue/viewers/scatter/layer_artist.py
+++ b/glue/viewers/scatter/layer_artist.py
@@ -219,6 +219,10 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
 
         if self.state.markers_visible:
             if self.state.density_map:
+                # We don't use x, y here because we actually make use of the
+                # ability of the density artist to call a custom histogram
+                # method which is defined on this class and does the data
+                # access.
                 self.density_artist.set_xy([1, 2, 3], [4, 5, 6])
                 self.plot_artist.set_data([], [])
                 self.scatter_artist.set_offsets(np.zeros((0, 2)))

--- a/glue/viewers/scatter/layer_artist.py
+++ b/glue/viewers/scatter/layer_artist.py
@@ -521,3 +521,9 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
     def update(self):
         self._update_scatter(force=True)
         self.redraw()
+
+    def remove(self):
+        super(ScatterLayerArtist, self).remove()
+        # Clean up the density artist to avoid circular references to do a
+        # reference to the self.histogram2d method in density artist.
+        self.density_artist = None

--- a/glue/viewers/scatter/layer_artist.py
+++ b/glue/viewers/scatter/layer_artist.py
@@ -10,7 +10,6 @@ from mpl_scatter_density.generic_density_artist import GenericDensityArtist
 from astropy.visualization import (ImageNormalize, LinearStretch, SqrtStretch,
                                    AsinhStretch, LogStretch)
 
-from glue.core.subset import Subset
 from glue.utils import defer_draw, broadcast_to, nanmax, categorical_ndarray
 from glue.viewers.scatter.state import ScatterLayerState
 from glue.viewers.scatter.python_export import python_export_scatter_layer

--- a/glue/viewers/scatter/layer_artist.py
+++ b/glue/viewers/scatter/layer_artist.py
@@ -163,8 +163,8 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
         self.density_artist = ScatterDensityArtist(self.axes, [], [], color='white',
                                                    vmin=self.density_auto_limits.min,
                                                    vmax=self.density_auto_limits.max,
-                                                   compute_on_pan=False,
-                                                   histogram2d_callable=self.histogram2d)
+                                                   update_while_panning=False,
+                                                   histogram2d_func=self.histogram2d)
         self.axes.add_artist(self.density_artist)
 
         self.mpl_artists = [self.scatter_artist, self.plot_artist,

--- a/glue/viewers/scatter/qt/tests/test_data_viewer.py
+++ b/glue/viewers/scatter/qt/tests/test_data_viewer.py
@@ -247,7 +247,7 @@ class TestScatterViewer(object):
         self.viewer.state.layers[0].points_mode = 'auto'
         assert len(self.viewer.layers[0].density_artist._x) == 0
         self.viewer.state.layers[0].points_mode = 'density'
-        assert len(self.viewer.layers[0].density_artist._x) == 4
+        assert len(self.viewer.layers[0].density_artist._x) > 0
         self.viewer.state.layers[0].points_mode = 'markers'
         assert len(self.viewer.layers[0].density_artist._x) == 0
 

--- a/glue/viewers/scatter/qt/tests/test_data_viewer.py
+++ b/glue/viewers/scatter/qt/tests/test_data_viewer.py
@@ -245,11 +245,11 @@ class TestScatterViewer(object):
 
         self.viewer.add_data(self.data)
         self.viewer.state.layers[0].points_mode = 'auto'
-        assert not self.viewer.layers[0].density_artist._compute_density_artist
+        assert not self.viewer.layers[0]._compute_density_artist
         self.viewer.state.layers[0].points_mode = 'density'
-        assert self.viewer.layers[0].density_artist._compute_density_artist
+        assert self.viewer.layers[0]._compute_density_artist
         self.viewer.state.layers[0].points_mode = 'markers'
-        assert not self.viewer.layers[0].density_artist._compute_density_artist
+        assert not self.viewer.layers[0]._compute_density_artist
 
     def test_density_map_color(self):
 

--- a/glue/viewers/scatter/qt/tests/test_data_viewer.py
+++ b/glue/viewers/scatter/qt/tests/test_data_viewer.py
@@ -243,7 +243,7 @@ class TestScatterViewer(object):
 
     def test_density_map(self):
 
-        kwargs = dict(range=[(-5, 5), (-5, 5)], bins = (2, 2))
+        kwargs = dict(range=[(-5, 5), (-5, 5)], bins=(2, 2))
 
         self.viewer.add_data(self.data)
         self.viewer.state.layers[0].points_mode = 'auto'

--- a/glue/viewers/scatter/qt/tests/test_data_viewer.py
+++ b/glue/viewers/scatter/qt/tests/test_data_viewer.py
@@ -245,11 +245,11 @@ class TestScatterViewer(object):
 
         self.viewer.add_data(self.data)
         self.viewer.state.layers[0].points_mode = 'auto'
-        assert len(self.viewer.layers[0].density_artist._x) == 0
+        assert not self.viewer.layers[0].density_artist._compute_density_artist
         self.viewer.state.layers[0].points_mode = 'density'
-        assert len(self.viewer.layers[0].density_artist._x) > 0
+        assert self.viewer.layers[0].density_artist._compute_density_artist
         self.viewer.state.layers[0].points_mode = 'markers'
-        assert len(self.viewer.layers[0].density_artist._x) == 0
+        assert not self.viewer.layers[0].density_artist._compute_density_artist
 
     def test_density_map_color(self):
 

--- a/glue/viewers/scatter/qt/tests/test_data_viewer.py
+++ b/glue/viewers/scatter/qt/tests/test_data_viewer.py
@@ -243,13 +243,15 @@ class TestScatterViewer(object):
 
     def test_density_map(self):
 
+        kwargs = dict(range=[(-5, 5), (-5, 5)], bins = (2, 2))
+
         self.viewer.add_data(self.data)
         self.viewer.state.layers[0].points_mode = 'auto'
-        assert not self.viewer.layers[0]._compute_density_artist
+        assert self.viewer.layers[0].state.compute_density_map(**kwargs).sum() == 0
         self.viewer.state.layers[0].points_mode = 'density'
-        assert self.viewer.layers[0]._compute_density_artist
+        assert self.viewer.layers[0].state.compute_density_map(**kwargs).sum() == 4
         self.viewer.state.layers[0].points_mode = 'markers'
-        assert not self.viewer.layers[0]._compute_density_artist
+        assert self.viewer.layers[0].state.compute_density_map(**kwargs).sum() == 0
 
     def test_density_map_color(self):
 


### PR DESCRIPTION
This changes the scatter plot viewer to properly use Data.compute_histogram (this makes it possible for it to work e.g. with remote datasets). This requires https://github.com/astrofrog/mpl-scatter-density/pull/16 to be merged and a new release of mpl-scatter-density.