### PR TITLE
display units for WCS axes that don't have CTYPE but do have CUNIT

### DIFF
--- a/glue/core/coordinates.py
+++ b/glue/core/coordinates.py
@@ -333,6 +333,9 @@ class WCSCoordinates(Coordinates):
                 Freq='Frequency'
             )
             return translate.get(ax, ax)
+        unit = self._header.get('CUNIT%i' % num)
+        if unit is not None:
+            return "World {} ({})".format(axis, unit)
         return super(WCSCoordinates, self).axis_label(axis)
 
     def __gluestate__(self, context):


### PR DESCRIPTION
This allows me to display axes units with my hacked up interface for integrating with yt.

<img width="607" alt="image" src="https://user-images.githubusercontent.com/3126246/44797584-8c6cc380-ab7d-11e8-9f2f-db0cdbc684b9.png">

(note the unit annotations on the axes labels)