### PR TITLE
Only update the array in ModestImage when the mouse is not pressed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,10 @@ v0.14.0 (unreleased)
 
   - ``glue.viewers.common.qt.DataViewerWithState`` is now deprecated.
 
+* Make it so that the modest image only resamples the data when the
+  mouse is no longer pressed - this avoids too many refreshes when
+  panning/zooming. [#1866]
+
 * Make it possible to unglue multiple links in one go. [#1809]
 
 * Make it so that adding a subset to a viewer no longer adds the

--- a/glue/external/modest_image.py
+++ b/glue/external/modest_image.py
@@ -46,13 +46,18 @@ class ModestImage(mi.AxesImage):
         self.axes.figure.canvas.mpl_connect('button_release_event', self._release)
         self.axes.figure.canvas.mpl_connect('resize_event', self._resize)
 
-        self.timer = self.axes.figure.canvas.new_timer(interval=500)
-        self.timer.single_shot = True
-        self.timer.add_callback(self._resize_paused)
+        self._timer = self.axes.figure.canvas.new_timer(interval=500)
+        self._timer.single_shot = True
+        self._timer.add_callback(self._resize_paused)
+
+    def remove(self):
+        super(ModestImage, self).remove()
+        self._timer.stop()
+        self._timer = None
 
     def _resize(self, *args):
         self._pressed = True
-        self.timer.start()
+        self._timer.start()
 
     def _resize_paused(self, *args):
         # If the artist has been removed, self.axes is no longer defined, so

--- a/glue/external/modest_image.py
+++ b/glue/external/modest_image.py
@@ -203,7 +203,7 @@ class ModestImage(mi.AxesImage):
     def draw(self, renderer, *args, **kwargs):
         if self._full_res.shape is None:
             return
-        if not self._pressed:
+        if not self._pressed or self._bounds is None:
             self._scale_to_res()
         # Due to a bug in Matplotlib, we need to return here if all values
         # in the array are masked.

--- a/glue/external/modest_image.py
+++ b/glue/external/modest_image.py
@@ -44,11 +44,24 @@ class ModestImage(mi.AxesImage):
         self.invalidate_cache()
         self.axes.figure.canvas.mpl_connect('button_press_event', self._press)
         self.axes.figure.canvas.mpl_connect('button_release_event', self._release)
+        self.axes.figure.canvas.mpl_connect('resize_event', self._resize)
 
-    def _press(self, event):
+        self.timer = self.axes.figure.canvas.new_timer(interval=500)
+        self.timer.single_shot = True
+        self.timer.add_callback(self._resize_paused)
+
+    def _resize(self, *args):
+        self._pressed = True
+        self.timer.start()
+
+    def _resize_paused(self, *args):
+        self._pressed = False
+        self.axes.figure.canvas.draw()
+
+    def _press(self, *args):
         self._pressed = True
 
-    def _release(self, event):
+    def _release(self, *args):
         self._pressed = False
         self.stale = True
         self.axes.figure.canvas.draw()

--- a/glue/external/modest_image.py
+++ b/glue/external/modest_image.py
@@ -55,6 +55,10 @@ class ModestImage(mi.AxesImage):
         self.timer.start()
 
     def _resize_paused(self, *args):
+        # If the artist has been removed, self.axes is no longer defined, so
+        # we can return early here.
+        if self.axes is None:
+            return
         self._pressed = False
         self.axes.figure.canvas.draw()
 


### PR DESCRIPTION
This fixes #1857 - when panning around, it causes the image to not be updated until the mouse is released. This is crucial for large remote datasets.

Before this is merged, we should consider whether this should be optional in some way. We could base it on the type of data, or on the image size for example.