### PR TITLE
Add show_axes property to viewer state

### DIFF
--- a/glue/viewers/matplotlib/state.py
+++ b/glue/viewers/matplotlib/state.py
@@ -54,6 +54,8 @@ class MatplotlibDataViewerState(ViewerState):
 
     aspect = DeferredDrawCallbackProperty('auto', docstring='Aspect ratio for the axes')
 
+    show_axes = DeferredDrawCallbackProperty(True, docstring='Whether the axes are shown')
+
     x_axislabel = DeferredDrawCallbackProperty('', docstring='Label for the x-axis')
     y_axislabel = DeferredDrawCallbackProperty('', docstring='Label for the y-axis')
 


### PR DESCRIPTION
Needed to have a clean implementation for https://github.com/glue-viz/glue-jupyter/pull/41 and to implement https://github.com/glue-viz/glue/issues/1591