### PR TITLE
Edit subset trigger

### DIFF
--- a/glue/core/edit_subset_mode.py
+++ b/glue/core/edit_subset_mode.py
@@ -70,7 +70,7 @@ class EditSubsetMode(object):
             if self.data_collection is None:
                 raise RuntimeError("Must set data_collection before "
                                    "calling update")
-            self._edit_subset = [self.data_collection.new_subset_group()]
+            self.edit_subset = [self.data_collection.new_subset_group()]
         subs = self._edit_subset
         for s in as_list(subs):
             mode(s, new_state)


### PR DESCRIPTION
Assigning to `edit_subset` will cause more Messages, which I need to refresh the UI, now only a message is send after the new_subset_group call, but not the assignment to `edit_subset`.