### PR TITLE
Use mode='denywrite' in FITS data factory

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@ v0.14.0 (unreleased)
 * Fix Plot.ly exporter for categorical components and histogram
   viewer. [#1886]
 
+* Fix issues with reading very large FITS files on some systems. [#1884]
+
 * Added documentation about plugins. [#1837]
 
 * Better isolate code related to pixel selection tool in image

--- a/glue/core/data_factories/fits.py
+++ b/glue/core/data_factories/fits.py
@@ -17,7 +17,7 @@ def is_fits(filename):
     try:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            with fits.open(filename, ignore_missing_end=True):
+            with fits.open(filename, ignore_missing_end=True, mode='denywrite'):
                 return True
     except IOError:
         return False
@@ -57,7 +57,7 @@ def fits_reader(source, auto_merge=False, exclude_exts=None, label=None):
         hdulist = source
         close_hdulist = False
     else:
-        hdulist = fits.open(source, ignore_missing_end=True)
+        hdulist = fits.open(source, ignore_missing_end=True, mode='denywrite')
         hdulist.verify('fix')
         close_hdulist = True
 
@@ -173,7 +173,7 @@ def is_casalike(filename, **kwargs):
 
     if not is_fits(filename):
         return False
-    with fits.open(filename, ignore_missing_end=True) as hdulist:
+    with fits.open(filename, ignore_missing_end=True, mode='denywrite') as hdulist:
         if len(hdulist) != 1:
             return False
         if hdulist[0].header['NAXIS'] != 4:
@@ -202,7 +202,7 @@ def casalike_cube(filename, **kwargs):
     if 'ignore_missing_end' not in kwargs:
         kwargs['ignore_missing_end'] = True
 
-    with fits.open(filename, **kwargs) as hdulist:
+    with fits.open(filename, mode='denywrite', **kwargs) as hdulist:
         array = hdulist[0].data
         header = hdulist[0].header
     result.coords = coordinates_from_header(header)


### PR DESCRIPTION
This is because the default mode ('readonly') results in files being opened with mmap with the ACCESS_COPY flag, which doesn't work properly on some platforms when the available address space is less than the file size.

cc @Cadair