### PR TITLE
Fix Plot.ly exporter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@ Full changelog
 v0.14.0 (unreleased)
 --------------------
 
+* Fix Plot.ly exporter for categorical components and histogram
+  viewer. [#1886]
+
 * Added documentation about plugins. [#1837]
 
 * Better isolate code related to pixel selection tool in image

--- a/glue/plugins/exporters/plotly/export_plotly.py
+++ b/glue/plugins/exporters/plotly/export_plotly.py
@@ -13,19 +13,6 @@ SYM = {'o': 'circle', 's': 'square', '+': 'cross', '^': 'triangle-up',
        '*': 'cross'}
 
 
-def _data(layer, component):
-    """
-    Extract the data associated with a Component
-
-    For categorical components, extracts the categories and not
-    the remapped integers
-    """
-    result = layer[component]
-    if layer.data.get_kind(component) == 'categorical':
-        result = layer[component].categories[result.astype(np.int)]
-    return result
-
-
 def _sanitize(*arrs):
     mask = np.ones(arrs[0].shape, dtype=np.bool)
     for a in arrs:
@@ -158,7 +145,7 @@ def export_scatter(viewer):
                       color=_color(l.style),
                       size=l.style.markersize)
 
-        x, y = _sanitize(_data(l, xatt), _data(l, yatt))
+        x, y = _sanitize(l[xatt], l[yatt])
 
         trace = dict(x=x, y=y,
                      type='scatter',
@@ -178,7 +165,7 @@ def export_scatter(viewer):
 
 def export_histogram(viewer):
     traces = []
-    att = viewer.component
+    att = viewer.state.x_att
     ymax = 1e-3
     for artist in viewer.layers:
         if not artist.visible:

--- a/glue/plugins/exporters/plotly/export_plotly.py
+++ b/glue/plugins/exporters/plotly/export_plotly.py
@@ -8,6 +8,7 @@ except ImportError:
     plotly = None
 
 from glue.core.layout import Rectangle, snap_to_grid
+from glue.utils import categorical_ndarray
 
 SYM = {'o': 'circle', 's': 'square', '+': 'cross', '^': 'triangle-up',
        '*': 'cross'}
@@ -99,12 +100,6 @@ def _axis(log=False, lo=0, hi=1, title='', categorical=False):
                   rangemode='normal',
                   range=[lo, hi], title=title)
 
-    if categorical:
-        result.pop('type')
-        # about 10 categorical ticks per graph
-        result['autotick'] = False
-        result['dtick'] = max(int(hi - lo) / 10, 1)
-
     return result
 
 
@@ -145,7 +140,13 @@ def export_scatter(viewer):
                       color=_color(l.style),
                       size=l.style.markersize)
 
-        x, y = _sanitize(l[xatt], l[yatt])
+        x, y = l[xatt], l[yatt]
+        if isinstance(x, categorical_ndarray):
+            x = x.codes
+        if isinstance(y, categorical_ndarray):
+            y = y.codes
+
+        x, y = _sanitize(x, y)
 
         trace = dict(x=x, y=y,
                      type='scatter',

--- a/glue/plugins/exporters/plotly/qt/exporter.ui
+++ b/glue/plugins/exporters/plotly/qt/exporter.ui
@@ -29,6 +29,13 @@
      <property name="verticalSpacing">
       <number>10</number>
      </property>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="text_title">
+       <property name="placeholderText">
+        <string>Your plot title</string>
+       </property>
+      </widget>
+     </item>
      <item row="0" column="0">
       <widget class="QLabel" name="label_9">
        <property name="font">
@@ -52,13 +59,6 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="1">
-      <widget class="QLineEdit" name="text_title">
-       <property name="placeholderText">
-        <string>Your plot title</string>
-       </property>
-      </widget>
-     </item>
      <item row="2" column="0">
       <widget class="QLabel" name="label_12">
        <property name="text">
@@ -69,6 +69,13 @@
        </property>
       </widget>
      </item>
+     <item row="5" column="0" colspan="2">
+      <widget class="QRadioButton" name="radio_account_manual">
+       <property name="text">
+        <string>Log in manually:</string>
+       </property>
+      </widget>
+     </item>
      <item row="2" column="1">
       <widget class="QCheckBox" name="checkbox_legend">
        <property name="text">
@@ -76,6 +83,20 @@
        </property>
        <property name="checked">
         <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="1">
+      <widget class="QLineEdit" name="text_api_key">
+       <property name="placeholderText">
+        <string>You can find your API key in the Plotly settings</string>
+       </property>
+      </widget>
+     </item>
+     <item row="10" column="0" colspan="2">
+      <widget class="QLabel" name="label_13">
+       <property name="text">
+        <string>Note that free Plotly accounts are limited to one secret/private plot</string>
        </property>
       </widget>
      </item>
@@ -93,27 +114,13 @@
       </widget>
      </item>
      <item row="4" column="0" colspan="2">
-      <widget class="QRadioButton" name="radio_account_glue">
-       <property name="text">
-        <string>Use glue account</string>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="0" colspan="2">
       <widget class="QRadioButton" name="radio_account_config">
        <property name="text">
         <string>Use settings from ~/.plotly/.credentials</string>
        </property>
       </widget>
      </item>
-     <item row="6" column="0" colspan="2">
-      <widget class="QRadioButton" name="radio_account_manual">
-       <property name="text">
-        <string>Log in manually:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="7" column="0">
+     <item row="6" column="0">
       <widget class="QLabel" name="label_7">
        <property name="text">
         <string>Username:</string>
@@ -123,14 +130,14 @@
        </property>
       </widget>
      </item>
-     <item row="7" column="1">
+     <item row="6" column="1">
       <widget class="QLineEdit" name="text_username">
        <property name="placeholderText">
         <string>Your username</string>
        </property>
       </widget>
      </item>
-     <item row="8" column="0">
+     <item row="7" column="0">
       <widget class="QLabel" name="label_8">
        <property name="text">
         <string>API Key:</string>
@@ -141,20 +148,13 @@
       </widget>
      </item>
      <item row="8" column="1">
-      <widget class="QLineEdit" name="text_api_key">
-       <property name="placeholderText">
-        <string>You can find your API key in the Plotly settings</string>
-       </property>
-      </widget>
-     </item>
-     <item row="9" column="1">
       <widget class="QCheckBox" name="checkbox_save">
        <property name="text">
         <string>Save settings to ~/.plotly/.credentials</string>
        </property>
       </widget>
      </item>
-     <item row="10" column="0">
+     <item row="9" column="0">
       <widget class="QLabel" name="label_4">
        <property name="font">
         <font>
@@ -167,28 +167,21 @@
        </property>
       </widget>
      </item>
-     <item row="11" column="0" colspan="2">
-      <widget class="QLabel" name="label_13">
-       <property name="text">
-        <string>Note that free Plotly accounts are limited to one secret/private plot</string>
-       </property>
-      </widget>
-     </item>
-     <item row="12" column="0">
+     <item row="11" column="0">
       <widget class="QRadioButton" name="radio_sharing_public">
        <property name="text">
         <string>Public</string>
        </property>
       </widget>
      </item>
-     <item row="12" column="1">
+     <item row="11" column="1">
       <widget class="QLabel" name="label">
        <property name="text">
         <string>Anyone will be able to view/find this plot</string>
        </property>
       </widget>
      </item>
-     <item row="13" column="0">
+     <item row="12" column="0">
       <widget class="QRadioButton" name="radio_sharing_secret">
        <property name="text">
         <string>Secret</string>
@@ -198,21 +191,21 @@
        </property>
       </widget>
      </item>
-     <item row="13" column="1">
+     <item row="12" column="1">
       <widget class="QLabel" name="label_2">
        <property name="text">
         <string>Anyone with the secret link will be able to view this plot</string>
        </property>
       </widget>
      </item>
-     <item row="14" column="0">
+     <item row="13" column="0">
       <widget class="QRadioButton" name="radio_sharing_private">
        <property name="text">
         <string>Private</string>
        </property>
       </widget>
      </item>
-     <item row="14" column="1">
+     <item row="13" column="1">
       <widget class="QLabel" name="label_3">
        <property name="text">
         <string>Only you will be able to see this plot</string>

--- a/glue/plugins/exporters/plotly/qt/tests/test_plotly.py
+++ b/glue/plugins/exporters/plotly/qt/tests/test_plotly.py
@@ -18,7 +18,7 @@ from ...export_plotly import build_plotly_call
 class TestPlotly(object):
 
     def setup_method(self, method):
-        d = Data(x=[1, 2, 3], y=[2, 3, 4], label='data')
+        d = Data(x=[1, 2, 3], y=[2, 3, 4], z=['a', 'b', 'c'], label='data')
         dc = DataCollection([d])
         self.app = GlueApplication(dc)
         self.data = d
@@ -110,7 +110,7 @@ class TestPlotly(object):
         d.style.color = '#000000'
 
         viewer = self.app.new_data_viewer(HistogramViewer, data=d)
-        viewer.component = d.id['y']
+        viewer.state.x_att = d.id['y']
         viewer.state.hist_x_min = 0
         viewer.state.hist_x_max = 10
         viewer.state.hist_n_bin = 20
@@ -128,5 +128,46 @@ class TestPlotly(object):
         for k in expected:
             assert expected[k] == data[0][k]
         assert args[0]['layout']['barmode'] == 'overlay'
+
+        viewer.close()
+
+    def test_scatter_categorical(self):
+
+        viewer = self.app.new_data_viewer(ScatterViewer, data=self.data)
+
+        viewer.state.x_att = self.data.id['x']
+        viewer.state.y_att = self.data.id['z']
+
+        args, kwargs = build_plotly_call(self.app)
+
+        xaxis = dict(type='linear', rangemode='normal',
+                     range=[0.9, 3.1], title='x', zeroline=False)
+        yaxis = dict(type='linear', rangemode='normal',
+                     range=[-0.65, 2.65], title='z', zeroline=False)
+        layout = args[0]['layout']
+        for k, v in layout['xaxis'].items():
+            assert xaxis.get(k, v) == v
+        for k, v in layout['yaxis'].items():
+            assert yaxis.get(k, v) == v
+
+        viewer.close()
+
+    def test_histogram_categorical(self):
+
+        viewer = self.app.new_data_viewer(HistogramViewer, data=self.data)
+
+        viewer.state.x_att = self.data.id['z']
+
+        args, kwargs = build_plotly_call(self.app)
+
+        xaxis = dict(type='linear', rangemode='normal',
+                     range=[-0.5, 2.5], title='z', zeroline=False)
+        yaxis = dict(type='linear', rangemode='normal',
+                     range=[0, 1.05], title='', zeroline=False)
+        layout = args[0]['layout']
+        for k, v in layout['xaxis'].items():
+            assert xaxis.get(k, v) == v
+        for k, v in layout['yaxis'].items():
+            assert yaxis.get(k, v) == v
 
         viewer.close()


### PR DESCRIPTION
This makes the plot.ly exporter functional again, and removes the option to publish to the glue account (since the maximum number of plots is easily reached)