### PR TITLE
Fixed a bug due to Numpy not being imported under certain circumstances

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@ Full changelog
 v0.14.0 (unreleased)
 --------------------
 
+* Fix bug that caused component arithmetic to not work if
+  Numpy was imported in user's config.py file. [#1887]
+
 * Fix Plot.ly exporter for categorical components and histogram
   viewer. [#1886]
 

--- a/glue/core/parse.py
+++ b/glue/core/parse.py
@@ -217,7 +217,7 @@ class ParsedCommand(object):
 
         # At this point, np may have been defined in the globals but not the
         # locals so we import it manually to avoid any issues.
-        import numpy as np
+        import numpy as np  # noqa
         if data is not None and np.isscalar(result):
             result = np.ones(data.shape) * result
 

--- a/glue/core/parse.py
+++ b/glue/core/parse.py
@@ -215,6 +215,9 @@ class ParsedCommand(object):
 
         result = eval(cmd, global_variables, locals())  # careful!
 
+        # At this point, np may have been defined in the globals but not the
+        # locals so we import it manually to avoid any issues.
+        import numpy as np
         if data is not None and np.isscalar(result):
             result = np.ones(data.shape) * result
 

--- a/glue/core/tests/test_parse.py
+++ b/glue/core/tests/test_parse.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, division, print_function
 
 import pytest
 import numpy as np
-from mock import MagicMock
+from mock import MagicMock, patch
 
 from .. import parse
 from ..data import ComponentID, Component, Data
@@ -148,6 +148,15 @@ class TestParsedCommand(object):
         with pytest.raises(NameError) as exc:
             pc.evaluate_test()
         assert exc.value.args[0] == "name 'nump' is not defined"
+
+    def test_globals(self):
+
+        with patch('glue.env') as patched_env:
+            import numpy as np
+            patched_env.np = np
+            data = Data()
+            pc = parse.ParsedCommand('np.sin(3.4)', {})
+            pc.evaluate(data)
 
 
 class TestParsedComponentLink(object):


### PR DESCRIPTION
This happened if Numpy was imported (as np) in ``config.py`` (which is a completely valid thing to do)