### PR TITLE
Fix performance issue in the profile viewer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -219,7 +219,7 @@ script:
   - if [[ $QT_PKG == False ]]; then glue --version; fi
 
   # Do style checks
-  - flake8 --exclude=external --ignore=E501,E731,F841,E127,E741,E402 glue
+  - flake8 --max-line-length=100 --exclude=external glue
 
   - pytest --cov glue --durations=20 -vs $PYTEST_ARGS glue
 

--- a/glue/viewers/profile/state.py
+++ b/glue/viewers/profile/state.py
@@ -80,6 +80,9 @@ class ProfileViewerState(MatplotlibDataViewerState):
         # and in the case of world coordinates we use online the spine of the
         # data.
 
+        if self.reference_data is None or self.x_att is None:
+            return
+
         data = self.reference_data
 
         if self.x_att in data.pixel_component_ids:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [flake8]
-ignore=E501,E731,F841,E127,E741,E402,W504
+ignore=E501,E731,F841,E127,E741,E402,W504,W605
 
 [tool:pytest]
 addopts=-p no:logging
-flake8-ignore=E501,E731,F841,E127,E741,E402,W504
+flake8-ignore=E501,E731,F841,E127,E741,E402,W504,W605

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [flake8]
-ignore=E501,E731,F841,E127,E741,E402 
+ignore=E501,E731,F841,E127,E741,E402,W504
 
 [tool:pytest]
 addopts=-p no:logging
-flake8-ignore=E501,E731,F841,E127,E741,E402 
+flake8-ignore=E501,E731,F841,E127,E741,E402,W504


### PR DESCRIPTION
We now compute the limits manually rather than rely on StateAttributeLimits (which tries to compute the world coordinates of all pixels).