### PR TITLE
Avoid unecessary warnings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ Full changelog
 v0.14.0 (unreleased)
 --------------------
 
+* Avoid showing a warning when closing an empty tab. [#1890]
+
 * Fix bug that caused component arithmetic to not work if
   Numpy was imported in user's config.py file. [#1887]
 

--- a/glue/app/qt/application.py
+++ b/glue/app/qt/application.py
@@ -570,22 +570,24 @@ class GlueApplication(Application, QtWidgets.QMainWindow):
         if self.tab_widget.count() == 1:
             return
 
-        if warn and not os.environ.get('GLUE_TESTING'):
-            buttons = QtWidgets.QMessageBox.Ok | QtWidgets.QMessageBox.Cancel
-            dialog = QtWidgets.QMessageBox.warning(
-                self, "Confirm Close",
-                "Are you sure you want to close this tab? "
-                "This will close all data viewers in the tab.",
-                buttons=buttons, defaultButton=QtWidgets.QMessageBox.Cancel)
-            if not dialog == QtWidgets.QMessageBox.Ok:
-                return
-
         w = self.tab_widget.widget(index)
 
-        for window in w.subWindowList():
-            widget = window.widget()
-            if isinstance(widget, DataViewer):
-                widget.close(warn=False)
+        if len(w.subWindowList()) > 0:
+
+            if warn and not os.environ.get('GLUE_TESTING'):
+                buttons = QtWidgets.QMessageBox.Ok | QtWidgets.QMessageBox.Cancel
+                dialog = QtWidgets.QMessageBox.warning(
+                    self, "Confirm Close",
+                    "Are you sure you want to close this tab? "
+                    "This will close all data viewers in the tab.",
+                    buttons=buttons, defaultButton=QtWidgets.QMessageBox.Cancel)
+                if not dialog == QtWidgets.QMessageBox.Ok:
+                    return
+
+            for window in w.subWindowList():
+                widget = window.widget()
+                if isinstance(widget, DataViewer):
+                    widget.close(warn=False)
 
         w.close()
 

--- a/glue/viewers/common/qt/base_widget.py
+++ b/glue/viewers/common/qt/base_widget.py
@@ -98,8 +98,6 @@ class BaseQtViewerWidget(QtWidgets.QMainWindow):
                 # ignore and carry on.
                 pass
 
-        self._warn_close = True
-
         self._closed = True
 
     def mdi_wrap(self):
@@ -175,7 +173,7 @@ class BaseQtViewerWidget(QtWidgets.QMainWindow):
         Call unregister on window close
         """
 
-        if not self._confirm_close():
+        if self._warn_close and not self._confirm_close():
             event.ignore()
             return
 


### PR DESCRIPTION
Avoid warning when closing empty tab, and avoid additional warnings when closing a tab with open viewers.