### PR TITLE
Refactor how we handle aspect ratios to not depend on Matplotlib

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@ Full changelog
 v0.14.0 (unreleased)
 --------------------
 
+* Improved how we handle equal aspect ratio to not depend on
+  Matplotlib. [#1894]
+
 * Avoid showing a warning when closing an empty tab. [#1890]
 
 * Fix bug that caused component arithmetic to not work if

--- a/glue/_mpl_backend.py
+++ b/glue/_mpl_backend.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
+import os
+
 
 class MatplotlibBackendSetter(object):
     """
@@ -42,3 +44,9 @@ def set_mpl_backend():
     from matplotlib import get_backend
     from matplotlib import backends
     backends.backend = get_backend()
+
+    # Set the MPLBACKEND variable explicitly, because ipykernel uses the lack of
+    # MPLBACKEND variable to indicate that it should use its own backend, and
+    # this in turn causes some rcParams to be changed, causing test failures
+    # etc.
+    os.environ['MPLBACKEND'] = 'Agg'

--- a/glue/app/qt/application.py
+++ b/glue/app/qt/application.py
@@ -69,7 +69,7 @@ def _fix_ipython_pylab():
             pass
 
     try:
-        shell.enable_pylab('inline', import_all=True)
+        shell.enable_pylab('agg', import_all=True)
     except ValueError:
         # if the shell is a normal terminal shell, we get here
         pass

--- a/glue/app/qt/application.py
+++ b/glue/app/qt/application.py
@@ -78,6 +78,9 @@ def _fix_ipython_pylab():
         pass
     except UsageError:
         pass
+    except KeyError:
+        # old versions of ipython
+        pass
 
     # Make sure we disable interactive mode (where figures get redrawn for
     # every single Matplotlib command)

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -1599,8 +1599,10 @@ class Data(BaseCartesianData):
         # By default fast-histogram drops values that are exactly xmax, so we
         # increase xmax very slightly to make sure that this doesn't happen, to
         # be consistent with np.histogram.
-        if ndim == 1:
+        if ndim >= 1:
             xmax += 10 * np.spacing(xmax)
+        if ndim >= 2:
+            ymax += 10 * np.spacing(ymax)
 
         if ndim == 1:
             range = (xmin, xmax)

--- a/glue/core/qt/tests/test_layer_artist_model.py
+++ b/glue/core/qt/tests/test_layer_artist_model.py
@@ -15,7 +15,7 @@ class LayerArtist(_LayerArtist):
     clear_count = 0
     redraw_count = 0
 
-    def update(self, view=None):
+    def update(self):
         self.update_count += 1
 
     def clear(self):

--- a/glue/plugins/exporters/plotly/qt/tests/test_plotly.py
+++ b/glue/plugins/exporters/plotly/qt/tests/test_plotly.py
@@ -141,9 +141,9 @@ class TestPlotly(object):
         args, kwargs = build_plotly_call(self.app)
 
         xaxis = dict(type='linear', rangemode='normal',
-                     range=[0.9, 3.1], title='x', zeroline=False)
+                     range=[0.92, 3.08], title='x', zeroline=False)
         yaxis = dict(type='linear', rangemode='normal',
-                     range=[-0.65, 2.65], title='z', zeroline=False)
+                     range=[-0.62, 2.62], title='z', zeroline=False)
         layout = args[0]['layout']
         for k, v in layout['xaxis'].items():
             assert xaxis.get(k, v) == v

--- a/glue/viewers/histogram/state.py
+++ b/glue/viewers/histogram/state.py
@@ -66,6 +66,8 @@ class HistogramViewerState(MatplotlibDataViewerState):
         self.add_callback('x_log', self._reset_x_limits, priority=1000)
 
     def _reset_x_limits(self, *args):
+        if self.x_att is None:
+            return
         with delay_callback(self, 'hist_x_min', 'hist_x_max', 'x_min', 'x_max', 'x_log'):
             self.x_lim_helper.percentile = 100
             self.x_lim_helper.update_values(force=True)

--- a/glue/viewers/image/qt/tests/test_data_viewer.py
+++ b/glue/viewers/image/qt/tests/test_data_viewer.py
@@ -123,16 +123,14 @@ class TestImageViewer(object):
         assert self.viewer.axes.get_xlabel() == 'World 1'
         assert self.viewer.state.x_att_world is self.image1.id['World 1']
         assert self.viewer.state.x_att is self.image1.pixel_component_ids[1]
-        # TODO: make sure limits are deterministic then update this
-        # assert self.viewer.state.x_min == -0.5
-        # assert self.viewer.state.x_max == +1.5
+        assert_allclose(self.viewer.state.x_min, -0.8419913419913423)
+        assert_allclose(self.viewer.state.x_max, +1.8419913419913423)
 
         assert self.viewer.axes.get_ylabel() == 'World 0'
         assert self.viewer.state.y_att_world is self.image1.id['World 0']
         assert self.viewer.state.y_att is self.image1.pixel_component_ids[0]
-        # TODO: make sure limits are deterministic then update this
-        # assert self.viewer.state.y_min == -0.5
-        # assert self.viewer.state.y_max == +1.5
+        assert self.viewer.state.y_min == -0.5
+        assert self.viewer.state.y_max == +1.5
 
         assert not self.viewer.state.x_log
         assert not self.viewer.state.y_log
@@ -246,7 +244,6 @@ class TestImageViewer(object):
         self.viewer.add_data(self.image1)
 
         assert self.viewer.state.aspect == 'equal'
-        assert self.viewer.axes.get_aspect() == 'equal'
 
         self.viewer.state.aspect = 'auto'
 
@@ -255,7 +252,6 @@ class TestImageViewer(object):
         assert len(self.viewer.state.layers) == 2
 
         assert self.viewer.state.aspect == 'auto'
-        assert self.viewer.axes.get_aspect() == 'auto'
 
         self.viewer.state.aspect = 'equal'
 
@@ -264,7 +260,6 @@ class TestImageViewer(object):
         assert len(self.viewer.state.layers) == 3
 
         assert self.viewer.state.aspect == 'equal'
-        assert self.viewer.axes.get_aspect() == 'equal'
 
     def test_hypercube(self):
 
@@ -278,16 +273,14 @@ class TestImageViewer(object):
         assert self.viewer.axes.get_xlabel() == 'World 3'
         assert self.viewer.state.x_att_world is self.hypercube.id['World 3']
         assert self.viewer.state.x_att is self.hypercube.pixel_component_ids[3]
-        # TODO: make sure limits are deterministic then update this
-        # assert self.viewer.state.x_min == -0.5
-        # assert self.viewer.state.x_max == +1.5
+        assert_allclose(self.viewer.state.x_min, -0.6839826839826846)
+        assert_allclose(self.viewer.state.x_max, +4.6839826839826846)
 
         assert self.viewer.axes.get_ylabel() == 'World 2'
         assert self.viewer.state.y_att_world is self.hypercube.id['World 2']
         assert self.viewer.state.y_att is self.hypercube.pixel_component_ids[2]
-        # TODO: make sure limits are deterministic then update this
-        # assert self.viewer.state.y_min == -0.5
-        # assert self.viewer.state.y_max == +1.5
+        assert self.viewer.state.y_min == -0.5
+        assert self.viewer.state.y_max == +3.5
 
         assert not self.viewer.state.x_log
         assert not self.viewer.state.y_log

--- a/glue/viewers/image/state.py
+++ b/glue/viewers/image/state.py
@@ -104,7 +104,7 @@ class ImageViewerState(MatplotlibDataViewerState):
 
         self.update_from_dict(kwargs)
 
-    def reset_limits(self, aspect_ratio=None):
+    def reset_limits(self):
 
         if self.reference_data is None or self.x_att is None or self.y_att is None:
             return
@@ -117,24 +117,14 @@ class ImageViewerState(MatplotlibDataViewerState):
         y_min = -0.5
         y_max = ny - 0.5
 
-        if aspect_ratio is not None:
-            data_ratio = abs(y_max - y_min) / abs(x_max - x_min)
-            if aspect_ratio > 1:
-                y_mid = 0.5 * (y_min + y_max)
-                y_width = abs(y_max - y_min) * aspect_ratio
-                y_min = y_mid - y_width / 2.
-                y_max = y_mid + y_width / 2.
-            elif aspect_ratio < 1:
-                x_mid = 0.5 * (x_min + x_max)
-                x_width = abs(x_max - x_min) / aspect_ratio
-                x_min = x_mid - x_width / 2.
-                x_max = x_mid + x_width / 2.
-
         with delay_callback(self, 'x_min', 'x_max', 'y_min', 'y_max'):
             self.x_min = x_min
             self.x_max = x_max
             self.y_min = y_min
             self.y_max = y_max
+            # We need to adjust the limits in here to avoid triggering all
+            # the update events then changing the limits again.
+            self._adjust_limits_aspect()
 
     @property
     def _display_world(self):

--- a/glue/viewers/image/state.py
+++ b/glue/viewers/image/state.py
@@ -112,16 +112,11 @@ class ImageViewerState(MatplotlibDataViewerState):
         nx = self.reference_data.shape[self.x_att.axis]
         ny = self.reference_data.shape[self.y_att.axis]
 
-        x_min = -0.5
-        x_max = nx - 0.5
-        y_min = -0.5
-        y_max = ny - 0.5
-
         with delay_callback(self, 'x_min', 'x_max', 'y_min', 'y_max'):
-            self.x_min = x_min
-            self.x_max = x_max
-            self.y_min = y_min
-            self.y_max = y_max
+            self.x_min = -0.5
+            self.x_max = nx - 0.5
+            self.y_min = -0.5
+            self.y_max = ny - 0.5
             # We need to adjust the limits in here to avoid triggering all
             # the update events then changing the limits again.
             self._adjust_limits_aspect()

--- a/glue/viewers/image/viewer.py
+++ b/glue/viewers/image/viewer.py
@@ -117,7 +117,7 @@ class MatplotlibImageMixin(object):
         self.update_y_ticklabel()
 
         if relim:
-            self._on_aspect_changed()
+            self.state.reset_limits()
 
         # Determine whether changing slices requires changing the WCS
         if ref_coords is None or type(ref_coords) == Coordinates:
@@ -199,12 +199,6 @@ class MatplotlibImageMixin(object):
             self._crosshairs.remove()
             self._crosshairs = None
             self.axes.figure.canvas.draw()
-
-    def _on_aspect_changed(self, *args):
-        if self.state.aspect == 'equal':
-            self.state.reset_limits(aspect_ratio=self.axes_ratio)
-        else:
-            self.state.reset_limits()
 
     def _script_header(self):
 

--- a/glue/viewers/image/viewer.py
+++ b/glue/viewers/image/viewer.py
@@ -117,7 +117,7 @@ class MatplotlibImageMixin(object):
         self.update_y_ticklabel()
 
         if relim:
-            self.state.reset_limits()
+            self._on_aspect_changed()
 
         # Determine whether changing slices requires changing the WCS
         if ref_coords is None or type(ref_coords) == Coordinates:
@@ -200,14 +200,11 @@ class MatplotlibImageMixin(object):
             self._crosshairs = None
             self.axes.figure.canvas.draw()
 
-    def update_aspect(self, aspect=None):
-        super(MatplotlibImageMixin, self).update_aspect(aspect=aspect)
-        if self.state.reference_data is not None and self.state.x_att is not None and self.state.y_att is not None:
-            nx = self.state.reference_data.shape[self.state.x_att.axis]
-            ny = self.state.reference_data.shape[self.state.y_att.axis]
-            self.axes.set_xlim(-0.5, nx - 0.5)
-            self.axes.set_ylim(-0.5, ny - 0.5)
-            self.axes.figure.canvas.draw()
+    def _on_aspect_changed(self, *args):
+        if self.state.aspect == 'equal':
+            self.state.reset_limits(aspect_ratio=self.axes_ratio)
+        else:
+            self.state.reset_limits()
 
     def _script_header(self):
 

--- a/glue/viewers/image/viewer.py
+++ b/glue/viewers/image/viewer.py
@@ -47,7 +47,7 @@ class MatplotlibImageMixin(object):
         self.state.add_callback('slices', self._on_slice_change)
         self.state.add_callback('reference_data', self._set_wcs)
         self.axes._composite = CompositeArray()
-        self.axes._composite_image = imshow(self.axes, self.axes._composite,
+        self.axes._composite_image = imshow(self.axes, self.axes._composite, aspect='auto',
                                             origin='lower', interpolation='nearest')
         self._set_wcs()
 

--- a/glue/viewers/matplotlib/qt/tests/test_data_viewer.py
+++ b/glue/viewers/matplotlib/qt/tests/test_data_viewer.py
@@ -17,6 +17,8 @@ from glue.app.qt.application import GlueApplication
 from glue.core.roi import XRangeROI
 from glue.utils.qt import get_qapp
 
+from glue.viewers.matplotlib.tests.test_viewer import assert_limits
+
 
 class MatplotlibDrawCounter(object):
 
@@ -530,3 +532,52 @@ class BaseTestMatplotlibDataViewer(object):
                 data.add_component(self.data[cid], cid.label)
         self.data.update_values_from_data(data)
         assert self.draw_count == 2
+
+    def test_aspect_resize(self):
+
+        # Make sure that the limits are adjusted appropriately when resizing
+        # depending on the aspect ratio mode. Note that we don't add any data
+        # here since it isn't needed for this test.
+
+        app = get_qapp()
+
+        self.viewer.state.aspect = 'equal'
+
+        # Resize events only work if widget is visible
+        self.viewer.show()
+        app.processEvents()
+
+        # Set viewer to an initial size
+        self.viewer.viewer_size = (800, 400)
+        app.processEvents()
+        assert_limits(self.viewer,
+                      -0.2926393590770347, 1.2926393590770346,
+                      0.18459804936875074, 0.8154019506312493)
+
+        # Change the viewer size, and make sure the limits are adjusted
+        self.viewer.viewer_size = (400, 400)
+        app.processEvents()
+        assert_limits(self.viewer,
+                      -0.003731395043092167, 1.0037313950430922,
+                      0.003703754699241113, 0.9962962453007589)
+
+        # Now change the viewer size a number of times and make sure if we
+        # return to the original size, the limits match the initial ones.
+        self.viewer.viewer_size = (350, 800)
+        app.processEvents()
+        self.viewer.viewer_size = (900, 300)
+        app.processEvents()
+        self.viewer.viewer_size = (600, 600)
+        app.processEvents()
+        self.viewer.viewer_size = (800, 400)
+        app.processEvents()
+        assert_limits(self.viewer,
+                      -0.2926393590770347, 1.2926393590770346,
+                      0.18459804936875074, 0.8154019506312493)
+
+        # Now check that the limits don't change in 'auto' mode
+        self.viewer.state.aspect = 'auto'
+        self.viewer.viewer_size = (900, 300)
+        assert_limits(self.viewer,
+                      -0.2926393590770347, 1.2926393590770346,
+                      0.18459804936875074, 0.8154019506312493)

--- a/glue/viewers/matplotlib/qt/tests/test_data_viewer.py
+++ b/glue/viewers/matplotlib/qt/tests/test_data_viewer.py
@@ -334,7 +334,7 @@ class BaseTestMatplotlibDataViewer(object):
         # glue, but leaving the tests below in case this is fixed some day. The
         # Matplotlib issue is https://github.com/matplotlib/matplotlib/issues/8439
 
-        axes.set_xscale('linear')
+        # axes.set_xscale('linear')
         #
         # assert viewer_state.x_min == 3
         # assert viewer_state.x_max == 9
@@ -343,7 +343,7 @@ class BaseTestMatplotlibDataViewer(object):
         # assert not viewer_state.x_log
         # assert viewer_state.y_log
         #
-        axes.set_yscale('linear')
+        # axes.set_yscale('linear')
         #
         # assert viewer_state.x_min == 3
         # assert viewer_state.x_max == 9
@@ -351,6 +351,9 @@ class BaseTestMatplotlibDataViewer(object):
         # assert viewer_state.y_max == 3
         # assert not viewer_state.x_log
         # assert not viewer_state.y_log
+
+        viewer_state.x_log = False
+        viewer_state.y_log = False
 
         axes.set_xlim(-1, 4)
 

--- a/glue/viewers/matplotlib/qt/tests/test_data_viewer.py
+++ b/glue/viewers/matplotlib/qt/tests/test_data_viewer.py
@@ -541,6 +541,13 @@ class BaseTestMatplotlibDataViewer(object):
 
         app = get_qapp()
 
+        # Set initial limits to deterministic values
+        self.viewer.state.aspect = 'auto'
+        self.viewer.state.x_min = 0.
+        self.viewer.state.x_max = 1.
+        self.viewer.state.y_min = 0.
+        self.viewer.state.y_max = 1.
+
         self.viewer.state.aspect = 'equal'
 
         # Resize events only work if widget is visible
@@ -551,15 +558,15 @@ class BaseTestMatplotlibDataViewer(object):
         self.viewer.viewer_size = (800, 400)
         app.processEvents()
         assert_limits(self.viewer,
-                      -0.2926393590770347, 1.2926393590770346,
-                      0.18459804936875074, 0.8154019506312493)
+                      -0.4182279131271667, 1.4182279131271665,
+                      0.1346246604993242, 0.8653753395006758)
 
         # Change the viewer size, and make sure the limits are adjusted
         self.viewer.viewer_size = (400, 400)
         app.processEvents()
         assert_limits(self.viewer,
-                      -0.003731395043092167, 1.0037313950430922,
-                      0.003703754699241113, 0.9962962453007589)
+                      -0.08354436018121303, 1.0835443601812127,
+                      -0.07493115929292937, 1.0749311592929294)
 
         # Now change the viewer size a number of times and make sure if we
         # return to the original size, the limits match the initial ones.
@@ -572,12 +579,12 @@ class BaseTestMatplotlibDataViewer(object):
         self.viewer.viewer_size = (800, 400)
         app.processEvents()
         assert_limits(self.viewer,
-                      -0.2926393590770347, 1.2926393590770346,
-                      0.18459804936875074, 0.8154019506312493)
+                      -0.4182279131271667, 1.4182279131271665,
+                      0.1346246604993242, 0.8653753395006758)
 
         # Now check that the limits don't change in 'auto' mode
         self.viewer.state.aspect = 'auto'
         self.viewer.viewer_size = (900, 300)
         assert_limits(self.viewer,
-                      -0.2926393590770347, 1.2926393590770346,
-                      0.18459804936875074, 0.8154019506312493)
+                      -0.4182279131271667, 1.4182279131271665,
+                      0.1346246604993242, 0.8653753395006758)

--- a/glue/viewers/matplotlib/state.py
+++ b/glue/viewers/matplotlib/state.py
@@ -91,7 +91,7 @@ class MatplotlibDataViewerState(ViewerState):
         the aspect callback property is set to 'equal'
         """
         self._axes_aspect_ratio = value
-        self._adjust_limits_aspect()
+        self._adjust_limits_aspect(aspect_adjustable='both')
 
     def _adjust_limits_aspect_x(self, *args):
         self._adjust_limits_aspect(aspect_adjustable='y')

--- a/glue/viewers/matplotlib/tests/test_viewer.py
+++ b/glue/viewers/matplotlib/tests/test_viewer.py
@@ -13,12 +13,15 @@ def test_aspect_ratio():
     # Test of the aspect ratio infrastructure
 
     class CustomViewer(MatplotlibViewerMixin, Viewer):
+
         _state_cls = MatplotlibDataViewerState
+
         def __init__(self, *args, **kwargs):
             Viewer.__init__(self, *args, **kwargs)
             self.figure = plt.figure(figsize=(12, 6))
             self.axes = self.figure.add_axes([0, 0, 1, 1])
             MatplotlibViewerMixin.setup_callbacks(self)
+
         def show(self):
             pass
 

--- a/glue/viewers/matplotlib/tests/test_viewer.py
+++ b/glue/viewers/matplotlib/tests/test_viewer.py
@@ -8,6 +8,16 @@ from glue.viewers.matplotlib.viewer import MatplotlibViewerMixin
 from glue.viewers.matplotlib.state import MatplotlibDataViewerState
 
 
+def assert_limits(viewer, x_min, x_max, y_min, y_max):
+    # Convenience to check both state and matplotlib
+    assert_allclose(viewer.state.x_min, x_min)
+    assert_allclose(viewer.state.x_max, x_max)
+    assert_allclose(viewer.state.y_min, y_min)
+    assert_allclose(viewer.state.y_max, y_max)
+    assert_allclose(viewer.axes.get_xlim(), (x_min, x_max))
+    assert_allclose(viewer.axes.get_ylim(), (y_min, y_max))
+
+
 def test_aspect_ratio():
 
     # Test of the aspect ratio infrastructure
@@ -28,15 +38,6 @@ def test_aspect_ratio():
     class CustomApplication(Application):
         def add_widget(self, *args, **kwargs):
             pass
-
-    def assert_limits(viewer, x_min, x_max, y_min, y_max):
-        # Convenience to check both state and matplotlib
-        assert_allclose(viewer.state.x_min, x_min)
-        assert_allclose(viewer.state.x_max, x_max)
-        assert_allclose(viewer.state.y_min, y_min)
-        assert_allclose(viewer.state.y_max, y_max)
-        assert_allclose(viewer.axes.get_xlim(), (x_min, x_max))
-        assert_allclose(viewer.axes.get_ylim(), (y_min, y_max))
 
     app = CustomApplication()
 
@@ -70,3 +71,6 @@ def test_aspect_ratio():
 
     viewer.axes.set_ylim(0., 2.)
     assert_limits(viewer, 0.0, 4.0, 0.0, 2.0)
+
+    # We include tests for resizing inside the Qt folder (since this doesn't
+    # work correctly with the Agg backend)

--- a/glue/viewers/matplotlib/tests/test_viewer.py
+++ b/glue/viewers/matplotlib/tests/test_viewer.py
@@ -1,0 +1,69 @@
+from numpy.testing import assert_allclose
+
+import matplotlib.pyplot as plt
+
+from glue.core.application_base import Application
+from glue.viewers.common.viewer import Viewer
+from glue.viewers.matplotlib.viewer import MatplotlibViewerMixin
+from glue.viewers.matplotlib.state import MatplotlibDataViewerState
+
+
+def test_aspect_ratio():
+
+    # Test of the aspect ratio infrastructure
+
+    class CustomViewer(MatplotlibViewerMixin, Viewer):
+        _state_cls = MatplotlibDataViewerState
+        def __init__(self, *args, **kwargs):
+            Viewer.__init__(self, *args, **kwargs)
+            self.figure = plt.figure(figsize=(12, 6))
+            self.axes = self.figure.add_axes([0, 0, 1, 1])
+            MatplotlibViewerMixin.setup_callbacks(self)
+        def show(self):
+            pass
+
+    class CustomApplication(Application):
+        def add_widget(self, *args, **kwargs):
+            pass
+
+    def assert_limits(viewer, x_min, x_max, y_min, y_max):
+        # Convenience to check both state and matplotlib
+        assert_allclose(viewer.state.x_min, x_min)
+        assert_allclose(viewer.state.x_max, x_max)
+        assert_allclose(viewer.state.y_min, y_min)
+        assert_allclose(viewer.state.y_max, y_max)
+        assert_allclose(viewer.axes.get_xlim(), (x_min, x_max))
+        assert_allclose(viewer.axes.get_ylim(), (y_min, y_max))
+
+    app = CustomApplication()
+
+    viewer = app.new_data_viewer(CustomViewer)
+    viewer.state.aspect = 'equal'
+
+    assert_limits(viewer, -0.5, 1.5, 0., 1.)
+
+    # Test changing x limits in state, which should just change the y limits
+
+    viewer.state.x_min = -2.5
+    assert_limits(viewer, -2.5, 1.5, -0.5, 1.5)
+
+    viewer.state.x_max = -1.5
+    assert_limits(viewer, -2.5, -1.5, 0.25, 0.75)
+
+    # Test changing y limits in state, which should just change the x limits
+
+    viewer.state.y_max = 1.25
+    assert_limits(viewer, -3.0, -1.0, 0.25, 1.25)
+
+    viewer.state.y_min = 0.75
+    assert_limits(viewer, -2.5, -1.5, 0.75, 1.25)
+
+    # Test changing x limits in Matplotlib, which should just change the x limits
+
+    viewer.axes.set_xlim(1., 3.)
+    assert_limits(viewer, 1.0, 3.0, 0.5, 1.5)
+
+    # Test changing x limits in Matplotlib, which should just change the x limits
+
+    viewer.axes.set_ylim(0., 2.)
+    assert_limits(viewer, 0.0, 4.0, 0.0, 2.0)

--- a/glue/viewers/matplotlib/viewer.py
+++ b/glue/viewers/matplotlib/viewer.py
@@ -296,8 +296,6 @@ class MatplotlibViewerMixin(object):
                     y_max = y_mid + y_width / 2.
                     changed = 'y'
 
-        data_ratio = abs(y_max - y_min) / abs(x_max - x_min)
-
         return x_min, x_max, y_min, y_max, changed
 
     def _on_aspect_changed(self, *args):

--- a/glue/viewers/matplotlib/viewer.py
+++ b/glue/viewers/matplotlib/viewer.py
@@ -133,7 +133,6 @@ class MatplotlibViewerMixin(object):
         self.axes.set_yscale('log' if self.state.y_log else 'linear')
         self.redraw()
 
-    # @avoid_circular
     def limits_from_mpl(self, *args, **kwargs):
 
         if getattr(self, '_skip_limits_from_mpl', False):

--- a/glue/viewers/matplotlib/viewer.py
+++ b/glue/viewers/matplotlib/viewer.py
@@ -203,7 +203,7 @@ class MatplotlibViewerMixin(object):
 
         return axes_ratio
 
-    def _on_resize(self):
+    def _on_resize(self, *args):
         self.state._set_axes_aspect_ratio(self.axes_ratio)
 
     def _update_appearance_from_settings(self, message=None):

--- a/glue/viewers/matplotlib/viewer.py
+++ b/glue/viewers/matplotlib/viewer.py
@@ -58,14 +58,10 @@ class MatplotlibViewerMixin(object):
                                            transform=self.axes.transAxes)
         self.loading_text.set_visible(False)
 
-        self.state.add_callback('x_min', self._on_state_xlim_changed)
-        self.state.add_callback('x_max', self._on_state_xlim_changed)
-        self.state.add_callback('y_min', self._on_state_ylim_changed)
-        self.state.add_callback('y_max', self._on_state_ylim_changed)
-
-        self.state.add_callback('aspect', self._on_aspect_changed)
-
-        self._on_aspect_changed()
+        self.state.add_callback('x_min', self.limits_to_mpl)
+        self.state.add_callback('x_max', self.limits_to_mpl)
+        self.state.add_callback('y_min', self.limits_to_mpl)
+        self.state.add_callback('y_max', self.limits_to_mpl)
 
         if (self.state.x_min or self.state.x_max or self.state.y_min or self.state.y_max) is None:
             self.limits_from_mpl()
@@ -77,9 +73,11 @@ class MatplotlibViewerMixin(object):
 
         self.update_x_log()
 
-        self.axes.callbacks.connect('xlim_changed', self._on_mpl_xlim_changed)
-        self.axes.callbacks.connect('ylim_changed', self._on_mpl_ylim_changed)
-        self.figure.canvas.mpl_connect('resize_event', self._on_aspect_changed)
+        self.axes.callbacks.connect('xlim_changed', self.limits_from_mpl)
+        self.axes.callbacks.connect('ylim_changed', self.limits_from_mpl)
+        self.figure.canvas.mpl_connect('resize_event', self._on_resize)
+
+        self._on_resize()
 
         self.axes.set_autoscale_on(False)
 
@@ -135,19 +133,10 @@ class MatplotlibViewerMixin(object):
         self.axes.set_yscale('log' if self.state.y_log else 'linear')
         self.redraw()
 
-    def _on_mpl_xlim_changed(self, *args):
-        # If the x limits have been set, if the aspect ratio is 'equal', we
-        # adjust the y limits to preserve the aspect ratio.
-        self.limits_from_mpl(aspect_adjustable='y')
+    # @avoid_circular
+    def limits_from_mpl(self, *args, **kwargs):
 
-    def _on_mpl_ylim_changed(self, *args):
-        # If the y limits have been set, if the aspect ratio is 'equal', we
-        # adjust the x limits to preserve the aspect ratio.
-        self.limits_from_mpl(aspect_adjustable='x')
-
-    def limits_from_mpl(self, aspect_adjustable='x'):
-
-        if getattr(self, '_skip_from_mpl', False):
+        if getattr(self, '_skip_limits_from_mpl', False):
             return
 
         if isinstance(self.state.x_min, np.datetime64):
@@ -160,42 +149,21 @@ class MatplotlibViewerMixin(object):
         else:
             y_min, y_max = self.axes.get_ylim()
 
-        x_min, x_max, y_min, y_max, changed = self.limits_with_aspect(x_min, x_max,
-                                                                      y_min, y_max,
-                                                                      aspect_adjustable=aspect_adjustable)
-
-        # If the aspect ratio has caused some of the limits to change, we simply
-        # change the relevant matplotlib limits and return - changing the
-        # matplotlib limits will cause this method to be called again, at which
-        # point the limits should no longer change, and will be set on the
-        # state.
-        if changed:
-            if changed == 'x':
-                self.axes.set_xlim(x_min, x_max)
-            else:
-                self.axes.set_ylim(y_min, y_max)
-            self.axes.figure.canvas.draw()
-            return
-
         with delay_callback(self.state, 'x_min', 'x_max', 'y_min', 'y_max'):
+
             self.state.x_min = x_min
             self.state.x_max = x_max
             self.state.y_min = y_min
             self.state.y_max = y_max
 
-    def _on_state_xlim_changed(self, *args):
-        self.limits_to_mpl(aspect_adjustable='y')
-
-    def _on_state_ylim_changed(self, *args):
-        self.limits_to_mpl(aspect_adjustable='x')
-
-    def limits_to_mpl(self, aspect_adjustable='x'):
+    def limits_to_mpl(self, *args):
 
         if (self.state.x_min is None or self.state.x_max is None or
             self.state.y_min is None or self.state.y_max is None):
             return
 
         x_min, x_max = self.state.x_min, self.state.x_max
+
         if self.state.x_log:
             if self.state.x_max <= 0:
                 x_min, x_max = 0.1, 1
@@ -209,25 +177,18 @@ class MatplotlibViewerMixin(object):
             elif self.state.y_min <= 0:
                 y_min = y_max / 10
 
-        x_min, x_max, y_min, y_max, changed = self.limits_with_aspect(x_min, x_max,
-                                                                      y_min, y_max,
-                                                                      aspect_adjustable=aspect_adjustable)
-
-        # If the limits have changed, we just change them back on the state
-        if changed:
-            with delay_callback(self.state, 'x_min', 'x_max', 'y_min', 'y_max'):
-                self.state.x_min = x_min
-                self.state.x_max = x_max
-                self.state.y_min = y_min
-                self.state.y_max = y_max
-            return
-
-        self._skip_from_mpl = True
-        self.axes.set_xlim(x_min, x_max)
-        self.axes.set_ylim(y_min, y_max)
-        self._skip_from_mpl = False
-
-        self.axes.figure.canvas.draw()
+        # Since we deal with aspect ratio internally, there are no conditions
+        # under which we would want to immediately change the state once the
+        # limits are set in Matplotlib, so we avoid this by setting the
+        # _skip_limits_from_mpl attribute which is then recognized inside
+        # limits_from_mpl
+        self._skip_limits_from_mpl = True
+        try:
+            self.axes.set_xlim(x_min, x_max)
+            self.axes.set_ylim(y_min, y_max)
+            self.axes.figure.canvas.draw()
+        finally:
+            self._skip_limits_from_mpl = False
 
     @property
     def axes_ratio(self):
@@ -242,81 +203,8 @@ class MatplotlibViewerMixin(object):
 
         return axes_ratio
 
-    def limits_with_aspect(self, x_min, x_max, y_min, y_max, aspect_adjustable='auto'):
-        """
-        Determine whether the limits need to be changed based on the aspect ratio.
-        """
-
-        changed = None
-
-        if self.state.aspect == 'equal':
-
-            # Find axes aspect ratio
-            axes_ratio = self.axes_ratio
-
-            # Find current data ratio
-            data_ratio = abs(y_max - y_min) / abs(x_max - x_min)
-
-            # Only do something if the data ratio is sufficiently different
-            # from the axes ratio.
-            if abs(data_ratio - axes_ratio) / (0.5 * (data_ratio + axes_ratio)) > 0.01:
-
-                # We now adjust the limits - which ones we adjust depends on
-                # the adjust keyword. We also make sure we preserve the
-                # mid-point of the current coordinates.
-
-                if aspect_adjustable == 'both':
-
-                    # We need to adjust both at the same time
-
-                    x_mid = 0.5 * (x_min + x_max)
-                    x_width = abs(x_max - x_min) * (data_ratio / axes_ratio) ** 0.5
-
-                    y_mid = 0.5 * (y_min + y_max)
-                    y_width = abs(y_max - y_min) / (data_ratio / axes_ratio) ** 0.5
-
-                    x_min = x_mid - x_width / 2.
-                    x_max = x_mid + x_width / 2.
-
-                    y_min = y_mid - y_width / 2.
-                    y_max = y_mid + y_width / 2.
-
-                    changed = 'both'
-
-                elif (aspect_adjustable == 'auto' and data_ratio > axes_ratio) or aspect_adjustable == 'x':
-                    x_mid = 0.5 * (x_min + x_max)
-                    x_width = abs(y_max - y_min) / axes_ratio
-                    x_min = x_mid - x_width / 2.
-                    x_max = x_mid + x_width / 2.
-                    changed = 'x'
-                else:
-                    y_mid = 0.5 * (y_min + y_max)
-                    y_width = abs(x_max - x_min) * axes_ratio
-                    y_min = y_mid - y_width / 2.
-                    y_max = y_mid + y_width / 2.
-                    changed = 'y'
-
-        return x_min, x_max, y_min, y_max, changed
-
-    def _on_aspect_changed(self, *args):
-
-        if (self.state.x_min is None or self.state.x_max is None or
-            self.state.y_min is None or self.state.y_max is None):
-            return
-
-        x_min, x_max, y_min, y_max, changed = self.limits_with_aspect(self.state.x_min,
-                                                                      self.state.x_max,
-                                                                      self.state.y_min,
-                                                                      self.state.y_max,
-                                                                      aspect_adjustable='both')
-
-        if changed:
-            with delay_callback(self.state, 'x_min', 'x_max', 'y_min', 'y_max'):
-                self.state.x_min = x_min
-                self.state.x_max = x_max
-                self.state.y_min = y_min
-                self.state.y_max = y_max
-
+    def _on_resize(self):
+        self.state._set_axes_aspect_ratio(self.axes_ratio)
 
     def _update_appearance_from_settings(self, message=None):
         update_appearance_from_settings(self.axes)

--- a/glue/viewers/matplotlib/viewer.py
+++ b/glue/viewers/matplotlib/viewer.py
@@ -159,7 +159,7 @@ class MatplotlibViewerMixin(object):
     def limits_to_mpl(self, *args):
 
         if (self.state.x_min is None or self.state.x_max is None or
-            self.state.y_min is None or self.state.y_max is None):
+                self.state.y_min is None or self.state.y_max is None):
             return
 
         x_min, x_max = self.state.x_min, self.state.x_max

--- a/glue/viewers/scatter/qt/tests/test_data_viewer.py
+++ b/glue/viewers/scatter/qt/tests/test_data_viewer.py
@@ -71,12 +71,12 @@ class TestScatterViewer(object):
         assert combo_as_string(self.viewer.options_widget().ui.combosel_y_att) == 'Main components:x:y:z:Coordinate components:Pixel Axis 0 [x]:World 0'
 
         assert viewer_state.x_att is self.data.id['x']
-        assert_allclose(viewer_state.x_min, -1.1 - 0.225)
-        assert_allclose(viewer_state.x_max, 3.4 + 0.225)
+        assert_allclose(viewer_state.x_min, -1.1 - 0.18)
+        assert_allclose(viewer_state.x_max, 3.4 + 0.18)
 
         assert viewer_state.y_att is self.data.id['y']
-        assert_allclose(viewer_state.y_min, 3.2 - 0.015)
-        assert_allclose(viewer_state.y_max, 3.5 + 0.015)
+        assert_allclose(viewer_state.y_min, 3.2 - 0.012)
+        assert_allclose(viewer_state.y_max, 3.5 + 0.012)
 
         assert not viewer_state.x_log
         assert not viewer_state.y_log
@@ -88,12 +88,12 @@ class TestScatterViewer(object):
         viewer_state.y_att = self.data.id['z']
 
         assert viewer_state.x_att is self.data.id['x']
-        assert_allclose(viewer_state.x_min, -1.1 - 0.225)
-        assert_allclose(viewer_state.x_max, 3.4 + 0.225)
+        assert_allclose(viewer_state.x_min, -1.1 - 0.18)
+        assert_allclose(viewer_state.x_max, 3.4 + 0.18)
 
         assert viewer_state.y_att is self.data.id['z']
-        assert_allclose(viewer_state.y_min, -0.5 - 0.15)
-        assert_allclose(viewer_state.y_max, 2.5 + 0.15)
+        assert_allclose(viewer_state.y_min, -0.5 - 0.12)
+        assert_allclose(viewer_state.y_max, 2.5 + 0.12)
 
         assert not viewer_state.x_log
         assert not viewer_state.y_log
@@ -104,21 +104,21 @@ class TestScatterViewer(object):
 
         self.viewer.add_data(self.data)
 
-        assert_allclose(viewer_state.x_min, -1.1 - 0.225)
-        assert_allclose(viewer_state.x_max, 3.4 + 0.225)
+        assert_allclose(viewer_state.x_min, -1.1 - 0.18)
+        assert_allclose(viewer_state.x_max, 3.4 + 0.18)
 
         self.viewer.options_widget().button_flip_x.click()
 
-        assert_allclose(viewer_state.x_max, -1.1 - 0.225)
-        assert_allclose(viewer_state.x_min, 3.4 + 0.225)
+        assert_allclose(viewer_state.x_max, -1.1 - 0.18)
+        assert_allclose(viewer_state.x_min, 3.4 + 0.18)
 
-        assert_allclose(viewer_state.y_min, 3.2 - 0.015)
-        assert_allclose(viewer_state.y_max, 3.5 + 0.015)
+        assert_allclose(viewer_state.y_min, 3.2 - 0.012)
+        assert_allclose(viewer_state.y_max, 3.5 + 0.012)
 
         self.viewer.options_widget().button_flip_y.click()
 
-        assert_allclose(viewer_state.y_max, 3.2 - 0.015)
-        assert_allclose(viewer_state.y_min, 3.5 + 0.015)
+        assert_allclose(viewer_state.y_max, 3.2 - 0.012)
+        assert_allclose(viewer_state.y_min, 3.5 + 0.012)
 
     def test_remove_data(self):
         self.viewer.add_data(self.data)
@@ -374,12 +374,12 @@ class TestScatterViewer(object):
         self.viewer.add_data(self.data_2d)
 
         assert viewer_state.x_att is self.data_2d.id['a']
-        assert_allclose(viewer_state.x_min, 1 - 0.15)
-        assert_allclose(viewer_state.x_max, 4 + 0.15)
+        assert_allclose(viewer_state.x_min, 1 - 0.12)
+        assert_allclose(viewer_state.x_max, 4 + 0.12)
 
         assert viewer_state.y_att is self.data_2d.id['b']
-        assert_allclose(viewer_state.y_min, 5 - 0.15)
-        assert_allclose(viewer_state.y_max, 8 + 0.15)
+        assert_allclose(viewer_state.y_min, 5 - 0.12)
+        assert_allclose(viewer_state.y_max, 8 + 0.12)
 
         assert self.viewer.layers[0].plot_artist.get_xdata().shape == (4,)
 
@@ -536,8 +536,8 @@ class TestScatterViewer(object):
         # Matplotlib deals with dates by converting them to the number of days
         # since 01-01-0001, so we can check that the limits are correctly
         # converted (and not 100 to 400)
-        assert self.viewer.axes.get_xlim() == (719248.0, 719578.0)
-        assert self.viewer.axes.get_ylim() == (3.2 - 0.015, 3.5 + 0.015)
+        assert self.viewer.axes.get_xlim() == (719251.0, 719575.0)
+        assert self.viewer.axes.get_ylim() == (3.2 - 0.012, 3.5 + 0.012)
 
         # Apply an ROI selection in plotting coordinates
         roi = RectangularROI(xmin=719313, xmax=719513, ymin=3, ymax=4)
@@ -549,8 +549,8 @@ class TestScatterViewer(object):
         # Now do the same with the y axis
         self.viewer.state.y_att = self.data.id['t2']
 
-        assert self.viewer.axes.get_xlim() == (719248.0, 719578.0)
-        assert self.viewer.axes.get_ylim() == (719348.0, 719678.0)
+        assert self.viewer.axes.get_xlim() == (719251.0, 719575.0)
+        assert self.viewer.axes.get_ylim() == (719351.0, 719675.0)
 
         # Apply an ROI selection in plotting coordinates
         edit = self.session.edit_subset_mode
@@ -562,16 +562,16 @@ class TestScatterViewer(object):
         # Make sure that the Qt labels look ok
         self.viewer.state.y_att = self.data.id['y']
         options = self.viewer.options_widget().ui
-        assert options.valuetext_x_min.text() == '1970-03-27'
-        assert options.valuetext_x_max.text() == '1971-02-20'
-        assert options.valuetext_y_min.text() == '3.185'
-        assert options.valuetext_y_max.text() == '3.515'
+        assert options.valuetext_x_min.text() == '1970-03-30'
+        assert options.valuetext_x_max.text() == '1971-02-17'
+        assert options.valuetext_y_min.text() == '3.188'
+        assert options.valuetext_y_max.text() == '3.512'
 
         # Make sure that we can set the xmin/xmax to a string date
-        assert_equal(self.viewer.state.x_min, np.datetime64('1970-03-27', 'D'))
+        assert_equal(self.viewer.state.x_min, np.datetime64('1970-03-30', 'D'))
         options.valuetext_x_min.setText('1970-04-14')
         options.valuetext_x_min.editingFinished.emit()
-        assert self.viewer.axes.get_xlim() == (719266.0, 719578.0)
+        assert self.viewer.axes.get_xlim() == (719266.0, 719575.0)
         assert_equal(self.viewer.state.x_min, np.datetime64('1970-04-14', 'D'))
 
         # Make sure that everything works fine after saving/reloading
@@ -587,6 +587,6 @@ class TestScatterViewer(object):
         assert_equal(self.viewer.state.x_min, np.datetime64('1970-04-14', 'D'))
 
         assert options.valuetext_x_min.text() == '1970-04-14'
-        assert options.valuetext_x_max.text() == '1971-02-20'
-        assert options.valuetext_y_min.text() == '3.185'
-        assert options.valuetext_y_max.text() == '3.515'
+        assert options.valuetext_x_max.text() == '1971-02-17'
+        assert options.valuetext_y_min.text() == '3.188'
+        assert options.valuetext_y_max.text() == '3.512'

--- a/glue/viewers/scatter/state.py
+++ b/glue/viewers/scatter/state.py
@@ -36,12 +36,12 @@ class ScatterViewerState(MatplotlibDataViewerState):
 
         self.x_lim_helper = StateAttributeLimitsHelper(self, attribute='x_att',
                                                        lower='x_min', upper='x_max',
-                                                       log='x_log', margin=0.05,
+                                                       log='x_log', margin=0.04,
                                                        limits_cache=self.limits_cache)
 
         self.y_lim_helper = StateAttributeLimitsHelper(self, attribute='y_att',
                                                        lower='y_min', upper='y_max',
-                                                       log='y_log', margin=0.05,
+                                                       log='y_log', margin=0.04,
                                                        limits_cache=self.limits_cache)
 
         self.add_callback('layers', self._layers_changed)

--- a/glue/viewers/scatter/state.py
+++ b/glue/viewers/scatter/state.py
@@ -55,10 +55,14 @@ class ScatterViewerState(MatplotlibDataViewerState):
         self.add_callback('y_log', self._reset_y_limits)
 
     def _reset_x_limits(self, *args):
+        if self.x_att is None:
+            return
         self.x_lim_helper.percentile = 100
         self.x_lim_helper.update_values(force=True)
 
     def _reset_y_limits(self, *args):
+        if self.y_att is None:
+            return
         self.y_lim_helper.percentile = 100
         self.y_lim_helper.update_values(force=True)
 


### PR DESCRIPTION
How Matplotlib deals with aspect ratio can be quite buggy and hard to control, so it would be easier to deal with it ourselves, with the bonus that if this is implemented in a generic way it could be used in glue-jupyter too.

This is currently a work in progress from a few months ago, so I need to remind myself of what worked/what didn't work, then make sure we add extensive tests!