### PR TITLE
Fix get_mask when key joins are present

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,12 @@ v0.15.0 (unreleased)
 
 * No changes yet.
 
+v0.14.1 (unreleased)
+--------------------
+
+* Fix bug that caused the links based on ``join_on_key`` to not
+  always work. [#1902]
+
 v0.14.0 (2018-11-14)
 --------------------
 

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -28,6 +28,7 @@ from glue.core.exceptions import IncompatibleAttribute
 from glue.core.visual import VisualAttributes
 from glue.core.coordinates import Coordinates
 from glue.core.contracts import contract
+from glue.core.joins import get_mask_with_key_joins
 from glue.config import settings
 from glue.utils import (compute_statistic, unbroadcast, iterate_chunks,
                         datetime64_to_mpl, broadcast_to, categorical_ndarray)
@@ -1203,7 +1204,10 @@ class Data(BaseCartesianData):
             raise TypeError("Unknown data kind")
 
     def get_mask(self, subset_state, view=None):
-        return subset_state.to_mask(self, view=view)
+        try:
+            return subset_state.to_mask(self, view=view)
+        except IncompatibleAttribute:
+            return get_mask_with_key_joins(self, self._key_joins, subset_state, view=view)
 
     def __setitem__(self, key, value):
         """

--- a/glue/core/joins.py
+++ b/glue/core/joins.py
@@ -1,0 +1,84 @@
+import numpy as np
+from glue.core.exceptions import IncompatibleAttribute
+
+__all__ = ['get_mask_with_key_joins']
+
+
+def get_mask_with_key_joins(data, key_joins, subset_state, view=None):
+    """
+    Given a dataset and a subset state, check whether the subset state
+    can be translated to the current dataset via key joins.
+
+    Note that this does not try simply applying the subset state to the
+    dataset, as it is assumed this has been tried first.
+    """
+
+    for other, (cid1, cid2) in key_joins.items():
+
+        if getattr(other, '_recursing', False):
+            continue
+
+        try:
+            data._recursing = True
+            mask_right = other.get_mask(subset_state)
+        except IncompatibleAttribute:
+            continue
+        finally:
+            data._recursing = False
+
+        if len(cid1) == 1 and len(cid2) == 1:
+
+            key_left = data.get_data(cid1[0], view=view)
+            key_right = other.get_data(cid2[0], view=mask_right)
+            mask = np.in1d(key_left.ravel(), key_right.ravel())
+
+            return mask.reshape(key_left.shape)
+
+        elif len(cid1) == len(cid2):
+
+            key_left_all = []
+            key_right_all = []
+
+            for cid1_i, cid2_i in zip(cid1, cid2):
+                key_left_all.append(data.get_data(cid1_i, view=view).ravel())
+                key_right_all.append(other.get_data(cid2_i, view=mask_right).ravel())
+
+            # TODO: The following is slow because we are looping in Python.
+            #       This could be made significantly faster by switching to
+            #       C/Cython.
+
+            key_left_all = zip(*key_left_all)
+            key_right_all = set(zip(*key_right_all))
+
+            result = [key in key_right_all for key in key_left_all]
+            result = np.array(result)
+
+            return result.reshape(data.get_data(cid1_i, view=view).shape)
+
+        elif len(cid1) == 1:
+
+            key_left = data.get_data(cid1[0], view=view).ravel()
+            mask = np.zeros_like(key_left, dtype=bool)
+            for cid2_i in cid2:
+                key_right = other.get_data(cid2_i, view=mask_right).ravel()
+                mask |= np.in1d(key_left, key_right)
+
+            return mask.reshape(data.get_data(cid1[0], view=view).shape)
+
+        elif len(cid2) == 1:
+
+            key_right = other.get_data(cid2[0], view=mask_right).ravel()
+            mask = np.zeros_like(data.get_data(cid1[0], view=view).ravel(), dtype=bool)
+            for cid1_i in cid1:
+                key_left = data.get_data(cid1_i, view=view).ravel()
+                mask |= np.in1d(key_left, key_right)
+
+            return mask.reshape(data.get_data(cid1[0], view=view).shape)
+
+        else:
+
+            raise Exception("Either the number of components in the key join sets "
+                            "should match, or one of the component sets should ",
+                            "contain a single component.")
+
+    raise IncompatibleAttribute

--- a/glue/core/joins.py
+++ b/glue/core/joins.py
@@ -56,7 +56,7 @@ def get_mask_with_key_joins(data, key_joins, subset_state, view=None):
 
             key_left = data.get_data(cid1[0], view=view)
             key_right = other.get_data(cid2[0], view=mask_right)
-            mask = np.isin(key_left.ravel(), key_right.ravel())
+            mask = np.in1d(key_left.ravel(), key_right.ravel())
 
             return mask.reshape(key_left.shape)
 
@@ -72,7 +72,7 @@ def get_mask_with_key_joins(data, key_joins, subset_state, view=None):
             key_left_all = concatenate_arrays(*key_left_all)
             key_right_all = concatenate_arrays(*key_right_all)
 
-            mask = np.isin(key_left_all, key_right_all)
+            mask = np.in1d(key_left_all, key_right_all)
 
             return mask.reshape(data.get_data(cid1_i, view=view).shape)
 
@@ -82,7 +82,7 @@ def get_mask_with_key_joins(data, key_joins, subset_state, view=None):
             mask = np.zeros_like(key_left, dtype=bool)
             for cid2_i in cid2:
                 key_right = other.get_data(cid2_i, view=mask_right).ravel()
-                mask |= np.isin(key_left, key_right)
+                mask |= np.in1d(key_left, key_right)
 
             return mask.reshape(data.get_data(cid1[0], view=view).shape)
 
@@ -92,7 +92,7 @@ def get_mask_with_key_joins(data, key_joins, subset_state, view=None):
             mask = np.zeros_like(data.get_data(cid1[0], view=view).ravel(), dtype=bool)
             for cid1_i in cid1:
                 key_left = data.get_data(cid1_i, view=view).ravel()
-                mask |= np.isin(key_left, key_right)
+                mask |= np.in1d(key_left, key_right)
 
             return mask.reshape(data.get_data(cid1[0], view=view).shape)
 

--- a/glue/core/subset.py
+++ b/glue/core/subset.py
@@ -74,7 +74,8 @@ class Subset(object):
         self.subset_state = SubsetState()  # calls proper setter method
 
         self.style = VisualAttributes(parent=self)
-        self.style.markersize *= 1.5
+        self.style.markersize *= 2.5
+        self.style.linewidth *= 2.5
         self.style.color = color
         self.style.alpha = alpha
 

--- a/glue/core/subset.py
+++ b/glue/core/subset.py
@@ -167,93 +167,7 @@ class Subset(object):
            for the requested data set.
 
         """
-        try:
-            return self.subset_state.to_index_list(self.data)
-        except IncompatibleAttribute as exc:
-            try:
-                return self._to_index_list_join()
-            except IncompatibleAttribute:
-                raise exc
-
-    def _to_index_list_join(self):
-        return np.where(self._to_mask_join(None).flat)[0]
-
-    def _to_mask_join(self, view):
-        """
-        Convert the subset to a mask through an entity join to another
-        dataset.
-        """
-        for other, (cid1, cid2) in self.data._key_joins.items():
-
-            if getattr(other, '_recursing', False):
-                continue
-
-            try:
-                self.data._recursing = True
-                s2 = Subset(other)
-                s2.subset_state = self.subset_state
-                mask_right = s2.to_mask()
-            except IncompatibleAttribute:
-                continue
-            finally:
-                self.data._recursing = False
-
-            if len(cid1) == 1 and len(cid2) == 1:
-
-                key_left = self.data[cid1[0], view]
-                key_right = other[cid2[0], mask_right]
-                mask = np.in1d(key_left.ravel(), key_right.ravel())
-
-                return mask.reshape(key_left.shape)
-
-            elif len(cid1) == len(cid2):
-
-                key_left_all = []
-                key_right_all = []
-
-                for cid1_i, cid2_i in zip(cid1, cid2):
-                    key_left_all.append(self.data[cid1_i, view].ravel())
-                    key_right_all.append(other[cid2_i, mask_right].ravel())
-
-                # TODO: The following is slow because we are looping in Python.
-                #       This could be made significantly faster by switching to
-                #       C/Cython.
-
-                key_left_all = zip(*key_left_all)
-                key_right_all = set(zip(*key_right_all))
-
-                result = [key in key_right_all for key in key_left_all]
-                result = np.array(result)
-
-                return result.reshape(self.data[cid1_i, view].shape)
-
-            elif len(cid1) == 1:
-
-                key_left = self.data[cid1[0], view].ravel()
-                mask = np.zeros_like(key_left, dtype=bool)
-                for cid2_i in cid2:
-                    key_right = other[cid2_i, mask_right].ravel()
-                    mask |= np.in1d(key_left, key_right)
-
-                return mask.reshape(self.data[cid1[0], view].shape)
-
-            elif len(cid2) == 1:
-
-                key_right = other[cid2[0], mask_right].ravel()
-                mask = np.zeros_like(self.data[cid1[0], view].ravel(), dtype=bool)
-                for cid1_i in cid1:
-                    key_left = self.data[cid1_i, view].ravel()
-                    mask |= np.in1d(key_left, key_right)
-
-                return mask.reshape(self.data[cid1[0], view].shape)
-
-            else:
-
-                raise Exception("Either the number of components in the key join sets "
-                                "should match, or one of the component sets should ",
-                                "contain a single component.")
-
-        raise IncompatibleAttribute
+        return self.subset_state.to_index_list(self.data)
 
     @contract(view='array_view', returns='array')
     def to_mask(self, view=None):
@@ -268,10 +182,7 @@ class Subset(object):
            defines whether each element belongs to the subset.
 
         """
-        try:
-            return self.data.get_mask(self.subset_state, view=view)
-        except IncompatibleAttribute as exc:
-            return self._to_mask_join(view)
+        return self.data.get_mask(self.subset_state, view=view)
 
     @contract(value=bool)
     def do_broadcast(self, value):
@@ -518,7 +429,7 @@ class SubsetState(object):
 
     @contract(data='isinstance(Data)')
     def to_index_list(self, data):
-        return np.where(self.to_mask(data).flat)[0]
+        return np.where(data.get_mask(self.subset_state).flat)[0]
 
     @contract(data='isinstance(Data)', view='array_view')
     def to_mask(self, data, view=None):

--- a/glue/core/subset_group.py
+++ b/glue/core/subset_group.py
@@ -109,6 +109,7 @@ class SubsetGroup(HubListener):
 
         self.style = VisualAttributes(parent=self)
         self.style.markersize *= 2.5
+        self.style.linewidth *= 2.5
         self.style.color = color
         self.style.alpha = alpha
 

--- a/glue/plugins/dendro_viewer/state.py
+++ b/glue/plugins/dendro_viewer/state.py
@@ -8,6 +8,7 @@ from glue.viewers.matplotlib.state import (MatplotlibDataViewerState,
                                            DeferredDrawCallbackProperty as DDCProperty,
                                            DeferredDrawSelectionCallbackProperty as DDSCProperty)
 from glue.core.data_combo_helper import ComponentIDComboHelper
+from glue.external.echo import keep_in_sync
 
 from .dendro_helpers import dendrogram_layout
 
@@ -101,3 +102,8 @@ class DendrogramLayerState(MatplotlibLayerState):
     A state class that includes all the attributes for layers in a dendrogram plot.
     """
     linewidth = DDCProperty(1, docstring="The line width")
+
+    def __init__(self, viewer_state=None, **kwargs):
+        super(DendrogramLayerState, self).__init__(viewer_state=viewer_state, **kwargs)
+        self.linewidth = self.layer.style.linewidth
+        self._sync_color = keep_in_sync(self, 'linewidth', self.layer.style, 'linewidth')

--- a/glue/plugins/dendro_viewer/state.py
+++ b/glue/plugins/dendro_viewer/state.py
@@ -106,4 +106,4 @@ class DendrogramLayerState(MatplotlibLayerState):
     def __init__(self, viewer_state=None, **kwargs):
         super(DendrogramLayerState, self).__init__(viewer_state=viewer_state, **kwargs)
         self.linewidth = self.layer.style.linewidth
-        self._sync_color = keep_in_sync(self, 'linewidth', self.layer.style, 'linewidth')
+        self._sync_linewidth = keep_in_sync(self, 'linewidth', self.layer.style, 'linewidth')


### PR DESCRIPTION
This fixes an issue that occurred when getting masks with ``Data.get_mask`` - this would ignore any key joins set up previously. I've now moved the key join code so that it gets called in ``Data.get_mask`` now instead of ``Subset.to_mask``

Fixes #1899 