### PR TITLE
Prevent scrolling of canvas when scrolling over viewers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,9 @@ v0.15.0 (unreleased)
 v0.14.2 (unreleased)
 --------------------
 
+* Make sure that scrolling above a viewer does not result in the
+  whole canvas also scrolling.
+
 * Fix bug that caused date/time columns in Excel files to not be
   read in correctly.
 


### PR DESCRIPTION
This is a bit of a hacky solution, but I couldn't find a cleaner way to do it.

Fixes https://github.com/glue-viz/glue/issues/1897