### PR TITLE
Speed up loading of large files when guessing format

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@ v0.14.2 (unreleased)
 * Fix bug that caused date/time columns in Excel files to not be
   read in correctly.
 
-* Improve performance when reading in large non-FITS files.
+* Improve performance when reading in large non-FITS files. [#1920]
 
 * Fix bug that caused demo VO Table to not be read in correctly with
   recent versions of Numpy and Astropy. [#1911]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@ v0.14.2 (unreleased)
 * Fix bug that caused date/time columns in Excel files to not be
   read in correctly.
 
+* Improve performance when reading in large non-FITS files.
+
 * Fix bug that caused demo VO Table to not be read in correctly with
   recent versions of Numpy and Astropy. [#1911]
 

--- a/glue/core/data_factories/fits.py
+++ b/glue/core/data_factories/fits.py
@@ -189,8 +189,6 @@ def is_casalike(filename, **kwargs):
     """
     from astropy.io import fits
 
-    print("IN HERE", is_fits(filename))
-
     if not is_fits(filename):
         return False
     with fits.open(filename, ignore_missing_end=True, mode='denywrite') as hdulist:

--- a/glue/core/data_factories/fits.py
+++ b/glue/core/data_factories/fits.py
@@ -24,7 +24,7 @@ def is_fits(filename):
 
         # It isn't, so maybe it's compressed?
         if start[:2] == b'\x1f\x8b':
-            with gzip.GzipFile('2MASS_k.fits.gz') as gz:
+            with gzip.GzipFile(filename) as gz:
                 if not gz.read(9) == b'SIMPLE  =':
                     return False
         else:


### PR DESCRIPTION
This adds a shortcut if loading a large file that isn't a FITS file. Previously astropy would try and load the whole file as a header.