### PR TITLE
Added a class to represent a derived dataset produced by indexing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,9 @@ v0.15.0 (unreleased)
 
 * Improve the user interface for the link editor. [#1934]
 
+* Added a new ``IndexedData`` class to represent a derived dataset produced
+  by indexing a higher-dimensional dataset. [#1953]
+
 v0.14.3 (unreleased)
 --------------------
 

--- a/glue/core/data_derived.py
+++ b/glue/core/data_derived.py
@@ -1,0 +1,119 @@
+# Base classes for various types of derived datasets - these are basically
+# wrapper classes around data objects that modify the data in some way
+# on-the-fly. These work by exposting the common data API described in
+# http://docs.glueviz.org/en/stable/developer_guide/data.html and transparently
+# applying changes.
+
+from glue.core.data import BaseCartesianData
+from glue.core.message import NumericalDataChangedMessage
+
+
+class DerivedData(BaseCartesianData):
+    """
+    Base class for all derived data classes.
+    """
+
+
+class IndexedData(BaseCartesianData):
+    """
+    A dataset where some dimensions have been removed via indexing.
+
+    The indices can be modified after the data has been created using the
+    ``indices`` property.
+
+    Parameters
+    ----------
+    original_data : `~glue.core.data.BaseCartesianData`
+        The original data to reduce the dimension of
+    indices : tuple of `int` or `None`
+        The indices to apply to the data, or `None` if a dimension should be
+        preserved. This tuple should have as many elements as there are
+        dimensions in ``original_data``.
+    """
+
+    def __init__(self, original_data, indices):
+
+        super(IndexedData, self).__init__()
+
+        if len(indices) != original_data.ndim:
+            raise ValueError("The 'indices' tuple should have length {0}"
+                             .format(original_data.ndim))
+
+        self._original_data = original_data
+        self._indices = indices
+
+    @property
+    def indices(self):
+        return self._indices
+
+    @indices.setter
+    def indices(self, value):
+
+        if len(value) != self._original_data.ndim:
+            raise ValueError("The 'indices' tuple should have length {0}"
+                             .format(self._original_data.ndim))
+
+        # For now we require the indices to be in the same position, i.e. we
+        # don't allow changes in dimensionality of the derived dataset.
+        for index in range(self._original_data.ndim):
+            before, after = self._indices[index], value[index]
+            if type(before) != type(after):
+                raise TypeError("Can't change where the ``None`` values are in indices")
+
+        self._indices = value
+
+        # Tell glue that the data has changed
+        if self.hub is not None:
+            msg = NumericalDataChangedMessage(self)
+            self.hub.broadcast(msg)
+
+    @property
+    def label(self):
+        return self._original_data.label + ' [indexed]'
+
+    @property
+    def shape(self):
+        shape = []
+        for idim in range(self._original_data.ndim):
+            if self.indices[idim] is None:
+                shape.append(self._original_data.shape[idim])
+        return shape
+
+    @property
+    def main_components(self):
+        return self._original_data.main_components
+
+    def get_kind(self, cid):
+        return self._original_data.get_kind(cid)
+
+    def _to_original_view(self, view):
+        original_view = list(self.indices)
+        idim_reduced = 0
+        for idim in range(self._original_data.ndim):
+            if original_view[idim] is None:
+                if view is None:
+                    original_view[idim] = slice(None)
+                else:
+                    original_view[idim] = view[idim_reduced]
+                idim_reduced += 1
+        return original_view
+
+    def get_data(self, cid, view=None):
+        original_view = self._to_original_view(view)
+        return self._original_data.get_data(cid, view=original_view)
+
+    def get_mask(self, subset_state, view=None):
+        original_view = self._to_original_view(view)
+        return self._original_data.get_mask(subset_state, view=original_view)
+
+    def compute_fixed_resolution_buffer(self, *args, **kwargs):
+        from glue.core.fixed_resolution_buffer import compute_fixed_resolution_buffer
+        return compute_fixed_resolution_buffer(self, *args, **kwargs)
+
+    # The following aren't correct yet
+
+    def compute_statistic(self, *args, **kwargs):
+        return self._original_data.compute_statistic(*args, **kwargs)
+
+    def compute_histogram(self, *args, **kwargs):
+        return self._original_data.compute_histogram(*args, **kwargs)

--- a/glue/core/data_derived.py
+++ b/glue/core/data_derived.py
@@ -115,7 +115,7 @@ class IndexedData(BaseCartesianData):
                 else:
                     original_view[idim] = view[idim_reduced]
                 idim_reduced += 1
-        return original_view
+        return tuple(original_view)
 
     def get_data(self, cid, view=None):
         if cid in self.pixel_component_ids:

--- a/glue/core/data_derived.py
+++ b/glue/core/data_derived.py
@@ -106,6 +106,8 @@ class IndexedData(BaseCartesianData):
         return self._original_data.get_kind(cid)
 
     def _to_original_view(self, view):
+        if view is None:
+            view = [slice(None)] * self.ndim
         original_view = list(self.indices)
         idim_reduced = 0
         for idim in range(self._original_data.ndim):
@@ -132,10 +134,7 @@ class IndexedData(BaseCartesianData):
         return compute_fixed_resolution_buffer(self, *args, **kwargs)
 
     def compute_statistic(self, *args, **kwargs):
-        if kwargs.get('subset_state') is None:
-            kwargs['subset_state'] = self._indices_subset_state
-        else:
-            kwargs['subset_state'] &= self._indices_subset_state
+        kwargs['view'] = self._to_original_view(kwargs.get('view'))
         return self._original_data.compute_statistic(*args, **kwargs)
 
     def compute_histogram(self, *args, **kwargs):

--- a/glue/core/data_derived.py
+++ b/glue/core/data_derived.py
@@ -58,8 +58,8 @@ class IndexedData(BaseCartesianData):
         # don't allow changes in dimensionality of the derived dataset.
         if hasattr(self, '_indices'):
             changed = False
-            for index in range(self._original_data.ndim):
-                before, after = self._indices[index], value[index]
+            for idim in range(self._original_data.ndim):
+                before, after = self._indices[idim], value[idim]
                 if type(before) != type(after):
                     raise TypeError("Can't change where the ``None`` values are in indices")
                 elif before != after:
@@ -73,6 +73,12 @@ class IndexedData(BaseCartesianData):
         # for compute_statistic and compute_histogram
         slices = [slice(x) if x is None else x for x in self._indices]
         self._indices_subset_state = SliceSubsetState(self._original_data, slices)
+
+        # Construct a list of original pixel component IDs
+        self._original_pixel_cids = []
+        for idim in range(self._original_data.ndim):
+            if self._indices[idim] is None:
+                self._original_pixel_cids.append(self._original_data.pixel_component_ids[idim])
 
         # Tell glue that the data has changed
         if changed and self.hub is not None:
@@ -112,6 +118,8 @@ class IndexedData(BaseCartesianData):
         return original_view
 
     def get_data(self, cid, view=None):
+        if cid in self.pixel_component_ids:
+            cid = self._original_pixel_cids[cid.axis]
         original_view = self._to_original_view(view)
         return self._original_data.get_data(cid, view=original_view)
 

--- a/glue/core/tests/test_data_derived.py
+++ b/glue/core/tests/test_data_derived.py
@@ -148,3 +148,8 @@ class TestIndexedData:
         with pytest.raises(ValueError) as exc:
             derived.indices = (2, None, 4, None)
         assert exc.value.args[0] == "The 'indices' tuple should have length 5"
+
+    def test_pixel_component_ids(self):
+        derived = IndexedData(self.data, (None, 2, None, 4, None))
+        assert_equal(derived.get_data(derived.pixel_component_ids[1]),
+                     self.data.get_data(self.data.pixel_component_ids[2])[:, 2, :, 4, :])

--- a/glue/core/tests/test_data_derived.py
+++ b/glue/core/tests/test_data_derived.py
@@ -30,7 +30,7 @@ class TestIndexedData:
 
         assert derived.label == 'Test data[:,:,:,:,:]'
         assert derived.shape == self.data.shape
-        assert derived.main_components == self.data.main_components
+        assert [str(c) for c in derived.main_components] == [str(c) for c in self.data.main_components]
         assert derived.get_kind(self.x_id) == self.data.get_kind(self.x_id)
 
         for view in [None, (1, slice(None), slice(None), slice(1, 4), slice(0, 7, 2))]:
@@ -72,7 +72,7 @@ class TestIndexedData:
 
         assert derived.label == 'Test data[:,2,:,4,:]'
         assert derived.shape == manual.shape
-        assert derived.main_components == manual.main_components
+        assert [str(c) for c in derived.main_components] == [str(c) for c in manual.main_components]
         assert derived.get_kind(self.x_id) == manual.get_kind(self.x_id)
 
         for view in [None, (1, slice(None), slice(1, 4))]:

--- a/glue/core/tests/test_data_derived.py
+++ b/glue/core/tests/test_data_derived.py
@@ -33,7 +33,7 @@ class TestIndexedData:
         assert derived.main_components == self.data.main_components
         assert derived.get_kind(self.x_id) == self.data.get_kind(self.x_id)
 
-        for view in [None, [1, slice(None), slice(None), slice(1, 4), slice(0, 7, 2)]]:
+        for view in [None, (1, slice(None), slice(None), slice(1, 4), slice(0, 7, 2))]:
 
             assert_equal(derived.get_data(self.x_id, view=view),
                          self.data.get_data(self.x_id, view=view))
@@ -75,7 +75,7 @@ class TestIndexedData:
         assert derived.main_components == manual.main_components
         assert derived.get_kind(self.x_id) == manual.get_kind(self.x_id)
 
-        for view in [None, [1, slice(None), slice(1, 4)]]:
+        for view in [None, (1, slice(None), slice(1, 4))]:
 
             assert_equal(derived.get_data(self.x_id, view=view),
                          manual.get_data(self.x_id, view=view))

--- a/glue/core/tests/test_data_derived.py
+++ b/glue/core/tests/test_data_derived.py
@@ -1,0 +1,150 @@
+import pytest
+
+import numpy as np
+from numpy.testing import assert_equal
+
+from glue.core.hub import HubListener
+from glue.core.message import NumericalDataChangedMessage
+from glue.core.data import Data
+from glue.core.data_collection import DataCollection
+from glue.core.data_derived import IndexedData
+
+
+class TestIndexedData:
+
+    def setup_class(self):
+
+        x = +np.arange(2520).reshape((3, 4, 5, 6, 7))
+        y = -np.arange(2520).reshape((3, 4, 5, 6, 7))
+
+        self.data = Data(x=x, y=y, label='Test data')
+        self.x_id, self.y_id = self.data.main_components
+
+        self.subset_state = self.x_id >= 1200
+
+    def test_identity(self):
+
+        # In this test, we don't actually slice any dimensions
+
+        derived = IndexedData(self.data, (None,) * 5)
+
+        assert derived.label == 'Test data[:,:,:,:,:]'
+        assert derived.shape == self.data.shape
+        assert derived.main_components == self.data.main_components
+        assert derived.get_kind(self.x_id) == self.data.get_kind(self.x_id)
+
+        for view in [None, [1, slice(None), slice(None), slice(1, 4), slice(0, 7, 2)]]:
+
+            assert_equal(derived.get_data(self.x_id, view=view),
+                         self.data.get_data(self.x_id, view=view))
+
+            assert_equal(derived.get_mask(self.subset_state, view=view),
+                         self.data.get_mask(self.subset_state, view=view))
+
+        bounds = [2, (-5, 5, 10), 3, 4, (-3, 3, 10)]
+        assert_equal(derived.compute_fixed_resolution_buffer(bounds=bounds, target_cid=self.x_id),
+                     self.data.compute_fixed_resolution_buffer(bounds=bounds, target_cid=self.x_id))
+
+        assert_equal(derived.compute_statistic('mean', self.x_id),
+                     self.data.compute_statistic('mean', self.x_id))
+
+        assert_equal(derived.compute_statistic('mean', self.x_id, axis=2),
+                     self.data.compute_statistic('mean', self.x_id, axis=2))
+
+        assert_equal(derived.compute_statistic('mean', self.x_id, subset_state=self.subset_state),
+                     self.data.compute_statistic('mean', self.x_id, subset_state=self.subset_state))
+
+        assert_equal(derived.compute_histogram([self.x_id], range=[(0, 1000)], bins=[30]),
+                     self.data.compute_histogram([self.x_id], range=[(0, 1000)], bins=[30]))
+
+        assert_equal(derived.compute_histogram([self.x_id], range=[(0, 1000)], bins=[30], subset_state=self.subset_state),
+                     self.data.compute_histogram([self.x_id], range=[(0, 1000)], bins=[30], subset_state=self.subset_state))
+
+    def test_indexed(self):
+
+        # Here we slice two of the dimensions and then compare the results to a
+        # manually sliced dataset.
+
+        derived = IndexedData(self.data, (None, 2, None, 4, None))
+        manual = Data()
+        manual.add_component(self.data[self.x_id][:, 2, :, 4, :], label=self.x_id)
+        manual.add_component(self.data[self.y_id][:, 2, :, 4, :], label=self.y_id)
+
+        assert derived.label == 'Test data[:,2,:,4,:]'
+        assert derived.shape == manual.shape
+        assert derived.main_components == manual.main_components
+        assert derived.get_kind(self.x_id) == manual.get_kind(self.x_id)
+
+        for view in [None, [1, slice(None), slice(1, 4)]]:
+
+            assert_equal(derived.get_data(self.x_id, view=view),
+                         manual.get_data(self.x_id, view=view))
+
+            assert_equal(derived.get_mask(self.subset_state, view=view),
+                         manual.get_mask(self.subset_state, view=view))
+
+        bounds = [2, (-5, 5, 10), (-3, 3, 10)]
+        assert_equal(derived.compute_fixed_resolution_buffer(bounds=bounds, target_cid=self.x_id),
+                     manual.compute_fixed_resolution_buffer(bounds=bounds, target_cid=self.x_id))
+
+        assert_equal(derived.compute_statistic('mean', self.x_id),
+                     manual.compute_statistic('mean', self.x_id))
+
+        assert_equal(derived.compute_statistic('mean', self.x_id, axis=2),
+                     manual.compute_statistic('mean', self.x_id, axis=2))
+
+        assert_equal(derived.compute_statistic('mean', self.x_id, subset_state=self.subset_state),
+                     manual.compute_statistic('mean', self.x_id, subset_state=self.subset_state))
+
+        assert_equal(derived.compute_histogram([self.x_id], range=[(0, 1000)], bins=[30]),
+                     manual.compute_histogram([self.x_id], range=[(0, 1000)], bins=[30]))
+
+        assert_equal(derived.compute_histogram([self.x_id], range=[(0, 1000)], bins=[30], subset_state=self.subset_state),
+                     manual.compute_histogram([self.x_id], range=[(0, 1000)], bins=[30], subset_state=self.subset_state))
+
+    def test_numerical_values_changed(self):
+
+        # Here we slice two of the dimensions and then compare the results to a
+        # manually sliced dataset.
+
+        derived = IndexedData(self.data, (None, 2, None, 4, None))
+        data_collection = DataCollection([self.data, derived])
+
+        class CustomListener(HubListener):
+
+            def __init__(self, hub):
+                self.received = 0
+                hub.subscribe(self, NumericalDataChangedMessage,
+                              handler=self.receive_message)
+
+            def receive_message(self, message):
+                self.received += 1
+
+        listener = CustomListener(data_collection.hub)
+
+        assert listener.received == 0
+
+        derived.indices = (None, 3, None, 5, None)
+
+        assert listener.received == 1
+
+        derived.indices = (None, 3, None, 5, None)
+
+        assert listener.received == 1
+
+    def test_invalid_indices_init(self):
+        with pytest.raises(ValueError) as exc:
+            derived = IndexedData(self.data, (2, None, 4, None))
+        assert exc.value.args[0] == "The 'indices' tuple should have length 5"
+
+    def test_invalid_indices_changed(self):
+
+        derived = IndexedData(self.data, (None, 2, None, 4, None))
+
+        with pytest.raises(TypeError) as exc:
+            derived.indices = (2, None, 4, None, 5)
+        assert exc.value.args[0] == "Can't change where the ``None`` values are in indices"
+
+        with pytest.raises(ValueError) as exc:
+            derived.indices = (2, None, 4, None)
+        assert exc.value.args[0] == "The 'indices' tuple should have length 5"


### PR DESCRIPTION
With the abstract data interface, it's now pretty easy to create so-called *derived* datasets which are computed on-the-fly from other datasets. We can use this to reduce dimensionality, including making PV slices as proper datasets, and so on.

This PR adds a first class that simply slices along some dimensions to reduce the dimensionality.

This is still a work in progress as ``compute_histogram`` and ``compute_statistic`` need to be updated accordingly.

To try it out:

```python
from glue.core import DataCollection
from glue.core.data_factories import load_data
from glue.app.qt.application import GlueApplication
from glue.viewers.image.qt import ImageViewer
from glue.core.data_derived import IndexedData

data1 = load_data('/Users/tom/Data/PPV/l1448_13co_small.fits')
data2 = IndexedData(data1, (None, 10, None))

dc = DataCollection([data1, data2])

ga = GlueApplication(dc)
ga.new_data_viewer(ImageViewer, data=data1)
ga.new_data_viewer(ImageViewer, data=data2)
ga.start()
