### PR TITLE
Fix continuous integration

### DIFF
--- a/glue/app/qt/tests/test_application.py
+++ b/glue/app/qt/tests/test_application.py
@@ -14,7 +14,7 @@ from glue.core.data import Data
 from glue.core.component_link import ComponentLink
 from glue.core.data_collection import DataCollection
 from glue.core.tests.test_state import Cloner, doubler, clone
-from glue.tests.helpers import requires_ipython, PYSIDE2_INSTALLED  # noqa
+from glue.tests.helpers import requires_ipython  # noqa
 from glue.viewers.image.qt import ImageViewer
 from glue.viewers.scatter.qt import ScatterViewer
 from glue.viewers.histogram.qt import HistogramViewer
@@ -139,7 +139,6 @@ class TestGlueApplication(object):
 
             pc.reset_mock()
 
-    @pytest.mark.skipif('PYSIDE2_INSTALLED')
     def test_new_data_viewer_ok(self):
 
         with patch('glue.app.qt.application.pick_class') as pc:
@@ -156,14 +155,12 @@ class TestGlueApplication(object):
 
             pc.reset_mock()
 
-    @pytest.mark.skipif('PYSIDE2_INSTALLED')
     def test_move(self):
         viewer = self.app.new_data_viewer(ScatterViewer)
         viewer.move(10, 20)
         assert viewer.position == (10, 20)
         viewer.close()
 
-    @pytest.mark.skipif('PYSIDE2_INSTALLED')
     def test_resize(self):
         viewer = self.app.new_data_viewer(ScatterViewer)
         viewer.viewer_size = (100, 200)
@@ -347,7 +344,6 @@ class TestApplicationSession(object):
         app = GlueApplication(dc)
         self.check_clone(app)
 
-    @pytest.mark.skipif('PYSIDE2_INSTALLED')
     def test_scatter_viewer(self):
         d = Data(label='x', x=[1, 2, 3, 4, 5], y=[2, 3, 4, 5, 6])
         dc = DataCollection([d])
@@ -369,7 +365,6 @@ class TestApplicationSession(object):
         copy1.close()
         copy2.close()
 
-    @pytest.mark.skipif('PYSIDE2_INSTALLED')
     def test_multi_tab(self):
         d = Data(label='hist', x=[[1, 2], [2, 3]])
         dc = DataCollection([d])
@@ -385,7 +380,6 @@ class TestApplicationSession(object):
         app.close()
         copy.close()
 
-    @pytest.mark.skipif('PYSIDE2_INSTALLED')
     def test_histogram(self):
         d = Data(label='hist', x=[[1, 2], [2, 3]])
         dc = DataCollection([d])
@@ -420,7 +414,6 @@ class TestApplicationSession(object):
         sg.style.color = '#112233'
         assert sg.subsets[0].style.color == '#112233'
 
-    @pytest.mark.skipif('PYSIDE2_INSTALLED')
     def test_deselect_tool_on_viewer_change(self):
 
         d = Data(label='hist', x=[[1, 2], [2, 3]])

--- a/glue/tests/helpers.py
+++ b/glue/tests/helpers.py
@@ -26,6 +26,8 @@ def make_skipper(module, label=None, version=None):
 ASTROPY_INSTALLED, requires_astropy = make_skipper('astropy',
                                                    label='Astropy')
 
+MATPLOTLIB_GE_22, requires_matplotlib_ge_22 = make_skipper('matplotlib', version='2.2')
+
 ASTRODENDRO_INSTALLED, requires_astrodendro = make_skipper('astrodendro')
 
 SCIPY_INSTALLED, requires_scipy = make_skipper('scipy',

--- a/glue/viewers/matplotlib/qt/tests/test_data_viewer.py
+++ b/glue/viewers/matplotlib/qt/tests/test_data_viewer.py
@@ -17,6 +17,7 @@ from glue.core.exceptions import IncompatibleDataException
 from glue.app.qt.application import GlueApplication
 from glue.core.roi import XRangeROI
 from glue.utils.qt import get_qapp
+from glue.tests.helpers import requires_matplotlib_ge_22
 
 
 class MatplotlibDrawCounter(object):
@@ -532,11 +533,15 @@ class BaseTestMatplotlibDataViewer(object):
         self.data.update_values_from_data(data)
         assert self.draw_count == 2
 
+    @requires_matplotlib_ge_22
     def test_aspect_resize(self):
 
         # Make sure that the limits are adjusted appropriately when resizing
         # depending on the aspect ratio mode. Note that we don't add any data
         # here since it isn't needed for this test.
+
+        # This test works with Matplotlib 2.0 and 2.2 but not 2.1, hence we
+        # skip it with Matplotlib 2.1 above.
 
         app = get_qapp()
 


### PR DESCRIPTION
This skips a non-critical test known to fail with Matplotlib 2.1 and also tries to re-enable some of the previously skipped tests.