### PR TITLE
Improvements to how drawing is handled

### DIFF
--- a/doc/customizing_guide/state_viewer/config.py
+++ b/doc/customizing_guide/state_viewer/config.py
@@ -98,7 +98,7 @@ class TutorialLayerArtist(LayerArtist):
         self.artist.remove()
 
     def redraw(self):
-        self.axes.figure.canvas.draw()
+        self.axes.figure.canvas.draw_idle()
 
     def update(self):
         self._on_fill_change()

--- a/glue/app/qt/tests/test_application.py
+++ b/glue/app/qt/tests/test_application.py
@@ -18,7 +18,7 @@ from glue.tests.helpers import requires_ipython  # noqa
 from glue.viewers.image.qt import ImageViewer
 from glue.viewers.scatter.qt import ScatterViewer
 from glue.viewers.histogram.qt import HistogramViewer
-from glue.utils.qt import get_qapp
+from glue.utils.qt import process_events
 
 
 from ..application import GlueApplication, GlueLogger
@@ -467,8 +467,7 @@ def test_logger_close():
     app = GlueApplication()
     app.close()
 
-    qapp = get_qapp()
-    qapp.processEvents()
+    process_events()
 
     assert not isinstance(sys.stderr, GlueLogger)
 

--- a/glue/core/roi.py
+++ b/glue/core/roi.py
@@ -694,7 +694,7 @@ class AbstractMplRoi(object):  # pragma: no cover
         self._scrubbing = False
 
     def _draw(self):
-        self._axes.figure.canvas.draw()
+        self._axes.figure.canvas.draw_idle()
 
     def _roi_factory(self):
         raise NotImplementedError()
@@ -1097,7 +1097,7 @@ class MplCircularROI(AbstractMplRoi):
         self._patch.set(**self.plot_opts)
 
         # Refresh
-        self._axes.figure.canvas.draw()
+        self._axes.figure.canvas.draw_idle()
 
     def start_selection(self, event):
 
@@ -1172,7 +1172,7 @@ class MplCircularROI(AbstractMplRoi):
         self._scrubbing = False
         self._mid_selection = False
         self._patch.set_visible(False)
-        self._axes.figure.canvas.draw()
+        self._axes.figure.canvas.draw_idle()
 
 
 class MplPolygonalROI(AbstractMplRoi):
@@ -1223,7 +1223,7 @@ class MplPolygonalROI(AbstractMplRoi):
         self._patch.set(**self.plot_opts)
 
         # Refresh
-        self._axes.figure.canvas.draw()
+        self._axes.figure.canvas.draw_idle()
 
     def start_selection(self, event, scrubbing=False):
 
@@ -1272,7 +1272,7 @@ class MplPolygonalROI(AbstractMplRoi):
         self._scrubbing = False
         self._mid_selection = False
         self._patch.set_visible(False)
-        self._axes.figure.canvas.draw()
+        self._axes.figure.canvas.draw_idle()
 
 
 class MplPathROI(MplPolygonalROI):
@@ -1301,13 +1301,13 @@ class MplPathROI(MplPolygonalROI):
         self._patch.set(**self.plot_opts)
 
         # Refresh
-        self._axes.figure.canvas.draw()
+        self._axes.figure.canvas.draw_idle()
 
     def finalize_selection(self, event):
         self._mid_selection = False
         if self._patch is not None:
             self._patch.set_visible(False)
-        self._axes.figure.canvas.draw()
+        self._axes.figure.canvas.draw_idle()
 
 
 class CategoricalROI(Roi):

--- a/glue/core/tests/test_roi.py
+++ b/glue/core/tests/test_roi.py
@@ -496,16 +496,16 @@ class TestMpl(object):
         assert not self.roi._roi.defined()
 
     def test_canvas_syncs_properly(self):
-        assert self.axes.figure.canvas.draw.call_count == 1
+        assert self.axes.figure.canvas.draw_idle.call_count == 1
         event = DummyEvent(5, 5, inaxes=self.axes)
         self.roi.start_selection(event)
-        assert self.axes.figure.canvas.draw.call_count == 3
+        assert self.axes.figure.canvas.draw_idle.call_count == 3
         self.roi.update_selection(event)
-        assert self.axes.figure.canvas.draw.call_count == 4
+        assert self.axes.figure.canvas.draw_idle.call_count == 4
         self.roi.update_selection(event)
-        assert self.axes.figure.canvas.draw.call_count == 5
+        assert self.axes.figure.canvas.draw_idle.call_count == 5
         self.roi.finalize_selection(event)
-        assert self.axes.figure.canvas.draw.call_count == 6
+        assert self.axes.figure.canvas.draw_idle.call_count == 6
 
     def test_patch_shown_on_start(self):
         assert not self.roi._patch.get_visible()

--- a/glue/dialogs/link_editor/qt/tests/test_link_editor.py
+++ b/glue/dialogs/link_editor/qt/tests/test_link_editor.py
@@ -1,7 +1,7 @@
 from mock import patch
 
 from qtpy import QtWidgets
-from glue.utils.qt import get_qapp
+from glue.utils.qt import process_events
 from glue.core import Data, DataCollection
 from glue.core.component_link import identity
 from glue.dialogs.link_editor.qt import LinkEditor
@@ -91,8 +91,6 @@ class TestLinkEditor:
         # This is a bit more detailed test that checks that things update
         # correctly as we change various settings
 
-        app = get_qapp()
-
         dialog = LinkEditor(self.data_collection)
         dialog.show()
         link_widget = dialog.link_widget
@@ -113,7 +111,7 @@ class TestLinkEditor:
         add_identity_link.trigger()
 
         # Ensure that all events get processed
-        app.processEvents()
+        process_events()
 
         # Now there should be one link in the main list and content in the
         # right hand panel.
@@ -135,7 +133,7 @@ class TestLinkEditor:
         add_lengths_volume_link.trigger()
 
         # Ensure that all events get processed
-        app.processEvents()
+        process_events()
 
         # and make sure the UI has updated
         assert link_widget.listsel_current_link.count() == 2
@@ -170,7 +168,7 @@ class TestLinkEditor:
         add_identity_link.trigger()
 
         # Ensure that all events get processed
-        app.processEvents()
+        process_events()
 
         # Now there should be one link in the main list
         assert link_widget.listsel_current_link.count() == 1
@@ -193,7 +191,7 @@ class TestLinkEditor:
         link_widget.button_remove_link.click()
 
         # Ensure that all events get processed
-        app.processEvents()
+        process_events()
 
         # We should now see the lengths/volume link
         assert link_widget.listsel_current_link.count() == 1
@@ -432,7 +430,7 @@ class TestLinkEditor:
         add_coordinate_link.trigger()
 
         # Ensure that all events get processed
-        app.processEvents()
+        process_events()
 
         assert link_widget.listsel_current_link.count() == 1
         assert link_widget.link_details.text() == 'Link ICRS and Galactic coordinates'

--- a/glue/dialogs/link_editor/qt/tests/test_link_editor.py
+++ b/glue/dialogs/link_editor/qt/tests/test_link_editor.py
@@ -340,8 +340,6 @@ class TestLinkEditor:
 
         # Check that things work properly if there are pre-existing links
 
-        app = get_qapp()
-
         link1 = ComponentLink([self.data1.id['x']], self.data2.id['c'])
 
         def add(x, y):
@@ -415,8 +413,6 @@ class TestLinkEditor:
 
     def test_add_helper(self):
 
-        app = get_qapp()
-
         dialog = LinkEditor(self.data_collection)
         dialog.show()
         link_widget = dialog.link_widget
@@ -453,8 +449,6 @@ class TestLinkEditor:
         assert links[0].cids2[1] is self.data2.id['b']
 
     def test_preexisting_helper(self):
-
-        app = get_qapp()
 
         link1 = Galactic_to_FK5(cids1=[self.data1.id['x'], self.data1.id['y']],
                                 cids2=[self.data2.id['c'], self.data2.id['b']])
@@ -496,8 +490,6 @@ class TestLinkEditor:
         # This is a bit more detailed test that checks that things update
         # correctly as we change various settings
 
-        app = get_qapp()
-
         link1 = ComponentLink([self.data1.id['x']], self.data2.id['c'])
 
         self.data_collection.add_link(link1)
@@ -533,8 +525,6 @@ class TestLinkEditor:
         # Test that if we use a @link_helper in 'legacy' mode, i.e. with only
         # input labels, both datasets are available from the combos in the
         # link editor dialog. Also test the new-style @link_helper.
-
-        app = get_qapp()
 
         def deg_arcsec(degree, arcsecond):
             return [ComponentLink([degree], arcsecond, using=lambda d: d * 3600),
@@ -598,8 +588,6 @@ class TestLinkEditor:
     def test_same_data(self):
 
         # Test that we can't set the same data twice
-
-        app = get_qapp()
 
         dialog = LinkEditor(self.data_collection)
         dialog.show()

--- a/glue/external/axescache.py
+++ b/glue/external/axescache.py
@@ -158,7 +158,7 @@ class AxesCache(object):
         enable() is next called
         """
         self._enabled = False
-        self.axes.figure.canvas.draw()
+        self.axes.figure.canvas.draw_idle()
 
     def enable(self):
         """

--- a/glue/external/modest_image.py
+++ b/glue/external/modest_image.py
@@ -65,7 +65,7 @@ class ModestImage(mi.AxesImage):
         if self.axes is None:
             return
         self._pressed = False
-        self.axes.figure.canvas.draw()
+        self.axes.figure.canvas.draw_idle()
 
     def _press(self, *args):
         self._pressed = True
@@ -73,7 +73,7 @@ class ModestImage(mi.AxesImage):
     def _release(self, *args):
         self._pressed = False
         self.stale = True
-        self.axes.figure.canvas.draw()
+        self.axes.figure.canvas.draw_idle()
 
     def set_data(self, A):
         """
@@ -240,7 +240,7 @@ def main():
     ax.add_artist(artist)
 
     t0 = time()
-    plt.gcf().canvas.draw()
+    plt.gcf().canvas.draw_idle()
     t1 = time()
 
     print("Draw time for %s: %0.1f ms" % (artist.__class__.__name__,

--- a/glue/plugins/exporters/plotly/qt/exporter.py
+++ b/glue/plugins/exporters/plotly/qt/exporter.py
@@ -8,7 +8,7 @@ import webbrowser
 
 from qtpy import QtWidgets
 from glue.utils import nonpartial
-from glue.utils.qt import load_ui
+from glue.utils.qt import load_ui, process_events
 from glue.utils.qt.widget_properties import TextProperty, ButtonProperty
 from glue.plugins.exporters.plotly.export_plotly import build_plotly_call
 
@@ -184,4 +184,4 @@ class QtPlotlyExporter(QtWidgets.QDialog):
     def set_status(self, text, color):
         self.ui.text_status.setText(text)
         self.ui.text_status.setStyleSheet("color: {0}".format(color))
-        QtWidgets.QApplication.instance().processEvents()
+        process_events()

--- a/glue/utils/matplotlib.py
+++ b/glue/utils/matplotlib.py
@@ -269,7 +269,7 @@ class AxesResizer(object):
         dy = max(0.01, y1 - y0)
 
         self.ax.set_position([x0, y0, dx, dy])
-        self.ax.figure.canvas.draw()
+        self.ax.figure.canvas.draw_idle()
 
 
 def freeze_margins(axes, margins=[1, 1, 1, 1]):

--- a/glue/utils/matplotlib.py
+++ b/glue/utils/matplotlib.py
@@ -139,6 +139,12 @@ def fast_limits(data, plo, phi):
     return lo, hi
 
 
+# We don't know in advance what backends are going to be used for Matplotlib
+# so we can set up a list here and use it in defer_draw below, and each front-
+# end is responsible for adding their backend here.
+DEFER_DRAW_BACKENDS = []
+
+
 def defer_draw(func):
     """
     Decorator that globally defers all Agg canvas draws until
@@ -150,25 +156,30 @@ def defer_draw(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
 
-        from matplotlib.backends.backend_agg import FigureCanvasAgg
+        if len(DEFER_DRAW_BACKENDS) == 0:
+            return func(*args, **kwargs)
 
-        # don't recursively defer draws
-        if isinstance(FigureCanvasAgg.draw, DeferredMethod):
+        # Don't recursively defer draws. We just check the first draw_idle
+        # method since all should be modified in sync.
+        if isinstance(DEFER_DRAW_BACKENDS[0].draw_idle, DeferredMethod):
             return func(*args, **kwargs)
 
         try:
-            FigureCanvasAgg.draw = DeferredMethod(FigureCanvasAgg.draw)
+            for backend in DEFER_DRAW_BACKENDS:
+                backend.draw_idle = DeferredMethod(backend.draw_idle)
             result = func(*args, **kwargs)
         finally:
-            # We need to use another try...finally block here in case the
-            # executed deferred draw calls fail for any reason
-            try:
+            for backend in DEFER_DRAW_BACKENDS:
+                # We need to use another try...finally block here in case the
+                # executed deferred draw calls fail for any reason
                 try:
-                    FigureCanvasAgg.draw.execute_deferred_calls()
-                except RuntimeError:  # For C/C++ errors
-                    pass
-            finally:
-                FigureCanvasAgg.draw = FigureCanvasAgg.draw.original_method
+                    try:
+                        backend.draw_idle.execute_deferred_calls()
+                    except RuntimeError:  # For C/C++ errors with Qt
+                        pass
+                finally:
+                    backend.draw_idle = backend.draw_idle.original_method
+
         return result
 
     wrapper._is_deferred = True

--- a/glue/utils/qt/app.py
+++ b/glue/utils/qt/app.py
@@ -6,7 +6,7 @@ from qtpy import QtCore, QtGui, QtWidgets
 from glue.config import settings
 from glue._settings_helpers import save_settings
 
-__all__ = ['get_qapp', 'fix_tab_widget_fontsize', 'update_global_font_size']
+__all__ = ['process_events', 'get_qapp', 'fix_tab_widget_fontsize', 'update_global_font_size']
 
 qapp = None
 
@@ -22,6 +22,11 @@ def __get_font_size_offset():
         # space too. Again, this should probably be a global setting.
         size_offset = 1
     return size_offset
+
+
+def process_events():
+    app = get_qapp()
+    app.processEvents()
 
 
 def get_qapp(icon_path=None):

--- a/glue/utils/tests/test_matplotlib.py
+++ b/glue/utils/tests/test_matplotlib.py
@@ -92,7 +92,7 @@ def test_defer_draw():
         fig = plt.figure()
         ax = fig.add_subplot(1, 1, 1)
         ax.plot([1, 2, 3], [4, 5, 6])
-        fig.canvas.draw()
+        fig.canvas.draw_idle()
         return 3.5
 
     result = draw_figure()

--- a/glue/viewers/common/qt/tests/test_data_viewer.py
+++ b/glue/viewers/common/qt/tests/test_data_viewer.py
@@ -13,7 +13,7 @@ from glue.viewers.common.qt.data_viewer import DataViewer, get_viewer_tools
 from glue.viewers.histogram.qt import HistogramViewer
 from glue.viewers.image.qt import ImageViewer
 from glue.viewers.scatter.qt import ScatterViewer
-from glue.utils.qt import get_qapp
+from glue.utils.qt import process_events
 
 
 # TODO: We should maybe consider running these tests for all
@@ -57,22 +57,19 @@ class BaseTestDataViewer(object):
 
         # regression test for 391
 
-        # Note: processEvents is needed for things to work correctly with PySide2
-        qtapp = get_qapp()
-
         d1 = Data(x=np.random.random((2,) * self.ndim))
         d2 = Data(y=np.random.random((2,) * self.ndim))
         dc = DataCollection([d1, d2])
         app = GlueApplication(dc)
         w = app.new_data_viewer(self.widget_cls, data=d1)
         w.add_data(d2)
-        qtapp.processEvents()
+        process_events()
         assert len(app.viewers[0]) == 1
         dc.remove(d1)
-        qtapp.processEvents()
+        process_events()
         assert len(app.viewers[0]) == 1
         dc.remove(d2)
-        qtapp.processEvents()
+        process_events()
         assert len(app.viewers[0]) == 0
         app.close()
 

--- a/glue/viewers/histogram/layer_artist.py
+++ b/glue/viewers/histogram/layer_artist.py
@@ -48,9 +48,8 @@ class HistogramLayerArtist(MatplotlibLayerArtist):
             time.sleep(0.5)
             while self._worker.running:
                 time.sleep(1 / 25)
-            from glue.utils.qt import get_qapp
-            app = get_qapp()
-            app.processEvents()
+            from glue.utils.qt import process_events
+            process_events()
 
     def remove(self):
         super(HistogramLayerArtist, self).remove()

--- a/glue/viewers/histogram/qt/tests/test_data_viewer.py
+++ b/glue/viewers/histogram/qt/tests/test_data_viewer.py
@@ -17,7 +17,7 @@ from glue.core.subset import RangeSubsetState, CategoricalROISubsetState
 from glue import core
 from glue.app.qt import GlueApplication
 from glue.core.component_id import ComponentID
-from glue.utils.qt import combo_as_string
+from glue.utils.qt import combo_as_string, process_events
 from glue.viewers.matplotlib.qt.tests.test_data_viewer import BaseTestMatplotlibDataViewer
 from glue.core.state import GlueUnSerializer
 from glue.app.qt.layer_tree_widget import LayerTreeWidget
@@ -111,6 +111,8 @@ class TestHistogramViewer(object):
 
         self.viewer.add_data(data)
         viewer_state.x_log = True
+
+        process_events()
 
         labels = [x.get_text() for x in self.viewer.axes.xaxis.get_ticklabels()]
 

--- a/glue/viewers/histogram/viewer.py
+++ b/glue/viewers/histogram/viewer.py
@@ -34,7 +34,7 @@ class MatplotlibHistogramMixin(object):
         else:
             self.state.y_axislabel = 'Number'
 
-        self.axes.figure.canvas.draw()
+        self.axes.figure.canvas.draw_idle()
 
     def apply_roi(self, roi, override_mode=None):
 

--- a/glue/viewers/image/qt/standalone_image_viewer.py
+++ b/glue/viewers/image/qt/standalone_image_viewer.py
@@ -112,7 +112,7 @@ class StandaloneImageViewer(QtWidgets.QMainWindow):
         self._redraw()
 
     def _redraw(self):
-        self.central_widget.canvas.draw()
+        self.central_widget.canvas.draw_idle()
 
     def set_cmap(self, cmap):
         self._composite.set('image', color=cmap)

--- a/glue/viewers/image/qt/tests/test_data_viewer.py
+++ b/glue/viewers/image/qt/tests/test_data_viewer.py
@@ -19,7 +19,7 @@ from glue.core.message import SubsetUpdateMessage
 from glue.core import HubListener, Data
 from glue.core.roi import XRangeROI, RectangularROI
 from glue.core.subset import RoiSubsetState
-from glue.utils.qt import combo_as_string
+from glue.utils.qt import combo_as_string, process_events
 from glue.viewers.matplotlib.qt.tests.test_data_viewer import BaseTestMatplotlibDataViewer
 from glue.core.state import GlueUnSerializer
 from glue.app.qt.layer_tree_widget import LayerTreeWidget
@@ -324,6 +324,7 @@ class TestImageViewer(object):
         self.viewer.layers[1].visible = False
         self.viewer.layers[1].image_artist.invalidate_cache()
         self.viewer.layers[1].redraw()
+        process_events()
         assert not np.any(self.viewer.layers[1].image_artist._A.mask)
         self.viewer.layers[1].visible = True
         assert not np.any(self.viewer.layers[1].image_artist._A.mask)
@@ -387,6 +388,8 @@ class TestImageViewer(object):
 
         self.data_collection.new_subset_group()
 
+        process_events()
+
         assert len(self.viewer.layers) == 4
 
         # Only the two layers associated with the reference data should be enabled
@@ -402,6 +405,8 @@ class TestImageViewer(object):
         link1 = LinkSame(px1, px2)
         self.data_collection.add_link(link1)
 
+        process_events()
+
         # One link isn't enough, second dataset layers are still not enabled
 
         for layer_artist in self.viewer.layers:
@@ -413,12 +418,16 @@ class TestImageViewer(object):
         link2 = LinkSame(py1, py2)
         self.data_collection.add_link(link2)
 
+        process_events()
+
         # All layers should now be enabled
 
         for layer_artist in self.viewer.layers:
             assert layer_artist.enabled
 
         self.data_collection.remove_link(link2)
+
+        process_events()
 
         # We should now be back to the original situation
 
@@ -575,6 +584,8 @@ class TestImageViewer(object):
 
         self.data_collection.new_subset_group(subset_state=self.catalog.id['e'] > 4)
 
+        process_events()
+
         assert self.viewer.layers[0].enabled  # image
         assert self.viewer.layers[1].enabled  # scatter
         assert not self.viewer.layers[2].enabled  # image subset
@@ -583,6 +594,8 @@ class TestImageViewer(object):
         assert not self.viewer.layers[2].image_artist.get_visible()
 
         self.data_collection.subset_groups[0].subset_state = self.catalog.id['c'] > -1
+
+        process_events()
 
         assert self.viewer.layers[0].enabled  # image
         assert self.viewer.layers[1].enabled  # scatter
@@ -602,6 +615,8 @@ class TestImageViewer(object):
 
         self.data_collection.new_subset_group(subset_state=self.catalog.id['e'] > 4)
 
+        process_events()
+
         assert self.viewer.layers[0].enabled  # image
         assert not self.viewer.layers[1].enabled  # scatter
         assert not self.viewer.layers[2].enabled  # image subset
@@ -611,6 +626,8 @@ class TestImageViewer(object):
         link2 = LinkSame(self.catalog.id['d'], self.image1.world_component_ids[1])
         self.data_collection.add_link(link1)
         self.data_collection.add_link(link2)
+
+        process_events()
 
         assert self.viewer.layers[0].enabled  # image
         assert self.viewer.layers[1].enabled  # scatter

--- a/glue/viewers/image/viewer.py
+++ b/glue/viewers/image/viewer.py
@@ -77,7 +77,7 @@ class MatplotlibImageMixin(object):
         if self.state.y_att_world is not None:
             self.state.y_axislabel = self.state.y_att_world.label
 
-        self.axes.figure.canvas.draw()
+        self.axes.figure.canvas.draw_idle()
 
     def add_data(self, data):
         result = super(MatplotlibImageMixin, self).add_data(data)
@@ -192,13 +192,13 @@ class MatplotlibImageMixin(object):
                                            mfc='none', mec='#d32d26',
                                            mew=1, zorder=100)
 
-        self.axes.figure.canvas.draw()
+        self.axes.figure.canvas.draw_idle()
 
     def hide_crosshairs(self):
         if getattr(self, '_crosshairs', None) is not None:
             self._crosshairs.remove()
             self._crosshairs = None
-            self.axes.figure.canvas.draw()
+            self.axes.figure.canvas.draw_idle()
 
     def _script_header(self):
 

--- a/glue/viewers/matplotlib/layer_artist.py
+++ b/glue/viewers/matplotlib/layer_artist.py
@@ -62,4 +62,4 @@ class MatplotlibLayerArtist(LayerArtist):
         return self.state.color
 
     def redraw(self):
-        self.axes.figure.canvas.draw()
+        self.axes.figure.canvas.draw_idle()

--- a/glue/viewers/matplotlib/qt/tests/test_data_viewer.py
+++ b/glue/viewers/matplotlib/qt/tests/test_data_viewer.py
@@ -16,7 +16,7 @@ from glue.core import Data
 from glue.core.exceptions import IncompatibleDataException
 from glue.app.qt.application import GlueApplication
 from glue.core.roi import XRangeROI
-from glue.utils.qt import get_qapp
+from glue.utils.qt import process_events
 from glue.tests.helpers import requires_matplotlib_ge_22
 
 
@@ -27,8 +27,7 @@ class MatplotlibDrawCounter(object):
 
     @property
     def draw_count(self):
-        app = get_qapp()
-        app.processEvents()
+        process_events()
         return self.figure.canvas._draw_count - 1
 
 
@@ -74,8 +73,7 @@ class BaseTestMatplotlibDataViewer(object):
 
     @property
     def viewer_count(self):
-        app = get_qapp()
-        app.processEvents()
+        process_events()
         obj = objgraph.by_type(self.viewer_cls.__name__)
         return len(obj)
 
@@ -545,8 +543,6 @@ class BaseTestMatplotlibDataViewer(object):
         # This test works with Matplotlib 2.0 and 2.2 but not 2.1, hence we
         # skip it with Matplotlib 2.1 above.
 
-        app = get_qapp()
-
         # Set initial limits to deterministic values
         self.viewer.state.aspect = 'auto'
         self.viewer.state.x_min = 0.
@@ -558,7 +554,7 @@ class BaseTestMatplotlibDataViewer(object):
 
         # Resize events only work if widget is visible
         self.viewer.show()
-        app.processEvents()
+        process_events()
 
         def limits(viewer):
             return (viewer.state.x_min, viewer.state.x_max,
@@ -566,25 +562,25 @@ class BaseTestMatplotlibDataViewer(object):
 
         # Set viewer to an initial size and save limits
         self.viewer.viewer_size = (800, 400)
-        app.processEvents()
+        process_events()
         initial_limits = limits(self.viewer)
 
         # Change the viewer size, and make sure the limits are adjusted
         self.viewer.viewer_size = (400, 400)
-        app.processEvents()
+        process_events()
         with pytest.raises(AssertionError):
             assert_allclose(limits(self.viewer), initial_limits)
 
         # Now change the viewer size a number of times and make sure if we
         # return to the original size, the limits match the initial ones.
         self.viewer.viewer_size = (350, 800)
-        app.processEvents()
+        process_events()
         self.viewer.viewer_size = (900, 300)
-        app.processEvents()
+        process_events()
         self.viewer.viewer_size = (600, 600)
-        app.processEvents()
+        process_events()
         self.viewer.viewer_size = (800, 400)
-        app.processEvents()
+        process_events()
         assert_allclose(limits(self.viewer), initial_limits)
 
         # Now check that the limits don't change in 'auto' mode

--- a/glue/viewers/matplotlib/qt/tests/test_data_viewer.py
+++ b/glue/viewers/matplotlib/qt/tests/test_data_viewer.py
@@ -23,11 +23,13 @@ from glue.tests.helpers import requires_matplotlib_ge_22
 class MatplotlibDrawCounter(object):
 
     def __init__(self, figure):
-        self.draw_count = 0
-        figure.canvas.mpl_connect('draw_event', self.on_draw)
+        self.figure = figure
 
-    def on_draw(self, event):
-        self.draw_count += 1
+    @property
+    def draw_count(self):
+        app = get_qapp()
+        app.processEvents()
+        return self.figure.canvas._draw_count - 1
 
 
 class BaseTestMatplotlibDataViewer(object):

--- a/glue/viewers/matplotlib/qt/tests/test_data_viewer.py
+++ b/glue/viewers/matplotlib/qt/tests/test_data_viewer.py
@@ -24,11 +24,13 @@ class MatplotlibDrawCounter(object):
 
     def __init__(self, figure):
         self.figure = figure
+        process_events()
+        self.start = self.figure.canvas._draw_count
 
     @property
     def draw_count(self):
         process_events()
-        return self.figure.canvas._draw_count - 1
+        return self.figure.canvas._draw_count - self.start
 
 
 class BaseTestMatplotlibDataViewer(object):

--- a/glue/viewers/matplotlib/qt/widget.py
+++ b/glue/viewers/matplotlib/qt/widget.py
@@ -125,10 +125,6 @@ class MplCanvas(FigureCanvasQTAgg):
         self._draw_count += 1
         return super(MplCanvas, self).draw(*args, **kwargs)
 
-    def draw_idle(self, *args, **kwargs):
-        self._draw_count += 1
-        return super(MplCanvas, self).draw_idle(*args, **kwargs)
-
     def keyPressEvent(self, event):
         event.setAccepted(False)
         super(MplCanvas, self).keyPressEvent(event)

--- a/glue/viewers/matplotlib/qt/widget.py
+++ b/glue/viewers/matplotlib/qt/widget.py
@@ -48,8 +48,8 @@ class MplCanvas(FigureCanvasQTAgg):
 
         FigureCanvasQTAgg.__init__(self, self.fig)
         FigureCanvasQTAgg.setSizePolicy(self,
-                                   QtWidgets.QSizePolicy.Expanding,
-                                   QtWidgets.QSizePolicy.Expanding)
+                                        QtWidgets.QSizePolicy.Expanding,
+                                        QtWidgets.QSizePolicy.Expanding)
 
         FigureCanvasQTAgg.updateGeometry(self)
         self.manager = FigureManagerQT(self, 0)

--- a/glue/viewers/matplotlib/viewer.py
+++ b/glue/viewers/matplotlib/viewer.py
@@ -124,7 +124,7 @@ class MatplotlibViewerMixin(object):
         self.redraw()
 
     def redraw(self):
-        self.figure.canvas.draw()
+        self.figure.canvas.draw_idle()
 
     def update_x_log(self, *args):
         self.axes.set_xscale('log' if self.state.x_log else 'linear')
@@ -186,7 +186,7 @@ class MatplotlibViewerMixin(object):
         try:
             self.axes.set_xlim(x_min, x_max)
             self.axes.set_ylim(y_min, y_max)
-            self.axes.figure.canvas.draw()
+            self.axes.figure.canvas.draw_idle()
         finally:
             self._skip_limits_from_mpl = False
 

--- a/glue/viewers/profile/layer_artist.py
+++ b/glue/viewers/profile/layer_artist.py
@@ -49,9 +49,8 @@ class ProfileLayerArtist(MatplotlibLayerArtist):
             time.sleep(0.5)
             while self._worker.running:
                 time.sleep(1 / 25)
-            from glue.utils.qt import get_qapp
-            app = get_qapp()
-            app.processEvents()
+            from glue.utils.qt import process_events
+            process_events()
 
     def remove(self):
         super(ProfileLayerArtist, self).remove()

--- a/glue/viewers/profile/qt/mouse_mode.py
+++ b/glue/viewers/profile/qt/mouse_mode.py
@@ -52,19 +52,19 @@ class NavigateMouseMode(MouseMode):
         else:
             if self.state.x is not None:
                 self._line = self._axes.axvline(self.state.x, color=COLOR)
-        self._canvas.draw()
+        self._canvas.draw_idle()
 
     def deactivate(self):
         if hasattr(self, '_line'):
             self._line.set_visible(False)
-        self._canvas.draw()
+        self._canvas.draw_idle()
         super(NavigateMouseMode, self).deactivate()
         self.active = False
 
     def activate(self):
         if hasattr(self, '_line'):
             self._line.set_visible(True)
-        self._canvas.draw()
+        self._canvas.draw_idle()
         super(NavigateMouseMode, self).activate()
         self.active = True
 
@@ -169,7 +169,7 @@ class RangeMouseMode(MouseMode):
                 self._interval = self._axes.axvspan(self.state.x_min,
                                                     self.state.x_max,
                                                     color=COLOR, alpha=0.05)
-        self._canvas.draw()
+        self._canvas.draw_idle()
 
     def deactivate(self):
         if hasattr(self, '_lines'):
@@ -177,7 +177,7 @@ class RangeMouseMode(MouseMode):
             self._lines[1].set_visible(False)
             self._interval.set_visible(False)
 
-        self._canvas.draw()
+        self._canvas.draw_idle()
         super(RangeMouseMode, self).deactivate()
         self.active = False
 
@@ -186,7 +186,7 @@ class RangeMouseMode(MouseMode):
             self._lines[0].set_visible(True)
             self._lines[1].set_visible(True)
             self._interval.set_visible(True)
-        self._canvas.draw()
+        self._canvas.draw_idle()
         super(RangeMouseMode, self).activate()
         self.active = True
 

--- a/glue/viewers/profile/qt/profile_tools.py
+++ b/glue/viewers/profile/qt/profile_tools.py
@@ -215,7 +215,7 @@ class ProfileTools(QtWidgets.QWidget):
         def on_done():
             self.ui.button_fit.setText("Fit")
             self.ui.button_fit.setEnabled(True)
-            self.canvas.draw()
+            self.canvas.draw_idle()
 
         self.ui.button_fit.setText("Running...")
         self.ui.button_fit.setEnabled(False)
@@ -237,7 +237,7 @@ class ProfileTools(QtWidgets.QWidget):
     def _on_clear(self):
         self.ui.text_log.document().setPlainText('')
         self._clear_fit()
-        self.canvas.draw()
+        self.canvas.draw_idle()
 
     def _fit(self, fitter, xlim=None):
 
@@ -273,7 +273,7 @@ class ProfileTools(QtWidgets.QWidget):
                                                  color=layer.state.color,
                                                  normalize=normalize.get(layer, None))[0])
 
-        self.canvas.draw()
+        self.canvas.draw_idle()
 
     def _visible_data(self):
         datasets = set()

--- a/glue/viewers/profile/qt/tests/test_profile_tools.py
+++ b/glue/viewers/profile/qt/tests/test_profile_tools.py
@@ -9,7 +9,7 @@ from glue.core import Data
 from glue.tests.helpers import PYSIDE2_INSTALLED  # noqa
 from glue.app.qt import GlueApplication
 from glue.utils import nanmean
-from glue.utils.qt import get_qapp
+from glue.utils.qt import process_events
 from glue.viewers.image.state import AggregateSlice
 
 from glue.viewers.image.qt import ImageViewer
@@ -57,8 +57,7 @@ class TestProfileTools(object):
         # Force events to be processed to make sure that the callback functions
         # for the computation thread are executed (since they rely on signals)
         self.viewer.layers[0].wait()
-        app = get_qapp()
-        app.processEvents()
+        process_events()
 
         x, y = self.viewer.axes.transData.transform([[1, 4]])[0]
         self.viewer.axes.figure.canvas.button_press_event(x, y, 1)
@@ -87,8 +86,7 @@ class TestProfileTools(object):
         # Force events to be processed to make sure that the callback functions
         # for the computation thread are executed (since they rely on signals)
         self.viewer.layers[0].wait()
-        app = get_qapp()
-        app.processEvents()
+        process_events()
 
         x, y = self.viewer.axes.transData.transform([[0.9, 4]])[0]
         self.viewer.axes.figure.canvas.button_press_event(x, y, 1)
@@ -102,7 +100,7 @@ class TestProfileTools(object):
 
         # Force events to be processed to make sure that the callback functions
         # for the computation thread are executed (since they rely on signals)
-        app.processEvents()
+        process_events()
 
         pixel_log = self.profile_tools.text_log.toPlainText().splitlines()
         assert pixel_log[0] == 'd1'
@@ -126,8 +124,7 @@ class TestProfileTools(object):
 
         self.profile_tools.ui.button_fit.click()
         self.profile_tools.wait_for_fit()
-        app = get_qapp()
-        app.processEvents()
+        process_events()
 
         world_log = self.profile_tools.text_log.toPlainText().splitlines()
         assert world_log[0] == 'd1'
@@ -151,8 +148,7 @@ class TestProfileTools(object):
         # Force events to be processed to make sure that the callback functions
         # for the computation thread are executed (since they rely on signals)
         self.viewer.layers[0].wait()
-        app = get_qapp()
-        app.processEvents()
+        process_events()
 
         x, y = self.viewer.axes.transData.transform([[0.9, 4]])[0]
         self.viewer.axes.figure.canvas.button_press_event(x, y, 1)
@@ -174,7 +170,7 @@ class TestProfileTools(object):
         # Force events to be processed to make sure that the callback functions
         # for the computation thread are executed (since they rely on signals)
         self.viewer.layers[0].wait()
-        app.processEvents()
+        process_events()
 
         x, y = self.viewer.axes.transData.transform([[1.9, 4]])[0]
         self.viewer.axes.figure.canvas.button_press_event(x, y, 1)

--- a/glue/viewers/profile/viewer.py
+++ b/glue/viewers/profile/viewer.py
@@ -21,7 +21,7 @@ class MatplotlibProfileMixin(object):
         else:
             self.state.y_axislabel = 'Data values'
 
-        self.axes.figure.canvas.draw()
+        self.axes.figure.canvas.draw_idle()
 
     def apply_roi(self, roi, override_mode=None):
 

--- a/glue/viewers/scatter/qt/tests/test_data_viewer.py
+++ b/glue/viewers/scatter/qt/tests/test_data_viewer.py
@@ -17,7 +17,7 @@ from glue.core.roi import XRangeROI, RectangularROI, CircularROI
 from glue.core.subset import RoiSubsetState, AndState
 from glue import core
 from glue.core.component_id import ComponentID
-from glue.utils.qt import combo_as_string
+from glue.utils.qt import combo_as_string, process_events
 from glue.viewers.matplotlib.qt.tests.test_data_viewer import BaseTestMatplotlibDataViewer
 from glue.core.state import GlueUnSerializer
 from glue.app.qt.layer_tree_widget import LayerTreeWidget
@@ -494,6 +494,8 @@ class TestScatterViewer(object):
 
         self.viewer.add_data(self.data)
         self.viewer.state.x_att = self.data.id['z']
+
+        process_events()
 
         assert visible_xaxis_labels(self.viewer.axes) == ['a', 'b', 'c']
 

--- a/glue/viewers/scatter/viewer.py
+++ b/glue/viewers/scatter/viewer.py
@@ -40,7 +40,7 @@ class MatplotlibScatterMixin(object):
             else:
                 self.state.y_axislabel = self.state.y_att.label
 
-        self.axes.figure.canvas.draw()
+        self.axes.figure.canvas.draw_idle()
 
     def apply_roi(self, roi, override_mode=None):
 

--- a/glue/viewers/table/qt/tests/test_data_viewer.py
+++ b/glue/viewers/table/qt/tests/test_data_viewer.py
@@ -10,7 +10,7 @@ from qtpy import QT_VERSION
 from qtpy import QtCore, QtGui
 from qtpy.QtCore import Qt
 
-from glue.utils.qt import get_qapp
+from glue.utils.qt import get_qapp, process_events
 from glue.core import Data, DataCollection
 from glue.utils.qt import qt_to_mpl_color
 from glue.app.qt import GlueApplication
@@ -169,13 +169,15 @@ def test_table_widget(tmpdir):
         app.postEvent(widget.ui.table, event)
         app.processEvents()
 
-    app.processEvents()
+    process_events()
 
     # We now use key presses to navigate down to the third row
 
     press_key(Qt.Key_Tab)
     press_key(Qt.Key_Down)
     press_key(Qt.Key_Down)
+
+    process_events()
 
     indices = selection.selectedRows()
 


### PR DESCRIPTION
This does a couple of different things:

* Use ``draw_idle`` instead of ``draw`` throughout, which improves performance especially when using the Jupyter notebook Matplotlib backend.
* Modify defer_draw to be configurable in terms of what Matplotlib backends are being used.