### PR TITLE
Remove methods that aren't actually needed on sub-classes of ApplicationBase

### DIFF
--- a/glue/core/application_base.py
+++ b/glue/core/application_base.py
@@ -160,15 +160,6 @@ class Application(HubListener):
         finally:
             os.chdir(start_dir)
 
-    def new_tab(self):
-        raise NotImplementedError()
-
-    def add_widget(self, widget, label=None, tab=None):
-        raise NotImplementedError()
-
-    def close_tab(self):
-        raise NotImplementedError()
-
     def get_setting(self, key):
         """
         Fetch the value of an application setting


### PR DESCRIPTION
Just some small cleanup to avoid seeing these methods in e.g. glue-jupyter