### PR TITLE
Add back glue.viewers.common.qt.tool with deprecation warning

### DIFF
--- a/glue/viewers/common/qt/tool.py
+++ b/glue/viewers/common/qt/tool.py
@@ -1,0 +1,6 @@
+import warnings
+
+from glue.viewers.common.tool import *  # noqa
+
+warnings.warn('glue.viewers.common.qt.tool is deprecated, use '
+              'glue.viewers.common.tool instead', UserWarning)


### PR DESCRIPTION
Just to give time for plugins to adapt