### PR TITLE
Fixed --no-maximized option when restoring from a session

### DIFF
--- a/glue/main.py
+++ b/glue/main.py
@@ -173,8 +173,8 @@ def start_glue(gluefile=None, config=None, datafiles=None, maximized=True,
 
     if gluefile is not None:
         with die_on_error("Error restoring Glue session"):
-            app = GlueApplication.restore_session(gluefile)
-        return app.start()
+            app = GlueApplication.restore_session(gluefile, show=False)
+        return app.start(maximized=maximized)
 
     if config is not None:
         glue.env = glue.config.load_configuration(search_path=[config])


### PR DESCRIPTION
Noticed this when using glue on a Linux machine