### PR TITLE
Fix compatibility with Numpy 1.16.x

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,8 @@ v0.15.0 (unreleased)
 v0.14.3 (unreleased)
 --------------------
 
+* Fixed compatibility with Numpy 1.16.x. [#1989]
+
 * Improve tab-completion of attribute names in Data to not include
   non-relevant items. [#1971]
 

--- a/glue/utils/array.py
+++ b/glue/utils/array.py
@@ -54,8 +54,8 @@ def unique(array):
     """
     # numpy.unique doesn't handle mixed-types on python3,
     # so we use pandas
-    U, I = pd.factorize(array, sort=True)
-    return I, U
+    I, U = pd.factorize(array, sort=True)
+    return U.astype(array.dtype), I
 
 
 def shape_to_string(shape):

--- a/glue/utils/array.py
+++ b/glue/utils/array.py
@@ -54,6 +54,7 @@ def unique(array):
     """
     # numpy.unique doesn't handle mixed-types on python3,
     # so we use pandas
+    array = np.asarray(array)
     I, U = pd.factorize(array, sort=True)
     return U.astype(array.dtype), I
 

--- a/glue/utils/tests/test_array.py
+++ b/glue/utils/tests/test_array.py
@@ -25,6 +25,14 @@ def test_unique(before, ref_after, ref_indices):
     np.testing.assert_array_equal(indices, ref_indices)
 
 
+def test_unique_dtype():
+    # Regression test to make sure that when working with strings, we don't
+    # get an object array back from the unique function
+    array = np.array(['a', 'b', 'c'])
+    U, I = unique(array)
+    assert U.dtype.kind in 'SU'
+
+
 def test_shape_to_string():
     assert shape_to_string((1, 4, 3)) == "(1, 4, 3)"
 

--- a/glue/utils/tests/test_array.py
+++ b/glue/utils/tests/test_array.py
@@ -26,10 +26,16 @@ def test_unique(before, ref_after, ref_indices):
 
 
 def test_unique_dtype():
+
     # Regression test to make sure that when working with strings, we don't
     # get an object array back from the unique function
+
     array = np.array(['a', 'b', 'c'])
     U, I = unique(array)
+    assert U.dtype.kind in 'SU'
+
+    li = ['a', 'b', 'c']
+    U, I = unique(li)
     assert U.dtype.kind in 'SU'
 
 


### PR DESCRIPTION
In Numpy 1.16.3, loading/saving Numpy object arrays causes errors by default - in fact we shouldn't be writing/reading object arrays anyway, so this fixes the underlying bug.

Hopefully this will fix the CI 🤞 