### PR TITLE
Fix bug with categorical histograms

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -80,6 +80,10 @@ v0.14.3 (unreleased)
 * Fix bug that caused an error when using the profile collapse tool and
   dragging from right to left. [#2002]
 
+* Fix bug that caused labels on the x-axis of the histogram viewer to
+  be incorrectly set to numbers instead of strings when showing a
+  histogram of a string variable and saving/reloading session. [#2009]
+
 v0.14.2 (2019-02-04)
 --------------------
 

--- a/glue/viewers/histogram/qt/tests/test_data_viewer.py
+++ b/glue/viewers/histogram/qt/tests/test_data_viewer.py
@@ -21,6 +21,7 @@ from glue.utils.qt import combo_as_string, process_events
 from glue.viewers.matplotlib.qt.tests.test_data_viewer import BaseTestMatplotlibDataViewer
 from glue.core.state import GlueUnSerializer
 from glue.app.qt.layer_tree_widget import LayerTreeWidget
+from glue.tests.helpers import requires_matplotlib_ge_22
 
 from ..data_viewer import HistogramViewer
 
@@ -639,6 +640,7 @@ class TestHistogramViewer(object):
 
         ga.close()
 
+    @requires_matplotlib_ge_22
     def test_categorical_labels(self, tmpdir):
 
         # Fix a bug that caused labels on histograms of categorical variables

--- a/glue/viewers/histogram/qt/tests/test_data_viewer.py
+++ b/glue/viewers/histogram/qt/tests/test_data_viewer.py
@@ -638,3 +638,30 @@ class TestHistogramViewer(object):
         assert options.valuetext_x_max.text() == '1971-02-05'
 
         ga.close()
+
+    def test_categorical_labels(self, tmpdir):
+
+        # Fix a bug that caused labels on histograms of categorical variables
+        # to not be restored correctly after saving and reloading session
+
+        self.viewer.add_data(self.data)
+        self.viewer.state.x_att = self.data.id['y']
+
+        self.viewer.figure.canvas.draw()
+
+        assert [x.get_text() for x in self.viewer.axes.xaxis.get_ticklabels()] == ['', 'a', 'b', 'c', '']
+
+        # Make sure that everything works fine after saving/reloading
+        filename = tmpdir.join('test_categorical_labels.glu').strpath
+        self.session.application.save_session(filename)
+        with open(filename, 'r') as f:
+            session = f.read()
+        state = GlueUnSerializer.loads(session)
+        ga = state.object('__main__')
+        viewer = ga.viewers[0][0]
+
+        viewer.figure.canvas.draw()
+
+        assert [x.get_text() for x in viewer.axes.xaxis.get_ticklabels()] == ['', 'a', 'b', 'c', '']
+
+        ga.close()

--- a/glue/viewers/histogram/viewer.py
+++ b/glue/viewers/histogram/viewer.py
@@ -16,6 +16,7 @@ class MatplotlibHistogramMixin(object):
         self.state.add_callback('x_att', self._update_axes)
         self.state.add_callback('x_log', self._update_axes)
         self.state.add_callback('normalize', self._update_axes)
+        self._update_axes()
 
     def _update_axes(self, *args):
 


### PR DESCRIPTION
Fixed bug that caused labels on the x-axis of the histogram viewer to be incorrectly set to numbers instead of strings when showing a histogram of a string variable and saving/reloading session