### PR TITLE
Isolate code related to QThread to make sure we don't import Qt in glue-jupyter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -52,6 +52,9 @@ v0.15.0 (unreleased)
   and ``glue.viewers.common.qt.toolbar_mode`` to ``glue.viewers.matplotlib.toolbar_mode``
   and ``glue.viewers.matplotlib.qt.toolbar_mode``. [#1984]
 
+* Avoiding importing Qt when using the base histogram and profile layer artists.
+  [#2012]
+
 v0.14.3 (unreleased)
 --------------------
 

--- a/glue/core/state_path_patches.txt
+++ b/glue/core/state_path_patches.txt
@@ -3,6 +3,7 @@ glue.clients.layer_artist.HistogramLayerArtist -> glue.viewers.histogram.qt.laye
 glue.viewers.histogram.layer_artist.HistogramLayerArtist -> glue.viewers.histogram.qt.layer_artist.QThreadedHistogramLayerArtist
 glue.clients.layer_artist.ImageLayerArtist -> glue.viewers.image.layer_artist.ImageLayerArtist
 glue.clients.layer_artist.ScatterLayerArtist -> glue.viewers.scatter.layer_artist.ScatterLayerArtist
+glue.viewers.profile.layer_artist.ProfileLayerArtist -> glue.viewers.profile.qt.layer_artist.QThreadedProfileLayerArtist
 glue.core.data_factories.gridded_data -> glue.core.data_factories.deprecated.gridded_data
 glue.core.data_factories.tables.astropy_tabular_data -> glue.core.data_factories.astropy_table.astropy_tabular_data
 glue.core.link_helpers.lb2dec -> glue.plugins.coordinate_helpers.deprecated.lb2dec

--- a/glue/core/state_path_patches.txt
+++ b/glue/core/state_path_patches.txt
@@ -1,5 +1,6 @@
 glue.clients.ds9norm.DS9Normalize -> glue.viewers.image.ds9norm.DS9Normalize
-glue.clients.layer_artist.HistogramLayerArtist -> glue.viewers.histogram.layer_artist.HistogramLayerArtist
+glue.clients.layer_artist.HistogramLayerArtist -> glue.viewers.histogram.qt.layer_artist.QThreadedHistogramLayerArtist
+glue.viewers.histogram.layer_artist.HistogramLayerArtist -> glue.viewers.histogram.qt.layer_artist.QThreadedHistogramLayerArtist
 glue.clients.layer_artist.ImageLayerArtist -> glue.viewers.image.layer_artist.ImageLayerArtist
 glue.clients.layer_artist.ScatterLayerArtist -> glue.viewers.scatter.layer_artist.ScatterLayerArtist
 glue.core.data_factories.gridded_data -> glue.core.data_factories.deprecated.gridded_data

--- a/glue/viewers/histogram/layer_artist.py
+++ b/glue/viewers/histogram/layer_artist.py
@@ -15,14 +15,6 @@ from glue.viewers.histogram.python_export import python_export_histogram_layer
 from glue.viewers.matplotlib.layer_artist import MatplotlibLayerArtist
 from glue.core.exceptions import IncompatibleAttribute, IncompatibleDataException
 
-try:
-    import qtpy  # noqa
-except Exception:
-    QT_INSTALLED = False
-else:
-    QT_INSTALLED = True
-    from glue.viewers.matplotlib.qt.compute_worker import ComputeWorker
-
 
 class HistogramLayerArtist(MatplotlibLayerArtist):
 
@@ -39,52 +31,15 @@ class HistogramLayerArtist(MatplotlibLayerArtist):
         self._viewer_state.add_global_callback(self._update_histogram)
         self.state.add_global_callback(self._update_histogram)
 
-        if QT_INSTALLED:
-            self.setup_thread()
-
-    def wait(self):
-        if QT_INSTALLED:
-            # Wait 0.5 seconds to make sure that the computation has properly started
-            time.sleep(0.5)
-            while self._worker.running:
-                time.sleep(1 / 25)
-            from glue.utils.qt import process_events
-            process_events()
-
-    def remove(self):
-        super(HistogramLayerArtist, self).remove()
-        if QT_INSTALLED and self._worker is not None:
-            self._worker.work_queue.put('stop')
-            self._worker.exit()
-            # Need to wait otherwise the thread will be destroyed while still
-            # running, causing a segmentation fault
-            self._worker.wait()
-            self._worker = None
-
-    @property
-    def is_computing(self):
-        if QT_INSTALLED:
-            return self._worker.running
-
-    def setup_thread(self):
-        self._worker = ComputeWorker(self._calculate_histogram_thread)
-        self._worker.compute_end.connect(self._calculate_histogram_postthread)
-        self._worker.compute_error.connect(self._calculate_histogram_error)
-        self._worker.compute_start.connect(self.notify_start_computation)
-        self._worker.start()
-
     @defer_draw
     def _calculate_histogram(self, reset=False):
-        if self.state.layer is not None and self.state.layer.size > 1e7 and QT_INSTALLED:
-            self._worker.work_queue.put(reset)
+        try:
+            self.notify_start_computation()
+            self._calculate_histogram_thread(reset=reset)
+        except Exception:
+            self._calculate_histogram_error(sys.exc_info())
         else:
-            try:
-                self.notify_start_computation()
-                self._calculate_histogram_thread(reset=reset)
-            except Exception:
-                self._calculate_histogram_error(sys.exc_info())
-            else:
-                self._calculate_histogram_postthread()
+            self._calculate_histogram_postthread()
 
     def _calculate_histogram_thread(self, reset=False):
         # We need to ignore any warnings that happen inside the thread
@@ -98,12 +53,6 @@ class HistogramLayerArtist(MatplotlibLayerArtist):
             self.state.update_histogram()
 
     def _calculate_histogram_postthread(self):
-
-        # If the worker has started running again, we should stop at this point
-        # since this function will get called again.
-        if QT_INSTALLED and self._worker.running:
-            return
-
         self.notify_end_computation()
         self._update_artists()
         self._update_visual_attributes()

--- a/glue/viewers/histogram/layer_artist.py
+++ b/glue/viewers/histogram/layer_artist.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
 import sys
-import time
 import warnings
 
 import numpy as np

--- a/glue/viewers/histogram/qt/data_viewer.py
+++ b/glue/viewers/histogram/qt/data_viewer.py
@@ -4,7 +4,7 @@ from glue.utils import defer_draw, decorate_all_methods
 from glue.viewers.matplotlib.qt.data_viewer import MatplotlibDataViewer
 from glue.viewers.histogram.qt.layer_style_editor import HistogramLayerStyleEditor
 from glue.viewers.histogram.qt.options_widget import HistogramOptionsWidget
-from glue.viewers.histogram.layer_artist import HistogramLayerArtist
+from glue.viewers.histogram.qt.layer_artist import QThreadedHistogramLayerArtist
 from glue.viewers.histogram.state import HistogramViewerState
 
 from glue.viewers.histogram.viewer import MatplotlibHistogramMixin
@@ -21,8 +21,8 @@ class HistogramViewer(MatplotlibHistogramMixin, MatplotlibDataViewer):
     _options_cls = HistogramOptionsWidget
 
     _state_cls = HistogramViewerState
-    _data_artist_cls = HistogramLayerArtist
-    _subset_artist_cls = HistogramLayerArtist
+    _data_artist_cls = QThreadedHistogramLayerArtist
+    _subset_artist_cls = QThreadedHistogramLayerArtist
 
     large_data_size = 2e7
 

--- a/glue/viewers/histogram/qt/layer_artist.py
+++ b/glue/viewers/histogram/qt/layer_artist.py
@@ -1,0 +1,63 @@
+from __future__ import absolute_import, division, print_function
+
+import time
+from glue.utils import defer_draw
+from glue.viewers.histogram.layer_artist import HistogramLayerArtist
+from glue.viewers.matplotlib.qt.compute_worker import ComputeWorker
+
+__all__ = ['QThreadedHistogramLayerArtist']
+
+
+class QThreadedHistogramLayerArtist(HistogramLayerArtist):
+
+    def __init__(self, axes, viewer_state, layer_state=None, layer=None):
+
+        super(QThreadedHistogramLayerArtist, self).__init__(axes, viewer_state,
+                                                            layer_state=layer_state, layer=layer)
+
+        self.setup_thread()
+
+    def wait(self):
+        # Wait 0.5 seconds to make sure that the computation has properly started
+        time.sleep(0.5)
+        while self._worker.running:
+            time.sleep(1 / 25)
+        from glue.utils.qt import process_events
+        process_events()
+
+    def remove(self):
+        super(QThreadedHistogramLayerArtist, self).remove()
+        if self._worker is not None:
+            self._worker.work_queue.put('stop')
+            self._worker.exit()
+            # Need to wait otherwise the thread will be destroyed while still
+            # running, causing a segmentation fault
+            self._worker.wait()
+            self._worker = None
+
+    @property
+    def is_computing(self):
+        return self._worker is not None and self._worker.running
+
+    def setup_thread(self):
+        self._worker = ComputeWorker(self._calculate_histogram_thread)
+        self._worker.compute_end.connect(self._calculate_histogram_postthread)
+        self._worker.compute_error.connect(self._calculate_histogram_error)
+        self._worker.compute_start.connect(self.notify_start_computation)
+        self._worker.start()
+
+    @defer_draw
+    def _calculate_histogram(self, reset=False):
+        if self.state.layer is not None and self.state.layer.size > 1e7:
+            self._worker.work_queue.put(reset)
+        else:
+            super(QThreadedHistogramLayerArtist, self)._calculate_histogram(reset=reset)
+
+    def _calculate_histogram_postthread(self):
+
+        # If the worker has started running again, we should stop at this point
+        # since this function will get called again.
+        if self._worker is not None and self._worker.running:
+            return
+
+        super(QThreadedHistogramLayerArtist, self)._calculate_histogram_postthread()

--- a/glue/viewers/profile/qt/data_viewer.py
+++ b/glue/viewers/profile/qt/data_viewer.py
@@ -4,7 +4,7 @@ from glue.utils import defer_draw, decorate_all_methods
 
 from glue.viewers.matplotlib.qt.data_viewer import MatplotlibDataViewer
 from glue.viewers.profile.qt.layer_style_editor import ProfileLayerStyleEditor
-from glue.viewers.profile.layer_artist import ProfileLayerArtist
+from glue.viewers.profile.qt.layer_artist import QThreadedProfileLayerArtist
 from glue.viewers.profile.qt.options_widget import ProfileOptionsWidget
 from glue.viewers.profile.state import ProfileViewerState
 
@@ -21,8 +21,8 @@ class ProfileViewer(MatplotlibProfileMixin, MatplotlibDataViewer):
     _layer_style_widget_cls = ProfileLayerStyleEditor
     _state_cls = ProfileViewerState
     _options_cls = ProfileOptionsWidget
-    _data_artist_cls = ProfileLayerArtist
-    _subset_artist_cls = ProfileLayerArtist
+    _data_artist_cls = QThreadedProfileLayerArtist
+    _subset_artist_cls = QThreadedProfileLayerArtist
 
     large_data_size = 1e8
 

--- a/glue/viewers/profile/qt/layer_artist.py
+++ b/glue/viewers/profile/qt/layer_artist.py
@@ -1,0 +1,64 @@
+from __future__ import absolute_import, division, print_function
+
+import time
+
+from glue.viewers.profile.layer_artist import ProfileLayerArtist
+from glue.viewers.matplotlib.qt.compute_worker import ComputeWorker
+from glue.utils import defer_draw
+
+__all__ = ['QThreadedProfileLayerArtist']
+
+
+class QThreadedProfileLayerArtist(ProfileLayerArtist):
+
+    def __init__(self, axes, viewer_state, layer_state=None, layer=None):
+
+        super(QThreadedProfileLayerArtist, self).__init__(axes, viewer_state,
+                                                          layer_state=layer_state, layer=layer)
+
+        self.setup_thread()
+
+    def wait(self):
+        # Wait 0.5 seconds to make sure that the computation has properly started
+        time.sleep(0.5)
+        while self._worker.running:
+            time.sleep(1 / 25)
+        from glue.utils.qt import process_events
+        process_events()
+
+    def remove(self):
+        super(QThreadedProfileLayerArtist, self).remove()
+        if self._worker is not None:
+            self._worker.work_queue.put('stop')
+            self._worker.exit()
+            # Need to wait otherwise the thread will be destroyed while still
+            # running, causing a segmentation fault
+            self._worker.wait()
+            self._worker = None
+
+    @property
+    def is_computing(self):
+        return self._worker is not None and self._worker.running
+
+    def setup_thread(self):
+        self._worker = ComputeWorker(self._calculate_profile_thread)
+        self._worker.compute_end.connect(self._calculate_profile_postthread)
+        self._worker.compute_error.connect(self._calculate_profile_error)
+        self._worker.compute_start.connect(self.notify_start_computation)
+        self._worker.start()
+
+    @defer_draw
+    def _calculate_profile(self, reset=False):
+        if self.state.layer is not None and self.state.layer.size > 1e7:
+            self._worker.work_queue.put(reset)
+        else:
+            super(QThreadedProfileLayerArtist, self)._calculate_profile(reset=reset)
+
+    def _calculate_profile_postthread(self):
+
+        # If the worker has started running again, we should stop at this point
+        # since this function will get called again.
+        if self._worker is not None and self._worker.running:
+            return
+
+        super(QThreadedProfileLayerArtist, self)._calculate_profile_postthread()

--- a/glue/viewers/profile/qt/tests/data/profile_v1.glu
+++ b/glue/viewers/profile/qt/tests/data/profile_v1.glu
@@ -1,0 +1,703 @@
+{
+  "CallbackList": {
+    "_type": "glue.external.echo.list.CallbackList",
+    "values": [
+      "ProfileLayerState",
+      "ProfileLayerState_0",
+      "ProfileLayerState_1"
+    ]
+  },
+  "CallbackList_0": {
+    "_type": "glue.external.echo.list.CallbackList",
+    "values": [
+      "ProfileLayerState_2",
+      "ProfileLayerState_3",
+      "ProfileLayerState_4"
+    ]
+  },
+  "CallbackList_1": {
+    "_type": "glue.external.echo.list.CallbackList",
+    "values": [
+      "ProfileLayerState_5",
+      "ProfileLayerState_6",
+      "ProfileLayerState_7"
+    ]
+  },
+  "CallbackList_2": {
+    "_type": "glue.external.echo.list.CallbackList",
+    "values": [
+      "ProfileLayerState_8",
+      "ProfileLayerState_9",
+      "ProfileLayerState_10"
+    ]
+  },
+  "Component": {
+    "_type": "glue.core.component.Component",
+    "data": {
+      "_type": "numpy.ndarray",
+      "data": "k05VTVBZAQB2AHsnZGVzY3InOiAnPGY4JywgJ2ZvcnRyYW5fb3JkZXInOiBGYWxzZSwgJ3NoYXBlJzogKDMsIDQsIDUpLCB9ICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAoAAAAAAAAAAAAAAAAAAPA/AAAAAAAAAEAAAAAAAAAIQAAAAAAAABBAAAAAAAAAFEAAAAAAAAAYQAAAAAAAABxAAAAAAAAAIEAAAAAAAAAiQAAAAAAAACRAAAAAAAAAJkAAAAAAAAAoQAAAAAAAACpAAAAAAAAALEAAAAAAAAAuQAAAAAAAADBAAAAAAAAAMUAAAAAAAAAyQAAAAAAAADNAAAAAAAAANEAAAAAAAAA1QAAAAAAAADZAAAAAAAAAN0AAAAAAAAA4QAAAAAAAADlAAAAAAAAAOkAAAAAAAAA7QAAAAAAAADxAAAAAAAAAPUAAAAAAAAA+QAAAAAAAAD9AAAAAAAAAQEAAAAAAAIBAQAAAAAAAAEFAAAAAAACAQUAAAAAAAABCQAAAAAAAgEJAAAAAAAAAQ0AAAAAAAIBDQAAAAAAAAERAAAAAAACAREAAAAAAAABFQAAAAAAAgEVAAAAAAAAARkAAAAAAAIBGQAAAAAAAAEdAAAAAAACAR0AAAAAAAABIQAAAAAAAgEhAAAAAAAAASUAAAAAAAIBJQAAAAAAAAEpAAAAAAACASkAAAAAAAABLQAAAAAAAgEtAAAAAAAAATEAAAAAAAIBMQAAAAAAAAE1AAAAAAACATUA="
+    },
+    "units": ""
+  },
+  "CoordinateComponent": {
+    "_type": "glue.core.component.CoordinateComponent",
+    "axis": 0,
+    "world": false
+  },
+  "CoordinateComponent_0": {
+    "_type": "glue.core.component.CoordinateComponent",
+    "axis": 1,
+    "world": false
+  },
+  "CoordinateComponent_1": {
+    "_type": "glue.core.component.CoordinateComponent",
+    "axis": 2,
+    "world": false
+  },
+  "CoordinateComponent_2": {
+    "_type": "glue.core.component.CoordinateComponent",
+    "axis": 0,
+    "world": true
+  },
+  "CoordinateComponent_3": {
+    "_type": "glue.core.component.CoordinateComponent",
+    "axis": 1,
+    "world": true
+  },
+  "CoordinateComponent_4": {
+    "_type": "glue.core.component.CoordinateComponent",
+    "axis": 2,
+    "world": true
+  },
+  "Coordinates": {
+    "_type": "glue.core.coordinates.Coordinates"
+  },
+  "DataCollection": {
+    "_protocol": 4,
+    "_type": "glue.core.data_collection.DataCollection",
+    "cids": [
+      "Pixel Axis 0 [z]",
+      "Pixel Axis 1 [y]",
+      "Pixel Axis 2 [x]",
+      "World 0",
+      "World 1",
+      "World 2",
+      "array_0"
+    ],
+    "components": [
+      "CoordinateComponent",
+      "CoordinateComponent_0",
+      "CoordinateComponent_1",
+      "CoordinateComponent_2",
+      "CoordinateComponent_3",
+      "CoordinateComponent_4",
+      "Component"
+    ],
+    "data": [
+      "array"
+    ],
+    "groups": [
+      "Subset 1",
+      "Subset 2"
+    ],
+    "links": [],
+    "subset_group_count": 2
+  },
+  "Pixel Axis 0 [z]": {
+    "_type": "glue.core.component_id.PixelComponentID",
+    "axis": 0,
+    "label": "Pixel Axis 0 [z]"
+  },
+  "Pixel Axis 1 [y]": {
+    "_type": "glue.core.component_id.PixelComponentID",
+    "axis": 1,
+    "label": "Pixel Axis 1 [y]"
+  },
+  "Pixel Axis 2 [x]": {
+    "_type": "glue.core.component_id.PixelComponentID",
+    "axis": 2,
+    "label": "Pixel Axis 2 [x]"
+  },
+  "ProfileLayerState": {
+    "_type": "glue.viewers.profile.state.ProfileLayerState",
+    "values": {
+      "alpha": 0.8,
+      "attribute": "array_0",
+      "color": "st__#919191",
+      "layer": "array",
+      "linewidth": 1,
+      "percentile": 100,
+      "v_max": 59.0,
+      "v_min": 19.0,
+      "visible": true,
+      "zorder": 1
+    }
+  },
+  "ProfileLayerState_0": {
+    "_type": "glue.viewers.profile.state.ProfileLayerState",
+    "values": {
+      "alpha": 0.5,
+      "attribute": "array_0",
+      "color": "st__#e31a1c",
+      "layer": "Subset 1_0",
+      "linewidth": 1,
+      "percentile": 100,
+      "v_max": 57.0,
+      "v_min": 17.0,
+      "visible": true,
+      "zorder": 2
+    }
+  },
+  "ProfileLayerState_1": {
+    "_type": "glue.viewers.profile.state.ProfileLayerState",
+    "values": {
+      "alpha": 0.5,
+      "attribute": "array_0",
+      "color": "st__#33a02c",
+      "layer": "Subset 2_0",
+      "linewidth": 1,
+      "percentile": 100,
+      "v_max": 58.0,
+      "v_min": 18.0,
+      "visible": true,
+      "zorder": 3
+    }
+  },
+  "ProfileLayerState_10": {
+    "_type": "glue.viewers.profile.state.ProfileLayerState",
+    "values": {
+      "alpha": 0.5,
+      "attribute": "array_0",
+      "color": "st__#33a02c",
+      "layer": "Subset 2_0",
+      "linewidth": 1,
+      "percentile": 100,
+      "v_max": 30.5,
+      "v_min": 30.5,
+      "visible": false,
+      "zorder": 3
+    }
+  },
+  "ProfileLayerState_2": {
+    "_type": "glue.viewers.profile.state.ProfileLayerState",
+    "values": {
+      "alpha": 0.8,
+      "attribute": "array_0",
+      "color": "st__#919191",
+      "layer": "array",
+      "linewidth": 1,
+      "percentile": 100,
+      "v_max": 59.0,
+      "v_min": 44.0,
+      "visible": true,
+      "zorder": 1
+    }
+  },
+  "ProfileLayerState_3": {
+    "_type": "glue.viewers.profile.state.ProfileLayerState",
+    "values": {
+      "alpha": 0.5,
+      "attribute": "array_0",
+      "color": "st__#e31a1c",
+      "layer": "Subset 1_0",
+      "linewidth": 1,
+      "percentile": 100,
+      "v_max": 57.0,
+      "v_min": 42.0,
+      "visible": false,
+      "zorder": 2
+    }
+  },
+  "ProfileLayerState_4": {
+    "_type": "glue.viewers.profile.state.ProfileLayerState",
+    "values": {
+      "alpha": 0.5,
+      "attribute": "array_0",
+      "color": "st__#33a02c",
+      "layer": "Subset 2_0",
+      "linewidth": 1,
+      "percentile": 100,
+      "v_max": 58.0,
+      "v_min": 43.0,
+      "visible": true,
+      "zorder": 3
+    }
+  },
+  "ProfileLayerState_5": {
+    "_type": "glue.viewers.profile.state.ProfileLayerState",
+    "values": {
+      "alpha": 0.8,
+      "attribute": "array_0",
+      "color": "st__#919191",
+      "layer": "array",
+      "linewidth": 1,
+      "percentile": 100,
+      "v_max": 4.0,
+      "v_min": 0.0,
+      "visible": true,
+      "zorder": 1
+    }
+  },
+  "ProfileLayerState_6": {
+    "_type": "glue.viewers.profile.state.ProfileLayerState",
+    "values": {
+      "alpha": 0.5,
+      "attribute": "array_0",
+      "color": "st__#e31a1c",
+      "layer": "Subset 1_0",
+      "linewidth": 1,
+      "percentile": 100,
+      "v_max": 2.0,
+      "v_min": 1.0,
+      "visible": true,
+      "zorder": 2
+    }
+  },
+  "ProfileLayerState_7": {
+    "_type": "glue.viewers.profile.state.ProfileLayerState",
+    "values": {
+      "alpha": 0.5,
+      "attribute": "array_0",
+      "color": "st__#33a02c",
+      "layer": "Subset 2_0",
+      "linewidth": 1,
+      "percentile": 100,
+      "v_max": 3.0,
+      "v_min": 3.0,
+      "visible": false,
+      "zorder": 3
+    }
+  },
+  "ProfileLayerState_8": {
+    "_type": "glue.viewers.profile.state.ProfileLayerState",
+    "values": {
+      "alpha": 0.8,
+      "attribute": "array_0",
+      "color": "st__#919191",
+      "layer": "array",
+      "linewidth": 1,
+      "percentile": 100,
+      "v_max": 31.5,
+      "v_min": 27.5,
+      "visible": true,
+      "zorder": 1
+    }
+  },
+  "ProfileLayerState_9": {
+    "_type": "glue.viewers.profile.state.ProfileLayerState",
+    "values": {
+      "alpha": 0.5,
+      "attribute": "array_0",
+      "color": "st__#e31a1c",
+      "layer": "Subset 1_0",
+      "linewidth": 1,
+      "percentile": 100,
+      "v_max": 29.5,
+      "v_min": 28.5,
+      "visible": false,
+      "zorder": 2
+    }
+  },
+  "ProfileViewer": {
+    "_protocol": 1,
+    "_type": "glue.viewers.profile.qt.data_viewer.ProfileViewer",
+    "layers": [
+      {
+        "_type": "glue.viewers.profile.layer_artist.ProfileLayerArtist",
+        "state": "ProfileLayerState"
+      },
+      {
+        "_type": "glue.viewers.profile.layer_artist.ProfileLayerArtist",
+        "state": "ProfileLayerState_0"
+      },
+      {
+        "_type": "glue.viewers.profile.layer_artist.ProfileLayerArtist",
+        "state": "ProfileLayerState_1"
+      }
+    ],
+    "pos": [
+      0,
+      0
+    ],
+    "session": "Session",
+    "size": [
+      600,
+      400
+    ],
+    "state": {
+      "values": {
+        "aspect": "st__auto",
+        "function": "st__maximum",
+        "layers": "CallbackList",
+        "normalize": false,
+        "reference_data": "array",
+        "show_axes": true,
+        "x_att": "Pixel Axis 0 [z]",
+        "x_att_pixel": "Pixel Axis 0 [z]",
+        "x_axislabel": "st__Pixel Axis 0 [z]",
+        "x_axislabel_size": 10,
+        "x_axislabel_weight": "st__normal",
+        "x_log": false,
+        "x_max": 2.5,
+        "x_min": -0.5,
+        "x_ticklabel_size": 8,
+        "y_axislabel": "st__Data values",
+        "y_axislabel_size": 10,
+        "y_axislabel_weight": "st__normal",
+        "y_log": false,
+        "y_max": 63.0,
+        "y_min": 13.0,
+        "y_ticklabel_size": 8
+      }
+    }
+  },
+  "ProfileViewer_0": {
+    "_protocol": 1,
+    "_type": "glue.viewers.profile.qt.data_viewer.ProfileViewer",
+    "layers": [
+      {
+        "_type": "glue.viewers.profile.layer_artist.ProfileLayerArtist",
+        "state": "ProfileLayerState_2"
+      },
+      {
+        "_type": "glue.viewers.profile.layer_artist.ProfileLayerArtist",
+        "state": "ProfileLayerState_3"
+      },
+      {
+        "_type": "glue.viewers.profile.layer_artist.ProfileLayerArtist",
+        "state": "ProfileLayerState_4"
+      }
+    ],
+    "pos": [
+      600,
+      1
+    ],
+    "session": "Session",
+    "size": [
+      600,
+      400
+    ],
+    "state": {
+      "values": {
+        "aspect": "st__auto",
+        "function": "st__maximum",
+        "layers": "CallbackList_0",
+        "normalize": true,
+        "reference_data": "array",
+        "show_axes": true,
+        "x_att": "Pixel Axis 1 [y]",
+        "x_att_pixel": "Pixel Axis 1 [y]",
+        "x_axislabel": "st__Pixel Axis 1 [y]",
+        "x_axislabel_size": 10,
+        "x_axislabel_weight": "st__normal",
+        "x_log": false,
+        "x_max": 3.5,
+        "x_min": -0.5,
+        "x_ticklabel_size": 8,
+        "y_axislabel": "st__Normalized data values",
+        "y_axislabel_size": 10,
+        "y_axislabel_weight": "st__normal",
+        "y_log": false,
+        "y_max": 1.1,
+        "y_min": -0.1,
+        "y_ticklabel_size": 8
+      }
+    }
+  },
+  "ProfileViewer_1": {
+    "_protocol": 1,
+    "_type": "glue.viewers.profile.qt.data_viewer.ProfileViewer",
+    "layers": [
+      {
+        "_type": "glue.viewers.profile.layer_artist.ProfileLayerArtist",
+        "state": "ProfileLayerState_5"
+      },
+      {
+        "_type": "glue.viewers.profile.layer_artist.ProfileLayerArtist",
+        "state": "ProfileLayerState_6"
+      },
+      {
+        "_type": "glue.viewers.profile.layer_artist.ProfileLayerArtist",
+        "state": "ProfileLayerState_7"
+      }
+    ],
+    "pos": [
+      0,
+      400
+    ],
+    "session": "Session",
+    "size": [
+      600,
+      400
+    ],
+    "state": {
+      "values": {
+        "aspect": "st__auto",
+        "function": "st__minimum",
+        "layers": "CallbackList_1",
+        "normalize": false,
+        "reference_data": "array",
+        "show_axes": true,
+        "x_att": "Pixel Axis 2 [x]",
+        "x_att_pixel": "Pixel Axis 2 [x]",
+        "x_axislabel": "st__Pixel Axis 2 [x]",
+        "x_axislabel_size": 10,
+        "x_axislabel_weight": "st__normal",
+        "x_log": false,
+        "x_max": 4.5,
+        "x_min": -0.5,
+        "x_ticklabel_size": 8,
+        "y_axislabel": "st__Data values",
+        "y_axislabel_size": 10,
+        "y_axislabel_weight": "st__normal",
+        "y_log": false,
+        "y_max": 4.4,
+        "y_min": -0.4,
+        "y_ticklabel_size": 8
+      }
+    }
+  },
+  "ProfileViewer_2": {
+    "_protocol": 1,
+    "_type": "glue.viewers.profile.qt.data_viewer.ProfileViewer",
+    "layers": [
+      {
+        "_type": "glue.viewers.profile.layer_artist.ProfileLayerArtist",
+        "state": "ProfileLayerState_8"
+      },
+      {
+        "_type": "glue.viewers.profile.layer_artist.ProfileLayerArtist",
+        "state": "ProfileLayerState_9"
+      },
+      {
+        "_type": "glue.viewers.profile.layer_artist.ProfileLayerArtist",
+        "state": "ProfileLayerState_10"
+      }
+    ],
+    "pos": [
+      600,
+      400
+    ],
+    "session": "Session",
+    "size": [
+      600,
+      400
+    ],
+    "state": {
+      "values": {
+        "aspect": "st__auto",
+        "function": "st__mean",
+        "layers": "CallbackList_2",
+        "normalize": false,
+        "reference_data": "array",
+        "show_axes": true,
+        "x_att": "Pixel Axis 2 [x]",
+        "x_att_pixel": "Pixel Axis 2 [x]",
+        "x_axislabel": "st__Pixel Axis 2 [x]",
+        "x_axislabel_size": 10,
+        "x_axislabel_weight": "st__normal",
+        "x_log": false,
+        "x_max": 9.5,
+        "x_min": -5.5,
+        "x_ticklabel_size": 8,
+        "y_axislabel": "st__Data values",
+        "y_axislabel_size": 10,
+        "y_axislabel_weight": "st__normal",
+        "y_log": false,
+        "y_max": 31.9,
+        "y_min": 27.1,
+        "y_ticklabel_size": 8
+      }
+    }
+  },
+  "RangeSubsetState": {
+    "_type": "glue.core.subset.RangeSubsetState",
+    "att": "Pixel Axis 2 [x]",
+    "hi": 2.2825159914712154,
+    "lo": 0.9925373134328361
+  },
+  "RangeSubsetState_0": {
+    "_type": "glue.core.subset.RangeSubsetState",
+    "att": "Pixel Axis 2 [x]",
+    "hi": 3.2633262260127935,
+    "lo": 2.932835820895522
+  },
+  "Session": {
+    "_type": "glue.core.session.Session"
+  },
+  "Subset 1": {
+    "_type": "glue.core.subset_group.SubsetGroup",
+    "label": "Subset 1",
+    "state": "RangeSubsetState",
+    "style": {
+      "_type": "glue.core.visual.VisualAttributes",
+      "alpha": 0.5,
+      "color": "#e31a1c",
+      "linestyle": "solid",
+      "linewidth": 2.5,
+      "marker": "o",
+      "markersize": 7
+    },
+    "subsets": [
+      "Subset 1_0"
+    ]
+  },
+  "Subset 1_0": {
+    "_type": "glue.core.subset_group.GroupedSubset",
+    "group": "Subset 1",
+    "style": {
+      "_type": "glue.core.visual.VisualAttributes",
+      "alpha": 0.5,
+      "color": "#e31a1c",
+      "linestyle": "solid",
+      "linewidth": 2.5,
+      "marker": "o",
+      "markersize": 7
+    }
+  },
+  "Subset 2": {
+    "_type": "glue.core.subset_group.SubsetGroup",
+    "label": "Subset 2",
+    "state": "RangeSubsetState_0",
+    "style": {
+      "_type": "glue.core.visual.VisualAttributes",
+      "alpha": 0.5,
+      "color": "#33a02c",
+      "linestyle": "solid",
+      "linewidth": 2.5,
+      "marker": "o",
+      "markersize": 7
+    },
+    "subsets": [
+      "Subset 2_0"
+    ]
+  },
+  "Subset 2_0": {
+    "_type": "glue.core.subset_group.GroupedSubset",
+    "group": "Subset 2",
+    "style": {
+      "_type": "glue.core.visual.VisualAttributes",
+      "alpha": 0.5,
+      "color": "#33a02c",
+      "linestyle": "solid",
+      "linewidth": 2.5,
+      "marker": "o",
+      "markersize": 7
+    }
+  },
+  "World 0": {
+    "_type": "glue.core.component_id.ComponentID",
+    "label": "World 0"
+  },
+  "World 1": {
+    "_type": "glue.core.component_id.ComponentID",
+    "label": "World 1"
+  },
+  "World 2": {
+    "_type": "glue.core.component_id.ComponentID",
+    "label": "World 2"
+  },
+  "__main__": {
+    "_type": "glue.app.qt.application.GlueApplication",
+    "data": "DataCollection",
+    "plugins": [
+      "glue_plotly",
+      "glue.plugins.export_d3po",
+      "glue.plugins.tools",
+      "glue_vispy_viewers.scatter",
+      "glue.plugins.wcs_autolinking",
+      "glue.viewers.image.qt",
+      "glue.viewers.scatter.qt",
+      "glue.viewers.profile.qt",
+      "glue.io.formats.fits",
+      "glue.plugins.tools.pv_slicer",
+      "glue.plugins.dendro_viewer.qt",
+      "glue.core.data_exporters",
+      "glue.viewers.table.qt",
+      "glue.viewers.histogram.qt",
+      "glue.plugins.coordinate_helpers",
+      "glue_vispy_viewers.volume",
+      "glue.plugins.data_factories.spectral_cube"
+    ],
+    "session": "Session",
+    "tab_names": [
+      "Tab 1"
+    ],
+    "viewers": [
+      [
+        "ProfileViewer",
+        "ProfileViewer_0",
+        "ProfileViewer_1",
+        "ProfileViewer_2"
+      ]
+    ]
+  },
+  "array": {
+    "_key_joins": [],
+    "_protocol": 5,
+    "_type": "glue.core.data.Data",
+    "components": [
+      [
+        "Pixel Axis 0 [z]",
+        "CoordinateComponent"
+      ],
+      [
+        "Pixel Axis 1 [y]",
+        "CoordinateComponent_0"
+      ],
+      [
+        "Pixel Axis 2 [x]",
+        "CoordinateComponent_1"
+      ],
+      [
+        "World 0",
+        "CoordinateComponent_2"
+      ],
+      [
+        "World 1",
+        "CoordinateComponent_3"
+      ],
+      [
+        "World 2",
+        "CoordinateComponent_4"
+      ],
+      [
+        "array_0",
+        "Component"
+      ]
+    ],
+    "coords": "Coordinates",
+    "label": "array",
+    "meta": {
+      "_type": "collections.OrderedDict",
+      "contents": {}
+    },
+    "primary_owner": [
+      "Pixel Axis 0 [z]",
+      "Pixel Axis 1 [y]",
+      "Pixel Axis 2 [x]",
+      "World 0",
+      "World 1",
+      "World 2",
+      "array_0"
+    ],
+    "style": {
+      "_type": "glue.core.visual.VisualAttributes",
+      "alpha": 0.8,
+      "color": "#919191",
+      "linestyle": "solid",
+      "linewidth": 1,
+      "marker": "o",
+      "markersize": 3
+    },
+    "subsets": [
+      "Subset 1_0",
+      "Subset 2_0"
+    ],
+    "uuid": "bcc66633-1537-48a3-8710-96e303bf6a6e"
+  },
+  "array_0": {
+    "_type": "glue.core.component_id.ComponentID",
+    "label": "array"
+  }
+}


### PR DESCRIPTION
Before this PR, if Qt was installed it could end up getting imported and used for QThread even if using a non-Qt frontend. This PR cleanly separates the part of the histogram and profile layer artist that depends on QThread into Qt-specific layer artist sub-classes.