### PR TITLE
Moved ensure_numerical to glue.utils

### DIFF
--- a/glue/utils/array.py
+++ b/glue/utils/array.py
@@ -16,7 +16,7 @@ __all__ = ['unique', 'shape_to_string', 'view_shape', 'stack_view',
            'coerce_numeric', 'check_sorted', 'broadcast_to', 'unbroadcast',
            'iterate_chunks', 'combine_slices', 'nanmean', 'nanmedian', 'nansum',
            'nanmin', 'nanmax', 'format_minimal', 'compute_statistic',
-           'categorical_ndarray', 'index_lookup']
+           'categorical_ndarray', 'index_lookup', 'ensure_numerical']
 
 
 def unbroadcast(array):
@@ -558,6 +558,13 @@ class categorical_ndarray(np.ndarray):
             self._jitter -= 0.5
         else:
             raise ValueError("method should be None or 'uniform'")
+
+
+def ensure_numerical(values):
+    if isinstance(values, categorical_ndarray):
+        return values.codes
+    else:
+        return values
 
 
 def index_lookup(data, items):

--- a/glue/viewers/scatter/layer_artist.py
+++ b/glue/viewers/scatter/layer_artist.py
@@ -11,7 +11,7 @@ from mpl_scatter_density.generic_density_artist import GenericDensityArtist
 from astropy.visualization import (ImageNormalize, LinearStretch, SqrtStretch,
                                    AsinhStretch, LogStretch)
 
-from glue.utils import defer_draw, broadcast_to, nanmax, categorical_ndarray
+from glue.utils import defer_draw, broadcast_to, nanmax, categorical_ndarray, ensure_numerical
 from glue.viewers.scatter.state import ScatterLayerState
 from glue.viewers.scatter.python_export import python_export_scatter_layer
 from glue.viewers.matplotlib.layer_artist import MatplotlibLayerArtist
@@ -57,13 +57,6 @@ class DensityMapLimits(object):
 
     def max(self, array):
         return 10. ** (np.log10(nanmax(array)) * self.contrast)
-
-
-def ensure_numerical(values):
-    if isinstance(values, categorical_ndarray):
-        return values.codes
-    else:
-        return values
 
 
 def set_mpl_artist_cmap(artist, values, state=None, cmap=None, vmin=None, vmax=None):

--- a/glue/viewers/scatter/layer_artist.py
+++ b/glue/viewers/scatter/layer_artist.py
@@ -11,7 +11,7 @@ from mpl_scatter_density.generic_density_artist import GenericDensityArtist
 from astropy.visualization import (ImageNormalize, LinearStretch, SqrtStretch,
                                    AsinhStretch, LogStretch)
 
-from glue.utils import defer_draw, broadcast_to, nanmax, categorical_ndarray, ensure_numerical
+from glue.utils import defer_draw, broadcast_to, nanmax, ensure_numerical
 from glue.viewers.scatter.state import ScatterLayerState
 from glue.viewers.scatter.python_export import python_export_scatter_layer
 from glue.viewers.matplotlib.layer_artist import MatplotlibLayerArtist


### PR DESCRIPTION
Just moving this function since it's pretty generic for anyone using ``categorical_ndarray``