### PR TITLE
No longer offer to merge datasets by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,20 +100,6 @@ matrix:
                IPYTHON_VERSION=4
                NUMPY_VERSION=1.12
 
-        # Test with PySide2
-
-        - os: osx
-          stage: Full
-          env: PYTHON_VERSION=3.6
-               CONDA_CHANNELS="astropy-ci-extras astropy glueviz conda-forge"
-               QT_PKG=pyside2
-
-        - os: linux
-          stage: Full
-          env: PYTHON_VERSION=3.6
-               CONDA_CHANNELS="astropy-ci-extras astropy glueviz conda-forge"
-               QT_PKG=pyside2
-
         # Test without any Qt installation, which will also cause all qt
         # sub-directories to be removed, to make sure that no non-Qt code has
         # any dependence on Qt code.
@@ -123,21 +109,7 @@ matrix:
                PIP_DEPENDENCIES="codecov pyavm astrodendro plotly objgraph flake8"
                QT_PKG=False
 
-    allow_failures:
 
-      # For now PySide2 can give segfaults when the process terminates - see
-      # https://bugreports.qt.io/browse/PYSIDE-585
-      # We therefore need to mark these as allowed failures for now
-
-      - os: osx
-        env: PYTHON_VERSION=3.6
-             CONDA_CHANNELS="astropy-ci-extras astropy glueviz conda-forge"
-             QT_PKG=pyside2
-
-      - os: linux
-        env: PYTHON_VERSION=3.6
-             CONDA_CHANNELS="astropy-ci-extras astropy glueviz conda-forge"
-             QT_PKG=pyside2
 
 before_install:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -55,6 +55,15 @@ v0.15.0 (unreleased)
 * Avoiding importing Qt when using the base histogram and profile layer artists.
   [#2012]
 
+* Fixed a bug that caused error bars to be colored incorrectly if NaN values
+  were present. [#8898]
+
+* Fixed compatibility with the latest versions of Matplotlib and Astropy. [#8898]
+
+* No longer suggest merging data by default whenever datasets are added to
+  the session. Merging different datasets should now be done manually through
+  the GUI. [#8898]
+
 v0.14.3 (unreleased)
 --------------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -56,13 +56,13 @@ v0.15.0 (unreleased)
   [#2012]
 
 * Fixed a bug that caused error bars to be colored incorrectly if NaN values
-  were present. [#8898]
+  were present. [#2020]
 
-* Fixed compatibility with the latest versions of Matplotlib and Astropy. [#8898]
+* Fixed compatibility with the latest versions of Matplotlib and Astropy. [#2020]
 
 * No longer suggest merging data by default whenever datasets are added to
   the session. Merging different datasets should now be done manually through
-  the GUI. [#8898]
+  the GUI. [#2020]
 
 v0.14.3 (unreleased)
 --------------------

--- a/doc/gui_guide/merging.rst
+++ b/doc/gui_guide/merging.rst
@@ -37,11 +37,8 @@ linking keeps each dataset separate.
 How to merge datasets
 ---------------------
 
-Whenever you load a file whose shape matches a pre-existing dataset,
-Glue will ask you if you want to merge them into a single object.
-If you choose not to merge at this time, you can merge later
-by highlighting the relevant datasets in the left panel, right-clicking,
-and selecting ``Merge datasets``.
+You can merge datasets by highlighting the relevant datasets in the left panel,
+right-clicking, and selecting **Merge datasets**.
 
 To merge datasets programmatically, use the :meth:`DataCollection.merge
 <glue.core.data_collection.DataCollection.merge>` method.

--- a/doc/whatsnew/whatsnew.rst
+++ b/doc/whatsnew/whatsnew.rst
@@ -26,6 +26,20 @@ about glue in general, you can find information :ref:`here
 <help>` about contacting us and/or
 reporting issues.
 
+.. _whatsnew_015:
+
+What's new in glue v0.15?
+=========================
+
+No more merging suggestions
+---------------------------
+
+Glue will no longer prompt you to merge multiple datasets into a single one
+automatically - instead this is something that you should now do manually by
+selecting the datasets to merge, then right-clicking (or ctrl-clicking) and
+selecting **Merge datasets**. We decided to not suggest this by default anymore
+since links are the preferred way of using multiple datasets together.
+
 .. _whatsnew_014:
 
 What's new in glue v0.14?

--- a/glue/app/qt/application.py
+++ b/glue/app/qt/application.py
@@ -1390,10 +1390,9 @@ class GlueApplication(Application, QtWidgets.QMainWindow):
         image.save(filename)
         painter.end()
 
-    @classmethod
-    def add_datasets(cls, data_collection, *args, **kwargs):
-        result = super(GlueApplication, cls).add_datasets(data_collection, *args, **kwargs)
-        run_autolinker(data_collection)
+    def add_datasets(self, *args, **kwargs):
+        result = super(GlueApplication, self).add_datasets(*args, **kwargs)
+        run_autolinker(self.data_collection)
         return result
 
     def __gluestate__(self, context):

--- a/glue/app/qt/layer_tree_widget.py
+++ b/glue/app/qt/layer_tree_widget.py
@@ -630,10 +630,8 @@ class LayerTreeWidget(QtWidgets.QMainWindow, HubListener):
     def _load_data(self):
         """ Interactively loads data from a data set. Adds
         as new layer """
-        from glue.app.qt import GlueApplication
-
         layers = data_wizard()
-        GlueApplication.add_datasets(self.data_collection, layers)
+        self.data_collection.extend(layers)
 
     def __getitem__(self, key):
         raise NotImplementedError()

--- a/glue/core/data_collection.py
+++ b/glue/core/data_collection.py
@@ -335,7 +335,7 @@ class DataCollection(HubListener):
 
             self.remove(d)
 
-        return self
+        return master
 
     @property
     def subset_groups(self):

--- a/glue/core/data_factories/tests/test_hdf5.py
+++ b/glue/core/data_factories/tests/test_hdf5.py
@@ -65,20 +65,21 @@ def test_hdf5_loader_fromfile():
 @requires_h5py
 def test_hdf5_auto_merge(tmpdir):
 
-    filename = tmpdir.join('test.hdf5').strpath
+    filename1 = tmpdir.mkdir('test1').join('test.hdf5').strpath
+    filename2 = tmpdir.mkdir('test2').join('test.hdf5').strpath
 
     import h5py
 
     # When heterogeneous arrays are present, auto_merge is ignored
 
-    f = h5py.File(filename, 'w')
+    f = h5py.File(filename1, 'w')
     f.create_dataset('a', data=np.array([[1, 2], [3, 4]]))
     f.create_dataset('b', data=np.array([1, 2, 3]))
     f.close()
 
     for auto_merge in [False, True]:
 
-        datasets = df.hdf5_reader(filename, auto_merge=auto_merge)
+        datasets = df.hdf5_reader(filename1, auto_merge=auto_merge)
 
         assert len(datasets) == 2
 
@@ -90,12 +91,12 @@ def test_hdf5_auto_merge(tmpdir):
 
     # Check that the default is to merge if all arrays are homogeneous
 
-    f = h5py.File(filename, 'w')
+    f = h5py.File(filename2, 'w')
     f.create_dataset('a', data=np.array([3, 4, 5]))
     f.create_dataset('b', data=np.array([1, 2, 3]))
     f.close()
 
-    datasets = df.hdf5_reader(filename)
+    datasets = df.hdf5_reader(filename2)
 
     assert len(datasets) == 1
 
@@ -105,7 +106,7 @@ def test_hdf5_auto_merge(tmpdir):
 
     # And check opt-out
 
-    datasets = df.hdf5_reader(filename, auto_merge=False)
+    datasets = df.hdf5_reader(filename2, auto_merge=False)
 
     assert len(datasets) == 2
 

--- a/glue/core/tests/test_application_base.py
+++ b/glue/core/tests/test_application_base.py
@@ -31,32 +31,6 @@ class MockApplication(Application):
         pass
 
 
-class TestApplicationBase(object):
-
-    def setup_method(self, method):
-        self.app = MockApplication()
-
-    def test_suggest_mergers(self):
-        x = Data(x=[1, 2, 3])
-        y = Data(y=[1, 2, 3, 4])
-        z = Data(z=[1, 2, 3])
-
-        Application._choose_merge = MagicMock()
-        Application._choose_merge.return_value = ([x], 'mydata')
-        self.app.data_collection.merge = MagicMock()
-
-        self.app.data_collection.append(x)
-        self.app.data_collection.append(y)
-
-        self.app.add_datasets(self.app.data_collection, z)
-
-        args = self.app._choose_merge.call_args[0]
-        assert args[0] == z
-        assert args[1] == [x]
-
-        assert self.app.data_collection.merge.call_count == 1
-
-
 def test_session(tmpdir):
     session_file = tmpdir.join('test.glu').strpath
     app = MockApplication()

--- a/glue/dialogs/data_wizard/qt/tests/test_data_wizard.py
+++ b/glue/dialogs/data_wizard/qt/tests/test_data_wizard.py
@@ -23,6 +23,7 @@ class TestGlueDataDialog(object):
     def test_factory(self):
         """Factory method should always match with filter"""
         fd = GlueDataDialog()
+        fd._fd.show()
         assert len(fd.filters) > 0
         for k, v in fd.filters:
             fd._fd.selectNameFilter(v)

--- a/glue/dialogs/link_editor/qt/tests/test_link_editor.py
+++ b/glue/dialogs/link_editor/qt/tests/test_link_editor.py
@@ -631,6 +631,8 @@ class TestLinkEditor:
         assert link_widget.state.data1 == self.data1
         assert link_widget.state.data2 == self.data2
 
+        dialog.accept()
+
     def test_preexisting_links_twodata(self):
 
         # Regression test for an issue that occurred specifically if there were
@@ -647,3 +649,5 @@ class TestLinkEditor:
 
         dialog = LinkEditor(data_collection)
         dialog.show()
+
+        dialog.accept()

--- a/glue/main.py
+++ b/glue/main.py
@@ -190,7 +190,7 @@ def start_glue(gluefile=None, config=None, datafiles=None, maximized=True,
     if datafiles:
         with die_on_error("Error reading data file"):
             datasets = load_data_files(datafiles)
-        ga.add_datasets(data_collection, datasets, auto_merge=auto_merge)
+        ga.add_datasets(datasets, auto_merge=auto_merge)
 
     if startup_actions is not None:
         for name in startup_actions:

--- a/glue/plugins/tools/python_export.py
+++ b/glue/plugins/tools/python_export.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 from qtpy import compat
 from glue.config import viewer_tool
-from glue.viewers.common.qt.tool import Tool
+from glue.viewers.common.tool import Tool
 
 
 @viewer_tool

--- a/glue/utils/qt/app.py
+++ b/glue/utils/qt/app.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+import time
 import platform
 from qtpy import QtCore, QtGui, QtWidgets
 
@@ -24,9 +25,14 @@ def __get_font_size_offset():
     return size_offset
 
 
-def process_events():
+def process_events(wait=None):
     app = get_qapp()
-    app.processEvents()
+    if wait is None:
+        app.processEvents()
+    else:
+        start = time.time()
+        while time.time() - start < wait:
+            app.processEvents()
 
 
 def get_qapp(icon_path=None):

--- a/glue/viewers/histogram/python_export.py
+++ b/glue/viewers/histogram/python_export.py
@@ -1,7 +1,13 @@
 from __future__ import absolute_import, division, print_function
 
+from distutils.version import LooseVersion
+
+from matplotlib import __version__
+
 from glue.viewers.common.python_export import code, serialize_options
 from glue.utils import nanmin, nanmax
+
+MATPLOTLIB_GE_30 = LooseVersion(__version__) > '3'
 
 
 def python_export_histogram_layer(layer, *args):
@@ -48,7 +54,10 @@ def python_export_histogram_layer(layer, *args):
         options['bins'] = code('hist_n_bin')
 
     if layer._viewer_state.normalize:
-        options['normed'] = True
+        if MATPLOTLIB_GE_30:
+            options['density'] = True
+        else:
+            options['normed'] = True
 
     if layer._viewer_state.cumulative:
         options['cumulative'] = True

--- a/glue/viewers/image/composite_array.py
+++ b/glue/viewers/image/composite_array.py
@@ -107,6 +107,7 @@ class CompositeArray(object):
                 scalar = False
 
             data = STRETCHES[layer['stretch']]()(contrast_bias(interval(array)))
+            data[np.isnan(data)] = 0
 
             if isinstance(layer['color'], Colormap):
 

--- a/glue/viewers/image/qt/tests/test_regression.py
+++ b/glue/viewers/image/qt/tests/test_regression.py
@@ -42,4 +42,8 @@ def test_resample_on_zoom():
     image.axes.figure.canvas.motion_notify_event(400 * device_ratio, 210 * device_ratio)
     image.axes.figure.canvas.button_release_event(400 * device_ratio, 210 * device_ratio, 1)
 
-    return image.axes.figure
+    figure = image.axes.figure
+
+    image.close()
+
+    return figure

--- a/glue/viewers/matplotlib/qt/tests/test_data_viewer.py
+++ b/glue/viewers/matplotlib/qt/tests/test_data_viewer.py
@@ -560,7 +560,7 @@ class BaseTestMatplotlibDataViewer(object):
         # Resize events only work if widget is visible
         self.viewer.show()
         self.viewer.figure.canvas.draw()
-        process_events()
+        process_events(wait=0.1)
 
         def limits(viewer):
             return (viewer.state.x_min, viewer.state.x_max,
@@ -569,13 +569,13 @@ class BaseTestMatplotlibDataViewer(object):
         # Set viewer to an initial size and save limits
         self.viewer.viewer_size = (800, 400)
         self.viewer.figure.canvas.draw()
-        process_events()
+        process_events(wait=0.1)
         initial_limits = limits(self.viewer)
 
         # Change the viewer size, and make sure the limits are adjusted
         self.viewer.viewer_size = (400, 400)
         self.viewer.figure.canvas.draw()
-        process_events()
+        process_events(wait=0.1)
         with pytest.raises(AssertionError):
             assert_allclose(limits(self.viewer), initial_limits)
 
@@ -583,23 +583,23 @@ class BaseTestMatplotlibDataViewer(object):
         # return to the original size, the limits match the initial ones.
         self.viewer.viewer_size = (350, 800)
         self.viewer.figure.canvas.draw()
-        process_events()
+        process_events(wait=0.1)
         self.viewer.viewer_size = (900, 300)
         self.viewer.figure.canvas.draw()
-        process_events()
+        process_events(wait=0.1)
         self.viewer.viewer_size = (600, 600)
         self.viewer.figure.canvas.draw()
-        process_events()
+        process_events(wait=0.1)
         self.viewer.viewer_size = (800, 400)
         self.viewer.figure.canvas.draw()
-        process_events()
+        process_events(wait=0.1)
         assert_allclose(limits(self.viewer), initial_limits)
 
         # Now check that the limits don't change in 'auto' mode
         self.viewer.state.aspect = 'auto'
         self.viewer.viewer_size = (900, 300)
         self.viewer.figure.canvas.draw()
-        process_events()
+        process_events(wait=0.1)
         assert_allclose(limits(self.viewer), initial_limits)
 
     def test_update_data_values(self):

--- a/glue/viewers/matplotlib/qt/tests/test_data_viewer.py
+++ b/glue/viewers/matplotlib/qt/tests/test_data_viewer.py
@@ -545,6 +545,9 @@ class BaseTestMatplotlibDataViewer(object):
         # This test works with Matplotlib 2.0 and 2.2 but not 2.1, hence we
         # skip it with Matplotlib 2.1 above.
 
+        # Note that we need to explicitly call draw() below because otherwise
+        # draw_idle is used, which has no guarantee of being effective.
+
         # Set initial limits to deterministic values
         self.viewer.state.aspect = 'auto'
         self.viewer.state.x_min = 0.
@@ -556,6 +559,7 @@ class BaseTestMatplotlibDataViewer(object):
 
         # Resize events only work if widget is visible
         self.viewer.show()
+        self.viewer.figure.canvas.draw()
         process_events()
 
         def limits(viewer):
@@ -564,11 +568,13 @@ class BaseTestMatplotlibDataViewer(object):
 
         # Set viewer to an initial size and save limits
         self.viewer.viewer_size = (800, 400)
+        self.viewer.figure.canvas.draw()
         process_events()
         initial_limits = limits(self.viewer)
 
         # Change the viewer size, and make sure the limits are adjusted
         self.viewer.viewer_size = (400, 400)
+        self.viewer.figure.canvas.draw()
         process_events()
         with pytest.raises(AssertionError):
             assert_allclose(limits(self.viewer), initial_limits)
@@ -576,18 +582,24 @@ class BaseTestMatplotlibDataViewer(object):
         # Now change the viewer size a number of times and make sure if we
         # return to the original size, the limits match the initial ones.
         self.viewer.viewer_size = (350, 800)
+        self.viewer.figure.canvas.draw()
         process_events()
         self.viewer.viewer_size = (900, 300)
+        self.viewer.figure.canvas.draw()
         process_events()
         self.viewer.viewer_size = (600, 600)
+        self.viewer.figure.canvas.draw()
         process_events()
         self.viewer.viewer_size = (800, 400)
+        self.viewer.figure.canvas.draw()
         process_events()
         assert_allclose(limits(self.viewer), initial_limits)
 
         # Now check that the limits don't change in 'auto' mode
         self.viewer.state.aspect = 'auto'
         self.viewer.viewer_size = (900, 300)
+        self.viewer.figure.canvas.draw()
+        process_events()
         assert_allclose(limits(self.viewer), initial_limits)
 
     def test_update_data_values(self):

--- a/glue/viewers/scatter/python_export.py
+++ b/glue/viewers/scatter/python_export.py
@@ -13,15 +13,16 @@ def python_export_scatter_layer(layer, *args):
 
     script += "# Get main data values\n"
     script += "x = layer_data['{0}']\n".format(layer._viewer_state.x_att.label)
-    script += "y = layer_data['{0}']\n\n".format(layer._viewer_state.y_att.label)
+    script += "y = layer_data['{0}']\n".format(layer._viewer_state.y_att.label)
+    script += "keep = ~np.isnan(x) & ~np.isnan(y)\n\n"
 
     if layer.state.cmap_mode == 'Linear':
 
         script += "# Set up colors\n"
-        script += "colors = layer_data['{0}'].copy()\n".format(layer.state.cmap_att.label)
+        script += "colors = layer_data['{0}']\n".format(layer.state.cmap_att.label)
         script += "cmap_vmin = {0}\n".format(layer.state.cmap_vmin)
         script += "cmap_vmax = {0}\n".format(layer.state.cmap_vmax)
-        script += "colors[np.isnan(colors)] = cmap_vmin\n"
+        script += "keep &= ~np.isnan(colors)\n"
         script += "colors = plt.cm.{0}((colors - cmap_vmin) / (cmap_vmax - cmap_vmin))\n\n".format(layer.state.cmap.name)
 
     if layer.state.size_mode == 'Linear':
@@ -32,6 +33,7 @@ def python_export_scatter_layer(layer, *args):
         script += "sizes = layer_data['{0}']\n".format(layer.state.size_att.label)
         script += "size_vmin = {0}\n".format(layer.state.size_vmin)
         script += "size_vmax = {0}\n".format(layer.state.size_vmax)
+        script += "keep &= ~np.isnan(sizes)\n"
         script += "sizes = 30 * (np.clip((sizes - size_vmin) / (size_vmax - size_vmin), 0, 1) * 0.95 + 0.05) * {0}\n\n".format(layer.state.size_scaling)
 
     if layer.state.markers_visible:
@@ -72,7 +74,7 @@ def python_export_scatter_layer(layer, *args):
                     options['mec'] = 'none'
                 else:
                     options['mfc'] = 'none'
-                script += "ax.plot(x, y, 'o', {0})\n\n".format(serialize_options(options))
+                script += "ax.plot(x[keep], y[keep], 'o', {0})\n\n".format(serialize_options(options))
             else:
                 options = dict(alpha=layer.state.alpha,
                                zorder=layer.state.zorder)
@@ -80,19 +82,19 @@ def python_export_scatter_layer(layer, *args):
                 if layer.state.cmap_mode == 'Fixed':
                     options['facecolor'] = layer.state.color
                 else:
-                    options['c'] = code('colors')
+                    options['c'] = code('colors[keep]')
 
                 if layer.state.size_mode == 'Fixed':
                     options['s'] = code('{0} ** 2'.format(layer.state.size * layer.state.size_scaling))
                 else:
-                    options['s'] = code('sizes ** 2')
+                    options['s'] = code('sizes[keep] ** 2')
 
                 if layer.state.fill:
                     options['edgecolor'] = 'none'
                 else:
                     script += "s = "
 
-                script += "ax.scatter(x, y, {0})\n".format(serialize_options(options))
+                script += "ax.scatter(x[keep], y[keep], {0})\n".format(serialize_options(options))
 
                 if not layer.state.fill:
                     script += "s.set_edgecolors(s.get_facecolors())\n"
@@ -108,13 +110,13 @@ def python_export_scatter_layer(layer, *args):
 
             script += "# Get vector data\n"
             if layer.state.vector_mode == 'Polar':
-                script += "angle = layer_data['{0}']\n".format(layer.state.vx_att.label)
-                script += "length = layer_data['{0}']\n".format(layer.state.vy_att.label)
+                script += "angle = layer_data['{0}'][keep]\n".format(layer.state.vx_att.label)
+                script += "length = layer_data['{0}'][keep]\n".format(layer.state.vy_att.label)
                 script += "vx = length * np.cos(np.radians(angle))\n"
                 script += "vy = length * np.sin(np.radians(angle))\n"
             else:
-                script += "vx = layer_data['{0}']\n".format(layer.state.vx_att.label)
-                script += "vy = layer_data['{0}']\n".format(layer.state.vy_att.label)
+                script += "vx = layer_data['{0}'][keep]\n".format(layer.state.vx_att.label)
+                script += "vy = layer_data['{0}'][keep]\n".format(layer.state.vy_att.label)
 
         if layer.state.vector_arrowhead:
             hw = 3
@@ -139,19 +141,19 @@ def python_export_scatter_layer(layer, *args):
         if layer.state.cmap_mode == 'Fixed':
             options['color'] = layer.state.color
         else:
-            options['color'] = code('colors')
+            options['color'] = code('colors[keep]')
 
-        script += "ax.quiver(x, y, vx, vy, {0})\n\n".format(serialize_options(options))
+        script += "ax.quiver(x[keep], y[keep], vx, vy, {0})\n\n".format(serialize_options(options))
 
     if layer.state.xerr_visible or layer.state.yerr_visible:
 
         if layer.state.xerr_visible and layer.state.xerr_att is not None:
-            xerr = code("layer_data['{0}']".format(layer.state.xerr_att.label))
+            xerr = code("xerr[keep]")
         else:
             xerr = code("None")
 
         if layer.state.yerr_visible and layer.state.yerr_att is not None:
-            yerr = code("layer_data['{0}']".format(layer.state.yerr_att.label))
+            yerr = code("yerr[keep]")
         else:
             yerr = code("None")
 
@@ -161,9 +163,12 @@ def python_export_scatter_layer(layer, *args):
         if layer.state.cmap_mode == 'Fixed':
             options['ecolor'] = layer.state.color
         else:
-            options['ecolor'] = code('colors')
+            options['ecolor'] = code('colors[keep]')
 
-        script += "ax.errorbar(x, y, {0})\n\n".format(serialize_options(options))
+        script += "xerr = layer_data['{0}']\n".format(layer.state.xerr_att.label)
+        script += "yerr = layer_data['{0}']\n".format(layer.state.yerr_att.label)
+        script += "keep &= ~np.isnan(xerr) & ~np.isnan(yerr)\n"
+        script += "ax.errorbar(x[keep], y[keep], {0})\n\n".format(serialize_options(options))
 
     if layer.state.line_visible:
 
@@ -173,7 +178,7 @@ def python_export_scatter_layer(layer, *args):
                        alpha=layer.state.alpha,
                        zorder=layer.state.zorder)
         if layer.state.cmap_mode == 'Fixed':
-            script += "ax.plot(x, y, '-', {0})\n\n".format(serialize_options(options))
+            script += "ax.plot(x[keep], y[keep], '-', {0})\n\n".format(serialize_options(options))
         else:
             options['c'] = code('colors')
             imports.append("from glue.viewers.scatter.layer_artist import plot_colored_line")

--- a/glue/viewers/scatter/python_export.py
+++ b/glue/viewers/scatter/python_export.py
@@ -9,7 +9,7 @@ def python_export_scatter_layer(layer, *args):
         return [], None
 
     script = ""
-    imports = []
+    imports = ["import numpy as np"]
 
     script += "# Get main data values\n"
     script += "x = layer_data['{0}']\n".format(layer._viewer_state.x_att.label)
@@ -18,9 +18,10 @@ def python_export_scatter_layer(layer, *args):
     if layer.state.cmap_mode == 'Linear':
 
         script += "# Set up colors\n"
-        script += "colors = layer_data['{0}']\n".format(layer.state.cmap_att.label)
+        script += "colors = layer_data['{0}'].copy()\n".format(layer.state.cmap_att.label)
         script += "cmap_vmin = {0}\n".format(layer.state.cmap_vmin)
         script += "cmap_vmax = {0}\n".format(layer.state.cmap_vmax)
+        script += "colors[np.isnan(colors)] = cmap_vmin\n"
         script += "colors = plt.cm.{0}((colors - cmap_vmin) / (cmap_vmax - cmap_vmin))\n\n".format(layer.state.cmap.name)
 
     if layer.state.size_mode == 'Linear':

--- a/glue/viewers/scatter/qt/tests/test_python_export.py
+++ b/glue/viewers/scatter/qt/tests/test_python_export.py
@@ -124,7 +124,7 @@ class TestExportPython(BaseTestExportPython):
         self.viewer.state.layers[0].vector_scaling = 1.5
         self.viewer.state.layers[0].color = 'teal'
         self.viewer.state.layers[0].alpha = 0.9
-        self.assert_same(tmpdir)
+        self.assert_same(tmpdir, tol=1)
 
     def test_vector_cartesian(self, tmpdir):
         self.viewer.state.layers[0].vector_mode = 'Cartesian'


### PR DESCRIPTION
Now that e.g. the image and 3D volume rendering viewers can show linked datasets, merging is becoming les and less useful, except maybe for making scatter plots of one dataset against another pixel-aligned dataset. So this PR makes it so that we no longer offer to merge data by default, which often confused users. Instead, users should manually select and merge data.

* [x] What's new entry
* [x] Add back some degree of auto-merging for e.g. HDF5 files with one column per dataset
* [x] Check documentation to see if anything needs to be updated

This also fixes a number of test failures I ran into while working on this.

Fixes https://github.com/glue-viz/glue/issues/1950
Fixes https://github.com/glue-viz/glue/issues/2017
Fixes https://github.com/glue-viz/glue/issues/1978