### PR TITLE
Add more information about WCS linkage

### DIFF
--- a/glue/core/link_helpers.py
+++ b/glue/core/link_helpers.py
@@ -285,6 +285,10 @@ class MultiLink(BaseMultiLink):
         Additional arguments are passed
     """
 
+    # Some sub-classes take only data and don't need CIDs, so we have a flag
+    # for this in case other parts of glue need to know.
+    cid_independent = True
+
     def __init__(self, cids1=None, cids2=None, forwards=None, backwards=None, labels1=None, labels2=None, **kwargs):
 
         # NOTE: we explicitly specify ``cids1`` and ``cids2`` as the two first

--- a/glue/core/link_helpers.py
+++ b/glue/core/link_helpers.py
@@ -217,6 +217,10 @@ class BaseMultiLink(LinkCollection):
     :meth:`~glue.core.link_helpers.BaseMultiLink.backwards` methods.
     """
 
+    # Some sub-classes take only data and don't need CIDs, so we have a flag
+    # for this in case other parts of glue need to know.
+    cid_independent = False
+
     # TODO: could add a metaclass to set labels1 and labels2 automatically
 
     def __init__(self, cids1=None, cids2=None, data1=None, data2=None):
@@ -284,10 +288,6 @@ class MultiLink(BaseMultiLink):
     kwargs :
         Additional arguments are passed
     """
-
-    # Some sub-classes take only data and don't need CIDs, so we have a flag
-    # for this in case other parts of glue need to know.
-    cid_independent = True
 
     def __init__(self, cids1=None, cids2=None, forwards=None, backwards=None, labels1=None, labels2=None, **kwargs):
 

--- a/glue/dialogs/autolinker/qt/autolinker.py
+++ b/glue/dialogs/autolinker/qt/autolinker.py
@@ -53,8 +53,10 @@ class AutoLinkPreview(QtWidgets.QDialog):
 
         if visible:
             self._ui.button_details.setText('Hide Details')
+            self.setFixedHeight(800)
         else:
             self._ui.button_details.setText('Show Details')
+            self.setFixedHeight(150)
 
         # Make sure the dialog is centered on the screen
         screen = QtWidgets.QApplication.desktop().screenGeometry(0)

--- a/glue/dialogs/autolinker/qt/autolinker.ui
+++ b/glue/dialogs/autolinker/qt/autolinker.ui
@@ -6,26 +6,20 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>756</width>
-    <height>496</height>
+    <width>900</width>
+    <height>700</height>
    </rect>
-  </property>
-  <property name="sizePolicy">
-   <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-    <horstretch>0</horstretch>
-    <verstretch>0</verstretch>
-   </sizepolicy>
   </property>
   <property name="windowTitle">
    <string>Link Suggestions</string>
   </property>
   <property name="sizeGripEnabled">
-   <bool>false</bool>
+   <bool>true</bool>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
-   <property name="sizeConstraint">
-    <enum>QLayout::SetFixedSize</enum>
-   </property>
+    <property name="sizeConstraint">
+     <enum>QLayout::SetDefaultConstraint</enum>
+    </property>
    <property name="topMargin">
     <number>5</number>
    </property>

--- a/glue/dialogs/link_editor/qt/link_editor_dialog.ui
+++ b/glue/dialogs/link_editor/qt/link_editor_dialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>808</width>
-    <height>660</height>
+    <width>900</width>
+    <height>700</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/glue/dialogs/link_editor/qt/link_editor_widget.ui
+++ b/glue/dialogs/link_editor/qt/link_editor_widget.ui
@@ -245,7 +245,7 @@
           <string>Details about the link</string>
          </property>
          <property name="alignment">
-          <set>Qt::AlignCenter</set>
+          <set>Qt::AlignJustify</set>
          </property>
          <property name="wordWrap">
           <bool>true</bool>

--- a/glue/dialogs/link_editor/state.py
+++ b/glue/dialogs/link_editor/state.py
@@ -148,6 +148,11 @@ class LinkEditorState(State):
                                              names2=function_or_helper.output_labels,
                                              description=function_or_helper.info,
                                              display=function_or_helper.function.__name__)
+        elif function_or_helper.helper.cid_independent:
+            # This shortcut is needed for e.g. the WCS auto-linker, which has a dynamic
+            # description but doesn't need to take any component IDs.
+            link = EditableLinkFunctionState(function_or_helper.helper(data1=self.data1,
+                                                                       data2=self.data2))
         else:
             link = EditableLinkFunctionState(function_or_helper.helper,
                                              data1=self.data1, data2=self.data2)
@@ -185,11 +190,9 @@ class EditableLinkFunctionState(State):
         elif isinstance(function, LinkCollection):
             names1 = function.labels1
             names2 = function.labels2
-            description = function.description
         elif type(function) is type and issubclass(function, LinkCollection):
             names1 = function.labels1
             names2 = function.labels2
-            description = function.description
 
         class CustomizedStateClass(EditableLinkFunctionState):
             pass

--- a/glue/plugins/wcs_autolinking/wcs_autolinking.py
+++ b/glue/plugins/wcs_autolinking/wcs_autolinking.py
@@ -37,9 +37,7 @@ class WCSLink(MultiLink):
     """
 
     display = 'WCS link'
-    description = ('This will automatically link the coordinates of the '
-                   'two datasets using the World Coordinate System (WCS) '
-                   'coordinates defined in the files.')
+    cid_independent = True
 
     def __init__(self, data1=None, data2=None, cids1=None, cids2=None):
 
@@ -68,6 +66,9 @@ class WCSLink(MultiLink):
                                                                                    data1.pixel_component_ids,
                                                                                    data2.pixel_component_ids)
 
+            self._physical_types_1 = wcs1.world_axis_physical_types
+            self._physical_types_2 = wcs2.world_axis_physical_types
+
         else:
 
             # Try setting only a celestial link. We try and extract the celestial
@@ -94,6 +95,9 @@ class WCSLink(MultiLink):
             pixel_cids1, pixel_cids2, forwards, backwards = get_cids_and_functions(wcs1_celestial, wcs2_celestial,
                                                                                    cids1_celestial, cids2_celestial)
 
+            self._physical_types_1 = wcs1_celestial.world_axis_physical_types
+            self._physical_types_2 = wcs2_celestial.world_axis_physical_types
+
         if pixel_cids1 is None:
             raise IncompatibleWCS("Can't create WCS link between {0} and {1}".format(data1.label, data2.label))
 
@@ -114,6 +118,17 @@ class WCSLink(MultiLink):
         self = cls(context.object(rec['data1']),
                    context.object(rec['data2']))
         return self
+
+    @property
+    def description(self):
+        types1 = ''.join(['<li>' + phys_type for phys_type in self._physical_types_1])
+        types2 = ''.join(['<li>' + phys_type for phys_type in self._physical_types_2])
+        return ('This automatically links the coordinates of the '
+                'two datasets using the World Coordinate System (WCS) '
+                'coordinates defined in the files.<br><br>The physical types '
+                'of the coordinates linked in the first dataset are: '
+                '<ul>{0}</ul>and in the second dataset:<ul>{1}</ul>'
+                .format(types1, types2))
 
 
 @autolinker('Astronomy WCS')


### PR DESCRIPTION
Note that this uses the WCS physical types rather than component names, since the linking is done at the pixel level, not using world components.

Fixes https://github.com/glue-viz/glue/issues/1995