### PR TITLE
Fix path to data bundle when exporting Python script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,9 @@ v0.15.0 (unreleased)
 * Removed plot.ly export plugin - this is now part of the glue-plotly
   package. [#1999]
 
+* Fix path to data bundle when exporting Python scripts to another directory
+  than the one glue was run from. [#2023]
+
 * Added a ``--faulthandler`` command-line flag to help debug segmentation
   faults. [#1974]
 

--- a/glue/viewers/common/viewer.py
+++ b/glue/viewers/common/viewer.py
@@ -437,7 +437,7 @@ class Viewer(BaseViewer):
 
         imports = os.linesep.join(sorted(set(imports)))
 
-        script = TEMPLATE_SCRIPT.format(data=data_filename,
+        script = TEMPLATE_SCRIPT.format(data=os.path.basename(data_filename),
                                         imports=imports.strip(),
                                         header=header.strip(),
                                         layers=layers.strip(),


### PR DESCRIPTION
Fixes https://github.com/glue-viz/glue/issues/1922