### PR TITLE
Fix component -> attribute terminology in UI

### DIFF
--- a/doc/customizing_guide/customization.rst
+++ b/doc/customizing_guide/customization.rst
@@ -61,8 +61,8 @@ Glue lets you create custom data loader functions,
 to use from within the GUI.
 
 Here's a quick example: the default image loader in Glue reads each color in
-an RGB image into 3 two-dimensional components. Perhaps you want to be able
-to load these images into a single 3-dimensional component called ``cube``.
+an RGB image into 3 two-dimensional attributes. Perhaps you want to be able
+to load these images into a single 3-dimensional attribute called ``cube``.
 Here's how you could do this::
 
  from glue.config import data_factory

--- a/glue/app/qt/merge.ui
+++ b/glue/app/qt/merge.ui
@@ -23,7 +23,7 @@
    <item>
     <widget class="QLabel" name="instructions">
      <property name="text">
-      <string>Several of the datasets (including at least one that you have added) have the same shape. Do you want to merge them? Merging means that these separate datasets will then become components of a single dataset.</string>
+      <string>Several of the datasets (including at least one that you have added) have the same shape. Do you want to merge them? Merging means that these separate datasets will then become attributes of a single dataset.</string>
      </property>
      <property name="scaledContents">
       <bool>false</bool>

--- a/glue/app/qt/save_data.ui
+++ b/glue/app/qt/save_data.ui
@@ -155,7 +155,7 @@
    <item row="0" column="0" colspan="5">
     <widget class="QLabel" name="label">
      <property name="text">
-      <string>Choose the dataset and component you want to save:</string>
+      <string>Choose the dataset and attribute you want to save:</string>
      </property>
     </widget>
    </item>

--- a/glue/dialogs/component_arithmetic/qt/component_arithmetic.ui
+++ b/glue/dialogs/component_arithmetic/qt/component_arithmetic.ui
@@ -110,7 +110,7 @@
       </font>
      </property>
      <property name="text">
-      <string>In this dialog you can define data attributes/components based on other attributes using arithmetic operations. First, select the dataset above, then you will be able to create/edit arithmetic attributes for that dataset below.</string>
+      <string>In this dialog you can define data attributes based on other attributes using arithmetic operations. First, select the dataset above, then you will be able to create/edit arithmetic attributes for that dataset below.</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignJustify|Qt::AlignVCenter</set>

--- a/glue/dialogs/component_arithmetic/qt/equation_editor.py
+++ b/glue/dialogs/component_arithmetic/qt/equation_editor.py
@@ -171,7 +171,7 @@ class EquationEditorDialog(QtWidgets.QDialog):
 
         if self.ui.text_label.text() == "":
             self.ui.label_status.setStyleSheet('color: red')
-            self.ui.label_status.setText("Component name not set")
+            self.ui.label_status.setText("Attribute name not set")
             self.ui.button_ok.setEnabled(False)
         elif self._get_raw_command() == "":
             self.ui.label_status.setText("")

--- a/glue/dialogs/component_arithmetic/qt/equation_editor.ui
+++ b/glue/dialogs/component_arithmetic/qt/equation_editor.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>477</width>
-    <height>331</height>
+    <height>400</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/glue/dialogs/component_arithmetic/qt/tests/test_equation_editor.py
+++ b/glue/dialogs/component_arithmetic/qt/tests/test_equation_editor.py
@@ -53,7 +53,7 @@ class TestEquationEditor:
         self.dialog.ui.text_label.setText('')
         self.dialog.expression.insertPlainText('1 + {x}')
         assert not self.dialog.ui.button_ok.isEnabled()
-        assert self.dialog.ui.label_status.text() == 'Component name not set'
+        assert self.dialog.ui.label_status.text() == 'Attribute name not set'
 
     def test_typing(self):
 

--- a/glue/dialogs/component_manager/qt/component_manager.ui
+++ b/glue/dialogs/component_manager/qt/component_manager.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Organize data components</string>
+   <string>Organize data attributes</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">

--- a/glue/dialogs/subset_facet/qt/subset_facet.ui
+++ b/glue/dialogs/subset_facet/qt/subset_facet.ui
@@ -52,7 +52,7 @@
       <enum>Qt::LeftToRight</enum>
      </property>
      <property name="text">
-      <string>Components</string>
+      <string>Attributes</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignCenter</set>
@@ -62,7 +62,7 @@
    <item>
     <widget class="QListWidget" name="listsel_att">
      <property name="toolTip">
-      <string>The Component IDs associated with this data set</string>
+      <string>The attributes associated with this data set</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
I think the next step will be to actually change it in the programmatic API, but that will be a much bigger task. For now, this tightens up the language in the UI.