### PR TITLE
Fixed compatibility with latest version of astropy

### DIFF
--- a/glue/core/data_factories/astropy_table.py
+++ b/glue/core/data_factories/astropy_table.py
@@ -75,7 +75,7 @@ def astropy_tabular_data(*args, **kwargs):
         c = table[column_name]
         u = c.unit if hasattr(c, 'unit') else c.units
 
-        if table.masked:
+        if hasattr(c, 'mask'):
             # fill array for now
             try:
                 c = c.filled(fill_value=np.nan)


### PR DESCRIPTION
Tables can now have a mix of masked and non-masked columns