### PR TITLE
Fix bug in autoconnect_callbacks_to_qt 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,13 @@ v0.16.0 (unreleased)
 
 * No changes yet.
 
+v0.15.2 (unreleased)
+--------------------
+
+* Fixed a bug in ``autoconnect_callbacks_to_qt`` which caused some widgets
+  to not stay connect to state callback properties if a callback property
+  was linked to multiple widgets. [#2032]
+
 v0.15.1 (2019-06-24)
 --------------------
 

--- a/glue/dialogs/link_editor/qt/link_editor.py
+++ b/glue/dialogs/link_editor/qt/link_editor.py
@@ -122,7 +122,7 @@ class LinkEditorWidget(QtWidgets.QWidget):
     @avoid_circular
     def _on_attribute_combo_change(self, *args, **kwargs):
         # Force a re-sync of the choices
-        self._handlers['current_link'].update_widget(self.state.current_link, force=True)
+        self._handlers['listsel_current_link'].update_widget(self.state.current_link, force=True)
 
     @avoid_circular
     def _on_data_change_graph(self):

--- a/glue/external/echo/qt/autoconnect.py
+++ b/glue/external/echo/qt/autoconnect.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-from qtpy import QtWidgets
-
 from .connect import (connect_checkable_button,
                       connect_value,
                       connect_combo_data,
@@ -113,6 +111,8 @@ def autoconnect_callbacks_to_qt(instance, widget, connect_kwargs={}):
             if hasattr(instance, wname):
                 if wtype in HANDLERS:
                     child = getattr(widget, original_name)
-                    returned_handlers[wname] = HANDLERS[wtype](instance, wname, child, **kwargs)
+                    # NOTE: we need to use original_name here since we need a
+                    # unique key, and some wname values might be duplicate.
+                    returned_handlers[original_name] = HANDLERS[wtype](instance, wname, child, **kwargs)
 
     return returned_handlers


### PR DESCRIPTION
The bug caused the x/y/z_stretch sliders in the 3D viewers to not work correctly because they were linked to the same state callback property as the text box with the slider value.