### PR TITLE
Fixes to preferences dialog

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,14 @@ v0.16.0 (unreleased)
 
 * No changes yet.
 
+v0.15.3 (unreleased)
+--------------------
+
+* Fixed bugs related to the preferences dialog - first, the dialog would
+  not open if no auto-linkers were present, and second, the preferences
+  dialog would sometimes get sent behind the main application when editing
+  the color. [#2034]
+
 v0.15.2 (2019-06-24)
 --------------------
 

--- a/glue/app/qt/preferences.py
+++ b/glue/app/qt/preferences.py
@@ -37,19 +37,22 @@ class AutolinkPreferencesPane(QtWidgets.QWidget):
 
         self.combos = {}
 
-        for i, (label, _) in enumerate(autolinker):
-            combo = QtWidgets.QComboBox()
-            for short, display in AUTOLINK_OPTIONS.items():
-                combo.addItem(display, userData=short)
-            if label in settings.AUTOLINK:
-                index = list(AUTOLINK_OPTIONS.keys()).index(settings.AUTOLINK[label])
-            else:
-                index = 0
-            combo.setCurrentIndex(index)
-            layout.addWidget(QtWidgets.QLabel(label), i, 0)
-            layout.addWidget(combo, i, 1)
-            self.combos[label] = combo
-        layout.addWidget(QtWidgets.QWidget(), i + 1, 0)
+        if len(autolinker) > 0:
+
+            for i, (label, _) in enumerate(autolinker):
+                combo = QtWidgets.QComboBox()
+                for short, display in AUTOLINK_OPTIONS.items():
+                    combo.addItem(display, userData=short)
+                if label in settings.AUTOLINK:
+                    index = list(AUTOLINK_OPTIONS.keys()).index(settings.AUTOLINK[label])
+                else:
+                    index = 0
+                combo.setCurrentIndex(index)
+                layout.addWidget(QtWidgets.QLabel(label), i, 0)
+                layout.addWidget(combo, i, 1)
+                self.combos[label] = combo
+
+            layout.addWidget(QtWidgets.QWidget(), i + 1, 0)
 
         self.setLayout(layout)
 

--- a/glue/app/qt/preferences.ui
+++ b/glue/app/qt/preferences.ui
@@ -13,6 +13,9 @@
   <property name="windowTitle">
    <string>Preferences</string>
   </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="1" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout">


### PR DESCRIPTION
This fixes a couple of issues - first the preferences dialog would crash if no autolinkers were present, which could happen if astropy <3.1 was installed. Second, the preferences dialog sometimes got sent behind the main application window when editing the color, so I've made it modal.