### PR TITLE
Fixed bugs related to profile viewer and loading session files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@ v0.16.0 (unreleased)
 
 * Python 2.7 and 3.5 are no longer supported. [#2075]
 
+* Fixed bugs in the profile viewer that occurred when using the profile viewer and
+  setting reference_data to a different value than the default one. [#2078]
+
 v0.15.6 (2019-08-22)
 --------------------
 

--- a/glue/core/data_factories/helpers.py
+++ b/glue/core/data_factories/helpers.py
@@ -27,6 +27,7 @@ import warnings
 
 from glue.core.contracts import contract
 from glue.core.coordinates import IdentityCoordinates
+from glue.core.component import CoordinateComponent
 from glue.core.data import Component, BaseData, Data
 from glue.config import auto_refresh, data_factory
 from glue.backends import get_timer
@@ -155,9 +156,20 @@ class LoadLog(object):
             path = os.path.abspath(self.path)
         else:
             path = os.path.relpath(self.path)
+
+        # If there are twice as many world coordinates as number of dimensions
+        # and Data.coords is set to Coordinates or None, we need to set
+        # force_coords to True to make sure that we always restore world
+        # coordinate components even if the transform is an identity transform.
+        n_coords = len([comp for comp in self.components
+                        if isinstance(comp, CoordinateComponent)])
+        if n_coords == self.components[0].ndim * 2:
+            force_coords = True
+
         return dict(path=path,
                     factory=context.do(self.factory),
                     kwargs=[list(self.kwargs.items())],
+                    _force_coords=force_coords,
                     _protocol=2)
 
     @classmethod
@@ -165,7 +177,7 @@ class LoadLog(object):
         fac = context.object(rec['factory'])
         kwargs = dict(*rec['kwargs'])
         kwargs['coord_first'] = rec.get('_protocol', 0) >= 1
-        kwargs['force_coords'] = rec.get('_protocol', 0) < 2
+        kwargs['force_coords'] = rec.get('_protocol', 0) < 2 or rec.get('_force_coords')
         d = load_data(rec['path'], factory=fac, **kwargs)
         return as_list(d)[0]._load_log
 

--- a/glue/core/data_factories/helpers.py
+++ b/glue/core/data_factories/helpers.py
@@ -169,7 +169,7 @@ class LoadLog(object):
         return dict(path=path,
                     factory=context.do(self.factory),
                     kwargs=[list(self.kwargs.items())],
-                    _force_coords=force_coords,
+                    force_coords=force_coords,
                     _protocol=2)
 
     @classmethod
@@ -177,7 +177,7 @@ class LoadLog(object):
         fac = context.object(rec['factory'])
         kwargs = dict(*rec['kwargs'])
         kwargs['coord_first'] = rec.get('_protocol', 0) >= 1
-        kwargs['force_coords'] = rec.get('_protocol', 0) < 2 or rec.get('_force_coords')
+        kwargs['force_coords'] = rec.get('_protocol', 0) < 2 or rec.get('force_coords')
         d = load_data(rec['path'], factory=fac, **kwargs)
         return as_list(d)[0]._load_log
 

--- a/glue/tests/data/simple_table_015.glu
+++ b/glue/tests/data/simple_table_015.glu
@@ -1,0 +1,152 @@
+{
+  "Component": {
+    "_type": "glue.core.component.Component",
+    "log": "LoadLog",
+    "log_item": 2
+  },
+  "Component_0": {
+    "_type": "glue.core.component.Component",
+    "log": "LoadLog",
+    "log_item": 3
+  },
+  "CoordinateComponent": {
+    "_type": "glue.core.component.CoordinateComponent",
+    "axis": 0,
+    "world": false
+  },
+  "CoordinateComponent_0": {
+    "_type": "glue.core.component.CoordinateComponent",
+    "axis": 0,
+    "world": true
+  },
+  "Coordinates": {
+    "_type": "glue.core.coordinates.Coordinates"
+  },
+  "DataCollection": {
+    "_protocol": 4,
+    "_type": "glue.core.data_collection.DataCollection",
+    "cids": [
+      "Pixel Axis 0 [x]",
+      "World 0",
+      "a",
+      "b"
+    ],
+    "components": [
+      "CoordinateComponent",
+      "CoordinateComponent_0",
+      "Component",
+      "Component_0"
+    ],
+    "data": [
+      "single_table[HDU1]"
+    ],
+    "groups": [],
+    "links": [],
+    "subset_group_count": 0
+  },
+  "LoadLog": {
+    "_protocol": 1,
+    "_type": "glue.core.data_factories.helpers.LoadLog",
+    "factory": {
+      "_type": "types.FunctionType",
+      "function": "glue.core.data_factories.fits.fits_reader"
+    },
+    "kwargs": [
+      []
+    ],
+    "path": "{DATA_PATH}/single_table.fits"
+  },
+  "Pixel Axis 0 [x]": {
+    "_type": "glue.core.component_id.PixelComponentID",
+    "axis": 0,
+    "label": "Pixel Axis 0 [x]"
+  },
+  "Session": {
+    "_type": "glue.core.session.Session"
+  },
+  "World 0": {
+    "_type": "glue.core.component_id.ComponentID",
+    "label": "World 0"
+  },
+  "__main__": {
+    "_type": "glue.app.qt.application.GlueApplication",
+    "data": "DataCollection",
+    "plugins": [
+      "glue.viewers.profile.qt",
+      "glue.core.data_exporters",
+      "glue.io.formats.fits",
+      "glue.plugins.data_factories.spectral_cube",
+      "glue.plugins.tools.pv_slicer",
+      "glue.viewers.histogram.qt",
+      "glue.plugins.coordinate_helpers",
+      "glue.viewers.image.qt",
+      "glue.plugins.export_d3po",
+      "glue.plugins.tools",
+      "glue.viewers.scatter.qt",
+      "glue.plugins.wcs_autolinking",
+      "glue.plugins.dendro_viewer.qt",
+      "glue.viewers.table.qt"
+    ],
+    "session": "Session",
+    "tab_names": [
+      "Tab 1"
+    ],
+    "viewers": [
+      []
+    ]
+  },
+  "a": {
+    "_type": "glue.core.component_id.ComponentID",
+    "label": "a"
+  },
+  "b": {
+    "_type": "glue.core.component_id.ComponentID",
+    "label": "b"
+  },
+  "single_table[HDU1]": {
+    "_key_joins": [],
+    "_protocol": 5,
+    "_type": "glue.core.data.Data",
+    "components": [
+      [
+        "Pixel Axis 0 [x]",
+        "CoordinateComponent"
+      ],
+      [
+        "World 0",
+        "CoordinateComponent_0"
+      ],
+      [
+        "a",
+        "Component"
+      ],
+      [
+        "b",
+        "Component_0"
+      ]
+    ],
+    "coords": "Coordinates",
+    "label": "single_table[HDU1]",
+    "meta": {
+      "_type": "collections.OrderedDict",
+      "contents": {}
+    },
+    "primary_owner": [
+      "Pixel Axis 0 [x]",
+      "World 0",
+      "a",
+      "b"
+    ],
+    "style": {
+      "_type": "glue.core.visual.VisualAttributes",
+      "alpha": 0.8,
+      "color": "#595959",
+      "linestyle": "solid",
+      "linewidth": 1,
+      "marker": "o",
+      "markersize": 3
+    },
+    "subsets": [],
+    "uuid": "d804c55e-ebee-4850-a0f1-3b854bda62b4"
+  }
+}

--- a/glue/tests/data/simple_table_resaved.glu
+++ b/glue/tests/data/simple_table_resaved.glu
@@ -1,0 +1,152 @@
+{
+  "Component": {
+    "_type": "glue.core.component.Component",
+    "log": "LoadLog",
+    "log_item": 2
+  },
+  "Component_0": {
+    "_type": "glue.core.component.Component",
+    "log": "LoadLog",
+    "log_item": 3
+  },
+  "CoordinateComponent": {
+    "_type": "glue.core.component.CoordinateComponent",
+    "axis": 0,
+    "world": false
+  },
+  "CoordinateComponent_0": {
+    "_type": "glue.core.component.CoordinateComponent",
+    "axis": 0,
+    "world": true
+  },
+  "Coordinates": {
+    "_type": "glue.core.coordinates.Coordinates"
+  },
+  "DataCollection": {
+    "_protocol": 4,
+    "_type": "glue.core.data_collection.DataCollection",
+    "cids": [
+      "Pixel Axis 0 [x]",
+      "World 0",
+      "a",
+      "b"
+    ],
+    "components": [
+      "CoordinateComponent",
+      "CoordinateComponent_0",
+      "Component",
+      "Component_0"
+    ],
+    "data": [
+      "single_table[HDU1]"
+    ],
+    "groups": [],
+    "links": [],
+    "subset_group_count": 0
+  },
+  "LoadLog": {
+    "_protocol": 2,
+    "_type": "glue.core.data_factories.helpers.LoadLog",
+    "factory": {
+      "_type": "types.FunctionType",
+      "function": "glue.core.data_factories.fits.fits_reader"
+    },
+    "kwargs": [
+      []
+    ],
+    "path": "{DATA_PATH}/single_table.fits"
+  },
+  "Pixel Axis 0 [x]": {
+    "_type": "glue.core.component_id.PixelComponentID",
+    "axis": 0,
+    "label": "Pixel Axis 0 [x]"
+  },
+  "Session": {
+    "_type": "glue.core.session.Session"
+  },
+  "World 0": {
+    "_type": "glue.core.component_id.ComponentID",
+    "label": "World 0"
+  },
+  "__main__": {
+    "_type": "glue.app.qt.application.GlueApplication",
+    "data": "DataCollection",
+    "plugins": [
+      "glue.viewers.scatter.qt",
+      "glue.plugins.data_factories.spectral_cube",
+      "glue.core.data_exporters",
+      "glue.viewers.image.qt",
+      "glue.plugins.coordinate_helpers",
+      "glue.plugins.tools",
+      "glue.viewers.table.qt",
+      "glue.plugins.dendro_viewer.qt",
+      "glue.viewers.histogram.qt",
+      "glue.plugins.wcs_autolinking",
+      "glue.io.formats.fits",
+      "glue.plugins.tools.pv_slicer",
+      "glue.plugins.export_d3po",
+      "glue.viewers.profile.qt"
+    ],
+    "session": "Session",
+    "tab_names": [
+      "Tab 1"
+    ],
+    "viewers": [
+      []
+    ]
+  },
+  "a": {
+    "_type": "glue.core.component_id.ComponentID",
+    "label": "a"
+  },
+  "b": {
+    "_type": "glue.core.component_id.ComponentID",
+    "label": "b"
+  },
+  "single_table[HDU1]": {
+    "_key_joins": [],
+    "_protocol": 5,
+    "_type": "glue.core.data.Data",
+    "components": [
+      [
+        "Pixel Axis 0 [x]",
+        "CoordinateComponent"
+      ],
+      [
+        "World 0",
+        "CoordinateComponent_0"
+      ],
+      [
+        "a",
+        "Component"
+      ],
+      [
+        "b",
+        "Component_0"
+      ]
+    ],
+    "coords": "Coordinates",
+    "label": "single_table[HDU1]",
+    "meta": {
+      "_type": "collections.OrderedDict",
+      "contents": {}
+    },
+    "primary_owner": [
+      "Pixel Axis 0 [x]",
+      "World 0",
+      "a",
+      "b"
+    ],
+    "style": {
+      "_type": "glue.core.visual.VisualAttributes",
+      "alpha": 0.8,
+      "color": "#595959",
+      "linestyle": "solid",
+      "linewidth": 1,
+      "marker": "o",
+      "markersize": 3
+    },
+    "subsets": [],
+    "uuid": "d804c55e-ebee-4850-a0f1-3b854bda62b4"
+  }
+}

--- a/glue/tests/test_session_back_compat.py
+++ b/glue/tests/test_session_back_compat.py
@@ -311,3 +311,23 @@ def test_load_resave_coords(tmp_path):
     ga = state.object('__main__')
     dc = ga.session.data_collection
     assert len(dc) == 1
+
+
+
+@requires_qt
+@requires_astropy
+def test_load_resave_coords_intermediate(tmp_path):
+
+    # Load in a file create with glue 0.15.* which includes a world component
+    # even though Data.coords is the default identity transform
+    with open(os.path.join(DATA, 'simple_table_resaved.glu'), 'r') as f:
+        template = f.read()
+
+    content = template.replace('{DATA_PATH}', (DATA + os.sep).replace('\\', '\\\\'))
+    state = GlueUnSerializer.loads(content)
+
+    ga = state.object('__main__')
+    dc = ga.session.data_collection
+    assert len(dc) == 1
+    ga.save_session(tmp_path / 'test.glu')
+    ga.close()

--- a/glue/viewers/profile/layer_artist.py
+++ b/glue/viewers/profile/layer_artist.py
@@ -143,8 +143,6 @@ class ProfileLayerArtist(MatplotlibLayerArtist):
 
     def _update_profile(self, force=False, **kwargs):
 
-        # TODO: we need to factor the following code into a common method.
-
         if (self._viewer_state.x_att is None or
                 self.state.attribute is None or
                 self.state.layer is None):

--- a/glue/viewers/profile/qt/tests/test_data_viewer.py
+++ b/glue/viewers/profile/qt/tests/test_data_viewer.py
@@ -44,12 +44,16 @@ class TestProfileViewer(object):
         self.data.coords = SimpleCoordinates()
         self.data['x'] = np.arange(24).reshape((3, 4, 2))
 
+        self.data2 = Data(label='d2')
+        self.data2['y'] = np.arange(24).reshape((3, 4, 2))
+
         self.app = GlueApplication()
         self.session = self.app.session
         self.hub = self.session.hub
 
         self.data_collection = self.session.data_collection
         self.data_collection.append(self.data)
+        self.data_collection.append(self.data2)
 
         self.viewer = self.app.new_data_viewer(ProfileViewer)
 
@@ -178,6 +182,19 @@ class TestProfileViewer(object):
 
         self.viewer.state.x_att = self.data.world_component_ids[2]
         assert self.viewer.options_widget().ui.text_warning.text() != ''
+
+    def test_multiple_data(self):
+
+        # Regression test for issues when multiple datasets are present
+        # and the reference data is not the default one
+
+        self.viewer.add_data(self.data)
+        self.viewer.add_data(self.data2)
+        assert self.viewer.layers[0].enabled
+        assert not self.viewer.layers[1].enabled
+        self.viewer.state.reference_data = self.data2
+        assert not self.viewer.layers[0].enabled
+        assert self.viewer.layers[1].enabled
 
     @pytest.mark.parametrize('protocol', [1])
     def test_session_back_compat(self, protocol):

--- a/glue/viewers/profile/state.py
+++ b/glue/viewers/profile/state.py
@@ -162,6 +162,17 @@ class ProfileViewerState(MatplotlibDataViewerState):
 
                 self._update_att()
 
+    def _update_priority(self, name):
+        if name == 'layers':
+            return 2
+        elif name == 'reference_data':
+            return 1.5
+        elif name.endswith(('_min', '_max')):
+            return 0
+        else:
+            return 1
+
+
 class ProfileLayerState(MatplotlibLayerState):
     """
     A state class that includes all the attributes for layers in a Profile plot.

--- a/glue/viewers/profile/state.py
+++ b/glue/viewers/profile/state.py
@@ -138,23 +138,29 @@ class ProfileViewerState(MatplotlibDataViewerState):
     @defer_draw
     def _reference_data_changed(self, *args):
 
+        for layer in self.layers:
+            layer.reset_cache()
+
         # This signal can get emitted if just the choices but not the actual
         # reference data change, so we check here that the reference data has
         # actually changed
         if self.reference_data is not getattr(self, '_last_reference_data', None):
             self._last_reference_data = self.reference_data
 
-            if self.reference_data is None:
-                self.x_att_helper.set_multiple_data([])
-            else:
-                self.x_att_helper.set_multiple_data([self.reference_data])
-                if self._display_world:
-                    self.x_att_helper.world_coord = True
-                    self.x_att = self.reference_data.world_component_ids[0]
-                else:
-                    self.x_att_helper.world_coord = False
-                    self.x_att = self.reference_data.pixel_component_ids[0]
+            with delay_callback(self, 'x_att'):
 
+                if self.reference_data is None:
+                    self.x_att_helper.set_multiple_data([])
+                else:
+                    self.x_att_helper.set_multiple_data([self.reference_data])
+                    if self._display_world:
+                        self.x_att_helper.world_coord = True
+                        self.x_att = self.reference_data.world_component_ids[0]
+                    else:
+                        self.x_att_helper.world_coord = False
+                        self.x_att = self.reference_data.pixel_component_ids[0]
+
+                self._update_att()
 
 class ProfileLayerState(MatplotlibLayerState):
     """


### PR DESCRIPTION
This fixes several bugs:

* Fixed a bug with the profile viewer which caused layers to not update correctly when changing the reference data
* Fixed issue with reloading session with profile viewer that has a non-default reference data
* Improve how we deal with backward-compatibility related to change in Data.coords to ``None``