### PR TITLE
Fix bug #1931: when creating a new subset, use ReplaceMode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ v0.16.0 (unreleased)
 
 * Python 2.7 and 3.5 are no longer supported. [#2075]
 
+* Always use replace mode when creating a new subset. [#2090]
+
 * Fixed bugs in the profile viewer that occurred when using the profile viewer and
   setting reference_data to a different value than the default one. [#2078]
 

--- a/glue/core/command.py
+++ b/glue/core/command.py
@@ -4,6 +4,7 @@ from abc import ABCMeta, abstractmethod
 
 from glue.utils import CallbackMixin
 from glue.core.data_factories import load_data
+from glue.core.edit_subset_mode import ReplaceMode
 
 MAX_UNDO = 50
 """
@@ -298,6 +299,12 @@ class ApplySubsetState(Command):
 
         mode = session.edit_subset_mode
         override_mode = self.extra.get('override_mode')
+        # when creating a new subset the creation mode is replace mode
+        # fix bug #1931
+        if override_mode is None:
+            if len(mode._edit_subset) == 0:
+                override_mode = ReplaceMode
+
         mode.update(self.data_collection, self.subset_state, override_mode=override_mode)
 
     def undo(self, session):


### PR DESCRIPTION
When a new subset is created, override the mode to use ReplaceMode.

The user does not have to remember to reset everytime the mode manually. The mode is only temporarily overriden for the creation of the new subset.
