### PR TITLE
Preserve circular ROI whenever possible

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,9 @@ v0.15.7 (2020-03-12)
 * Fixed a bug that caused issues when saving and re-loading sessions that were
   originally created using Excel data with string columns. [#2101]
 
+* Avoid converting circular selections in Matplotlib plots to polygons if
+  it can be avoided. [#2094]
+
 v0.15.6 (2019-08-22)
 --------------------
 

--- a/glue/core/roi.py
+++ b/glue/core/roi.py
@@ -447,6 +447,10 @@ class CircularROI(Roi):
     def transformed(self, xfunc=None, yfunc=None):
         return PolygonalROI(*self.to_polygon()).transformed(xfunc=xfunc, yfunc=yfunc)
 
+    def move_to(self, xdelta, ydelta):
+        self.xc += xdelta
+        self.yc += ydelta
+
     def __gluestate__(self, context):
         return dict(xc=context.do(self.xc),
                     yc=context.do(self.yc),
@@ -522,6 +526,10 @@ class EllipticalROI(Roi):
 
     def transformed(self, xfunc=None, yfunc=None):
         return PolygonalROI(*self.to_polygon()).transformed(xfunc=xfunc, yfunc=yfunc)
+
+    def move_to(self, xdelta, ydelta):
+        self.xc += xdelta
+        self.yc += ydelta
 
     def __gluestate__(self, context):
         return dict(xc=context.do(self.xc),

--- a/glue/core/roi.py
+++ b/glue/core/roi.py
@@ -492,8 +492,6 @@ class EllipticalROI(Roi):
             x = np.asarray(x)
         if not isinstance(y, np.ndarray):
             y = np.asarray(y)
-        print(x - self.xc, self.radius_x)
-        print(y - self.yc, self.radius_y)
         return (((x - self.xc) ** 2 / self.radius_x ** 2 +
                  (y - self.yc) ** 2 / self.radius_y ** 2) < 1.)
 

--- a/glue/core/roi.py
+++ b/glue/core/roi.py
@@ -16,7 +16,7 @@ __all__ = ['Roi', 'RectangularROI', 'CircularROI', 'PolygonalROI',
            'AbstractMplRoi', 'MplRectangularROI', 'MplCircularROI',
            'MplPolygonalROI', 'MplXRangeROI', 'MplYRangeROI',
            'XRangeROI', 'RangeROI', 'YRangeROI', 'VertexROIBase',
-           'CategoricalROI']
+           'CategoricalROI', 'EllipticalROI']
 
 PATCH_COLOR = '#FFFF00'
 SCRUBBING_KEY = 'control'
@@ -455,6 +455,86 @@ class CircularROI(Roi):
     @classmethod
     def __setgluestate__(cls, rec, context):
         return cls(xc=rec['xc'], yc=rec['yc'], radius=rec['radius'])
+
+
+class EllipticalROI(Roi):
+    """
+    A 2D elliptical region of interest.
+    """
+
+    def __init__(self, xc=None, yc=None, radius_x=None, radius_y=None, theta=None):
+        super(EllipticalROI, self).__init__()
+        if theta is not None:
+            raise NotImplementedError("Rotated ellipses are not yet supported")
+        self.xc = xc
+        self.yc = yc
+        self.radius_x = radius_x
+        self.radius_y = radius_y
+
+    def contains(self, x, y):
+        """
+        Test whether a set of (x,y) points falls within
+        the region of interest
+
+        :param x: A list of x points
+        :param y: A list of y points
+
+        *Returns*
+
+           A list of True/False values, for whether each (x,y)
+           point falls within the ROI
+
+        """
+        if not self.defined():
+            raise UndefinedROI
+
+        if not isinstance(x, np.ndarray):
+            x = np.asarray(x)
+        if not isinstance(y, np.ndarray):
+            y = np.asarray(y)
+        print(x - self.xc, self.radius_x)
+        print(y - self.yc, self.radius_y)
+        return (((x - self.xc) ** 2 / self.radius_x ** 2 +
+                 (y - self.yc) ** 2 / self.radius_y ** 2) < 1.)
+
+    def reset(self):
+        """
+        Reset the rectangular region.
+        """
+        self.xc = None
+        self.yc = None
+        self.radius_x = 0.
+        self.radius_y = 0.
+
+    def defined(self):
+        """ Returns True if the ROI is defined """
+        return (self.xc is not None and
+                self.yc is not None and
+                self.radius_x is not None and
+                self.radius_y is not None)
+
+    def to_polygon(self):
+        """ Returns x, y, where each is a list of points """
+        if not self.defined():
+            return [], []
+        theta = np.linspace(0, 2 * np.pi, num=20)
+        x = self.xc + self.radius_x * np.cos(theta)
+        y = self.yc + self.radius_y * np.sin(theta)
+        return x, y
+
+    def transformed(self, xfunc=None, yfunc=None):
+        return PolygonalROI(*self.to_polygon()).transformed(xfunc=xfunc, yfunc=yfunc)
+
+    def __gluestate__(self, context):
+        return dict(xc=context.do(self.xc),
+                    yc=context.do(self.yc),
+                    radius_x=context.do(self.radius_x),
+                    radius_y=context.do(self.radius_y))
+
+    @classmethod
+    def __setgluestate__(cls, rec, context):
+        return cls(xc=rec['xc'], yc=rec['yc'],
+                   radius_x=rec['radius_x'], radius_y=rec['radius_y'])
 
 
 class VertexROIBase(Roi):
@@ -1187,15 +1267,35 @@ class MplCircularROI(AbstractMplRoi):
     def roi(self):
         if not self._roi.defined():
             return PolygonalROI()
-        theta = np.linspace(0, 2 * np.pi, num=200)
+
+        # Get the circular ROI parameters in pixel units
         xy_center = self._roi.get_center()
         rad = self._roi.get_radius()
-        x = xy_center[0] + rad * np.cos(theta)
-        y = xy_center[1] + rad * np.sin(theta)
-        xy_data = pixel_to_data(self._axes, x, y)
-        vx = xy_data[:, 0].ravel().tolist()
-        vy = xy_data[:, 1].ravel().tolist()
-        result = PolygonalROI(vx, vy)
+
+        # At this point, if one of the axes is not linear, we convert to a polygon
+        if self._axes.get_xscale() != 'linear' or self._axes.get_yscale() != 'linear':
+            theta = np.linspace(0, 2 * np.pi, num=200)
+            x = xy_center[0] + rad * np.cos(theta)
+            y = xy_center[1] + rad * np.sin(theta)
+            xy_data = pixel_to_data(self._axes, x, y)
+            vx = xy_data[:, 0].ravel().tolist()
+            vy = xy_data[:, 1].ravel().tolist()
+            result = PolygonalROI(vx, vy)
+        else:
+            # We should now check if the radius in data coordinates is the same
+            # along x and y, as if so then we can return a circle, otherwise we
+            # should return an ellipse.
+            x = xy_center[0] + np.array([0, 0, rad])
+            y = xy_center[1] + np.array([0, rad, rad])
+            xy_data = pixel_to_data(self._axes, x, y)
+            rx = xy_data[2, 0] - xy_data[0, 0]
+            ry = xy_data[1, 1] - xy_data[0, 1]
+            xc, yc = xy_data[0, :]
+            if np.allclose(rx, ry):
+                return CircularROI(xc=xc, yc=yc, radius=rx)
+            else:
+                return EllipticalROI(xc=xc, yc=yc, radius_x=rx, radius_y=ry)
+
         return result
 
     def finalize_selection(self, event):

--- a/glue/core/subset.py
+++ b/glue/core/subset.py
@@ -5,7 +5,7 @@ import operator
 import numpy as np
 
 from glue.core.roi import (PolygonalROI, CategoricalROI, RangeROI, XRangeROI,
-                           YRangeROI, RectangularROI)
+                           YRangeROI, RectangularROI, CircularROI, EllipticalROI)
 from glue.core.contracts import contract
 from glue.core.util import split_component_view
 from glue.core.registry import Registry
@@ -1949,9 +1949,12 @@ def roi_to_subset_state(roi, x_att=None, y_att=None, x_categories=None, y_catego
 
         # The selection is polygon-like and components are numerical
 
+        if not isinstance(roi, (PolygonalROI, CircularROI, EllipticalROI)):
+            roi = PolygonalROI(*roi.to_polygon())
+
         subset_state = RoiSubsetState()
         subset_state.xatt = x_att
         subset_state.yatt = y_att
-        subset_state.roi = PolygonalROI(*roi.to_polygon())
+        subset_state.roi = roi
 
         return subset_state

--- a/glue/core/tests/test_roi.py
+++ b/glue/core/tests/test_roi.py
@@ -850,73 +850,6 @@ class TestYRangeMpl(TestMpl):
         assert_almost_equal(roi._roi.max, 10.0)
 
 
-class TestCircleMpl(TestMpl):
-
-    def _roi_factory(self):
-        return MplCircularROI(self.axes)
-
-    def setup_method(self, method):
-        super(TestCircleMpl, self).setup_method(method)
-        self.pixel_to_data = r.pixel_to_data
-        self.data_to_pixel = r.data_to_pixel
-
-        r.pixel_to_data = lambda x, y, z: np.column_stack((y, z))
-        r.data_to_pixel = lambda x, y, z: np.column_stack((y, z))
-
-    def teardown_method(self, method):
-        # restore methods
-        r.pixel_to_data = self.pixel_to_data
-        r.data_to_pixel = self.data_to_pixel
-
-    def test_proper_roi(self):
-        assert isinstance(self.roi._roi, CircularROI)
-
-    def test_to_polygon_undefined(self):
-        """to_polygon() result should be undefined before defining polygon"""
-        roi = self.roi.roi()
-        assert not roi.defined()
-
-    def test_roi_defined_correctly(self):
-        ev0 = DummyEvent(0, 0, inaxes=self.axes)
-        ev1 = DummyEvent(5, 0, inaxes=self.axes)
-        self.roi.start_selection(ev0)
-        self.roi.update_selection(ev1)
-        self.roi.finalize_selection(ev1)
-        self.assert_roi_correct(0, 0, 5)
-
-    def assert_roi_correct(self, x, y, r):
-        roi = self.roi.roi()
-        assert roi.defined()
-        assert roi.contains(x, y)
-        assert roi.contains(x + .95 * r, y)
-        assert not roi.contains(x + 1.05 * r, y)
-        assert not roi.contains(x + .8 * r, y + .8 * r)
-
-    def test_scrub(self):
-
-        roi = self.scrub()
-
-        assert roi._roi.xc == 6
-        assert roi._roi.yc == 7
-        assert_almost_equal(roi._roi.radius, 7.0, decimal=0)
-
-    def test_abort(self):
-
-        roi = self.scrub(abort=True)
-
-        assert roi._roi.xc == 5
-        assert roi._roi.yc == 5
-        assert_almost_equal(roi._roi.radius, 7.0, decimal=0)
-
-    def test_outside(self):
-
-        roi = self.scrub(outside=True)
-
-        assert roi._roi.xc == 5
-        assert roi._roi.yc == 5
-        assert_almost_equal(roi._roi.radius, 7.0, decimal=0)
-
-
 def test_circular_roi_representation():
 
     # Test cases where drawn circular ROIs are converted to circles, ellipses,
@@ -977,7 +910,6 @@ def test_circular_roi_representation():
     assert_allclose(roi.xc, 50)
     assert_allclose(roi.yc, 1)
     assert_allclose(roi.radius, 30)
-
 
 
 class TestCircleMpl(TestMpl):

--- a/glue/core/tests/test_roi.py
+++ b/glue/core/tests/test_roi.py
@@ -1,7 +1,11 @@
 # pylint: disable=I0011,W0613,W0201,W0212,E1101,E1103
 
+from collections import namedtuple
+
 import pytest
 import numpy as np
+from numpy.testing import assert_allclose
+import matplotlib.pyplot as plt
 from unittest.mock import MagicMock
 from matplotlib.figure import Figure
 from numpy.testing import assert_almost_equal
@@ -10,7 +14,8 @@ from .. import roi as r
 from ..component import CategoricalComponent
 from ..roi import (RectangularROI, UndefinedROI, CircularROI, PolygonalROI, CategoricalROI,
                    MplCircularROI, MplRectangularROI, MplPolygonalROI, MplPickROI, PointROI,
-                   XRangeROI, MplXRangeROI, YRangeROI, MplYRangeROI, RangeROI, Projected3dROI)
+                   XRangeROI, MplXRangeROI, YRangeROI, MplYRangeROI, RangeROI, Projected3dROI,
+                   EllipticalROI)
 
 
 FIG = Figure()
@@ -272,6 +277,78 @@ class TestCircle(object):
         y = np.array([-.1, -.2, -.3, -.4]).reshape(2, 2)
         assert self.roi.contains(x, y).all()
         assert not self.roi.contains(x + 1, y).any()
+        assert self.roi.contains(x, y).shape == (2, 2)
+
+
+class TestEllipse(object):
+
+    def setup_method(self, method):
+        self.roi_empty = EllipticalROI()
+        self.roi = EllipticalROI(1, 2, 3, 4)
+
+    def test_undefined_on_creation(self):
+        assert not self.roi_empty.defined()
+        assert self.roi.defined()
+
+    def test_contains_on_undefined_contains_raises(self):
+        with pytest.raises(UndefinedROI):
+            self.roi_empty.contains(1, 1)
+        self.roi.contains(1, 1)
+
+    def test_set_center(self):
+        assert self.roi.contains(0, 0)
+        assert not self.roi.contains(12, 12)
+        self.roi.xc = 11
+        self.roi.yc = 12
+        assert not self.roi.contains(0, 0)
+        assert self.roi.contains(12, 12)
+
+    def test_set_radius(self):
+        assert self.roi.contains(0, 0)
+        assert not self.roi.contains(12, 12)
+        self.roi.radius_y = 100
+        assert self.roi.contains(0, 0)
+        assert not self.roi.contains(12, 12)
+        self.roi.radius_x = 100
+        assert self.roi.contains(0, 0)
+        assert self.roi.contains(12, 12)
+
+    def test_contains_many(self):
+        x = [0, 0, 0, 0, 0]
+        y = [0, 0, 0, 0, 0]
+        assert all(self.roi.contains(x, y))
+        assert all(self.roi.contains(np.asarray(x), np.asarray(y)))
+        assert not any(self.roi.contains(np.asarray(x) + 10, y))
+
+    def test_poly(self):
+        x, y = self.roi.to_polygon()
+        poly = PolygonalROI(vx=x, vy=y)
+        assert poly.contains(0, 0)
+        assert not poly.contains(10, 0)
+
+    def test_poly_undefined(self):
+        x, y = self.roi_empty.to_polygon()
+        assert x == []
+        assert y == []
+
+    def test_reset(self):
+        assert not self.roi_empty.defined()
+        self.roi_empty.xc = 1
+        assert not self.roi_empty.defined()
+        self.roi_empty.yc = 2
+        assert not self.roi_empty.defined()
+        self.roi_empty.radius_x = 3
+        assert not self.roi_empty.defined()
+        self.roi_empty.radius_y = 4
+        assert self.roi_empty.defined()
+        self.roi_empty.reset()
+        assert not self.roi_empty.defined()
+
+    def test_multidim(self):
+        x = np.array([.1, .2, .3, .4]).reshape(2, 2)
+        y = np.array([-.1, -.2, -.3, -.4]).reshape(2, 2)
+        assert self.roi.contains(x, y).all()
+        assert not self.roi.contains(x + 10, y).any()
         assert self.roi.contains(x, y).shape == (2, 2)
 
 
@@ -771,6 +848,136 @@ class TestYRangeMpl(TestMpl):
 
         assert_almost_equal(roi._roi.min, 5.0)
         assert_almost_equal(roi._roi.max, 10.0)
+
+
+class TestCircleMpl(TestMpl):
+
+    def _roi_factory(self):
+        return MplCircularROI(self.axes)
+
+    def setup_method(self, method):
+        super(TestCircleMpl, self).setup_method(method)
+        self.pixel_to_data = r.pixel_to_data
+        self.data_to_pixel = r.data_to_pixel
+
+        r.pixel_to_data = lambda x, y, z: np.column_stack((y, z))
+        r.data_to_pixel = lambda x, y, z: np.column_stack((y, z))
+
+    def teardown_method(self, method):
+        # restore methods
+        r.pixel_to_data = self.pixel_to_data
+        r.data_to_pixel = self.data_to_pixel
+
+    def test_proper_roi(self):
+        assert isinstance(self.roi._roi, CircularROI)
+
+    def test_to_polygon_undefined(self):
+        """to_polygon() result should be undefined before defining polygon"""
+        roi = self.roi.roi()
+        assert not roi.defined()
+
+    def test_roi_defined_correctly(self):
+        ev0 = DummyEvent(0, 0, inaxes=self.axes)
+        ev1 = DummyEvent(5, 0, inaxes=self.axes)
+        self.roi.start_selection(ev0)
+        self.roi.update_selection(ev1)
+        self.roi.finalize_selection(ev1)
+        self.assert_roi_correct(0, 0, 5)
+
+    def assert_roi_correct(self, x, y, r):
+        roi = self.roi.roi()
+        assert roi.defined()
+        assert roi.contains(x, y)
+        assert roi.contains(x + .95 * r, y)
+        assert not roi.contains(x + 1.05 * r, y)
+        assert not roi.contains(x + .8 * r, y + .8 * r)
+
+    def test_scrub(self):
+
+        roi = self.scrub()
+
+        assert roi._roi.xc == 6
+        assert roi._roi.yc == 7
+        assert_almost_equal(roi._roi.radius, 7.0, decimal=0)
+
+    def test_abort(self):
+
+        roi = self.scrub(abort=True)
+
+        assert roi._roi.xc == 5
+        assert roi._roi.yc == 5
+        assert_almost_equal(roi._roi.radius, 7.0, decimal=0)
+
+    def test_outside(self):
+
+        roi = self.scrub(outside=True)
+
+        assert roi._roi.xc == 5
+        assert roi._roi.yc == 5
+        assert_almost_equal(roi._roi.radius, 7.0, decimal=0)
+
+
+def test_circular_roi_representation():
+
+    # Test cases where drawn circular ROIs are converted to circles, ellipses,
+    # and polygons. Here we don't override pixel_to_data and data_to_pixel
+    # since these are important.
+
+    event = namedtuple('Event', ['inaxes', 'xdata', 'ydata', 'key'])
+
+    fig = plt.figure(figsize=(6, 4))
+    ax = fig.add_subplot(1, 1, 1)
+
+    # Case 1: log-linear axes
+
+    ax.set_xlim(10, 100)
+    ax.set_ylim(-2, 5)
+    ax.set_xscale('log')
+    ax.set_yscale('linear')
+
+    fig.canvas.draw()
+
+    mpl_roi = MplCircularROI(ax)
+    mpl_roi.start_selection(event(inaxes=ax, xdata=50, ydata=1, key=None))
+    mpl_roi.update_selection(event(inaxes=ax, xdata=100, ydata=1, key=None))
+    roi = mpl_roi.roi()
+    assert isinstance(roi, PolygonalROI)
+
+    # Case 2: linear-linear axes with non-square aspect ratio
+
+    ax.set_xlim(-40, 100)
+    ax.set_ylim(-2, 5)
+    ax.set_xscale('linear')
+    ax.set_yscale('linear')
+
+    fig.canvas.draw()
+
+    mpl_roi = MplCircularROI(ax)
+    mpl_roi.start_selection(event(inaxes=ax, xdata=30, ydata=1, key=None))
+    mpl_roi.update_selection(event(inaxes=ax, xdata=80, ydata=1, key=None))
+    roi = mpl_roi.roi()
+    assert isinstance(roi, EllipticalROI)
+    assert_allclose(roi.xc, 30)
+    assert_allclose(roi.yc, 1)
+    assert_allclose(roi.radius_x, 50)
+    assert_allclose(roi.radius_y, 5.871212)
+
+    # Case 3: linear-linear axes with square aspect ratio
+
+    ax.set_aspect('equal')
+    ax.set_xlim(-40, 100)
+
+    fig.canvas.draw()
+
+    mpl_roi = MplCircularROI(ax)
+    mpl_roi.start_selection(event(inaxes=ax, xdata=50, ydata=1, key=None))
+    mpl_roi.update_selection(event(inaxes=ax, xdata=80, ydata=1, key=None))
+    roi = mpl_roi.roi()
+    assert isinstance(roi, CircularROI)
+    assert_allclose(roi.xc, 50)
+    assert_allclose(roi.yc, 1)
+    assert_allclose(roi.radius, 30)
+
 
 
 class TestCircleMpl(TestMpl):


### PR DESCRIPTION
These changes make it so that when doing a circular selection in a Matplotlib viewer, we get a ``CircularROI`` back if the aspect ratio is equal and axes are linear, and an ``EllipticalROI`` back if the aspect ratio is unequal and the axes are linear (otherwise return a ``PolygonalROI`` as before).