### PR TITLE
Fix issue where profile of subset was not correctly hidden if the subset was emptied

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,9 @@ v0.16.0 (unreleased)
 
 * Added a ``DataCollection.clear()`` method to remove all datasets. [#2079]
 
+* Fixed a bug that caused profiles of subsets to not be hidden if an
+  existing subset was emptied. [#2095]
+
 * Improved ``IndexedData`` so that world coordinates can now be shown. [#2081]
 
 v0.15.6 (2019-08-22)

--- a/glue/viewers/profile/layer_artist.py
+++ b/glue/viewers/profile/layer_artist.py
@@ -77,11 +77,10 @@ class ProfileLayerArtist(MatplotlibLayerArtist):
             if self._viewer_state.normalize:
                 y = self.state.normalize_values(y)
             self.plot_artist.set_data(x, y)
-            self.plot_artist.set_visible(self.state.visible)
         else:
             # We need to do this otherwise we get issues on Windows when
             # passing an empty list to plot_artist
-            self.plot_artist.set_visible(False)
+            self.plot_artist.set_data([0.], [0.])
 
         # TODO: the following was copy/pasted from the histogram viewer, maybe
         # we can find a way to avoid duplication?


### PR DESCRIPTION
This was first spotted in glue-jupyter (https://github.com/glue-viz/glue-jupyter/issues/160) but the issue exists in glue-core too.