### PR TITLE
Fix #2003: Have a way of seeing what session file was opened

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@ v0.16.0 (unreleased)
 
 * Move spectral-cube data loader to glue-astronomy plugin package. [#2077]
 
+* Show session filename path in window title. [#2096]
+
 * Change ``Data.coords`` API to now rely on the API described in
   https://github.com/astropy/astropy-APEs/blob/master/APE14.rst [#2079]
 

--- a/glue/app/qt/application.py
+++ b/glue/app/qt/application.py
@@ -292,7 +292,7 @@ class GlueApplication(Application, QtWidgets.QMainWindow):
         # in case glue was started directly by initializing this class.
         load_plugins()
 
-        self.setWindowTitle("Glue")
+        self.set_window_title()
         self.setWindowIcon(icon)
         self.setAttribute(Qt.WA_DeleteOnClose)
         self._actions = {}
@@ -1012,6 +1012,18 @@ class GlueApplication(Application, QtWidgets.QMainWindow):
             viewer.show()
         return viewer
 
+    def set_window_title(self, detail=None):
+        """Set the window title"""
+        if detail is None:
+            title = "Glue"
+        else:
+            title = "Glue ("+detail+")"
+        self.setWindowTitle(title)
+
+    def _on_session_changed(self, name):
+        """Call when the session is changed"""
+        self.set_window_title(name)
+
     def _choose_save_session(self, *args):
         """ Save the data collection and hub to file.
 
@@ -1042,6 +1054,9 @@ class GlueApplication(Application, QtWidgets.QMainWindow):
             self.save_session(outfile,
                               include_data="including data" in file_filter,
                               absolute_paths="absolute" in file_filter)
+        self._on_session_changed(outfile)
+
+
 
     @messagebox_on_error("Failed to restore session")
     def _restore_session(self, *args):
@@ -1053,6 +1068,7 @@ class GlueApplication(Application, QtWidgets.QMainWindow):
             return
 
         ga = self.restore_session_and_close(file_name)
+        ga._on_session_changed(file_name)
         return ga
 
     @property
@@ -1258,6 +1274,8 @@ class GlueApplication(Application, QtWidgets.QMainWindow):
             self._new_application = app
 
             self.close()
+
+        return app
 
     def closeEvent(self, event):
         """Emit a message to hub before closing."""

--- a/glue/app/qt/application.py
+++ b/glue/app/qt/application.py
@@ -1017,7 +1017,7 @@ class GlueApplication(Application, QtWidgets.QMainWindow):
         if detail is None:
             title = "Glue"
         else:
-            title = "Glue ("+detail+")"
+            title = "Glue (" + detail + ")"
         self.setWindowTitle(title)
 
     def _on_session_changed(self, name):
@@ -1055,8 +1055,6 @@ class GlueApplication(Application, QtWidgets.QMainWindow):
                               include_data="including data" in file_filter,
                               absolute_paths="absolute" in file_filter)
         self._on_session_changed(outfile)
-
-
 
     @messagebox_on_error("Failed to restore session")
     def _restore_session(self, *args):

--- a/glue/app/qt/application.py
+++ b/glue/app/qt/application.py
@@ -1066,7 +1066,6 @@ class GlueApplication(Application, QtWidgets.QMainWindow):
             return
 
         ga = self.restore_session_and_close(file_name)
-        ga._on_session_changed(file_name)
         return ga
 
     @property
@@ -1133,6 +1132,7 @@ class GlueApplication(Application, QtWidgets.QMainWindow):
         ga = Application.restore_session(path)
         if show:
             ga.start(block=False)
+        ga._on_session_changed(path)
         return ga
 
     def has_terminal(self, create_if_not=True):


### PR DESCRIPTION
This commit add the session filename in the window title

The window title is updated on export, restore and reset.

