### PR TITLE
Fixed a bug with re-loading sessions that had LinkCollections

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,12 @@ v0.16.0 (unreleased)
 
 * Improved ``IndexedData`` so that world coordinates can now be shown. [#2081]
 
+v0.15.7 (2020-03-12)
+--------------------
+
+* Fixed a bug that caused session files that were saved with LinkCollection to
+  not work correctly when re-loaded. [#2100]
+
 v0.15.6 (2019-08-22)
 --------------------
 

--- a/glue/core/state.py
+++ b/glue/core/state.py
@@ -581,7 +581,7 @@ def _load_tuple(rec, context):
 
 @saver(list)
 def _save_list(state, context):
-    return dict(contents=[context.do(item) for item in state])
+    return dict(contents=[context.id(item) for item in state])
 
 
 @loader(list)


### PR DESCRIPTION
This should fix issues with opening the link editor after re-loading a session with complex links