### PR TITLE
Fixed the dropdowns for vector and error markers to not include datetime components

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,9 @@ v0.15.7 (2020-03-12)
 * Fixed a bug that caused an error when an invalid data was added to the table
   viewer and the table viewer was then automatically closed. [#2103]
 
+* Fixed the dropdowns for vector and error markers to not include datetime
+  components (since they represent absolute times, not deltas). [#2102]
+
 * Fixed a bug that caused session files that were saved with LinkCollection to
   not work correctly when re-loaded. [#2100]
 

--- a/glue/core/data_combo_helper.py
+++ b/glue/core/data_combo_helper.py
@@ -138,6 +138,8 @@ class ComponentIDComboHelper(ComboHelper):
         datasets to be added/removed
     numeric : bool, optional
         Show numeric components
+    datetime : bool, optional
+        Show datetime components
     categorical : bool, optional
         Show categorical components
     pixel_coord : bool, optional
@@ -154,7 +156,7 @@ class ComponentIDComboHelper(ComboHelper):
 
     def __init__(self, state, selection_property,
                  data_collection=None, data=None,
-                 numeric=True, categorical=True,
+                 numeric=True, datetime=True, categorical=True,
                  pixel_coord=False, world_coord=False, derived=True, none=False):
 
         super(ComponentIDComboHelper, self).__init__(state, selection_property)
@@ -175,6 +177,7 @@ class ComponentIDComboHelper(ComboHelper):
         self.display = display_func_label
 
         self._numeric = numeric
+        self._datetime = datetime
         self._categorical = categorical
         self._pixel_coord = pixel_coord
         self._world_coord = world_coord
@@ -210,6 +213,15 @@ class ComponentIDComboHelper(ComboHelper):
     @numeric.setter
     def numeric(self, value):
         self._numeric = value
+        self.refresh()
+
+    @property
+    def datetime(self):
+        return self._datetime
+
+    @datetime.setter
+    def datetime(self, value):
+        self._datetime = value
         self.refresh()
 
     @property
@@ -338,7 +350,8 @@ class ComponentIDComboHelper(ComboHelper):
 
             cids = [ChoiceSeparator('Main components')]
             for cid in data.main_components:
-                if ((data.get_kind(cid) in ('numerical', 'datetime') and self.numeric) or
+                if ((data.get_kind(cid) == 'numerical' and self.numeric) or
+                        (data.get_kind(cid) == 'datetime' and self.datetime) or
                         (data.get_kind(cid) == 'categorical' and self.categorical)):
                     cids.append(cid)
             if len(cids) > 1:

--- a/glue/viewers/image/state.py
+++ b/glue/viewers/image/state.py
@@ -106,10 +106,10 @@ class ImageViewerState(MatplotlibDataViewerState):
         self.ref_data_helper = ManualDataComboHelper(self, 'reference_data')
 
         self.xw_att_helper = ComponentIDComboHelper(self, 'x_att_world',
-                                                    numeric=False, categorical=False)
+                                                    numeric=False, datetime=False, categorical=False)
 
         self.yw_att_helper = ComponentIDComboHelper(self, 'y_att_world',
-                                                    numeric=False, categorical=False)
+                                                    numeric=False, datetime=False, categorical=False)
 
         self.add_callback('reference_data', self._reference_data_changed, priority=1000)
         self.add_callback('layers', self._layers_changed, priority=1000)

--- a/glue/viewers/profile/state.py
+++ b/glue/viewers/profile/state.py
@@ -58,7 +58,7 @@ class ProfileViewerState(MatplotlibDataViewerState):
         self.add_callback('normalize', self._reset_y_limits)
 
         self.x_att_helper = ComponentIDComboHelper(self, 'x_att',
-                                                   numeric=False, categorical=False,
+                                                   numeric=False, datetime=False, categorical=False,
                                                    pixel_coord=True)
 
         ProfileViewerState.function.set_choices(self, list(FUNCTIONS))

--- a/glue/viewers/scatter/layer_artist.py
+++ b/glue/viewers/scatter/layer_artist.py
@@ -224,8 +224,7 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
                     self.scatter_artist.set_offsets(np.zeros((0, 2)))
                 else:
                     self.plot_artist.set_data([], [])
-                    offsets = np.vstack((x, y)).transpose()
-                    self.scatter_artist.set_offsets(offsets)
+                    self.scatter_artist.set_offsets([x, y])
         else:
             self.plot_artist.set_data([], [])
             self.scatter_artist.set_offsets(np.zeros((0, 2)))

--- a/glue/viewers/scatter/qt/layer_style_editor.py
+++ b/glue/viewers/scatter/qt/layer_style_editor.py
@@ -5,8 +5,10 @@ import numpy as np
 from qtpy import QtWidgets, QtGui
 from qtpy.QtCore import Qt
 
+from glue.core import BaseData
 from glue.external.echo.qt import autoconnect_callbacks_to_qt, connect_value
 from glue.utils.qt import load_ui, fix_tab_widget_fontsize
+from glue.core.exceptions import IncompatibleAttribute
 
 
 class ScatterLayerStyleEditor(QtWidgets.QWidget):
@@ -142,8 +144,22 @@ class ScatterLayerStyleEditor(QtWidgets.QWidget):
         self.ui.value_density_contrast.setEnabled(self.layer_state.markers_visible)
 
     def _update_checkboxes(self, *args):
-        x_datetime = self.layer_state.layer.get_kind(self.layer_state.viewer_state.x_att) == 'datetime'
-        y_datetime = self.layer_state.layer.get_kind(self.layer_state.viewer_state.y_att) == 'datetime'
+
+        if isinstance(self.layer_state.layer, BaseData):
+            layer = self.layer_state.layer
+        else:
+            layer = self.layer_state.layer.data
+
+        try:
+            x_datetime = layer.get_kind(self.layer_state.viewer_state.x_att) == 'datetime'
+        except IncompatibleAttribute:
+            x_datetime = False
+
+        try:
+            y_datetime = layer.get_kind(self.layer_state.viewer_state.y_att) == 'datetime'
+        except IncompatibleAttribute:
+            y_datetime = False
+
         for checkbox in [self.ui.bool_line_visible, self.ui.bool_xerr_visible,
                          self.ui.bool_yerr_visible, self.ui.bool_vector_visible]:
             if self.layer_state.density_map:

--- a/glue/viewers/scatter/qt/layer_style_editor.py
+++ b/glue/viewers/scatter/qt/layer_style_editor.py
@@ -45,6 +45,9 @@ class ScatterLayerStyleEditor(QtWidgets.QWidget):
         self.layer_state.add_callback('density_map', self._update_warnings)
         self.layer_state.add_callback('density_map', self._update_checkboxes)
 
+        self.layer_state.viewer_state.add_callback('x_att', self._update_checkboxes)
+        self.layer_state.viewer_state.add_callback('y_att', self._update_checkboxes)
+
         self.layer_state.add_callback('layer', self._update_warnings)
 
         self._update_markers_visible()
@@ -139,14 +142,21 @@ class ScatterLayerStyleEditor(QtWidgets.QWidget):
         self.ui.value_density_contrast.setEnabled(self.layer_state.markers_visible)
 
     def _update_checkboxes(self, *args):
+        x_datetime = self.layer_state.layer.get_kind(self.layer_state.viewer_state.x_att) == 'datetime'
+        y_datetime = self.layer_state.layer.get_kind(self.layer_state.viewer_state.y_att) == 'datetime'
         for checkbox in [self.ui.bool_line_visible, self.ui.bool_xerr_visible,
                          self.ui.bool_yerr_visible, self.ui.bool_vector_visible]:
             if self.layer_state.density_map:
                 checkbox.setEnabled(False)
                 checkbox.setToolTip('Not available with density map')
             else:
-                checkbox.setEnabled(True)
-                checkbox.setToolTip('')
+                if ((x_datetime and checkbox in (self.ui.bool_xerr_visible, self.ui.bool_vector_visible)) or
+                       (y_datetime and checkbox in (self.ui.bool_yerr_visible, self.ui.bool_vector_visible))):
+                    checkbox.setEnabled(False)
+                    checkbox.setToolTip('Not available when using datetime attribute')
+                else:
+                    checkbox.setEnabled(True)
+                    checkbox.setToolTip('')
 
     def _update_line_visible(self, *args):
         self.ui.value_linewidth.setEnabled(self.layer_state.line_visible)

--- a/glue/viewers/scatter/qt/tests/test_data_viewer.py
+++ b/glue/viewers/scatter/qt/tests/test_data_viewer.py
@@ -597,6 +597,30 @@ class TestScatterViewer(object):
 
         ga.close()
 
+    def test_datetime64_disabled(self, capsys):
+
+        # Make sure that datetime components aren't options for the vector and
+        # error markers.
+
+        data = Data(label='test')
+        data.add_component(np.array([100, 200, 300, 400], dtype='M8[D]'), 't1')
+        data.add_component(np.array([200, 300, 400, 500], dtype='M8[D]'), 't2')
+        data.add_component(np.array([200, 300, 400, 500]), 'x')
+        data.add_component(np.array([200, 300, 400, 500]), 'y')
+        self.data_collection.append(data)
+
+        self.viewer.add_data(data)
+        self.viewer.state.layers[0].vector_visible = True
+        self.viewer.state.layers[0].xerr_visible = True
+        self.viewer.state.layers[0].yerr_visible = True
+
+        process_events()
+
+        #  We use capsys here because the # error is otherwise only apparent in stderr.
+        out, err = capsys.readouterr()
+        assert out.strip() == ""
+        assert err.strip() == ""
+
     def test_density_map_incompatible_subset(self, capsys):
 
         # Regression test for a bug that caused the scatter viewer to crash

--- a/glue/viewers/scatter/qt/tests/test_data_viewer.py
+++ b/glue/viewers/scatter/qt/tests/test_data_viewer.py
@@ -605,16 +605,25 @@ class TestScatterViewer(object):
         data = Data(label='test')
         data.add_component(np.array([100, 200, 300, 400], dtype='M8[D]'), 't1')
         data.add_component(np.array([200, 300, 400, 500], dtype='M8[D]'), 't2')
-        data.add_component(np.array([200, 300, 400, 500]), 'x')
-        data.add_component(np.array([200, 300, 400, 500]), 'y')
+        data.add_component(np.array([200., 300., 400., 500.]), 'x')
+        data.add_component(np.array([200., 300., 400., 500.]), 'y')
         self.data_collection.append(data)
 
         self.viewer.add_data(data)
+        self.viewer.state.x_att = data.id['x']
+        self.viewer.state.y_att = data.id['y']
         self.viewer.state.layers[0].cmap_mode = 'Linear'
+        self.viewer.state.layers[0].cmap_att = data.id['x']
         self.viewer.state.layers[0].size_mode = 'Linear'
+        self.viewer.state.layers[0].size_att = data.id['y']
         self.viewer.state.layers[0].vector_visible = True
         self.viewer.state.layers[0].xerr_visible = True
         self.viewer.state.layers[0].yerr_visible = True
+
+        process_events()
+
+        self.viewer.state.x_att = data.id['t1']
+        self.viewer.state.y_att = data.id['t2']
 
         process_events()
 

--- a/glue/viewers/scatter/qt/tests/test_data_viewer.py
+++ b/glue/viewers/scatter/qt/tests/test_data_viewer.py
@@ -610,6 +610,8 @@ class TestScatterViewer(object):
         self.data_collection.append(data)
 
         self.viewer.add_data(data)
+        self.viewer.state.layers[0].cmap_mode = 'Linear'
+        self.viewer.state.layers[0].size_mode = 'Linear'
         self.viewer.state.layers[0].vector_visible = True
         self.viewer.state.layers[0].xerr_visible = True
         self.viewer.state.layers[0].yerr_visible = True

--- a/glue/viewers/scatter/state.py
+++ b/glue/viewers/scatter/state.py
@@ -291,6 +291,10 @@ class ScatterLayerState(MatplotlibLayerState):
         ScatterLayerState.stretch.set_choices(self, ['linear', 'sqrt', 'arcsinh', 'log'])
         ScatterLayerState.stretch.set_display_func(self, stretch_display.get)
 
+        self.viewer_state.add_callback('x_att', self._on_xy_change, priority=10000)
+        self.viewer_state.add_callback('y_att', self._on_xy_change, priority=10000)
+        self._on_xy_change()
+
         self.add_callback('layer', self._on_layer_change)
         if layer is not None:
             self._on_layer_change()
@@ -302,6 +306,19 @@ class ScatterLayerState(MatplotlibLayerState):
         self._sync_size = keep_in_sync(self, 'size', self.layer.style, 'markersize')
 
         self.update_from_dict(kwargs)
+
+    def _on_xy_change(self, *event):
+        if self.viewer_state.x_att is None or self.viewer_state.y_att is None:
+            return
+        x_datetime = self.layer.get_kind(self.viewer_state.x_att) == 'datetime'
+        y_datetime = self.layer.get_kind(self.viewer_state.y_att) == 'datetime'
+        with delay_callback(self, 'xerr_visible', 'yerr_visible', 'vector_visible'):
+            if x_datetime:
+                self.xerr_visible = False
+            if y_datetime:
+                self.yerr_visible = False
+            if x_datetime or y_datetime:
+                self.vector_visible = False
 
     def _on_layer_change(self, layer=None):
 

--- a/glue/viewers/scatter/state.py
+++ b/glue/viewers/scatter/state.py
@@ -291,9 +291,10 @@ class ScatterLayerState(MatplotlibLayerState):
         ScatterLayerState.stretch.set_choices(self, ['linear', 'sqrt', 'arcsinh', 'log'])
         ScatterLayerState.stretch.set_display_func(self, stretch_display.get)
 
-        self.viewer_state.add_callback('x_att', self._on_xy_change, priority=10000)
-        self.viewer_state.add_callback('y_att', self._on_xy_change, priority=10000)
-        self._on_xy_change()
+        if self.viewer_state is not None:
+            self.viewer_state.add_callback('x_att', self._on_xy_change, priority=10000)
+            self.viewer_state.add_callback('y_att', self._on_xy_change, priority=10000)
+            self._on_xy_change()
 
         self.add_callback('layer', self._on_layer_change)
         if layer is not None:
@@ -317,8 +318,15 @@ class ScatterLayerState(MatplotlibLayerState):
         else:
             layer = self.layer.data
 
-        x_datetime = layer.get_kind(self.viewer_state.x_att) == 'datetime'
-        y_datetime = layer.get_kind(self.viewer_state.y_att) == 'datetime'
+        try:
+            x_datetime = layer.get_kind(self.viewer_state.x_att) == 'datetime'
+        except IncompatibleAttribute:
+            x_datetime = False
+
+        try:
+            y_datetime = layer.get_kind(self.viewer_state.y_att) == 'datetime'
+        except IncompatibleAttribute:
+            y_datetime = False
 
         with delay_callback(self, 'xerr_visible', 'yerr_visible', 'vector_visible'):
             if x_datetime:

--- a/glue/viewers/scatter/state.py
+++ b/glue/viewers/scatter/state.py
@@ -236,10 +236,10 @@ class ScatterLayerState(MatplotlibLayerState):
                                                           limits_cache=self.limits_cache)
 
         self.cmap_att_helper = ComponentIDComboHelper(self, 'cmap_att',
-                                                      numeric=True, categorical=False)
+                                                      numeric=True, datetime=False, categorical=False)
 
         self.size_att_helper = ComponentIDComboHelper(self, 'size_att',
-                                                      numeric=True, categorical=False)
+                                                      numeric=True, datetime=False, categorical=False)
 
         self.xerr_att_helper = ComponentIDComboHelper(self, 'xerr_att',
                                                       numeric=True, datetime=False, categorical=False)

--- a/glue/viewers/scatter/state.py
+++ b/glue/viewers/scatter/state.py
@@ -308,10 +308,18 @@ class ScatterLayerState(MatplotlibLayerState):
         self.update_from_dict(kwargs)
 
     def _on_xy_change(self, *event):
+
         if self.viewer_state.x_att is None or self.viewer_state.y_att is None:
             return
-        x_datetime = self.layer.get_kind(self.viewer_state.x_att) == 'datetime'
-        y_datetime = self.layer.get_kind(self.viewer_state.y_att) == 'datetime'
+
+        if isinstance(self.layer, BaseData):
+            layer = self.layer
+        else:
+            layer = self.layer.data
+
+        x_datetime = layer.get_kind(self.viewer_state.x_att) == 'datetime'
+        y_datetime = layer.get_kind(self.viewer_state.y_att) == 'datetime'
+
         with delay_callback(self, 'xerr_visible', 'yerr_visible', 'vector_visible'):
             if x_datetime:
                 self.xerr_visible = False

--- a/glue/viewers/scatter/state.py
+++ b/glue/viewers/scatter/state.py
@@ -242,16 +242,16 @@ class ScatterLayerState(MatplotlibLayerState):
                                                       numeric=True, categorical=False)
 
         self.xerr_att_helper = ComponentIDComboHelper(self, 'xerr_att',
-                                                      numeric=True, categorical=False)
+                                                      numeric=True, datetime=False, categorical=False)
 
         self.yerr_att_helper = ComponentIDComboHelper(self, 'yerr_att',
-                                                      numeric=True, categorical=False)
+                                                      numeric=True, datetime=False, categorical=False)
 
         self.vx_att_helper = ComponentIDComboHelper(self, 'vx_att',
-                                                    numeric=True, categorical=False)
+                                                    numeric=True, datetime=False, categorical=False)
 
         self.vy_att_helper = ComponentIDComboHelper(self, 'vy_att',
-                                                    numeric=True, categorical=False)
+                                                    numeric=True, datetime=False, categorical=False)
 
         points_mode_display = {'auto': 'Density map or markers (auto)',
                                'markers': 'Markers',


### PR DESCRIPTION
Since datetime components represent absolute times, not deltas
