### PR TITLE
Fixed a bug that caused an error when an invalid data was added to the table viewer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,9 @@ v0.16.0 (unreleased)
 v0.15.7 (2020-03-12)
 --------------------
 
+* Fixed a bug that caused an error when an invalid data was added to the table
+  viewer and the table viewer was then automatically closed. [#2103]
+
 * Fixed a bug that caused session files that were saved with LinkCollection to
   not work correctly when re-loaded. [#2100]
 

--- a/glue/viewers/table/qt/data_viewer.py
+++ b/glue/viewers/table/qt/data_viewer.py
@@ -297,7 +297,8 @@ class TableViewer(DataViewer):
         we swap out with a tiny data set before closing
         """
         super(TableViewer, self).closeEvent(event)
-        self.model._data = Data(x=[0])
+        if self.model is not None:
+            self.model._data = Data(x=[0])
         event.accept()
 
     def get_layer_artist(self, cls, layer=None, layer_state=None):


### PR DESCRIPTION
and the table viewer was then automatically closed. The error was:

```
AttributeError: 'NoneType' object has no attribute '_data'
```
