### PR TITLE
Fix table viewer performance

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,9 @@ v0.16.0 (unreleased)
 v0.15.7 (2020-03-12)
 --------------------
 
+* Fix bug that caused an infinite loop in the table viewer and caused glue to
+  hang if too many incompatible subsets were in a table viewer. [#2105]
+
 * Fixed a bug that caused an error when an invalid data was added to the table
   viewer and the table viewer was then automatically closed. [#2103]
 

--- a/glue/viewers/table/qt/data_viewer.py
+++ b/glue/viewers/table/qt/data_viewer.py
@@ -100,7 +100,11 @@ class DataTableModel(QtCore.QAbstractTableModel):
                         if subset.to_mask(view=slice(idx, idx + 1))[0]:
                             colors.append(subset.style.color)
                     except IncompatibleAttribute as exc:
-                        layer_artist.disable_invalid_attributes(*exc.args)
+                        # Only disable the layer if enabled, as otherwise we
+                        # will recursively call clear and _refresh, causing
+                        # an infinite loop and performance issues.
+                        if layer_artist.enabled:
+                            layer_artist.disable_invalid_attributes(*exc.args)
                     else:
                         layer_artist.enabled = True
 


### PR DESCRIPTION
This fixes a bug that caused an infinite loop in the table viewer and caused glue to hang if too many incompatible subsets were in a table viewer