### PR TITLE
Make Qt-related plugins optional in load_plugins

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,10 @@ v0.16.0 (unreleased)
 
 * Improved ``IndexedData`` so that world coordinates can now be shown. [#2081]
 
+* Make loading Qt plugins optional when calling ``load_plugins``. [#2112]
+
+* Preserve ``RectangularROI`` rather than converting them to ``PolygonalROI``. [#2112]
+
 v0.15.7 (2020-03-12)
 --------------------
 

--- a/glue/app/qt/application.py
+++ b/glue/app/qt/application.py
@@ -290,7 +290,7 @@ class GlueApplication(Application, QtWidgets.QMainWindow):
 
         # Even though we loaded the plugins in start_glue, we re-load them here
         # in case glue was started directly by initializing this class.
-        load_plugins()
+        load_plugins(require_qt_plugins=True)
 
         self.setWindowTitle("Glue")
         self.setWindowIcon(icon)

--- a/glue/core/roi.py
+++ b/glue/core/roi.py
@@ -270,8 +270,8 @@ class RectangularROI(Roi):
 
     @classmethod
     def __setgluestate__(cls, rec, context):
-        return cls(xmin=rec['xmin'], xmax=rec['xmax'],
-                   ymin=rec['ymin'], ymax=rec['ymax'])
+        return cls(xmin=context.object(rec['xmin']), xmax=context.object(rec['xmax']),
+                   ymin=context.object(rec['ymin']), ymax=context.object(rec['ymax']))
 
 
 class RangeROI(Roi):

--- a/glue/core/subset.py
+++ b/glue/core/subset.py
@@ -1949,7 +1949,7 @@ def roi_to_subset_state(roi, x_att=None, y_att=None, x_categories=None, y_catego
 
         # The selection is polygon-like and components are numerical
 
-        if not isinstance(roi, (PolygonalROI, CircularROI, EllipticalROI)):
+        if not isinstance(roi, (PolygonalROI, RectangularROI, CircularROI, EllipticalROI)):
             roi = PolygonalROI(*roi.to_polygon())
 
         subset_state = RoiSubsetState()

--- a/glue/main.py
+++ b/glue/main.py
@@ -153,7 +153,7 @@ def start_glue(gluefile=None, config=None, datafiles=None, maximized=True,
     # Start off by loading plugins. We need to do this before restoring
     # the session or loading the configuration since these may use existing
     # plugins.
-    load_plugins(splash=splash)
+    load_plugins(splash=splash, require_qt_plugins=True)
 
     from glue.app.qt import GlueApplication
 
@@ -262,17 +262,19 @@ def main(argv=sys.argv):
 _loaded_plugins = set()
 _installed_plugins = set()
 
-REQUIRED_PLUGINS = ['glue.plugins.tools.pv_slicer',
-                    'glue.plugins.coordinate_helpers',
-                    'glue.viewers.image',
-                    'glue.viewers.scatter',
-                    'glue.viewers.histogram',
-                    'glue.viewers.table',
+REQUIRED_PLUGINS = ['glue.plugins.coordinate_helpers',
                     'glue.core.data_exporters',
                     'glue.io.formats.fits']
 
 
-def load_plugins(splash=None):
+REQUIRED_PLUGINS_QT = ['glue.plugins.tools.pv_slicer.qt',
+                       'glue.viewers.image.qt',
+                       'glue.viewers.scatter.qt',
+                       'glue.viewers.histogram.qt',
+                       'glue.viewers.table.qt']
+
+
+def load_plugins(splash=None, require_qt_plugins=False):
 
     # Search for plugins installed via entry_points. Basically, any package can
     # define plugins for glue, and needs to define an entry point using the
@@ -331,6 +333,8 @@ def load_plugins(splash=None):
             # Here we check that some of the 'core' plugins load well and
             # raise an actual exception if not.
             if item.module_name in REQUIRED_PLUGINS:
+                raise
+            elif item.module_name in REQUIRED_PLUGINS_QT and require_qt_plugins:
                 raise
             else:
                 logger.info("Loading plugin {0} failed "

--- a/glue/plugins/tools/pv_slicer/__init__.py
+++ b/glue/plugins/tools/pv_slicer/__init__.py
@@ -1,4 +1,0 @@
-def setup():
-    from glue.viewers.image.qt import ImageViewer
-    from glue.plugins.tools.pv_slicer.qt import PVSlicerMode  # noqa
-    ImageViewer.tools.append('slice')

--- a/glue/plugins/tools/pv_slicer/qt/__init__.py
+++ b/glue/plugins/tools/pv_slicer/qt/__init__.py
@@ -1,1 +1,7 @@
 from .pv_slicer import *  # noqa
+
+
+def setup():
+    from glue.viewers.image.qt import ImageViewer
+    from glue.plugins.tools.pv_slicer.qt import PVSlicerMode  # noqa
+    ImageViewer.tools.append('slice')

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ install_requires =
 [options.entry_points]
 glue.plugins =
     export_d3po = glue.plugins.export_d3po:setup
-    pv_slicer = glue.plugins.tools.pv_slicer:setup
+    pv_slicer = glue.plugins.tools.pv_slicer.qt:setup
     coordinate_helpers = glue.plugins.coordinate_helpers:setup
     wcs_autolinking = glue.plugins.wcs_autolinking:setup
     dendro_factory = glue.plugins.dendro_viewer:setup


### PR DESCRIPTION
@nmearl - this should make ``load_plugins`` ignore the Qt plugins if Qt is not installed.