### PR TITLE
Fixed missing .units on CoordinateComponent

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,8 @@ v0.16.0 (unreleased)
 
 * Improve performance of profile viewer when not all layers are visible. [#2115]
 
+* Fixed missing .units on ``CoordinateComponent``. [#2117]
+
 v0.15.7 (2020-03-12)
 --------------------
 

--- a/glue/core/component.py
+++ b/glue/core/component.py
@@ -197,7 +197,6 @@ class CoordinateComponent(Component):
     """
 
     def __init__(self, data, axis, world=False):
-        super(CoordinateComponent, self).__init__(None, None)
         self.world = world
         self._data = data
         self.axis = axis
@@ -205,6 +204,13 @@ class CoordinateComponent(Component):
     @property
     def data(self):
         return self._calculate()
+
+    @property
+    def units(self):
+        if self.world:
+            return self._data.coords.world_axis_units[self._data.ndim - 1 - self.axis]
+        else:
+            return ''
 
     def _calculate(self, view=None):
 

--- a/glue/core/data_factories/tests/test_fits.py
+++ b/glue/core/data_factories/tests/test_fits.py
@@ -212,3 +212,19 @@ def test_save_meta():
     from glue.core.tests.test_state import clone
     data = df.load_data(os.path.join(DATA, 'comment.fits'))
     clone(data)
+
+
+@requires_astropy
+def test_coordinate_component_units():
+    # Regression test for a bug that caused units to be missing from coordinate
+    # components.
+    d = df.load_data(os.path.join(DATA, 'casalike.fits'), factory=df.casalike_cube)
+    wid = d.world_component_ids
+    assert wid[0].label == 'Stokes'
+    assert d.get_component(wid[0]).units == ''
+    assert wid[1].label == 'Vopt'
+    assert d.get_component(wid[1]).units == 'm s-1'
+    assert wid[2].label == 'Declination'
+    assert d.get_component(wid[2]).units == 'deg'
+    assert wid[3].label == 'Right Ascension'
+    assert d.get_component(wid[3]).units == 'deg'


### PR DESCRIPTION
This was an oversight, we should pull in the units from the WCS