### PR TITLE
Implement callback property for dictionaries

### DIFF
--- a/glue/core/state_objects.py
+++ b/glue/core/state_objects.py
@@ -6,7 +6,8 @@ import numpy as np
 
 from glue.core import Subset
 from glue.external.echo import (delay_callback, CallbackProperty,
-                                HasCallbackProperties, CallbackList)
+                                HasCallbackProperties, CallbackList,
+                                CallbackDict)
 from glue.core.state import saver, loader
 from glue.core.component_id import PixelComponentID
 
@@ -22,6 +23,17 @@ def _save_callback_list(items, context):
 @loader(CallbackList)
 def _load_callback_list(rec, context):
     return [context.object(obj) for obj in rec['values']]
+
+
+@saver(CallbackDict)
+def _save_callback_dict(items, context):
+    return {'values': [context.id(item) for item in items.items()]}
+
+
+@loader(CallbackDict)
+def _load_callback_dict(rec, context):
+    return {context.object(obj)[0]: context.object(obj)[1]
+            for obj in rec['values']}
 
 
 class State(HasCallbackProperties):

--- a/glue/external/echo/__init__.py
+++ b/glue/external/echo/__init__.py
@@ -1,3 +1,4 @@
 from .core import *  # noqa
 from .list import *  # noqa
 from .selection import *  # noqa
+from .dict import *  # noqa

--- a/glue/external/echo/dict.py
+++ b/glue/external/echo/dict.py
@@ -60,11 +60,6 @@ class CallbackDict(dict):
 
         return result
 
-    def __setattr__(self, *args, **kwargs):
-        super().__setattr__(*args, **kwargs)
-
-        self.callback()
-
     def __delattr__(self, *args):
         super().__delattr__(*args)
 

--- a/glue/external/echo/dict.py
+++ b/glue/external/echo/dict.py
@@ -8,6 +8,7 @@ class CallbackDict(dict):
     The first argument should be the callback function (which takes no
     arguments), and subsequent arguments are passed to `dict`.
     """
+
     def __init__(self, callback, *args, **kwargs):
         super(CallbackDict, self).__init__(*args, **kwargs)
 
@@ -60,6 +61,11 @@ class CallbackDict(dict):
 
         return result
 
+    def __setitem__(self, k, v):
+        super().__setitem__(k, v)
+
+        self.callback()
+
     def __delattr__(self, *args):
         super().__delattr__(*args)
 
@@ -84,8 +90,8 @@ class DictCallbackProperty(CallbackProperty):
             raise TypeError("Callback property should be a dictionary.")
 
         def callback(*args, **kwargs):
-            self.notify(instance, wrapped_list, wrapped_list)
+            self.notify(instance, wrapped_dict, wrapped_dict)
 
-        wrapped_list = CallbackDict(callback, value)
+        wrapped_dict = CallbackDict(callback, value)
 
-        super()._default_setter(instance, wrapped_list)
+        super()._default_setter(instance, wrapped_dict)

--- a/glue/external/echo/dict.py
+++ b/glue/external/echo/dict.py
@@ -80,7 +80,7 @@ class DictCallbackProperty(CallbackProperty):
     """
     def _default_getter(self, instance, owner=None):
         if instance not in self._values:
-            self._default_setter(instance, [])
+            self._default_setter(instance, {})
         return super()._default_getter(instance, owner)
 
     def _default_setter(self, instance, value):

--- a/glue/external/echo/dict.py
+++ b/glue/external/echo/dict.py
@@ -1,0 +1,96 @@
+from . import CallbackProperty, HasCallbackProperties
+
+
+class CallbackDict(dict):
+    """
+    A dictionary that calls a callback function when it is modified.
+
+    The first argument should be the callback function (which takes no
+    arguments), and subsequent arguments are passed to `dict`.
+    """
+    def __init__(self, callback, *args, **kwargs):
+        super(CallbackDict, self).__init__(*args, **kwargs)
+
+        self.callback = callback
+
+    def clear(self):
+        super().clear()
+
+        self.callback()
+
+    def popitem(self):
+        result = super().popitem()
+
+        if isinstance(result, HasCallbackProperties):
+            result.remove_global_callback(self.callback)
+
+        self.callback()
+
+        return result
+
+    def setdefault(self, *args, **kwargs):
+        key = super().setdefault(*args, **kwargs)
+
+        if isinstance(key, HasCallbackProperties):
+            key.remove_global_callback(self.callback)
+
+        self.callback()
+
+        return key
+
+    def update(self, *args, **kwargs):
+        super().update(*args, **kwargs)
+
+        self.callback()
+
+    def pop(self, *args, **kwargs):
+        result = super().pop(*args, **kwargs)
+
+        if isinstance(result, HasCallbackProperties):
+            result.remove_global_callback(self.callback)
+
+        self.callback()
+
+        return result
+
+    def __reversed__(self):
+        result = super().__reversed__()
+
+        self.callback()
+
+        return result
+
+    def __setattr__(self, *args, **kwargs):
+        super().__setattr__(*args, **kwargs)
+
+        self.callback()
+
+    def __delattr__(self, *args):
+        super().__delattr__(*args)
+
+        self.callback()
+
+    def __repr__(self):
+        return f"<CallbackDict with {len(self)} elements>"
+
+
+class DictCallbackProperty(CallbackProperty):
+    """
+    A dictionary property that calls callbacks when its contents are modified
+    """
+    def _default_getter(self, instance, owner=None):
+        if instance not in self._values:
+            self._default_setter(instance, [])
+        return super()._default_getter(instance, owner)
+
+    def _default_setter(self, instance, value):
+
+        if not isinstance(value, dict):
+            raise TypeError("Callback property should be a dictionary.")
+
+        def callback(*args, **kwargs):
+            self.notify(instance, wrapped_list, wrapped_list)
+
+        wrapped_list = CallbackDict(callback, value)
+
+        super()._default_setter(instance, wrapped_list)


### PR DESCRIPTION
This PR implements a callback property for dictionary objects analogous to the list callback property currently existing. This would allow changes to complex nested dictionary structures to notify listeners of changes to the internal data, especially useful in conjunction with the glue-jupyter project.