### PR TITLE
Add new registry to apply in-place patches to the session file

### DIFF
--- a/doc/customizing_guide/customization.rst
+++ b/doc/customizing_guide/customization.rst
@@ -515,6 +515,29 @@ using
                                       format='my-serialized-format')
     "a > 3"
 
+Custom session patch
+--------------------
+
+Adding new features and keeping backward compatibility is hard. Because the
+features of glue, and/or its plugins changes over time, old but tprecious
+sessions files might not open anymore. To solve this problem, custom patch
+functions can be provided to edit *in-place* the session file, just after it
+is loaded. These patch functions should take a loaded session file (as a dict),
+detect if it is invalid, and if so correct the problem, e.g.::
+
+    from glue.config import subset_definition_translator
+
+    @session_patch(priority=0)
+    def correct_bad_version_plugin(session_obj):
+        # if problem:
+            # correct problem
+
+        ...
+
+        return
+
+
+
 Complete list of registries
 ---------------------------
 
@@ -545,6 +568,7 @@ Registry name                  Registry class
 ``autolinker``               :class:`glue.config.AutoLinkerRegistry`
 ``data_translator``          :class:`glue.config.DataTranslatorRegistry`
 ``subset_state_translator``  :class:`glue.config.SubsetDefinitionTranslatorRegistry`
+``session_patch``            :class:`glue.config.SessionPatchRegistry`
 =========================== =========================================================
 
 .. _lazy_load_plugin:

--- a/doc/customizing_guide/customization.rst
+++ b/doc/customizing_guide/customization.rst
@@ -519,7 +519,7 @@ Custom session patch
 --------------------
 
 Adding new features and keeping backward compatibility is hard. Because the
-features of glue, and/or its plugins changes over time, old but tprecious
+features of glue, and/or its plugins changes over time, old but precious
 sessions files might not open anymore. To solve this problem, custom patch
 functions can be provided to edit *in-place* the session file, just after it
 is loaded. These patch functions should take a loaded session file (as a dict),

--- a/doc/customizing_guide/scripts/coord_convert.py
+++ b/doc/customizing_guide/scripts/coord_convert.py
@@ -1,9 +1,11 @@
 from glue.config import link_function
 
+
 @link_function(info="Celsius to Fahrenheit",
                output_labels=['F'])
 def celsius2farhenheit(c):
     return c * 9. / 5. + 32
+
 
 @link_function(info="Fahrenheit to Celsius",
                output_labels=['C'])

--- a/glue/core/tests/test_state.py
+++ b/glue/core/tests/test_state.py
@@ -8,6 +8,7 @@ from numpy.testing import assert_equal
 from glue import core
 from glue.core.component import CategoricalComponent, DateTimeComponent
 from glue.tests.helpers import requires_astropy, make_file
+from glue.config import session_patch
 
 from ..data_factories import load_data
 from ..data_factories.tests.test_fits import TEST_FITS_DATA
@@ -99,6 +100,19 @@ def test_data_style():
     d.style.color = 'blue'
     d2 = clone(d)
     assert d2.style.color == 'blue'
+
+
+def test_user_patch_is_called():
+    @session_patch()
+    def a_patch(session):
+        session["__main__"]["label"] = 'has_changed'
+
+    d = core.Data(x=[1, 2, 3], label='testing')
+    d2 = clone(d)
+
+    session_patch._members.pop(-1)  # clean registry
+
+    assert d2.label == 'has_changed'
 
 
 @requires_astropy


### PR DESCRIPTION
This PR adds a new registry to apply in-place patches to the session file, as discussed in #2120 

I needed it so I implemented it, but it might also be useful for #2126, so I share it.
Some tests and documentation have been added.

The syntax in the config.py file is :

```
@session_patch(priority=0)
def fix_Session_file(session_object):
    pass
```
