### PR TITLE
Add a preferred_cmap attribute to visual.py

### DIFF
--- a/glue/core/registry.py
+++ b/glue/core/registry.py
@@ -37,7 +37,7 @@ class Registry(object):
         self._disable = False
 
     def register(self, obj, label, group=None):
-        """ Register label with object (possibly disamgiguating)
+        """ Register label with object (possibly disambiguating)
 
         :param obj: The object to label
         :param label: The desired label

--- a/glue/core/state.py
+++ b/glue/core/state.py
@@ -709,6 +709,8 @@ def _save_style(style, context):
 @loader(VisualAttributes)
 def _load_style(rec, context):
     result = VisualAttributes()
+    if 'preferred_cmap' in result._atts:
+        result._atts.remove('preferred_cmap')
     for attr in result._atts:
         setattr(result, attr, rec[attr])
     return result

--- a/glue/core/visual.py
+++ b/glue/core/visual.py
@@ -1,6 +1,8 @@
 from matplotlib.colors import ColorConverter
+from matplotlib.cm import get_cmap
 
 from glue.config import settings
+
 from echo import callback_property, HasCallbackProperties
 
 # Define acceptable line styles
@@ -25,7 +27,7 @@ class VisualAttributes(HasCallbackProperties):
 
     """
 
-    def __init__(self, parent=None, washout=False, color=None, alpha=None):
+    def __init__(self, parent=None, washout=False, color=None, alpha=None, preferred_cmap=None):
 
         super(VisualAttributes, self).__init__()
 
@@ -36,9 +38,10 @@ class VisualAttributes(HasCallbackProperties):
 
         self.parent = parent
         self._atts = ['color', 'alpha', 'linewidth', 'linestyle', 'marker',
-                      'markersize']
+                      'markersize', 'preferred_cmap']
         self.color = color
         self.alpha = alpha
+        self.preferred_cmap = preferred_cmap
         self.linewidth = 1
         self.linestyle = 'solid'
         self.marker = 'o'
@@ -93,6 +96,20 @@ class VisualAttributes(HasCallbackProperties):
             self._color = value.lower()
         else:
             self._color = value
+
+    @callback_property
+    def preferred_cmap(self):
+        """
+        A preferred colormap specified using Matplotlib notation
+        """
+        return self._preferred_cmap
+
+    @preferred_cmap.setter
+    def preferred_cmap(self, value):
+        if isinstance(value, str):
+            self._preferred_cmap = get_cmap(value)
+        else:
+            self._preferred_cmap = value
 
     @callback_property
     def alpha(self):
@@ -163,7 +180,8 @@ class VisualAttributes(HasCallbackProperties):
 
         # Check that the attribute exists (don't allow new attributes)
         allowed = set(['color', 'linewidth', 'linestyle',
-                       'alpha', 'parent', 'marker', 'markersize'])
+                       'alpha', 'parent', 'marker', 'markersize',
+                       'preferred_cmap'])
         if attribute not in allowed and not attribute.startswith('_'):
             raise Exception("Attribute %s does not exist" % attribute)
 

--- a/glue/viewers/image/state.py
+++ b/glue/viewers/image/state.py
@@ -87,9 +87,9 @@ class ImageViewerState(MatplotlibDataViewerState):
                                             'which the images are shown')
     slices = DDCProperty(docstring='The current slice along all dimensions')
     color_mode = DDSCProperty(0, docstring='Whether each layer can have '
-                                                    'its own colormap (``Colormaps``) or '
-                                                    'whether each layer is assigned '
-                                                    'a single color (``One color per layer``)')
+                                           'its own colormap (``Colormaps``) or '
+                                           'whether each layer is assigned '
+                                           'a single color (``One color per layer``)')
 
     dpi = DDCProperty(72, docstring='The resolution (in dots per inch) of density maps, if present')
 
@@ -544,7 +544,7 @@ class ImageLayerState(BaseImageLayerState):
         self.update_from_dict(kwargs)
 
         if self.cmap is None:
-            self.cmap = colormaps.members[0][1]
+            self.cmap = self.layer.style.preferred_cmap or colormaps.members[0][1]
 
     def _update_attribute(self, *args):
         if self.layer is not None:


### PR DESCRIPTION
<!--# Pull Request Template-->

## Description

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.-->

To enable the addition of a `preferred_cmap` attribute so that if this parameter is set a `matplotlib.colors.Colormap` object can be used as the colormap setting of the `2D image`.
