### PR TITLE
MNT: Ignore import error in pytest collection

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -110,7 +110,7 @@ glue.viewers.scatter.qt.tests = data/*.glu
 ignore = E501,E731,F841,E127,E741,E402,W504,W605
 
 [tool:pytest]
-addopts=-p no:logging
+addopts=-p no:logging --doctest-ignore-import-errors
 flake8-ignore = E501,E731,F841,E127,E741,E402,W504,W605
 filterwarnings =
     ignore::PendingDeprecationWarning:xlrd


### PR DESCRIPTION
This is an automated update made by the `batchpr` tool :robot: to future-proof test collection behavior `pytest-doctestplus` - feel free to close if it doesn't look good or isn't relevant! You can report issues to @pllim.