### PR TITLE
Add support for dask arrays and improve how image limits are determined with big datasets in mind

### DIFF
--- a/glue/core/component.py
+++ b/glue/core/component.py
@@ -7,6 +7,11 @@ from glue.core.coordinate_helpers import dependent_axes, pixel2world_single_axis
 from glue.utils import (shape_to_string, coerce_numeric,
                         broadcast_to, categorical_ndarray)
 
+try:
+    import dask.array as da
+    DASK_INSTALLED = True
+except ImportError:
+    DASK_INSTALLED = False
 
 __all__ = ['Component', 'DerivedComponent', 'CategoricalComponent',
            'CoordinateComponent', 'DateTimeComponent']
@@ -131,6 +136,10 @@ class Component(object):
 
         :returns: A Component (or subclass)
         """
+
+        if DASK_INSTALLED and isinstance(data, da.Array):
+            return DaskComponent(data, units=units)
+
         data = np.asarray(data)
 
         if np.issubdtype(data.dtype, np.object_):
@@ -472,3 +481,52 @@ class DateTimeComponent(Component):
     @property
     def datetime(self):
         return True
+
+
+class DaskComponent(Component):
+    """
+    A data component powered by a dask array.
+    """
+
+    def __init__(self, data, units=None):
+        print("IN DASK")
+        self._data = data
+        self.units = units
+
+    @property
+    def units(self):
+        return self._units
+
+    @units.setter
+    def units(self, value):
+        if value is None:
+            self._units = ''
+        else:
+            self._units = str(value)
+
+    @property
+    def data(self):
+        return self._data
+
+    @property
+    def shape(self):
+        return self._data.shape
+
+    @property
+    def ndim(self):
+        return len(self._data.shape)
+
+    def __getitem__(self, key):
+        return self._data[key].compute()
+
+    @property
+    def numeric(self):
+        return True
+
+    @property
+    def categorical(self):
+        return False
+
+    @property
+    def datetime(self):
+        return False

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -1595,6 +1595,11 @@ class Data(BaseCartesianData):
             chunks with at most this size.
         """
 
+        print('statistic', statistic, view)
+
+        if view is Ellipsis or view is None:
+            raise Exception("WHENCE?")
+
         # TODO: generalize chunking to more types of axis
 
         if (view is None and
@@ -1674,11 +1679,18 @@ class Data(BaseCartesianData):
             data = unbroadcast(data)
 
         if random_subset and data.size > random_subset:
-            if not hasattr(self, '_random_subset_indices') or self._random_subset_indices[0] != data.size:
-                self._random_subset_indices = (data.size, np.random.randint(0, data.size, random_subset))
-            data = data.ravel(order="K")[self._random_subset_indices[1]]
-            if mask is not None:
-                mask = mask.ravel(order="K")[self._random_subset_indices[1]]
+            if isinstance(data, np.ndarray):
+                if not hasattr(self, '_random_subset_indices') or self._random_subset_indices[0] != data.size:
+                    self._random_subset_indices = (data.size, np.random.randint(0, data.size, random_subset))
+                data = data.ravel(order="K")[self._random_subset_indices[1]]
+                if mask is not None:
+                    mask = mask.ravel(order="K")[self._random_subset_indices[1]]
+            else:
+                if not hasattr(self, '_random_subset_indices') or self._random_subset_indices[0] != data.size:
+                    self._random_subset_indices = (data.size, np.random.randint(0, data.size, random_subset))
+                data = data.ravel()[self._random_subset_indices[1]]
+                if mask is not None:
+                    mask = mask.ravel()[self._random_subset_indices[1]]
 
         return compute_statistic(statistic, data, mask=mask, axis=axis, finite=finite,
                                  positive=positive, percentile=percentile)

--- a/glue/core/state_objects.py
+++ b/glue/core/state_objects.py
@@ -287,7 +287,7 @@ class StateAttributeLimitsHelper(StateAttributeCacheHelper):
     """
 
     values_names = ('lower', 'upper')
-    modifiers_names = ('log', 'percentile', 'view')
+    modifiers_names = ('log', 'percentile')
 
     def __init__(self, state, attribute, random_subset=10000, margin=0, **kwargs):
 
@@ -311,24 +311,25 @@ class StateAttributeLimitsHelper(StateAttributeCacheHelper):
 
     def update_values(self, force=False, use_default_modifiers=False, **properties):
 
-        if not force and not any(prop in properties for prop in ('attribute', 'percentile', 'log', 'view')):
+        if not force and not any(prop in properties for prop in ('attribute', 'percentile', 'log')):
             self.set(percentile='Custom')
             return
 
         if use_default_modifiers:
             percentile = 100
             log = False
-            view = None
         else:
             percentile = getattr(self, 'percentile', None) or 100
             log = getattr(self, 'log', None) or False
-            view = getattr(self, 'view', None)
 
-        print(percentile, log, view)
+        if isinstance(percentile, tuple):
+            percentile, view = percentile
+        else:
+            view = None
 
         if not force and (percentile == 'Custom' or not hasattr(self, 'data') or self.data is None):
 
-            self.set(percentile=percentile, log=log, view=view)
+            self.set(percentile=percentile, log=log)
 
         else:
 
@@ -336,7 +337,7 @@ class StateAttributeLimitsHelper(StateAttributeCacheHelper):
             if isinstance(self.component_id, PixelComponentID) and percentile == 100 and not log:
                 lower = -0.5
                 upper = self.data.shape[self.component_id.axis] - 0.5
-                self.set(lower=lower, upper=upper, percentile=percentile, log=log, view=view)
+                self.set(lower=lower, upper=upper, percentile=percentile, log=log)
                 return
 
             exclude = (100 - percentile) / 2.
@@ -377,7 +378,7 @@ class StateAttributeLimitsHelper(StateAttributeCacheHelper):
                     lower -= value_range * self.margin
                     upper += value_range * self.margin
 
-            self.set(lower=lower, upper=upper, percentile=percentile, log=log, view=view)
+            self.set(lower=lower, upper=upper, percentile=percentile, log=log)
 
     def flip_limits(self):
         self.set(lower=self.upper, upper=self.lower)

--- a/glue/core/state_objects.py
+++ b/glue/core/state_objects.py
@@ -189,7 +189,7 @@ class StateAttributeCacheHelper(object):
             self.set(cache=False, **self._cache[self.component_id])
         else:
             # We need to compute the values for the first time
-            self.update_values(attribute=self.component_id, use_default_modifiers=True)
+            self.update_values(attribute=self.component_id)
 
     def _update_values(self, **properties):
 
@@ -310,6 +310,8 @@ class StateAttributeLimitsHelper(StateAttributeCacheHelper):
                 self._update_attribute()
 
     def update_values(self, force=False, use_default_modifiers=False, **properties):
+
+        print('use_default_modifiers', use_default_modifiers)
 
         if not force and not any(prop in properties for prop in ('attribute', 'percentile', 'log')):
             self.set(percentile='Custom')

--- a/glue/core/state_objects.py
+++ b/glue/core/state_objects.py
@@ -378,6 +378,9 @@ class StateAttributeLimitsHelper(StateAttributeCacheHelper):
                     lower -= value_range * self.margin
                     upper += value_range * self.margin
 
+            if view is not None:
+                percentile = (percentile, view)
+
             self.set(lower=lower, upper=upper, percentile=percentile, log=log)
 
     def flip_limits(self):

--- a/glue/core/tests/test_state_objects.py
+++ b/glue/core/tests/test_state_objects.py
@@ -183,6 +183,57 @@ class TestStateAttributeLimitsHelper():
         assert self.helper.upper == 234
         assert self.helper.log
 
+    def test_view(self):
+
+        data = Data(x=np.arange(24).reshape(2, 3, 4),
+                    y=np.arange(24).reshape(2, 3, 4) + 24, label='test_data')
+
+        data_collection = DataCollection([data])
+
+        class SimpleViewState(State):
+
+            layer = CallbackProperty()
+            comp = CallbackProperty()
+            lower = CallbackProperty()
+            upper = CallbackProperty()
+            array_view = CallbackProperty()
+
+        state = SimpleViewState()
+
+        helper = StateAttributeLimitsHelper(state, attribute='comp',
+                                            lower='lower', upper='upper',
+                                            view='array_view')
+        state.data = data
+        state.comp = data.id['x']
+
+        assert helper.lower == 0
+        assert helper.upper == 23
+
+        state.array_view = [slice(0, 1), slice(0, 1), slice(0, 1)]
+
+        assert helper.lower == 0
+        assert helper.upper == 0
+
+        state.array_view = [slice(1, 2), slice(None), slice(None)]
+
+        assert helper.lower == 12
+        assert helper.upper == 23
+
+        state.comp = data.id['y']
+
+        assert helper.lower == 24
+        assert helper.upper == 47
+
+        state.array_view = [slice(0, 1), slice(0, 1), slice(0, 1)]
+
+        assert helper.lower == 24
+        assert helper.upper == 24
+
+        state.comp = data.id['x']
+
+        assert helper.lower == 12
+        assert helper.upper == 23
+
 
 class TestStateAttributeSingleValueHelper():
 

--- a/glue/core/tests/test_state_objects.py
+++ b/glue/core/tests/test_state_objects.py
@@ -185,54 +185,47 @@ class TestStateAttributeLimitsHelper():
 
     def test_view(self):
 
+        # Test option that allows a view to be optionally specified with the
+        # percentile.
+
         data = Data(x=np.arange(24).reshape(2, 3, 4),
                     y=np.arange(24).reshape(2, 3, 4) + 24, label='test_data')
 
-        data_collection = DataCollection([data])
+        self.state.data = data
+        self.state.comp = data.id['x']
 
-        class SimpleViewState(State):
+        assert self.helper.lower == 0
+        assert self.helper.upper == 23
 
-            layer = CallbackProperty()
-            comp = CallbackProperty()
-            lower = CallbackProperty()
-            upper = CallbackProperty()
-            array_view = CallbackProperty()
+        self.state.scale = (100, [slice(0, 1), slice(0, 1), slice(0, 1)])
 
-        state = SimpleViewState()
+        assert self.helper.lower == 0
+        assert self.helper.upper == 0
 
-        helper = StateAttributeLimitsHelper(state, attribute='comp',
-                                            lower='lower', upper='upper',
-                                            view='array_view')
-        state.data = data
-        state.comp = data.id['x']
+        self.state.scale = (100, [slice(1, 2), slice(None), slice(None)])
 
-        assert helper.lower == 0
-        assert helper.upper == 23
+        assert self.helper.lower == 12
+        assert self.helper.upper == 23
 
-        state.array_view = [slice(0, 1), slice(0, 1), slice(0, 1)]
+        self.state.comp = data.id['y']
 
-        assert helper.lower == 0
-        assert helper.upper == 0
+        assert self.helper.lower == 24
+        assert self.helper.upper == 47
 
-        state.array_view = [slice(1, 2), slice(None), slice(None)]
+        self.state.scale = (100, [slice(0, 1), slice(0, 1), slice(0, 1)])
 
-        assert helper.lower == 12
-        assert helper.upper == 23
+        assert self.helper.lower == 24
+        assert self.helper.upper == 24
 
-        state.comp = data.id['y']
+        self.state.comp = data.id['x']
 
-        assert helper.lower == 24
-        assert helper.upper == 47
+        assert self.helper.lower == 12
+        assert self.helper.upper == 23
 
-        state.array_view = [slice(0, 1), slice(0, 1), slice(0, 1)]
+        self.state.scale = (90, [slice(1, 2), slice(None), slice(None)])
 
-        assert helper.lower == 24
-        assert helper.upper == 24
-
-        state.comp = data.id['x']
-
-        assert helper.lower == 12
-        assert helper.upper == 23
+        assert self.helper.lower == 12.55
+        assert self.helper.upper == 22.45
 
 
 class TestStateAttributeSingleValueHelper():

--- a/glue/utils/array.py
+++ b/glue/utils/array.py
@@ -23,7 +23,7 @@ def unbroadcast(array):
     for more details.
     """
 
-    if array.ndim == 0:
+    if array.ndim == 0 or not hasattr(array, 'strides'):
         return array
 
     new_shape = np.where(np.array(array.strides) == 0, 1, array.shape)


### PR DESCRIPTION
This PR adds initial support for Dask datasets by adding a ``DaskComponent`` class, and also makes it so the image viewer defaults to using the first slice of a cube to determine the limits rather than a random set of pixels in the whole cube.

I'm not fully happy with this yet - it's very image-viewer-centric and doesn't really solve the issue of using other viewers with large Dask arrays. I'm also not a big fan of changing the current limits behavior for plain Numpy arrays which do support fancy indexing since the random sampling for limits has worked well until now.

I'll have a think to see if I can find a better method...

This requires https://github.com/glue-viz/echo/pull/26
