### PR TITLE
Improve efficiency of image viewer when using dask arrays

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ Full changelog
 v0.16.0 (unreleased)
 --------------------
 
+* Initial support for dask arrays. [#2137]
+
 * Don't sync color and transparency of image layers by default. [#2116]
 
 * Python 2.7 and 3.5 are no longer supported. [#2075]

--- a/doc/customizing_guide/scripts/coord_convert.py
+++ b/doc/customizing_guide/scripts/coord_convert.py
@@ -1,9 +1,11 @@
 from glue.config import link_function
 
+
 @link_function(info="Celsius to Fahrenheit",
                output_labels=['F'])
 def celsius2farhenheit(c):
     return c * 9. / 5. + 32
+
 
 @link_function(info="Fahrenheit to Celsius",
                output_labels=['C'])

--- a/glue/core/component.py
+++ b/glue/core/component.py
@@ -333,7 +333,7 @@ class CoordinateComponent(Component):
             slices = [slice(0, s, 1) for s in self.shape]
             grids = np.broadcast_arrays(*np.ogrid[slices])
             if view is not None:
-                grids = [g[view] for g in grids]
+                grids = [g[tuple(view)] for g in grids]
             return grids[self.axis]
 
     @property

--- a/glue/core/component.py
+++ b/glue/core/component.py
@@ -333,7 +333,7 @@ class CoordinateComponent(Component):
             slices = [slice(0, s, 1) for s in self.shape]
             grids = np.broadcast_arrays(*np.ogrid[slices])
             if view is not None:
-                grids = [g[tuple(view)] for g in grids]
+                grids = [g[view] for g in grids]
             return grids[self.axis]
 
     @property

--- a/glue/core/component.py
+++ b/glue/core/component.py
@@ -7,6 +7,11 @@ from glue.core.coordinate_helpers import dependent_axes, pixel2world_single_axis
 from glue.utils import (shape_to_string, coerce_numeric,
                         broadcast_to, categorical_ndarray)
 
+try:
+    import dask.array as da
+    DASK_INSTALLED = True
+except ImportError:
+    DASK_INSTALLED = False
 
 __all__ = ['Component', 'DerivedComponent', 'CategoricalComponent',
            'CoordinateComponent', 'DateTimeComponent']
@@ -131,6 +136,10 @@ class Component(object):
 
         :returns: A Component (or subclass)
         """
+
+        if DASK_INSTALLED and isinstance(data, da.Array):
+            return DaskComponent(data, units=units)
+
         data = np.asarray(data)
 
         if np.issubdtype(data.dtype, np.object_):
@@ -472,3 +481,52 @@ class DateTimeComponent(Component):
     @property
     def datetime(self):
         return True
+
+
+class DaskComponent(Component):
+    """
+    A data component powered by a dask array.
+    """
+
+    def __init__(self, data, units=None):
+        print("IN DASK")
+        self._data = data
+        self.units = units
+
+    @property
+    def units(self):
+        return self._units
+
+    @units.setter
+    def units(self, value):
+        if value is None:
+            self._units = ''
+        else:
+            self._units = str(value)
+
+    @property
+    def data(self):
+        return self._data
+
+    @property
+    def shape(self):
+        return self._data.shape
+
+    @property
+    def ndim(self):
+        return len(self._data.shape)
+
+    def __getitem__(self, key):
+        return self._data[key].compute()
+
+    @property
+    def numeric(self):
+        return True
+
+    @property
+    def categorical(self):
+        return False
+
+    @property
+    def datetime(self):
+        return False

--- a/glue/core/component.py
+++ b/glue/core/component.py
@@ -489,7 +489,6 @@ class DaskComponent(Component):
     """
 
     def __init__(self, data, units=None):
-        print("IN DASK")
         self._data = data
         self.units = units
 

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -1595,6 +1595,11 @@ class Data(BaseCartesianData):
             chunks with at most this size.
         """
 
+        print('statistic', statistic, view)
+
+        if view is Ellipsis or view is None:
+            raise Exception("WHENCE?")
+
         # TODO: generalize chunking to more types of axis
 
         if (view is None and
@@ -1674,11 +1679,18 @@ class Data(BaseCartesianData):
             data = unbroadcast(data)
 
         if random_subset and data.size > random_subset:
-            if not hasattr(self, '_random_subset_indices') or self._random_subset_indices[0] != data.size:
-                self._random_subset_indices = (data.size, np.random.randint(0, data.size, random_subset))
-            data = data.ravel(order="K")[self._random_subset_indices[1]]
-            if mask is not None:
-                mask = mask.ravel(order="K")[self._random_subset_indices[1]]
+            if isinstance(data, np.ndarray):
+                if not hasattr(self, '_random_subset_indices') or self._random_subset_indices[0] != data.size:
+                    self._random_subset_indices = (data.size, np.random.randint(0, data.size, random_subset))
+                data = data.ravel(order="K")[self._random_subset_indices[1]]
+                if mask is not None:
+                    mask = mask.ravel(order="K")[self._random_subset_indices[1]]
+            else:
+                if not hasattr(self, '_random_subset_indices') or self._random_subset_indices[0] != data.size:
+                    self._random_subset_indices = (data.size, np.random.randint(0, data.size, random_subset))
+                data = data.ravel()[self._random_subset_indices[1]]
+                if mask is not None:
+                    mask = mask.ravel()[self._random_subset_indices[1]]
 
         return compute_statistic(statistic, data, mask=mask, axis=axis, finite=finite,
                                  positive=positive, percentile=percentile)

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -29,7 +29,7 @@ from glue.core.joins import get_mask_with_key_joins
 from glue.config import settings, data_translator, subset_state_translator
 from glue.utils import (compute_statistic, unbroadcast, iterate_chunks,
                         datetime64_to_mpl, broadcast_to, categorical_ndarray,
-                        format_choices)
+                        format_choices, random_views_for_dask_array)
 from glue.core.coordinate_helpers import axis_label
 
 
@@ -38,6 +38,12 @@ from glue.core.coordinate_helpers import axis_label
 # file)
 from glue.core.component import Component, CoordinateComponent, DerivedComponent
 from glue.core.component_id import ComponentID, ComponentIDDict, PixelComponentID
+
+try:
+    import dask.array as da
+    DASK_INSTALLED = True
+except ImportError:
+    DASK_INSTALLED = False
 
 __all__ = ['Data', 'BaseCartesianData', 'BaseData']
 
@@ -1595,11 +1601,6 @@ class Data(BaseCartesianData):
             chunks with at most this size.
         """
 
-        print('statistic', statistic, view)
-
-        if view is Ellipsis or view is None:
-            raise Exception("WHENCE?")
-
         # TODO: generalize chunking to more types of axis
 
         if (view is None and
@@ -1615,20 +1616,25 @@ class Data(BaseCartesianData):
 
             # In the specific case where the subset state depends only on pixel
             # component IDs but not the one for the chunk iteration axis used
-            # here, we should not need to chunk.
+            # here, we should not need to chunk. However this doesn't quite
+            # work because compute_statistic still makes a copy of the data
+            # so we need to make sure we never have too large arrays there.
+            # efficient_subset_state = False
+            # if subset_state is not None:
+            #     from glue.core.link_manager import pixel_cid_to_pixel_cid_matrix
+            #     for att in subset_state.attributes:
+            #         # TODO: in principle we cold still deal with non-pixel
+            #         # componnet IDs, so this should be fixed.
+            #         if not isinstance(att, PixelComponentID):
+            #             break
+            #         matrix = pixel_cid_to_pixel_cid_matrix(att.parent, self)
+            #         if matrix[att.axis, axis_index]:
+            #             break
+            #     else:
+            #         efficient_subset_state = True
+
+            # For now, just assume we always have to chunk
             efficient_subset_state = False
-            if subset_state is not None:
-                from glue.core.link_manager import pixel_cid_to_pixel_cid_matrix
-                for att in subset_state.attributes:
-                    # TODO: in principle we cold still deal with non-pixel
-                    # componnet IDs, so this should be fixed.
-                    if not isinstance(att, PixelComponentID):
-                        break
-                    matrix = pixel_cid_to_pixel_cid_matrix(att.parent, self)
-                    if matrix[att.axis, axis_index]:
-                        break
-                else:
-                    efficient_subset_state = True
 
             if not efficient_subset_state:
 
@@ -1679,18 +1685,18 @@ class Data(BaseCartesianData):
             data = unbroadcast(data)
 
         if random_subset and data.size > random_subset:
-            if isinstance(data, np.ndarray):
+            if DASK_INSTALLED and isinstance(data, da.Array):
+                if not hasattr(self, '_random_subset_indices') or self._random_subset_indices[0] != data.size:
+                    self._random_subset_indices = (data.size, random_views_for_dask_array(data, random_subset, n_chunks=10))
+                data = np.hstack([data[slices].ravel() for slices in self._random_subset_indices[1]])
+                if mask is not None:
+                    mask = np.hstack([mask[slices].ravel() for slices in self._random_subset_indices[1]])
+            else:
                 if not hasattr(self, '_random_subset_indices') or self._random_subset_indices[0] != data.size:
                     self._random_subset_indices = (data.size, np.random.randint(0, data.size, random_subset))
                 data = data.ravel(order="K")[self._random_subset_indices[1]]
                 if mask is not None:
                     mask = mask.ravel(order="K")[self._random_subset_indices[1]]
-            else:
-                if not hasattr(self, '_random_subset_indices') or self._random_subset_indices[0] != data.size:
-                    self._random_subset_indices = (data.size, np.random.randint(0, data.size, random_subset))
-                data = data.ravel()[self._random_subset_indices[1]]
-                if mask is not None:
-                    mask = mask.ravel()[self._random_subset_indices[1]]
 
         return compute_statistic(statistic, data, mask=mask, axis=axis, finite=finite,
                                  positive=positive, percentile=percentile)

--- a/glue/core/data_factories/helpers.py
+++ b/glue/core/data_factories/helpers.py
@@ -308,6 +308,8 @@ def load_data(path, factory=None, **kwargs):
 def data_label(path):
     """Convert a file path into a data label, by stripping out
     slashes, file extensions, etc."""
+    if os.path.basename(path) == '':
+        path = os.path.dirname(path)
     _, fname = os.path.split(path)
     name, _ = os.path.splitext(fname)
     return name

--- a/glue/core/fixed_resolution_buffer.py
+++ b/glue/core/fixed_resolution_buffer.py
@@ -241,7 +241,7 @@ def compute_fixed_resolution_buffer(data, bounds, target_data=None, target_cid=N
     # array. This won't be very efficient when dealing with 3d fixed
     # resolution buffers, but it will at least work as opposed to not.
 
-    if isinstance(data, Data) and isinstance(data.get_component(target_cid), DaskComponent):
+    if target_cid is not None and isinstance(data, Data) and isinstance(data.get_component(target_cid), DaskComponent):
 
         # Extract sub-region of data first, then fetch exact coordinate values
         subregion = tuple([slice(np.nanmin(coord), np.nanmax(coord) + 1) for coord in translated_coords])

--- a/glue/core/fixed_resolution_buffer.py
+++ b/glue/core/fixed_resolution_buffer.py
@@ -1,4 +1,5 @@
 import numpy as np
+from glue.core import Data
 from glue.core.exceptions import IncompatibleDataException
 from glue.core.component import CoordinateComponent, DaskComponent
 from glue.core.coordinate_helpers import dependent_axes
@@ -240,9 +241,7 @@ def compute_fixed_resolution_buffer(data, bounds, target_data=None, target_cid=N
     # array. This won't be very efficient when dealing with 3d fixed
     # resolution buffers, but it will at least work as opposed to not.
 
-    comp = data.get_component(target_cid)
-
-    if isinstance(comp, DaskComponent):
+    if isinstance(data, Data) and isinstance(data.get_component(target_cid), DaskComponent):
 
         # Extract sub-region of data first, then fetch exact coordinate values
         subregion = tuple([slice(np.nanmin(coord), np.nanmax(coord) + 1) for coord in translated_coords])

--- a/glue/core/link_manager.py
+++ b/glue/core/link_manager.py
@@ -417,7 +417,7 @@ def pixel_cid_to_pixel_cid_matrix(data1, data2):
 
     for idim, pix_cid in enumerate(data1.pixel_component_ids):
         try:
-            pix_coords = unbroadcast(data2[pix_cid, [slice(2)] * data2.ndim])
+            pix_coords = unbroadcast(data2[pix_cid, (slice(2),) * data2.ndim])
             matrix[idim] = np.array(pix_coords.shape) == 2
         except IncompatibleAttribute:
             pass

--- a/glue/plugins/coordinate_helpers/link_helpers.py
+++ b/glue/plugins/coordinate_helpers/link_helpers.py
@@ -1,7 +1,8 @@
 # A plugin to enable link helpers for Astronomical coordinate conversions.
 
 from astropy import units as u
-from astropy.coordinates import ICRS, FK5, FK4, Galactic, Galactocentric
+from astropy.coordinates import (ICRS, FK5, FK4, Galactic, Galactocentric,
+                                 galactocentric_frame_defaults)
 
 from glue.core.link_helpers import BaseMultiLink
 from glue.config import link_helper
@@ -102,9 +103,11 @@ class GalactocentricToGalactic(BaseMultiLink):
     display = "3D Galactocentric <-> Galactic"
 
     def forwards(self, x_kpc, y_kpc, z_kpc):
-        gal = Galactocentric(x=x_kpc * u.kpc, y=y_kpc * u.kpc, z=z_kpc * u.kpc).transform_to(Galactic)
+        with galactocentric_frame_defaults.set('pre-v4.0'):
+            gal = Galactocentric(x=x_kpc * u.kpc, y=y_kpc * u.kpc, z=z_kpc * u.kpc).transform_to(Galactic)
         return gal.l.degree, gal.b.degree, gal.distance.to(u.kpc).value
 
     def backwards(self, l_deg, b_deg, d_kpc):
-        gal = Galactic(l=l_deg * u.deg, b=b_deg * u.deg, distance=d_kpc * u.kpc).transform_to(Galactocentric)
+        with galactocentric_frame_defaults.set('pre-v4.0'):
+            gal = Galactic(l=l_deg * u.deg, b=b_deg * u.deg, distance=d_kpc * u.kpc).transform_to(Galactocentric)
         return gal.x.to(u.kpc).value, gal.y.to(u.kpc).value, gal.z.to(u.kpc).value

--- a/glue/utils/array.py
+++ b/glue/utils/array.py
@@ -23,7 +23,7 @@ def unbroadcast(array):
     for more details.
     """
 
-    if array.ndim == 0:
+    if array.ndim == 0 or not hasattr(array, 'strides'):
         return array
 
     new_shape = np.where(np.array(array.strides) == 0, 1, array.shape)

--- a/glue/viewers/table/qt/tests/test_data_viewer.py
+++ b/glue/viewers/table/qt/tests/test_data_viewer.py
@@ -450,7 +450,7 @@ def test_incompatible_subset():
 
     dc.new_subset_group('test subset', data2.id['a'] > 2)
     gapp.show()
-    process_events()
+    process_events(0.5)
 
     with patch.object(viewer.layers[0], '_refresh') as refresh1:
         with patch.object(viewer.layers[1], '_refresh') as refresh2:


### PR DESCRIPTION
This is an alternative to #2136 and I find it cleaner since it is consistent with the conceptual behavior for non-dask arrays, and doesn't change anything for non-dask arrays.

More work is needed to make glue fully benefit from dask arrays, but this is a start.