### PR TITLE
Fix a bug where x_att and y_att could end up being out of sync in image viewer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -45,6 +45,8 @@ v0.16.0 (unreleased)
 v0.15.7 (2020-03-12)
 --------------------
 
+* Fix a bug where x_att and y_att could end up being out of sync in image viewer. [#2141]
+
 * Fix bug that caused an infinite loop in the table viewer and caused glue to
   hang if too many incompatible subsets were in a table viewer. [#2105]
 

--- a/glue/viewers/image/state.py
+++ b/glue/viewers/image/state.py
@@ -173,6 +173,11 @@ class ImageViewerState(MatplotlibDataViewerState):
                         self.yw_att_helper.world_coord = False
                     self._update_combo_att()
                     self._set_default_slices()
+                    # We need to make sure that we update x_att and y_att
+                    # at the same time before any other callbacks get called,
+                    # so we do this here manually.
+                    self._on_xatt_world_change()
+                    self._on_yatt_world_change()
 
     def _layers_changed(self, *args):
 


### PR DESCRIPTION
This caused issues in glue-jupyter because of the way the callbacks are set up there for the image viewer (the image data is retrieved sooner after a change in reference data)