### PR TITLE
Legend background and foreground colors can be modified

### DIFF
--- a/glue/viewers/histogram/qt/options_widget.py
+++ b/glue/viewers/histogram/qt/options_widget.py
@@ -22,8 +22,8 @@ class HistogramOptionsWidget(QtWidgets.QWidget):
 
         self._connections = autoconnect_callbacks_to_qt(viewer_state, self.ui)
         self._connections_axes = autoconnect_callbacks_to_qt(viewer_state, self.ui.axes_editor.ui)
-        connect_kwargs = {'legend_alpha': dict(value_range=(0, 1))}
-        self._connections_legend = autoconnect_callbacks_to_qt(viewer_state, self.ui.legend_editor.ui, connect_kwargs)
+        connect_kwargs = {'alpha': dict(value_range=(0, 1))}
+        self._connections_legend = autoconnect_callbacks_to_qt(viewer_state.legend, self.ui.legend_editor.ui, connect_kwargs)
 
         self.viewer_state = viewer_state
 

--- a/glue/viewers/histogram/qt/tests/test_data_viewer.py
+++ b/glue/viewers/histogram/qt/tests/test_data_viewer.py
@@ -672,7 +672,7 @@ class TestHistogramViewer(object):
         viewer_state = self.viewer.state
 
         self.viewer.add_data(self.data)
-        self.viewer.state.show_legend = True
+        self.viewer.state.legend.visible = True
 
         handles, labels, handler_dict = self.viewer.get_handles_legend()
         assert len(handles) == 1

--- a/glue/viewers/histogram/qt/tests/test_python_export.py
+++ b/glue/viewers/histogram/qt/tests/test_python_export.py
@@ -33,7 +33,7 @@ class TestExportPython(BaseTestExportPython):
         self.assert_same(tmpdir)
 
     def test_simple_visual_legend(self, tmpdir):
-        self.viewer.state.show_legend = True
+        self.viewer.state.legend.visible = True
         self.viewer.state.layers[0].color = 'blue'
         self.viewer.state.layers[0].alpha = 0.5
         self.assert_same(tmpdir)
@@ -51,7 +51,7 @@ class TestExportPython(BaseTestExportPython):
         self.assert_same(tmpdir)
 
     def test_subset_legend(self, tmpdir):
-        self.viewer.state.show_legend = True
+        self.viewer.state.legend.visible = True
         self.data_collection.new_subset_group('mysubset', self.data.id['a'] > 0.5)
         self.assert_same(tmpdir)
 

--- a/glue/viewers/image/qt/options_widget.py
+++ b/glue/viewers/image/qt/options_widget.py
@@ -23,8 +23,8 @@ class ImageOptionsWidget(QtWidgets.QWidget):
 
         self._connections = autoconnect_callbacks_to_qt(viewer_state, self.ui)
         self._connections_axes = autoconnect_callbacks_to_qt(viewer_state, self.ui.axes_editor.ui)
-        connect_kwargs = {'legend_alpha': dict(value_range=(0, 1))}
-        self._connections_legend = autoconnect_callbacks_to_qt(viewer_state, self.ui.legend_editor.ui, connect_kwargs)
+        connect_kwargs = {'alpha': dict(value_range=(0, 1))}
+        self._connections_legend = autoconnect_callbacks_to_qt(viewer_state.legend, self.ui.legend_editor.ui, connect_kwargs)
 
         self.viewer_state = viewer_state
 

--- a/glue/viewers/image/qt/tests/test_data_viewer.py
+++ b/glue/viewers/image/qt/tests/test_data_viewer.py
@@ -726,7 +726,7 @@ class TestImageViewer(object):
 
         viewer_state = self.viewer.state
         self.viewer.add_data(self.image1)
-        self.viewer.state.show_legend = True
+        self.viewer.state.legend.visible = True
 
         handles, labels, handler_dict = self.viewer.get_handles_legend()
         assert len(handles) == 1

--- a/glue/viewers/image/qt/tests/test_python_export.py
+++ b/glue/viewers/image/qt/tests/test_python_export.py
@@ -47,7 +47,7 @@ class TestExportPython(BaseTestExportPython):
         self.assert_same(tmpdir)
 
     def test_simple_visual(self, tmpdir):
-        self.viewer.state.show_legend = True
+        self.viewer.state.legend.visible = True
         self.viewer.state.layers[0].cmap = plt.cm.RdBu
         self.viewer.state.layers[0].v_min = 0.2
         self.viewer.state.layers[0].v_max = 0.8
@@ -72,7 +72,7 @@ class TestExportPython(BaseTestExportPython):
         self.assert_same(tmpdir)
 
     def test_subset_legend(self, tmpdir):
-        self.viewer.state.show_legend = True
+        self.viewer.state.legend.visible = True
         self.data_collection.new_subset_group('mysubset', self.data.id['cube'] > 0.5)
         self.assert_same(tmpdir, tol=0.15)  # transparency and such
 

--- a/glue/viewers/matplotlib/qt/legend_editor.ui
+++ b/glue/viewers/matplotlib/qt/legend_editor.ui
@@ -66,7 +66,7 @@
     </widget>
    </item>
    <item row="3" column="1">
-    <widget class="QComboBox" name="combosel_loc_and_drag"/>
+    <widget class="QComboBox" name="combosel_location"/>
    </item>
    <item row="5" column="0">
     <widget class="QLabel" name="label_2">

--- a/glue/viewers/matplotlib/qt/legend_editor.ui
+++ b/glue/viewers/matplotlib/qt/legend_editor.ui
@@ -117,8 +117,49 @@
      </property>
     </widget>
    </item>
+   <item row="9" column="0">
+    <widget class="QLabel" name="label_6">
+     <property name="text">
+      <string>frame color</string>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="0">
+    <widget class="QLabel" name="label_7">
+     <property name="text">
+      <string>text color</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="1">
+    <widget class="QColorBox" name="color_legend_frame_color">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="1">
+    <widget class="QColorBox" name="color_legend_text_color">
+     <property name="text">
+      <string>           </string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QColorBox</class>
+   <extends>QLabel</extends>
+   <header>glue.utils.qt.colors</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/glue/viewers/matplotlib/qt/legend_editor.ui
+++ b/glue/viewers/matplotlib/qt/legend_editor.ui
@@ -32,6 +32,29 @@
    <property name="bottomMargin">
     <number>5</number>
    </property>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>enable</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QCheckBox" name="bool_show_legend">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
    <item row="3" column="0">
     <widget class="QLabel" name="label">
      <property name="text">
@@ -55,51 +78,12 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
-    <widget class="QCheckBox" name="bool_show_legend">
-     <property name="text">
-      <string/>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_3">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>enable</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
    <item row="5" column="1">
     <widget class="QSlider" name="value_legend_alpha">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
     </widget>
-   </item>
-   <item row="8" column="0">
-    <widget class="QLabel" name="label_4">
-     <property name="text">
-      <string>label size</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="1">
-    <widget class="QSpinBox" name="value_legend_fontsize"/>
-   </item>
-   <item row="7" column="1">
-    <widget class="QLineEdit" name="text_legend_title"/>
    </item>
    <item row="7" column="0">
     <widget class="QLabel" name="label_5">
@@ -117,17 +101,26 @@
      </property>
     </widget>
    </item>
-   <item row="9" column="0">
-    <widget class="QLabel" name="label_6">
+   <item row="7" column="1">
+    <widget class="QLineEdit" name="text_legend_title"/>
+   </item>
+   <item row="8" column="0">
+    <widget class="QLabel" name="label_4">
      <property name="text">
-      <string>frame color</string>
+      <string>label size</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
     </widget>
    </item>
-   <item row="10" column="0">
-    <widget class="QLabel" name="label_7">
+   <item row="8" column="1">
+    <widget class="QSpinBox" name="value_legend_fontsize"/>
+   </item>
+   <item row="9" column="0">
+    <widget class="QLabel" name="label_6">
      <property name="text">
-      <string>text color</string>
+      <string>box color</string>
      </property>
     </widget>
    </item>
@@ -145,9 +138,30 @@
     </widget>
    </item>
    <item row="10" column="1">
+    <widget class="QCheckBox" name="bool_legend_show_frame_edge">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="0">
+    <widget class="QLabel" name="label_7">
+     <property name="text">
+      <string>text color</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="1">
     <widget class="QColorBox" name="color_legend_text_color">
      <property name="text">
-      <string>           </string>
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="0">
+    <widget class="QLabel" name="label_8">
+     <property name="text">
+      <string>box edge</string>
      </property>
     </widget>
    </item>

--- a/glue/viewers/matplotlib/qt/legend_editor.ui
+++ b/glue/viewers/matplotlib/qt/legend_editor.ui
@@ -49,7 +49,7 @@
     </widget>
    </item>
    <item row="1" column="1">
-    <widget class="QCheckBox" name="bool_show_legend">
+    <widget class="QCheckBox" name="bool_visible">
      <property name="text">
       <string/>
      </property>
@@ -66,7 +66,7 @@
     </widget>
    </item>
    <item row="3" column="1">
-    <widget class="QComboBox" name="combosel_legend_location"/>
+    <widget class="QComboBox" name="combosel_loc_and_drag"/>
    </item>
    <item row="5" column="0">
     <widget class="QLabel" name="label_2">
@@ -79,7 +79,7 @@
     </widget>
    </item>
    <item row="5" column="1">
-    <widget class="QSlider" name="value_legend_alpha">
+    <widget class="QSlider" name="value_alpha">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
@@ -102,7 +102,7 @@
     </widget>
    </item>
    <item row="7" column="1">
-    <widget class="QLineEdit" name="text_legend_title"/>
+    <widget class="QLineEdit" name="text_title"/>
    </item>
    <item row="8" column="0">
     <widget class="QLabel" name="label_4">
@@ -115,7 +115,7 @@
     </widget>
    </item>
    <item row="8" column="1">
-    <widget class="QSpinBox" name="value_legend_fontsize"/>
+    <widget class="QSpinBox" name="value_fontsize"/>
    </item>
    <item row="9" column="0">
     <widget class="QLabel" name="label_6">
@@ -125,7 +125,7 @@
     </widget>
    </item>
    <item row="9" column="1">
-    <widget class="QColorBox" name="color_legend_frame_color">
+    <widget class="QColorBox" name="color_frame_color">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
        <horstretch>0</horstretch>
@@ -138,7 +138,7 @@
     </widget>
    </item>
    <item row="10" column="1">
-    <widget class="QCheckBox" name="bool_legend_show_frame_edge">
+    <widget class="QCheckBox" name="bool_show_edge">
      <property name="text">
       <string/>
      </property>
@@ -152,7 +152,7 @@
     </widget>
    </item>
    <item row="11" column="1">
-    <widget class="QColorBox" name="color_legend_text_color">
+    <widget class="QColorBox" name="color_text_color">
      <property name="text">
       <string/>
      </property>

--- a/glue/viewers/matplotlib/qt/tests/test_data_viewer.py
+++ b/glue/viewers/matplotlib/qt/tests/test_data_viewer.py
@@ -625,7 +625,7 @@ class BaseTestMatplotlibDataViewer(object):
         # no legend by default
         assert self.viewer.axes.get_legend() is None
 
-        self.viewer.state.show_legend = True
+        self.viewer.state.legend.visible = True
 
         # a legend appears
         legend = self.viewer.axes.get_legend()
@@ -644,7 +644,7 @@ class BaseTestMatplotlibDataViewer(object):
     # The next set of test check that the legend does not create extra draws !
     def test_legend_single_draw(self):
         # Make sure that the number of draws is kept to a minimum
-        self.viewer.show_legend = True
+        self.viewer.state.legend.visible = True
         self.init_draw_count()
         self.init_subset()
         assert self.draw_count == 0
@@ -652,7 +652,7 @@ class BaseTestMatplotlibDataViewer(object):
         assert self.draw_count == 1
 
     def test_legend_numerical_data_changed(self):
-        self.viewer.show_legend = True
+        self.viewer.state.legend.visible = True
         self.init_draw_count()
         self.init_subset()
         assert self.draw_count == 0

--- a/glue/viewers/matplotlib/state.py
+++ b/glue/viewers/matplotlib/state.py
@@ -34,7 +34,7 @@ class DeferredDrawSelectionCallbackProperty(SelectionCallbackProperty):
 
 VALID_WEIGHTS = ['light', 'normal', 'medium', 'semibold', 'bold', 'heavy', 'black']
 
-VALID_LOCATIONS = ['best',
+VALID_LOCATIONS = ['best (draggable)', 'best',
                    'upper right', 'upper left',
                    'lower left', 'lower right',
                    'center left', 'center right',
@@ -75,9 +75,10 @@ class MatplotlibDataViewerState(ViewerState):
     show_legend = DeferredDrawCallbackProperty(False, docstring="Whether to show the legend")
     legend_location = DeferredDrawSelectionCallbackProperty(0, docstring="The location of the legend in the axis")
     legend_alpha = DeferredDrawCallbackProperty(0.8, docstring='Transparency of the legend frame')
-    legend_title = DeferredDrawCallbackProperty("", docstring='Transparency of the legend frame')
-    legend_fontsize = DeferredDrawCallbackProperty(10, docstring='Transparency of the legend frame')
-    legend_frame_color = DeferredDrawCallbackProperty("#FFFFFF", docstring='Background color of the legend')
+    legend_title = DeferredDrawCallbackProperty("", docstring='The title of the legend')
+    legend_fontsize = DeferredDrawCallbackProperty(10, docstring='The font size of the title')
+    legend_frame_color = DeferredDrawCallbackProperty("#ffffff", docstring='Frame color of the legend')
+    legend_show_frame_edge = DeferredDrawCallbackProperty(True, docstring="Whether to show the edge of the frame ")
     legend_text_color = DeferredDrawCallbackProperty("#000000", docstring='Text color of the legend')
 
     def __init__(self, *args, **kwargs):
@@ -205,6 +206,7 @@ class MatplotlibDataViewerState(ViewerState):
         self.legend_title = state.legend_title
         self.legend_fontsize = state.legend_fontsize
         self.legend_frame_color = state.legend_frame_color
+        self.legend_show_edge = state.legend_show_edge
         self.legend_text_color = state.legend_text_color
 
     @defer_draw

--- a/glue/viewers/matplotlib/state.py
+++ b/glue/viewers/matplotlib/state.py
@@ -88,7 +88,7 @@ class MatplotlibLegendState(State):
         if self.location == 'draggable':
             return 'best'
         else:
-            return self.loc_and_drag
+            return self.location
 
     def update_axes_settings_from(self, state):
         self.visible = state.show_legend

--- a/glue/viewers/matplotlib/state.py
+++ b/glue/viewers/matplotlib/state.py
@@ -1,7 +1,10 @@
 from echo import CallbackProperty, SelectionCallbackProperty, keep_in_sync, delay_callback
 
+from matplotlib.colors import to_rgba
+
 from glue.core.message import LayerArtistUpdatedMessage
 
+from glue.core.state_objects import State
 from glue.viewers.common.state import ViewerState, LayerState
 
 from glue.utils import defer_draw, avoid_circular
@@ -41,6 +44,62 @@ VALID_LOCATIONS = ['best (draggable)', 'best',
                    'lower center', 'upper center']
 
 
+class MatplotlibLegendState(State):
+    """The legend state"""
+
+    visible = DeferredDrawCallbackProperty(False, docstring="Whether to show the legend")
+
+    loc_and_drag = DeferredDrawSelectionCallbackProperty(0, docstring="The location of the legend in the axis")
+
+    title = DeferredDrawCallbackProperty("", docstring='The title of the legend')
+    fontsize = DeferredDrawCallbackProperty(10, docstring='The font size of the title')
+
+    alpha = DeferredDrawCallbackProperty(0.6, docstring='Transparency of the legend frame')
+    frame_color = DeferredDrawCallbackProperty("#ffffff", docstring='Frame color of the legend')
+    show_edge = DeferredDrawCallbackProperty(True, docstring="Whether to show the edge of the frame ")
+    text_color = DeferredDrawCallbackProperty("#000000", docstring='Text color of the legend')
+
+    def __init__(self, *args, **kwargs):
+        MatplotlibLegendState.loc_and_drag.set_choices(self, VALID_LOCATIONS)
+
+        super().__init__(*args, **kwargs)
+        self._set_color_choices()
+
+    def _set_color_choices(self):
+        from glue.config import settings
+
+        self.frame_color = settings.BACKGROUND_COLOR
+        self.text_color = settings.FOREGROUND_COLOR
+
+    @property
+    def edge_color(self):
+        if self.show_edge:
+            return to_rgba(self.text_color, self.alpha)
+        else:
+            return 'none'
+
+    @property
+    def draggable(self):
+        return self.loc_and_drag.endswith('(draggable)')
+
+    @property
+    def location(self):
+        if self.loc_and_drag.endswith('(draggable)'):
+            return self.loc_and_drag[:-12]
+        else:
+            return self.loc_and_drag
+
+
+    def update_axes_settings_from(self, state):
+        self.visible = state.show_legend
+        self.loc_and_drag = state.loc_and_drag
+        self.alpha = state.alpha
+        self.title = state.title
+        self.fontsize = state.fontsize
+        self.frame_color = state.frame_color
+        self.show_edge = state.show_edge
+        self.text_color = state.text_color
+
 class MatplotlibDataViewerState(ViewerState):
     """
     A base class that includes common attributes for viewers based on
@@ -72,14 +131,6 @@ class MatplotlibDataViewerState(ViewerState):
     x_ticklabel_size = DeferredDrawCallbackProperty(8, docstring='Size of the x-axis tick labels')
     y_ticklabel_size = DeferredDrawCallbackProperty(8, docstring='Size of the y-axis tick labels')
 
-    show_legend = DeferredDrawCallbackProperty(False, docstring="Whether to show the legend")
-    legend_location = DeferredDrawSelectionCallbackProperty(0, docstring="The location of the legend in the axis")
-    legend_alpha = DeferredDrawCallbackProperty(0.8, docstring='Transparency of the legend frame')
-    legend_title = DeferredDrawCallbackProperty("", docstring='The title of the legend')
-    legend_fontsize = DeferredDrawCallbackProperty(10, docstring='The font size of the title')
-    legend_frame_color = DeferredDrawCallbackProperty("#ffffff", docstring='Frame color of the legend')
-    legend_show_frame_edge = DeferredDrawCallbackProperty(True, docstring="Whether to show the edge of the frame ")
-    legend_text_color = DeferredDrawCallbackProperty("#000000", docstring='Text color of the legend')
 
     def __init__(self, *args, **kwargs):
 
@@ -87,11 +138,9 @@ class MatplotlibDataViewerState(ViewerState):
 
         MatplotlibDataViewerState.x_axislabel_weight.set_choices(self, VALID_WEIGHTS)
         MatplotlibDataViewerState.y_axislabel_weight.set_choices(self, VALID_WEIGHTS)
-        MatplotlibDataViewerState.legend_location.set_choices(self, VALID_LOCATIONS)
-
 
         super(MatplotlibDataViewerState, self).__init__(*args, **kwargs)
-        self._set_color_choices()
+        self.legend = MatplotlibLegendState(*args, **kwargs)
 
         self.add_callback('aspect', self._adjust_limits_aspect, priority=10000)
         self.add_callback('x_min', self._adjust_limits_aspect_x, priority=10000)
@@ -99,11 +148,6 @@ class MatplotlibDataViewerState(ViewerState):
         self.add_callback('y_min', self._adjust_limits_aspect_y, priority=10000)
         self.add_callback('y_max', self._adjust_limits_aspect_y, priority=10000)
 
-    def _set_color_choices(self):
-        from glue.config import settings
-
-        self.legend_frame_color = settings.BACKGROUND_COLOR
-        self.legend_text_color = settings.FOREGROUND_COLOR
 
     def _set_axes_aspect_ratio(self, value):
         """
@@ -200,14 +244,7 @@ class MatplotlibDataViewerState(ViewerState):
         self.x_ticklabel_size = state.x_ticklabel_size
         self.y_ticklabel_size = state.y_ticklabel_size
         # legend
-        self.show_legend = state.show_legend
-        self.legend_location = state.legend_location
-        self.legend_alpha = state.legend_alpha
-        self.legend_title = state.legend_title
-        self.legend_fontsize = state.legend_fontsize
-        self.legend_frame_color = state.legend_frame_color
-        self.legend_show_edge = state.legend_show_edge
-        self.legend_text_color = state.legend_text_color
+        self.legend.update_axes_settings_from(state.legend)
 
     @defer_draw
     def _notify_global(self, *args, **kwargs):

--- a/glue/viewers/matplotlib/state.py
+++ b/glue/viewers/matplotlib/state.py
@@ -77,6 +77,8 @@ class MatplotlibDataViewerState(ViewerState):
     legend_alpha = DeferredDrawCallbackProperty(0.8, docstring='Transparency of the legend frame')
     legend_title = DeferredDrawCallbackProperty("", docstring='Transparency of the legend frame')
     legend_fontsize = DeferredDrawCallbackProperty(10, docstring='Transparency of the legend frame')
+    legend_frame_color = DeferredDrawCallbackProperty("#FFFFFF", docstring='Background color of the legend')
+    legend_text_color = DeferredDrawCallbackProperty("#000000", docstring='Text color of the legend')
 
     def __init__(self, *args, **kwargs):
 
@@ -86,13 +88,21 @@ class MatplotlibDataViewerState(ViewerState):
         MatplotlibDataViewerState.y_axislabel_weight.set_choices(self, VALID_WEIGHTS)
         MatplotlibDataViewerState.legend_location.set_choices(self, VALID_LOCATIONS)
 
+
         super(MatplotlibDataViewerState, self).__init__(*args, **kwargs)
+        self._set_color_choices()
 
         self.add_callback('aspect', self._adjust_limits_aspect, priority=10000)
         self.add_callback('x_min', self._adjust_limits_aspect_x, priority=10000)
         self.add_callback('x_max', self._adjust_limits_aspect_x, priority=10000)
         self.add_callback('y_min', self._adjust_limits_aspect_y, priority=10000)
         self.add_callback('y_max', self._adjust_limits_aspect_y, priority=10000)
+
+    def _set_color_choices(self):
+        from glue.config import settings
+
+        self.legend_frame_color = settings.BACKGROUND_COLOR
+        self.legend_text_color = settings.FOREGROUND_COLOR
 
     def _set_axes_aspect_ratio(self, value):
         """
@@ -181,17 +191,21 @@ class MatplotlibDataViewerState(ViewerState):
                 self.y_max = y_max
 
     def update_axes_settings_from(self, state):
+        # axis
         self.x_axislabel_size = state.x_axislabel_size
         self.y_axislabel_size = state.y_axislabel_size
         self.x_axislabel_weight = state.x_axislabel_weight
         self.y_axislabel_weight = state.y_axislabel_weight
         self.x_ticklabel_size = state.x_ticklabel_size
         self.y_ticklabel_size = state.y_ticklabel_size
+        # legend
         self.show_legend = state.show_legend
         self.legend_location = state.legend_location
         self.legend_alpha = state.legend_alpha
         self.legend_title = state.legend_title
         self.legend_fontsize = state.legend_fontsize
+        self.legend_frame_color = state.legend_frame_color
+        self.legend_text_color = state.legend_text_color
 
     @defer_draw
     def _notify_global(self, *args, **kwargs):

--- a/glue/viewers/matplotlib/state.py
+++ b/glue/viewers/matplotlib/state.py
@@ -37,7 +37,8 @@ class DeferredDrawSelectionCallbackProperty(SelectionCallbackProperty):
 
 VALID_WEIGHTS = ['light', 'normal', 'medium', 'semibold', 'bold', 'heavy', 'black']
 
-VALID_LOCATIONS = ['best (draggable)', 'best',
+
+VALID_LOCATIONS = ['draggable', 'best',
                    'upper right', 'upper left',
                    'lower left', 'lower right',
                    'center left', 'center right',
@@ -49,7 +50,7 @@ class MatplotlibLegendState(State):
 
     visible = DeferredDrawCallbackProperty(False, docstring="Whether to show the legend")
 
-    loc_and_drag = DeferredDrawSelectionCallbackProperty(0, docstring="The location of the legend in the axis")
+    location = DeferredDrawSelectionCallbackProperty(0, docstring="The location of the legend in the axis")
 
     title = DeferredDrawCallbackProperty("", docstring='The title of the legend')
     fontsize = DeferredDrawCallbackProperty(10, docstring='The font size of the title')
@@ -60,7 +61,7 @@ class MatplotlibLegendState(State):
     text_color = DeferredDrawCallbackProperty("#000000", docstring='Text color of the legend')
 
     def __init__(self, *args, **kwargs):
-        MatplotlibLegendState.loc_and_drag.set_choices(self, VALID_LOCATIONS)
+        MatplotlibLegendState.location.set_choices(self, VALID_LOCATIONS)
 
         super().__init__(*args, **kwargs)
         self._set_color_choices()
@@ -76,19 +77,18 @@ class MatplotlibLegendState(State):
         if self.show_edge:
             return to_rgba(self.text_color, self.alpha)
         else:
-            return 'none'
+            return None
 
     @property
     def draggable(self):
-        return self.loc_and_drag.endswith('(draggable)')
+        return self.location == 'draggable'
 
     @property
-    def location(self):
-        if self.loc_and_drag.endswith('(draggable)'):
-            return self.loc_and_drag[:-12]
+    def mpl_location(self):
+        if self.location == 'draggable':
+            return 'best'
         else:
             return self.loc_and_drag
-
 
     def update_axes_settings_from(self, state):
         self.visible = state.show_legend
@@ -99,6 +99,7 @@ class MatplotlibLegendState(State):
         self.frame_color = state.frame_color
         self.show_edge = state.show_edge
         self.text_color = state.text_color
+
 
 class MatplotlibDataViewerState(ViewerState):
     """
@@ -131,7 +132,6 @@ class MatplotlibDataViewerState(ViewerState):
     x_ticklabel_size = DeferredDrawCallbackProperty(8, docstring='Size of the x-axis tick labels')
     y_ticklabel_size = DeferredDrawCallbackProperty(8, docstring='Size of the y-axis tick labels')
 
-
     def __init__(self, *args, **kwargs):
 
         self._axes_aspect_ratio = None
@@ -147,7 +147,6 @@ class MatplotlibDataViewerState(ViewerState):
         self.add_callback('x_max', self._adjust_limits_aspect_x, priority=10000)
         self.add_callback('y_min', self._adjust_limits_aspect_y, priority=10000)
         self.add_callback('y_max', self._adjust_limits_aspect_y, priority=10000)
-
 
     def _set_axes_aspect_ratio(self, value):
         """

--- a/glue/viewers/matplotlib/tests/test_state.py
+++ b/glue/viewers/matplotlib/tests/test_state.py
@@ -1,0 +1,27 @@
+from ..state import MatplotlibLegendState
+from glue.config import settings
+
+from matplotlib.colors import to_rgba
+
+
+class TestMatplotlibLegendState:
+    def setup_method(self, method):
+        self.state = MatplotlibLegendState()
+
+    def test_draggable(self):
+        self.state.location = 'draggable'
+        assert self.state.draggable
+        assert self.state.mpl_location == 'best'
+
+    def test_no_draggable(self):
+        self.state.location = 'lower left'
+        assert not self.state.draggable
+        assert self.state.mpl_location == 'lower left'
+
+    def test_no_edge(self):
+        self.state.show_edge = False
+        assert self.state.edge_color is None
+
+    def test_default_color(self):
+        assert self.state.frame_color == settings.BACKGROUND_COLOR
+        assert self.state.edge_color == to_rgba(settings.FOREGROUND_COLOR, self.state.alpha)

--- a/glue/viewers/matplotlib/viewer.py
+++ b/glue/viewers/matplotlib/viewer.py
@@ -3,7 +3,6 @@ from textwrap import indent
 import numpy as np
 
 from matplotlib.patches import Rectangle
-from matplotlib.colors import to_rgba
 from matplotlib.artist import setp as msetp
 
 from glue.viewers.matplotlib.mpl_axes import update_appearance_from_settings
@@ -120,7 +119,7 @@ class MatplotlibViewerMixin(object):
         self.state.add_callback('y_ticklabel_size', self.update_y_ticklabel)
 
         self.state.legend.add_callback('visible', self.draw_legend)
-        self.state.legend.add_callback('loc_and_drag', self.draw_legend)
+        self.state.legend.add_callback('location', self.draw_legend)
         self.state.legend.add_callback('alpha', self.update_legend)
         self.state.legend.add_callback('title', self.draw_legend)
         self.state.legend.add_callback('fontsize', self.draw_legend)
@@ -193,14 +192,13 @@ class MatplotlibViewerMixin(object):
     def draw_legend(self, *args):
         if self.state.legend.visible:
             handles, labels, handler_map = self.get_handles_legend()
-            kwargs = dict(loc=self.state.legend.location,
+            kwargs = dict(loc=self.state.legend.mpl_location,
                           title=self.state.legend.title,
                           title_fontsize=self.state.legend.fontsize,
                           fontsize=self.state.legend.fontsize)
             if handler_map is not None:
                 kwargs["handler_map"] = handler_map
-            legend = self.axes.legend(
-                    handles, labels, **kwargs)
+            legend = self.axes.legend(handles, labels, **kwargs)
             self._update_legend_visual(legend)
             legend.set_draggable(self.state.legend.draggable)
         else:
@@ -318,7 +316,7 @@ class MatplotlibViewerMixin(object):
 
     def _script_legend(self):
         state_dict = self.state.legend.as_dict()
-        state_dict['location'] = self.state.legend.location
+        state_dict['location'] = self.state.legend.mpl_location
         state_dict['edge_color'] = self.state.legend.edge_color
         legend_str = SCRIPT_LEGEND.format(**state_dict)
         if not self.state.legend.visible:

--- a/glue/viewers/profile/qt/options_widget.py
+++ b/glue/viewers/profile/qt/options_widget.py
@@ -26,8 +26,8 @@ class ProfileOptionsWidget(QtWidgets.QWidget):
 
         self._connections = autoconnect_callbacks_to_qt(viewer_state, self.ui)
         self._connections_axes = autoconnect_callbacks_to_qt(viewer_state, self.ui.axes_editor.ui)
-        connect_kwargs = {'legend_alpha': dict(value_range=(0, 1))}
-        self._connections_legend = autoconnect_callbacks_to_qt(viewer_state, self.ui.legend_editor.ui, connect_kwargs)
+        connect_kwargs = {'alpha': dict(value_range=(0, 1))}
+        self._connections_legend = autoconnect_callbacks_to_qt(viewer_state.legend, self.ui.legend_editor.ui, connect_kwargs)
 
         self.viewer_state = viewer_state
 

--- a/glue/viewers/profile/qt/tests/test_python_export.py
+++ b/glue/viewers/profile/qt/tests/test_python_export.py
@@ -31,7 +31,7 @@ class TestExportPython(BaseTestExportPython):
         self.assert_same(tmpdir)
 
     def test_simple_legend(self, tmpdir):
-        self.viewer.state.show_legend = True
+        self.viewer.state.legend.visible = True
         self.assert_same(tmpdir)
 
     def test_color(self, tmpdir):
@@ -72,7 +72,7 @@ class TestExportPython(BaseTestExportPython):
         self.assert_same(tmpdir)
 
     def test_subset_legend(self, tmpdir):
-        self.viewer.state.show_legend = True
+        self.viewer.state.legend.visible = True
         self.viewer.state.function = 'mean'
         self.viewer.state.layers[0].linewidth = 7.25
         self.data_collection.new_subset_group('mysubset', self.data.id['x'] > 0.25)

--- a/glue/viewers/scatter/qt/options_widget.py
+++ b/glue/viewers/scatter/qt/options_widget.py
@@ -22,8 +22,8 @@ class ScatterOptionsWidget(QtWidgets.QWidget):
 
         self._connections = autoconnect_callbacks_to_qt(viewer_state, self.ui)
         self._connections_axes = autoconnect_callbacks_to_qt(viewer_state, self.ui.axes_editor.ui)
-        connect_kwargs = {'legend_alpha': dict(value_range=(0, 1))}
-        self._connections_legend = autoconnect_callbacks_to_qt(viewer_state, self.ui.legend_editor.ui, connect_kwargs)
+        connect_kwargs = {'alpha': dict(value_range=(0, 1))}
+        self._connections_legend = autoconnect_callbacks_to_qt(viewer_state.legend, self.ui.legend_editor.ui, connect_kwargs)
 
         self.viewer_state = viewer_state
 

--- a/glue/viewers/scatter/qt/tests/test_data_viewer.py
+++ b/glue/viewers/scatter/qt/tests/test_data_viewer.py
@@ -681,7 +681,7 @@ class TestScatterViewer(object):
         viewer_state = self.viewer.state
 
         self.viewer.add_data(self.data)
-        self.viewer.state.show_legend = True
+        viewer_state.legend.visible = True
 
         handles, labels, handler_dict = self.viewer.get_handles_legend()
         assert len(handles) == 1

--- a/glue/viewers/scatter/qt/tests/test_python_export.py
+++ b/glue/viewers/scatter/qt/tests/test_python_export.py
@@ -32,7 +32,7 @@ class TestExportPython(BaseTestExportPython):
         self.assert_same(tmpdir)
 
     def test_simple_legend(self, tmpdir):
-        self.viewer.state.show_legend = True
+        self.viewer.state.legend.visible = True
         self.assert_same(tmpdir)
 
     def test_simple_nofill(self, tmpdir):
@@ -47,7 +47,7 @@ class TestExportPython(BaseTestExportPython):
         self.assert_same(tmpdir)
 
     def test_simple_visual_legend(self, tmpdir):
-        self.viewer.state.show_legend = True
+        self.viewer.state.legend.visible = True
         self.viewer.state.layers[0].color = 'blue'
         self.viewer.state.layers[0].markersize = 30
         self.viewer.state.layers[0].alpha = 0.5
@@ -76,7 +76,7 @@ class TestExportPython(BaseTestExportPython):
         self.assert_same(tmpdir)
 
     def test_size_mode_legend(self, tmpdir):
-        self.viewer.state.show_legend = True
+        self.viewer.state.legend.visible = True
         self.viewer.state.layers[0].size_mode = 'Linear'
         self.viewer.state.layers[0].size_att = self.data.id['d']
         self.viewer.state.layers[0].size_vmin = 0.1
@@ -129,7 +129,7 @@ class TestExportPython(BaseTestExportPython):
         self.assert_same(tmpdir)
 
     def test_errorbarxy_legend(self, tmpdir):
-        self.viewer.state.show_legend = True
+        self.viewer.state.legend.visible = True
         self.viewer.state.layers[0].xerr_visible = True
         self.viewer.state.layers[0].xerr_att = self.data.id['e']
         self.viewer.state.layers[0].yerr_visible = True
@@ -200,7 +200,7 @@ class TestExportPython(BaseTestExportPython):
         self.assert_same(tmpdir)
 
     def test_density_map_cmap_with_subset_legend(self, tmpdir):
-        self.viewer.state.show_legend = True
+        self.viewer.state.legend.visible = True
         self.viewer.state.dpi = 2
         self.viewer.state.layers[0].density_map = True
         self.viewer.state.layers[0].cmap_mode = 'Linear'


### PR DESCRIPTION
Resolves #2145 

- Change in visual properties of the legend do not require to get the handles anymore
- Background and foreground can be changed
- Defaults for these properties are taken from the settings
- The legend is also set to be draggable
