### PR TITLE
Improve efficiency of compute_statistic by minimizing data access

### DIFF
--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -1829,11 +1829,20 @@ class Data(BaseCartesianData):
 
         if subset_state is not None:
             mask = subset_state.to_mask(self)
-            x = x[mask]
+            if DASK_INSTALLED and isinstance(x, da.Array) and not isinstance(mask, da.Array):
+                x = x[da.asarray(mask)]
+            else:
+                x = x[mask]
             if ndim > 1:
-                y = y[mask]
+                if DASK_INSTALLED and isinstance(y, da.Array) and not isinstance(mask, da.Array):
+                    y = y[da.asarray(mask)]
+                else:
+                    y = y[mask]
             if w is not None:
-                w = w[mask]
+                if DASK_INSTALLED and isinstance(w, da.Array) and not isinstance(mask, da.Array):
+                    w = w[da.asarray(mask)]
+                else:
+                    w = w[mask]
 
         if ndim == 1:
             xmin, xmax = range[0]
@@ -1865,6 +1874,16 @@ class Data(BaseCartesianData):
             y = y[keep]
         if w is not None:
             w = w[keep]
+
+        # For now, compute dask arrays at this point. In future we could delegate
+        # the histogram calculation to dask.
+        if DASK_INSTALLED:
+            if isinstance(x, da.Array):
+                x = x.compute()
+            if ndim > 1 and isinstance(y, da.Array):
+                x = x.compute()
+            if isinstance(w, da.Array):
+                w = w.compute()
 
         if len(x) == 0:
             return np.zeros(bins)

--- a/glue/core/tests/test_data.py
+++ b/glue/core/tests/test_data.py
@@ -995,6 +995,21 @@ def test_compute_histogram_log():
     assert result.shape == (2, 3) and np.sum(result) == 0
 
 
+def test_compute_histogram_dask():
+
+    # Make sure that compute_histogram works for dask arrays
+
+    da = pytest.importorskip('dask.array')
+
+    data = Data(x=da.arange(10))
+
+    result = data.compute_histogram([data.id['x']], range=[[-0.5, 11.75]], bins=[2])
+    assert_allclose(result, [6, 4])
+
+    result = data.compute_histogram([data.id['x']], range=[[-0.5, 11.25]], bins=[2], subset_state=data.id['x'] > 4.5)
+    assert_allclose(result, [1, 4])
+
+
 def test_base_cartesian_data_coords():
 
     # Make sure that world_component_ids works in both the case where

--- a/glue/core/tests/test_data.py
+++ b/glue/core/tests/test_data.py
@@ -871,7 +871,7 @@ def test_compute_statistic_random_subset():
         result = data.compute_statistic('mean', data.id['x'], random_subset=5,
                                         subset_state=MaskSubsetState([0, 1, 0, 1, 1, 1, 0, 1, 0, 1],
                                                                      data.pixel_component_ids))
-        assert_allclose(result, 4.75)
+        assert_allclose(result, 5)
 
 
 def test_compute_statistic_empty_subset():

--- a/glue/viewers/matplotlib/qt/toolbar.py
+++ b/glue/viewers/matplotlib/qt/toolbar.py
@@ -18,7 +18,11 @@ def _ensure_mpl_nav(viewer):
 def _cleanup_mpl_nav(viewer):
     if getattr(viewer, '_mpl_nav', None) is not None:
         viewer._mpl_nav.setParent(None)
-        viewer._mpl_nav.parent = None
+        try:
+            viewer._mpl_nav.parent = None
+        except AttributeError:
+            pass
+        viewer._mpl_nav = None
 
 
 class MatplotlibTool(Tool):


### PR DESCRIPTION
This improves the efficiency of compute_statistic, especially in the context of the profile viewer, when subsets are applied, by first finding the minimal bounding box for the selection and then extracting data using this bounding box only. In simple tests, this can improve performance by 30x or more. This works especially well when loading CASA datasets since those are very sensitive to disk access.

This needs tests and a changelog entry, and the runtime errors need to be addressed.

cc @keflavich 