### PR TITLE
Fix Wrong Unit on Slider for Images

### DIFF
--- a/glue/viewers/image/qt/slice_widget.py
+++ b/glue/viewers/image/qt/slice_widget.py
@@ -89,10 +89,11 @@ class MultiSliceWidgetHelper(object):
                 # check the type of data.coords here since we want to treat
                 # subclasses differently.
                 if getattr(self.data, 'coords') is not None and type(self.data.coords) != LegacyCoordinates:
+                    world_axis_index = self.data.ndim - 1 - i
                     world = world_axis(self.data.coords, self.data,
-                                       pixel_axis=self.data.ndim - 1 - i,
-                                       world_axis=self.data.ndim - 1 - i)
-                    world_unit = self.data.coords.world_axis_units[i]
+                                       pixel_axis=world_axis_index,
+                                       world_axis=world_axis_index)
+                    world_unit = self.data.coords.world_axis_units[world_axis_index]
                     world_warning = len(dependent_axes(self.data.coords, i)) > 1
                     world_label = self.data.world_component_ids[i].label
                 else:


### PR DESCRIPTION
Fix for #2132. The issue was that we had to flip the index when looking up the string for the unit.