### PR TITLE
Patch get cmap method code

### DIFF
--- a/glue/core/visual.py
+++ b/glue/core/visual.py
@@ -2,6 +2,7 @@ from matplotlib.colors import ColorConverter
 from matplotlib.cm import get_cmap
 
 from glue.config import settings
+from glue.config import colormaps
 
 from echo import callback_property, HasCallbackProperties
 
@@ -107,7 +108,12 @@ class VisualAttributes(HasCallbackProperties):
     @preferred_cmap.setter
     def preferred_cmap(self, value):
         if isinstance(value, str):
-            self._preferred_cmap = get_cmap(value)
+            try:
+                for i, element in enumerate(colormaps.members):
+                    if element[0] == value:
+                        self._preferred_cmap = element[1]
+            except TypeError:
+                self._preferred_cmap = get_cmap(value)
         else:
             self._preferred_cmap = value
 


### PR DESCRIPTION
<!-- # Pull Request Template -->

## Description

To patch the part of the codebase dealing with getting `cmap` in the case of `cmap`'s that are native to `glue` but not to `matplotlib`. Otherwise for example in the case of IRIS Level 2 SJI data an error would be thrown to complain that there is no such `cmap`. 

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
