### PR TITLE
Adding polar and other plots

### DIFF
--- a/glue/core/roi.py
+++ b/glue/core/roi.py
@@ -49,6 +49,9 @@ def pixel_to_data(axes, x, y):
     xy = np.column_stack((np.asarray(x).ravel(), np.asarray(y).ravel()))
     return axes.transData.inverted().transform(xy)
 
+def pixel_to_axes(axes, x, y):
+    xy = np.column_stack((np.asarray(x).ravel(), np.asarray(y).ravel()))
+    return axes.transAxes.inverted().transform(xy)
 
 class Roi(object):  # pragma: no cover
 
@@ -775,13 +778,14 @@ class AbstractMplRoi(object):
 
     _roi_cls = None
 
-    def __init__(self, axes, roi=None):
+    def __init__(self, axes, roi=None, data_space=True):
         self._axes = axes
         self._roi = roi or self._roi_cls()
         self._previous_roi = None
         self._mid_selection = False
         self._scrubbing = False
         self._background_cache = None
+        self._data_space = data_space
 
     def _draw(self):
 
@@ -897,45 +901,52 @@ class MplRectangularROI(AbstractMplRoi):
 
     _roi_cls = RectangularROI
 
-    def __init__(self, axes):
+    def __init__(self, axes, data_space=True):
 
-        super(MplRectangularROI, self).__init__(axes)
+        super(MplRectangularROI, self).__init__(axes, data_space=data_space)
 
         self._xi = None
         self._yi = None
-
         self.plot_opts = {'edgecolor': PATCH_COLOR,
                           'facecolor': PATCH_COLOR,
                           'alpha': 0.3}
 
         self._patch = Rectangle((0., 0.), 1., 1., zorder=100)
         self._patch.set_visible(False)
+        if not self._data_space:
+            self._patch.set_transform(self._axes.transAxes)
         self._axes.add_patch(self._patch)
 
     def start_selection(self, event):
-
         if event.inaxes != self._axes:
             return False
+
+        if self._data_space:
+            xval = event.xdata
+            yval = event.ydata
+        else:
+            axes_trans = self._axes.transAxes.inverted()
+            xval, yval = axes_trans.transform([event.x, event.y])
 
         if event.key == SCRUBBING_KEY:
             if not self._roi.defined():
                 return False
-            elif not self._roi.contains(event.xdata, event.ydata):
+            elif not self._roi.contains(xval, yval):
                 return False
 
         self._store_previous_roi()
         self._store_background()
 
-        self._xi = event.xdata
-        self._yi = event.ydata
+        self._xi = xval
+        self._yi = yval
 
         if event.key == SCRUBBING_KEY:
             self._scrubbing = True
             self._cx, self._cy = self._roi.center()
         else:
             self.reset()
-            self._roi.update_limits(event.xdata, event.ydata,
-                                    event.xdata, event.ydata)
+            self._roi.update_limits(self._xi, self._xi,
+                                    self._yi, self._yi)
 
         self._mid_selection = True
 
@@ -951,14 +962,21 @@ class MplRectangularROI(AbstractMplRoi):
             if not self._roi.defined():
                 return False
 
-        if self._scrubbing:
-            self._roi.move_to(self._cx + event.xdata - self._xi,
-                              self._cy + event.ydata - self._yi)
+        if self._data_space:
+            xval = event.xdata
+            yval = event.ydata
         else:
-            self._roi.update_limits(min(event.xdata, self._xi),
-                                    min(event.ydata, self._yi),
-                                    max(event.xdata, self._xi),
-                                    max(event.ydata, self._yi))
+            axes_trans = self._axes.transAxes.inverted()
+            xval, yval = axes_trans.transform([event.x, event.y])
+
+        if self._scrubbing:
+            self._roi.move_to(self._cx + xval - self._xi,
+                              self._cy + yval - self._yi)
+        else:
+            self._roi.update_limits(min(xval, self._xi),
+                                    min(yval, self._yi),
+                                    max(xval, self._xi),
+                                    max(yval, self._yi))
 
         self._sync_patch()
         self._draw()
@@ -998,18 +1016,20 @@ class MplXRangeROI(AbstractMplRoi):
 
     _roi_cls = XRangeROI
 
-    def __init__(self, axes):
+    def __init__(self, axes, data_space=True):
 
-        super(MplXRangeROI, self).__init__(axes)
+        super(MplXRangeROI, self).__init__(axes, data_space=data_space)
 
         self._xi = None
 
         self.plot_opts = {'edgecolor': PATCH_COLOR,
                           'facecolor': PATCH_COLOR,
                           'alpha': 0.3}
-
-        trans = blended_transform_factory(self._axes.transData,
-                                          self._axes.transAxes)
+        if self._data_space:
+            trans = blended_transform_factory(self._axes.transData,
+                                              self._axes.transAxes)
+        else:
+            trans = self._axes.transAxes
         self._patch = Rectangle((0., 0.), 1., 1., transform=trans, zorder=100)
         self._patch.set_visible(False)
         self._axes.add_patch(self._patch)
@@ -1018,11 +1038,16 @@ class MplXRangeROI(AbstractMplRoi):
 
         if event.inaxes != self._axes:
             return False
-
+        if self._data_space:
+            x_val = event.xdata
+            y_val = event.ydata
+        else:
+            transform = self._axes.transAxes.inverted()
+            x_val, y_val = transform.transform([event.x, event.y])
         if event.key == SCRUBBING_KEY:
             if not self._roi.defined():
                 return False
-            elif not self._roi.contains(event.xdata, event.ydata):
+            elif not self._roi.contains(x_val, y_val):
                 return False
 
         self._store_previous_roi()
@@ -1030,11 +1055,11 @@ class MplXRangeROI(AbstractMplRoi):
 
         if event.key == SCRUBBING_KEY:
             self._scrubbing = True
-            self._dx = event.xdata - self._roi.center()
+            self._dx = x_val - self._roi.center()
         else:
             self.reset()
-            self._roi.set_range(event.xdata, event.xdata)
-            self._xi = event.xdata
+            self._roi.set_range(x_val, x_val)
+            self._xi = x_val
 
         self._mid_selection = True
 
@@ -1050,11 +1075,17 @@ class MplXRangeROI(AbstractMplRoi):
             if not self._roi.defined():
                 return False
 
-        if self._scrubbing:
-            self._roi.move_to(event.xdata + self._dx)
+        if self._data_space:
+            xval = event.xdata
         else:
-            self._roi.set_range(min(event.xdata, self._xi),
-                                max(event.xdata, self._xi))
+            axes_trans = self._axes.transAxes.inverted()
+            xval, _ = axes_trans.transform([event.x, event.y])
+
+        if self._scrubbing:
+            self._roi.move_to(xval + self._dx)
+        else:
+            self._roi.set_range(min(xval, self._xi),
+                                max(xval, self._xi))
 
         self._sync_patch()
         self._draw()
@@ -1089,18 +1120,20 @@ class MplYRangeROI(AbstractMplRoi):
 
     _roi_cls = YRangeROI
 
-    def __init__(self, axes):
+    def __init__(self, axes, data_space=True):
 
-        super(MplYRangeROI, self).__init__(axes)
+        super(MplYRangeROI, self).__init__(axes, data_space=data_space)
 
-        self._xi = None
+        self._yi = None
 
         self.plot_opts = {'edgecolor': PATCH_COLOR,
                           'facecolor': PATCH_COLOR,
                           'alpha': 0.3}
-
-        trans = blended_transform_factory(self._axes.transAxes,
-                                          self._axes.transData)
+        if self._data_space:
+            trans = blended_transform_factory(self._axes.transAxes,
+                                              self._axes.transData)
+        else:
+            trans = self._axes.transAxes
         self._patch = Rectangle((0., 0.), 1., 1., transform=trans, zorder=100)
         self._patch.set_visible(False)
         self._axes.add_patch(self._patch)
@@ -1110,10 +1143,17 @@ class MplYRangeROI(AbstractMplRoi):
         if event.inaxes != self._axes:
             return False
 
+        if self._data_space:
+            xval = event.xdata
+            yval = event.ydata
+        else:
+            axes_trans = self._axes.transAxes.inverted()
+            xval, yval = axes_trans.transform([event.x, event.y])
+
         if event.key == SCRUBBING_KEY:
             if not self._roi.defined():
                 return False
-            elif not self._roi.contains(event.xdata, event.ydata):
+            elif not self._roi.contains(xval, yval):
                 return False
 
         self._store_previous_roi()
@@ -1121,11 +1161,11 @@ class MplYRangeROI(AbstractMplRoi):
 
         if event.key == SCRUBBING_KEY:
             self._scrubbing = True
-            self._dy = event.ydata - self._roi.center()
+            self._dy = yval - self._roi.center()
         else:
             self.reset()
-            self._roi.set_range(event.ydata, event.ydata)
-            self._xi = event.ydata
+            self._roi.set_range(yval, yval)
+            self._yi = yval
 
         self._mid_selection = True
 
@@ -1141,11 +1181,17 @@ class MplYRangeROI(AbstractMplRoi):
             if not self._roi.defined():
                 return False
 
-        if self._scrubbing:
-            self._roi.move_to(event.ydata + self._dy)
+        if self._data_space:
+            yval = event.ydata
         else:
-            self._roi.set_range(min(event.ydata, self._xi),
-                                max(event.ydata, self._xi))
+            axes_trans = self._axes.transAxes.inverted()
+            _, yval = axes_trans.transform([event.x, event.y])
+
+        if self._scrubbing:
+            self._roi.move_to(yval + self._dy)
+        else:
+            self._roi.set_range(min(yval, self._yi),
+                                max(yval, self._yi))
 
         self._sync_patch()
         self._draw()
@@ -1184,9 +1230,9 @@ class MplCircularROI(AbstractMplRoi):
 
     _roi_cls = CircularROI
 
-    def __init__(self, axes):
+    def __init__(self, axes, data_space=True):
 
-        super(MplCircularROI, self).__init__(axes)
+        super(MplCircularROI, self).__init__(axes, data_space=data_space)
 
         self.plot_opts = {'edgecolor': PATCH_COLOR,
                           'facecolor': PATCH_COLOR,
@@ -1293,7 +1339,7 @@ class MplCircularROI(AbstractMplRoi):
             # should return an ellipse.
             x = xy_center[0] + np.array([0, 0, rad])
             y = xy_center[1] + np.array([0, rad, rad])
-            xy_data = pixel_to_data(self._axes, x, y)
+            xy_data = pixel_to_data(self._axes, x, y) if self._data_space else pixel_to_axes(self._axes, x, y)
             rx = xy_data[2, 0] - xy_data[0, 0]
             ry = xy_data[1, 1] - xy_data[0, 1]
             xc, yc = xy_data[0, :]
@@ -1326,9 +1372,9 @@ class MplPolygonalROI(AbstractMplRoi):
 
     _roi_cls = PolygonalROI
 
-    def __init__(self, axes, roi=None):
+    def __init__(self, axes, roi=None, data_space=True):
 
-        super(MplPolygonalROI, self).__init__(axes, roi=roi)
+        super(MplPolygonalROI, self).__init__(axes, roi=roi, data_space=data_space)
 
         self.plot_opts = {'edgecolor': PATCH_COLOR,
                           'facecolor': PATCH_COLOR,
@@ -1336,6 +1382,8 @@ class MplPolygonalROI(AbstractMplRoi):
 
         self._patch = Polygon(np.array(list(zip([0, 1], [0, 1]))), zorder=100)
         self._patch.set_visible(False)
+        if not self._data_space:
+            self._patch.set_transform(self._axes.transAxes)
         self._axes.add_patch(self._patch)
 
     def _sync_patch(self):
@@ -1353,10 +1401,17 @@ class MplPolygonalROI(AbstractMplRoi):
         if event.inaxes != self._axes:
             return False
 
+        if self._data_space:
+            xval = event.xdata
+            yval = event.ydata
+        else:
+            axes_trans = self._axes.transAxes.inverted()
+            xval, yval = axes_trans.transform([event.x, event.y])
+
         if scrubbing or event.key == SCRUBBING_KEY:
             if not self._roi.defined():
                 return False
-            elif not self._roi.contains(event.xdata, event.ydata):
+            elif not self._roi.contains(xval, yval):
                 return False
 
         self._store_previous_roi()
@@ -1364,11 +1419,11 @@ class MplPolygonalROI(AbstractMplRoi):
 
         if scrubbing or event.key == SCRUBBING_KEY:
             self._scrubbing = True
-            self._cx = event.xdata
-            self._cy = event.ydata
+            self._cx = xval
+            self._cy = yval
         else:
             self.reset()
-            self._roi.add_point(event.xdata, event.ydata)
+            self._roi.add_point(xval, yval)
 
         self._mid_selection = True
 
@@ -1384,13 +1439,20 @@ class MplPolygonalROI(AbstractMplRoi):
             if not self._roi.defined():
                 return False
 
-        if self._scrubbing:
-            self._roi.move_to(event.xdata - self._cx,
-                              event.ydata - self._cy)
-            self._cx = event.xdata
-            self._cy = event.ydata
+        if self._data_space:
+            xval = event.xdata
+            yval = event.ydata
         else:
-            self._roi.add_point(event.xdata, event.ydata)
+            axes_trans = self._axes.transAxes.inverted()
+            xval, yval = axes_trans.transform([event.x, event.y])
+
+        if self._scrubbing:
+            self._roi.move_to(xval - self._cx,
+                              yval - self._cy)
+            self._cx = xval
+            self._cy = yval
+        else:
+            self._roi.add_point(xval, yval)
 
         self._sync_patch()
         self._draw()

--- a/glue/core/roi.py
+++ b/glue/core/roi.py
@@ -356,7 +356,10 @@ class RangeROI(Roi):
 
     @classmethod
     def __setgluestate__(cls, rec, context):
-        return cls(rec['ori'], min=rec['min'], max=rec['max'])
+        if cls is XRangeROI or cls is YRangeROI:
+            return cls(min=rec['min'], max=rec['max'])
+        else:
+            return cls(rec['ori'], min=rec['min'], max=rec['max'])
 
 
 class XRangeROI(RangeROI):

--- a/glue/core/roi.py
+++ b/glue/core/roi.py
@@ -1330,7 +1330,7 @@ class MplCircularROI(AbstractMplRoi):
         rad = self._roi.get_radius()
 
         # At this point, if one of the axes is not linear, we convert to a polygon
-        if self._axes.get_xscale() != 'linear' or self._axes.get_yscale() != 'linear':
+        if (self._axes.get_xscale() != 'linear' or self._axes.get_yscale() != 'linear') and self._data_space:
             theta = np.linspace(0, 2 * np.pi, num=200)
             x = xy_center[0] + rad * np.cos(theta)
             y = xy_center[1] + rad * np.sin(theta)

--- a/glue/core/roi.py
+++ b/glue/core/roi.py
@@ -49,9 +49,11 @@ def pixel_to_data(axes, x, y):
     xy = np.column_stack((np.asarray(x).ravel(), np.asarray(y).ravel()))
     return axes.transData.inverted().transform(xy)
 
+
 def pixel_to_axes(axes, x, y):
     xy = np.column_stack((np.asarray(x).ravel(), np.asarray(y).ravel()))
     return axes.transAxes.inverted().transform(xy)
+
 
 class Roi(object):  # pragma: no cover
 

--- a/glue/core/roi_pretransforms.py
+++ b/glue/core/roi_pretransforms.py
@@ -6,7 +6,7 @@ import numpy as np
 
 class ProjectionMplTransform(object):
     def __init__(self, projection, x_lim, y_lim, x_scale, y_scale):
-        self._state = {'projection': projection, 'x_lim': x_lim,'y_lim': y_lim,
+        self._state = {'projection': projection, 'x_lim': x_lim, 'y_lim': y_lim,
                        'x_scale': x_scale, 'y_scale': y_scale}
         _, axes = init_mpl(Figure(), projection=self._state['projection'])
         axes.set_xscale(self._state['x_scale'])
@@ -19,9 +19,9 @@ class ProjectionMplTransform(object):
     def __call__(self, x, y):
         assert self._transform is not None
         assert x.shape == y.shape
-        points = np.hstack((x.reshape(-1,1),y.reshape(-1,1)))
+        points = np.hstack((x.reshape(-1, 1), y.reshape(-1, 1)))
         res = self._transform.transform(points)
-        out = np.hsplit(res,2)
+        out = np.hsplit(res, 2)
         return out[0].reshape(x.shape), out[1].reshape(y.shape)
 
     def __gluestate__(self, context):

--- a/glue/core/roi_pretransforms.py
+++ b/glue/core/roi_pretransforms.py
@@ -1,0 +1,34 @@
+from glue.viewers.matplotlib.mpl_axes import init_mpl
+
+from matplotlib.figure import Figure
+import numpy as np
+
+
+class ProjectionMplTransform(object):
+    def __init__(self, projection, x_lim, y_lim, x_scale, y_scale):
+        self._state = {'projection': projection, 'x_lim': x_lim,'y_lim': y_lim,
+                       'x_scale': x_scale, 'y_scale': y_scale}
+        _, axes = init_mpl(Figure(), projection=self._state['projection'])
+        axes.set_xscale(self._state['x_scale'])
+        axes.set_yscale(self._state['y_scale'])
+        if self._state['projection'] not in ['aitoff', 'hammer', 'lambert', 'mollweide']:
+            axes.set_xlim(self._state['x_lim'])
+            axes.set_ylim(self._state['y_lim'])
+        self._transform = (axes.transData + axes.transAxes.inverted()).frozen()
+
+    def __call__(self, x, y):
+        assert self._transform is not None
+        assert x.shape == y.shape
+        points = np.hstack((x.reshape(-1,1),y.reshape(-1,1)))
+        res = self._transform.transform(points)
+        out = np.hsplit(res,2)
+        return out[0].reshape(x.shape), out[1].reshape(y.shape)
+
+    def __gluestate__(self, context):
+        return dict(state=context.id(self._state))
+
+    @classmethod
+    def __setgluestate__(cls, rec, context):
+        state = context.object(rec['state'])
+        return cls(state['projection'], state['x_lim'], state['y_lim'],
+                   state['x_scale'], state['y_scale'])

--- a/glue/core/roi_pretransforms.py
+++ b/glue/core/roi_pretransforms.py
@@ -17,15 +17,13 @@ class ProjectionMplTransform(object):
         self._transform = (axes.transData + axes.transAxes.inverted()).frozen()
 
     def __call__(self, x, y):
-        assert self._transform is not None
-        assert x.shape == y.shape
         points = np.hstack((x.reshape(-1, 1), y.reshape(-1, 1)))
         res = self._transform.transform(points)
         out = np.hsplit(res, 2)
         return out[0].reshape(x.shape), out[1].reshape(y.shape)
 
     def __gluestate__(self, context):
-        return dict(state=context.id(self._state))
+        return dict(state=context.do(self._state))
 
     @classmethod
     def __setgluestate__(cls, rec, context):

--- a/glue/core/state.py
+++ b/glue/core/state.py
@@ -667,14 +667,16 @@ def _load_range_subset_state(rec, context):
 def _save_roi_subset_state(state, context):
     return dict(xatt=context.id(state.xatt),
                 yatt=context.id(state.yatt),
-                roi=context.id(state.roi))
+                roi=context.id(state.roi),
+                pretransform=context.id(state.pretransform))
 
 
 @loader(RoiSubsetState)
 def _load_roi_subset_state(rec, context):
     return RoiSubsetState(context.object(rec['xatt']),
                           context.object(rec['yatt']),
-                          context.object(rec['roi']))
+                          context.object(rec['roi']),
+                          context.object(rec['pretransform']))
 
 
 @saver(InequalitySubsetState)

--- a/glue/core/state.py
+++ b/glue/core/state.py
@@ -676,7 +676,7 @@ def _load_roi_subset_state(rec, context):
     return RoiSubsetState(context.object(rec['xatt']),
                           context.object(rec['yatt']),
                           context.object(rec['roi']),
-                          context.object(rec['pretransform']))
+                          context.object(rec['pretransform'] if 'pretransform' in rec else None))
 
 
 @saver(InequalitySubsetState)

--- a/glue/core/subset.py
+++ b/glue/core/subset.py
@@ -491,13 +491,13 @@ class RoiSubsetStateNd(SubsetState):
         self._roi = value
 
     @property
-    def pretransfrom(self):
+    def pretransform(self):
         """
         An optional transformation function to apply before checking if points are in the ROI.
         """
         return self._pretransform
 
-    @pretransfrom.setter
+    @pretransform.setter
     def pretransform(self, value):
         if not callable(value) and value is not None:
             raise TypeError("The pretransform must be callable or None.")

--- a/glue/core/subset.py
+++ b/glue/core/subset.py
@@ -592,8 +592,8 @@ class RoiSubsetState(RoiSubsetStateNd):
     def to_mask(self, data, view=None):
         x_data = data[self.xatt, view]
         if (x_data.ndim == data.ndim and
-            self.xatt in data.pixel_component_ids and
-            self.yatt in data.pixel_component_ids):
+                    self.xatt in data.pixel_component_ids and
+                    self.yatt in data.pixel_component_ids):
 
             # This is a special case - the ROI is defined in pixel space, so we
             #  can apply it to a single slice and then broadcast it to all other
@@ -1807,7 +1807,6 @@ class RoiSubsetState3d(RoiSubsetStateNd):
     @zatt.setter
     def zatt(self, value):
         self._atts[2] = value
-
 
     def copy(self):
         result = RoiSubsetState3d()

--- a/glue/core/subset.py
+++ b/glue/core/subset.py
@@ -535,7 +535,7 @@ class RoiSubsetStateNd(SubsetState):
                 if i in axis_ids:
                     subset.append(slice(None))
                 else:
-                    subset.append(slice(0,1))
+                    subset.append(slice(0, 1))
             for i in range(len(raw_comps)):
                 raw_comps[i] = raw_comps[i][tuple(subset)]
 

--- a/glue/core/subset.py
+++ b/glue/core/subset.py
@@ -18,7 +18,7 @@ from glue.utils import (view_shape, broadcast_to, floodfill, combine_slices,
                         polygon_line_intersections, categorical_ndarray, iterate_chunks)
 
 
-__all__ = ['Subset', 'SubsetState', 'RoiSubsetState', 'CategoricalROISubsetState',
+__all__ = ['Subset', 'SubsetState', 'RoiSubsetStateNd', 'RoiSubsetState', 'CategoricalROISubsetState',
            'RangeSubsetState', 'MultiRangeSubsetState', 'CompositeSubsetState',
            'OrState', 'AndState', 'XorState', 'InvertState', 'MaskSubsetState', 'CategorySubsetState',
            'ElementSubsetState', 'InequalitySubsetState', 'combine_multiple',

--- a/glue/core/subset.py
+++ b/glue/core/subset.py
@@ -529,7 +529,7 @@ class RoiSubsetStateNd(SubsetState):
                 res = self.pretransform(*comp_subsets)
                 while len(transformed_points) < len(res):
                     transformed_points.append(np.zeros(raw_comps[0].shape))
-                for i in len(res):
+                for i in range(len(res)):
                     transformed_points[i][slices] = res[i]
         else:
             transformed_points = raw_comps
@@ -1852,13 +1852,13 @@ def combine_multiple(subsets, operator):
         return combined
 
 
-def roi_to_subset_state(roi, x_att=None, y_att=None, x_categories=None, y_categories=None):
+def roi_to_subset_state(roi, x_att=None, y_att=None, x_categories=None, y_categories=None, use_pretransform=False):
     """
     Given a 2D ROI and attributes on the x and y axis, determine the
     corresponding subset state.
     """
 
-    if isinstance(roi, RangeROI):
+    if isinstance(roi, RangeROI) and not use_pretransform:
 
         if roi.ori == 'x':
             att = x_att
@@ -1962,9 +1962,9 @@ def roi_to_subset_state(roi, x_att=None, y_att=None, x_categories=None, y_catego
 
     else:
 
-        # The selection is polygon-like and components are numerical
+        # The selection is polygon-like or requires a pretransform and components are numerical
 
-        if not isinstance(roi, (PolygonalROI, RectangularROI, CircularROI, EllipticalROI)):
+        if not isinstance(roi, (PolygonalROI, RectangularROI, CircularROI, EllipticalROI, RangeROI)):
             roi = PolygonalROI(*roi.to_polygon())
 
         subset_state = RoiSubsetState()

--- a/glue/core/subset.py
+++ b/glue/core/subset.py
@@ -471,7 +471,19 @@ class SubsetState(object):
 
 class RoiSubsetStateNd(SubsetState):
     """
-    A base class that combines the logic of the 2D and 3D RoiSubsetStates
+    A subset defined as the set of points in N dimensions that lie inside
+    a region of interest (ROI).
+
+    The dimensions are defined as numerical data attributes.
+
+    Parameters
+    ----------
+    atts : list of :class:`~glue.core.component_id.ComponentID`
+        The data attributes that define the dimensions of the region.
+    roi : :class:`~glue.core.roi.Roi`
+        The region of interest.
+    pretransform: callable, optional
+        A function that can be optionally applied to the data before checking points against the region.
     """
 
     def __init__(self, atts=[], roi=None, pretransform=None):
@@ -546,8 +558,12 @@ class RoiSubsetStateNd(SubsetState):
                 for raw_comp in raw_comps:
                     comp_subsets.append(raw_comp[slices])
                 res = self.pretransform(*comp_subsets)
+
+                # Do this here in case the pretransform changes the dimensionality
+                # e.g. 3D input to a 2D projection like Projected3dROI does internally
                 while len(transformed_points) < len(res):
                     transformed_points.append(np.zeros(raw_comps[0].shape))
+
                 for i in range(len(res)):
                     transformed_points[i][slices] = res[i]
         else:
@@ -579,6 +595,8 @@ class RoiSubsetState(RoiSubsetStateNd):
         The data attribute on the y axis.
     roi : :class:`~glue.core.roi.Roi`
         The region of interest.
+    pretransform: callable, optional
+        A function that can be optionally applied to the data before checking points against the region.
     """
 
     @contract(xatt='isinstance(ComponentID)', yatt='isinstance(ComponentID)')
@@ -1747,6 +1765,8 @@ class RoiSubsetState3d(RoiSubsetStateNd):
         The data attribute on the z axis.
     roi : :class:`~glue.core.roi.Roi`
         The region of interest (which should implement ``contains3d``)
+    pretransform: callable, optional
+        A function that can be optionally applied to the data before checking points against the region.
     """
 
     @contract(xatt='isinstance(ComponentID)', yatt='isinstance(ComponentID)', zatt='isinstance(ComponentID)')

--- a/glue/core/subset.py
+++ b/glue/core/subset.py
@@ -1827,11 +1827,12 @@ class RoiSubsetState3d(RoiSubsetStateNd):
 
     @classmethod
     def __setgluestate__(cls, rec, context):
+        pretrans = rec['pretransform'] if 'pretransform' in rec else None
         return RoiSubsetState3d(context.object(rec['xatt']),
                                 context.object(rec['yatt']),
                                 context.object(rec['zatt']),
                                 context.object(rec['roi']),
-                                context.object(rec['pretransform']))
+                                context.object(pretrans))
 
 
 @contract(subsets='list(isinstance(Subset))', returns=Subset)

--- a/glue/core/tests/test_roi.py
+++ b/glue/core/tests/test_roi.py
@@ -22,11 +22,13 @@ from ..state import GlueSerializer, GlueUnSerializer
 FIG = Figure()
 AXES = FIG.add_subplot(111)
 
+
 def roundtrip_roi(roi):
     gs = GlueSerializer(roi)
     out_str = gs.dumps()
     obj = GlueUnSerializer.loads(out_str)
     return obj.object('__main__')
+
 
 class TestPoint(object):
 
@@ -185,12 +187,13 @@ class TestXRange(object):
                                       [-1e100, -1e100, 1e100, 1e100, -1e100])
 
     def test_serialization(self):
-         roi = XRangeROI()
-         roi.set_range(7, 8)
-         new_roi = roundtrip_roi(roi)
-         assert_almost_equal(new_roi.min, 7)
-         assert_almost_equal(new_roi.max, 8)
-         assert new_roi.ori == 'x'
+        roi = XRangeROI()
+        roi.set_range(7, 8)
+        new_roi = roundtrip_roi(roi)
+        assert_almost_equal(new_roi.min, 7)
+        assert_almost_equal(new_roi.max, 8)
+        assert new_roi.ori == 'x'
+
 
 class TestYRange(object):
     def test_undefined_on_init(self):
@@ -496,6 +499,7 @@ class TestPolygon(object):
         new_roi = roundtrip_roi(self.roi)
         assert_almost_equal(new_roi.vx, np.array([0, 0, 1, 1]))
         assert_almost_equal(new_roi.vy, np.array([0, 1, 1, 0]))
+
 
 class TestProjected3dROI(object):
     # matrix that converts xyzw to yxzw

--- a/glue/core/tests/test_roi_transfoms.py
+++ b/glue/core/tests/test_roi_transfoms.py
@@ -17,11 +17,23 @@ def test_simple_polar_mpl_transform():
     radii = np.array([0, 5, 4, 1, 0, 2, -10, 10])
     transform = ProjectionMplTransform('polar', [0, 2 * np.pi], [-5, 5], 'linear', 'linear')
     x, y = transform(angles, radii)
-    sr2 = np.sqrt(2)
-    sr3 = np.sqrt(3)
     expected_x = np.array([0.75, 0.8535533905932736, 0.5, 0.2, .625, 0.5, np.nan, 1.25])
     expected_y = np.array([0.5, 0.8535533905932736, 0.95, 0.5, 0.28349364905389035,
                            0.85, np.nan, 0.5])
+    assert_allclose(x, expected_x)
+    assert_allclose(y, expected_y)
+    new_transform = roundtrip_transform(transform)
+    new_x, new_y = new_transform(angles, radii)
+    assert_allclose(new_x, x, rtol=1e-14)
+    assert_allclose(new_y, y, rtol=1e-14)
+
+def test_log_polar_mpl_transform():
+    angles = np.deg2rad(np.array([0, 90, 180]))
+    radii = np.array([10, 100, 1000])
+    transform = ProjectionMplTransform('polar', [0, 2 * np.pi], [1, 10000], 'linear', 'log')
+    x, y = transform(angles, radii)
+    expected_x = np.array([0.5, 0.5, 0.25])
+    expected_y = np.array([0.5, 0.625, 0.5])
     assert_allclose(x, expected_x)
     assert_allclose(y, expected_y)
     new_transform = roundtrip_transform(transform)
@@ -35,7 +47,6 @@ def test_wedge_polar_mpl_transform():
     radii = np.array([0.1, 0.2, 0.3, 0.4, 0.5])
     transform = ProjectionMplTransform('polar', [0, np.pi], [0, 0.5], 'linear', 'linear')
     x, y = transform(angles, radii)
-    sr2 = np.sqrt(2)
     assert_allclose(x, np.array([0.6, 0.64142136, 0.5, 0.21715729, 0]))
     # For just the upper half, y is between 0.25 and 0.75
     assert_allclose(y, np. array([0.25, 0.39142136, 0.55, 0.53284271, 0.25]))

--- a/glue/core/tests/test_roi_transfoms.py
+++ b/glue/core/tests/test_roi_transfoms.py
@@ -27,6 +27,7 @@ def test_simple_polar_mpl_transform():
     assert_allclose(new_x, x, rtol=1e-14)
     assert_allclose(new_y, y, rtol=1e-14)
 
+
 def test_log_polar_mpl_transform():
     angles = np.deg2rad(np.array([0, 90, 180]))
     radii = np.array([10, 100, 1000])

--- a/glue/core/tests/test_roi_transfoms.py
+++ b/glue/core/tests/test_roi_transfoms.py
@@ -1,0 +1,101 @@
+import numpy as np
+from numpy.testing import assert_allclose
+
+from glue.core.roi_pretransforms import ProjectionMplTransform
+from glue.core.state import GlueSerializer, GlueUnSerializer
+
+def roundtrip_transform(transform):
+    gs = GlueSerializer(transform)
+    out_str = gs.dumps()
+    obj = GlueUnSerializer.loads(out_str)
+    return obj.object('__main__')
+
+def test_simple_polar_mpl_transform():
+    angles = np.deg2rad(np.array([0, 45, 90, 180, 300, 810, 0, 0]))
+    radii = np.array([0, 5, 4, 1, 0, 2, -10, 10])
+    transform = ProjectionMplTransform('polar', [0, 2*np.pi], [-5, 5], 'linear', 'linear')
+    x, y = transform(angles, radii)
+    sr2 = np.sqrt(2)
+    sr3 = np.sqrt(3)
+    expected_x = np.array([0.75, (1+sr2)/(2*sr2), 0.5, 0.2, .625, 0.5, np.nan, 1.25])
+    expected_y = np.array([0.5, (1+sr2)/(2*sr2), 0.95, 0.5,  0.5-sr3*0.125, 0.85, np.nan, 0.5])
+    assert_allclose(x, expected_x)
+    assert_allclose(y, expected_y)
+    new_transform = roundtrip_transform(transform)
+    new_x, new_y = new_transform(angles, radii)
+    assert_allclose(new_x, x, rtol=1e-14)
+    assert_allclose(new_y, y, rtol=1e-14)
+
+def test_wedge_polar_mpl_transform():
+    angles = np.deg2rad(np.array([0, 45, 90, 135, 180]))
+    radii = np.array([0.1, 0.2, 0.3, 0.4, 0.5])
+    transform = ProjectionMplTransform('polar', [0, np.pi], [0, 0.5], 'linear', 'linear')
+    x, y = transform(angles, radii)
+    sr2 = np.sqrt(2)
+    assert_allclose(x, np.array([0.6, 0.5+0.2/sr2, 0.5, 0.5-0.4/sr2, 0]))
+    # For just the upper half, y is between 0.25 and 0.75
+    assert_allclose(y, np.array([0.25, 0.25+0.2/sr2, 0.55, 0.25+0.4/sr2, 0.25]))
+    new_transform = roundtrip_transform(transform)
+    new_x, new_y = new_transform(angles, radii)
+    assert_allclose(new_x, x, rtol=1e-14)
+    assert_allclose(new_y, y, rtol=1e-14)
+
+def test_aitoff_mpl_transform():
+    transform = ProjectionMplTransform('aitoff', [-np.pi, np.pi],
+                                       [-np.pi / 2, np.pi / 2], 'linear', 'linear')
+    long = np.deg2rad(np.array([0, -90, 0, 45]))
+    lat = np.deg2rad(np.array([0, 0, 45, -45]))
+    x, y = transform(long, lat)
+    expected_x = np.array([0.5, 0.25, 0.5, 0.59771208])
+    expected_y =  np.array([0.5, 0.5, 0.75, 0.24466602])
+    assert_allclose(x,expected_x)
+    assert_allclose(y, expected_y)
+    new_transform = roundtrip_transform(transform)
+    new_x, new_y = new_transform(long, lat)
+    assert_allclose(new_x, x, rtol=1e-14)
+    assert_allclose(new_y, y, rtol=1e-14)
+
+def test_hammer_mpl_transform():
+    transform = ProjectionMplTransform('hammer', [-np.pi, np.pi],
+                                       [-np.pi / 2, np.pi / 2], 'linear', 'linear')
+    long = np.deg2rad(np.array([0, -90, 0, 45]))
+    lat = np.deg2rad(np.array([0, 0, 45, -45]))
+    x, y = transform(long, lat)
+    expected_x = np.array([0.5, 0.22940195, 0.5, 0.60522557])
+    expected_y = np.array([0.5, 0.5, 0.77059805, 0.22503235])
+    assert_allclose(x, expected_x)
+    assert_allclose(y, expected_y)
+    new_transform = roundtrip_transform(transform)
+    new_x, new_y = new_transform(long, lat)
+    assert_allclose(new_x, x, rtol=1e-14)
+    assert_allclose(new_y, y, rtol=1e-14)
+
+def test_lambert_mpl_projection():
+    transform = ProjectionMplTransform('lambert', [-np.pi, np.pi],
+                                       [-np.pi / 2, np.pi / 2], 'linear', 'linear')
+    long = np.deg2rad(np.array([0, -90, 0, 45]))
+    lat = np.deg2rad(np.array([0, 0, 45, -45]))
+    x, y = transform(long, lat)
+    expected_x = np.array([0.5, 0.14644661, 0.5, 0.64433757])
+    expected_y = np.array([0.5, 0.5, 0.69134172, 0.29587585])
+    assert_allclose(x, expected_x)
+    assert_allclose(y, expected_y)
+    new_transform = roundtrip_transform(transform)
+    new_x, new_y = new_transform(long, lat)
+    assert_allclose(new_x, x, rtol=1e-14)
+    assert_allclose(new_y, y, rtol=1e-14)
+
+def test_mollweide_mpl_projection():
+    transform = ProjectionMplTransform('mollweide', [-np.pi, np.pi],
+                                       [-np.pi / 2, np.pi / 2], 'linear', 'linear')
+    long = np.deg2rad(np.array([0, -90, 0, 45]))
+    lat = np.deg2rad(np.array([0, 0, 45, -45]))
+    x, y = transform(long, lat)
+    expected_x = np.array([0.5, 0.25, 0.5, 0.60076564])
+    expected_y = np.array([0.5, 0.5, 0.79587254, 0.20412746])
+    assert_allclose(x, expected_x)
+    assert_allclose(y, expected_y)
+    new_transform = roundtrip_transform(transform)
+    new_x, new_y = new_transform(long, lat)
+    assert_allclose(new_x, x, rtol=1e-14)
+    assert_allclose(new_y, y, rtol=1e-14)

--- a/glue/core/tests/test_roi_transfoms.py
+++ b/glue/core/tests/test_roi_transfoms.py
@@ -4,21 +4,24 @@ from numpy.testing import assert_allclose
 from glue.core.roi_pretransforms import ProjectionMplTransform
 from glue.core.state import GlueSerializer, GlueUnSerializer
 
+
 def roundtrip_transform(transform):
     gs = GlueSerializer(transform)
     out_str = gs.dumps()
     obj = GlueUnSerializer.loads(out_str)
     return obj.object('__main__')
 
+
 def test_simple_polar_mpl_transform():
     angles = np.deg2rad(np.array([0, 45, 90, 180, 300, 810, 0, 0]))
     radii = np.array([0, 5, 4, 1, 0, 2, -10, 10])
-    transform = ProjectionMplTransform('polar', [0, 2*np.pi], [-5, 5], 'linear', 'linear')
+    transform = ProjectionMplTransform('polar', [0, 2 * np.pi], [-5, 5], 'linear', 'linear')
     x, y = transform(angles, radii)
     sr2 = np.sqrt(2)
     sr3 = np.sqrt(3)
-    expected_x = np.array([0.75, (1+sr2)/(2*sr2), 0.5, 0.2, .625, 0.5, np.nan, 1.25])
-    expected_y = np.array([0.5, (1+sr2)/(2*sr2), 0.95, 0.5,  0.5-sr3*0.125, 0.85, np.nan, 0.5])
+    expected_x = np.array([0.75, 0.8535533905932736, 0.5, 0.2, .625, 0.5, np.nan, 1.25])
+    expected_y = np.array([0.5, 0.8535533905932736, 0.95, 0.5, 0.28349364905389035,
+                           0.85, np.nan, 0.5])
     assert_allclose(x, expected_x)
     assert_allclose(y, expected_y)
     new_transform = roundtrip_transform(transform)
@@ -26,19 +29,21 @@ def test_simple_polar_mpl_transform():
     assert_allclose(new_x, x, rtol=1e-14)
     assert_allclose(new_y, y, rtol=1e-14)
 
+
 def test_wedge_polar_mpl_transform():
     angles = np.deg2rad(np.array([0, 45, 90, 135, 180]))
     radii = np.array([0.1, 0.2, 0.3, 0.4, 0.5])
     transform = ProjectionMplTransform('polar', [0, np.pi], [0, 0.5], 'linear', 'linear')
     x, y = transform(angles, radii)
     sr2 = np.sqrt(2)
-    assert_allclose(x, np.array([0.6, 0.5+0.2/sr2, 0.5, 0.5-0.4/sr2, 0]))
+    assert_allclose(x, np.array([0.6, 0.64142136, 0.5, 0.21715729, 0]))
     # For just the upper half, y is between 0.25 and 0.75
-    assert_allclose(y, np.array([0.25, 0.25+0.2/sr2, 0.55, 0.25+0.4/sr2, 0.25]))
+    assert_allclose(y, np. array([0.25, 0.39142136, 0.55, 0.53284271, 0.25]))
     new_transform = roundtrip_transform(transform)
     new_x, new_y = new_transform(angles, radii)
     assert_allclose(new_x, x, rtol=1e-14)
     assert_allclose(new_y, y, rtol=1e-14)
+
 
 def test_aitoff_mpl_transform():
     transform = ProjectionMplTransform('aitoff', [-np.pi, np.pi],
@@ -47,13 +52,14 @@ def test_aitoff_mpl_transform():
     lat = np.deg2rad(np.array([0, 0, 45, -45]))
     x, y = transform(long, lat)
     expected_x = np.array([0.5, 0.25, 0.5, 0.59771208])
-    expected_y =  np.array([0.5, 0.5, 0.75, 0.24466602])
-    assert_allclose(x,expected_x)
+    expected_y = np.array([0.5, 0.5, 0.75, 0.24466602])
+    assert_allclose(x, expected_x)
     assert_allclose(y, expected_y)
     new_transform = roundtrip_transform(transform)
     new_x, new_y = new_transform(long, lat)
     assert_allclose(new_x, x, rtol=1e-14)
     assert_allclose(new_y, y, rtol=1e-14)
+
 
 def test_hammer_mpl_transform():
     transform = ProjectionMplTransform('hammer', [-np.pi, np.pi],
@@ -70,6 +76,7 @@ def test_hammer_mpl_transform():
     assert_allclose(new_x, x, rtol=1e-14)
     assert_allclose(new_y, y, rtol=1e-14)
 
+
 def test_lambert_mpl_projection():
     transform = ProjectionMplTransform('lambert', [-np.pi, np.pi],
                                        [-np.pi / 2, np.pi / 2], 'linear', 'linear')
@@ -84,6 +91,7 @@ def test_lambert_mpl_projection():
     new_x, new_y = new_transform(long, lat)
     assert_allclose(new_x, x, rtol=1e-14)
     assert_allclose(new_y, y, rtol=1e-14)
+
 
 def test_mollweide_mpl_projection():
     transform = ProjectionMplTransform('mollweide', [-np.pi, np.pi],

--- a/glue/core/tests/test_subset.py
+++ b/glue/core/tests/test_subset.py
@@ -848,13 +848,11 @@ class TestCloneSubsetStates():
 
     def test_roi_subset_state_with_pretransform(self):
         roi = RectangularROI(xmin=2, xmax=4, ymin=0, ymax=1)
-        # ([-1.8, 3.3, 5.5, 2.9], [-4.2, 0.7, 2.5, -0.9])
         subset = self.data.new_subset()
         subset.subset_state = RoiSubsetState(xatt=self.data.id['a'], yatt=self.data.id['c'],
                                              roi=roi, pretransform=example_transform)
-        print(example_transform(self.data['a'], self.data['c']))
-        import types
-        print(type(example_transform), isinstance(example_transform, types.FunctionType))
+
+        # Post transform outputs are x=[-1.8, 3.3, 5.5, 2.9], y=[-4.2, 0.7, 2.5, -0.9]
         assert_equal(self.data.subsets[0].to_mask(), [0, 1, 0, 0])
 
         data_clone = clone(self.data)

--- a/glue/core/tests/test_subset.py
+++ b/glue/core/tests/test_subset.py
@@ -31,6 +31,9 @@ from ..subset import XorState
 from .test_state import clone
 
 
+def example_transform(x, y):
+    return x+y, x-y
+
 class TestSubset(object):
 
     def setup_method(self, method):
@@ -842,6 +845,20 @@ class TestCloneSubsetStates():
 
         assert_equal(data_clone.subsets[0].to_mask(), [0, 1, 0, 0])
 
+    def test_roi_subset_state_with_pretransform(self):
+        roi = RectangularROI(xmin=2, xmax=4, ymin=0, ymax=1)
+        # ([-1.8, 3.3, 5.5, 2.9], [-4.2, 0.7, 2.5, -0.9])
+        subset = self.data.new_subset()
+        subset.subset_state = RoiSubsetState(xatt=self.data.id['a'], yatt=self.data.id['c'],
+                                             roi=roi, pretransform=example_transform)
+        print(example_transform(self.data['a'], self.data['c']))
+        import types
+        print(type(example_transform), isinstance(example_transform, types.FunctionType))
+        assert_equal(self.data.subsets[0].to_mask(), [0,1,0,0])
+
+        data_clone = clone(self.data)
+
+        assert_equal(data_clone.subsets[0].to_mask(), [0, 1, 0, 0])
 
 @requires_scipy
 def test_floodfill_subset_state():

--- a/glue/core/tests/test_subset.py
+++ b/glue/core/tests/test_subset.py
@@ -1021,3 +1021,17 @@ def test_multi_or_state():
 
     # Test str
     assert str(state3) == "('or' combination of 3 individual states)"
+
+
+def test_roi_reduction():
+    # This test checks that the ROI dimensionality shortcut works as expected
+
+    data4d = Data(val=np.zeros((3, 4, 2, 2)))
+    roi = RectangularROI(0.9, 2.1, 1.9, 3.1)
+    state = RoiSubsetState(xatt=data4d.pixel_component_ids[0], yatt=data4d.pixel_component_ids[1], roi=roi)
+    out = state.to_mask(data4d)
+    expected_slice = np.array([[0, 0, 0, 0], [0, 0, 1, 1], [0, 0, 1, 1]])
+    assert_equal(out[:, :, 0, 0], expected_slice)
+    assert_equal(out[:, :, 0, 1], expected_slice)
+    assert_equal(out[:, :, 1, 0], expected_slice)
+    assert_equal(out[:, :, 1, 1], expected_slice)

--- a/glue/core/tests/test_subset.py
+++ b/glue/core/tests/test_subset.py
@@ -32,7 +32,8 @@ from .test_state import clone
 
 
 def example_transform(x, y):
-    return x+y, x-y
+    return x + y, x - y
+
 
 class TestSubset(object):
 
@@ -854,11 +855,12 @@ class TestCloneSubsetStates():
         print(example_transform(self.data['a'], self.data['c']))
         import types
         print(type(example_transform), isinstance(example_transform, types.FunctionType))
-        assert_equal(self.data.subsets[0].to_mask(), [0,1,0,0])
+        assert_equal(self.data.subsets[0].to_mask(), [0, 1, 0, 0])
 
         data_clone = clone(self.data)
 
         assert_equal(data_clone.subsets[0].to_mask(), [0, 1, 0, 0])
+
 
 @requires_scipy
 def test_floodfill_subset_state():

--- a/glue/core/util.py
+++ b/glue/core/util.py
@@ -5,9 +5,8 @@ from functools import partial
 
 import numpy as np
 
-from matplotlib.ticker import AutoLocator, MaxNLocator, LogLocator, FixedLocator
-from matplotlib.ticker import (LogFormatterMathtext, ScalarFormatter,
-                               FuncFormatter)
+from matplotlib.ticker import AutoLocator, MaxNLocator, LogLocator
+from matplotlib.ticker import LogFormatterMathtext, ScalarFormatter, FuncFormatter
 from matplotlib.dates import AutoDateLocator, AutoDateFormatter
 from matplotlib.projections.polar import ThetaFormatter, ThetaLocator
 
@@ -335,7 +334,7 @@ def tick_linker(all_categories, pos, *args):
             return ''
 
 
-def update_ticks(axes, coord, kinds, is_log, categories, projection = 'rectilinear'):
+def update_ticks(axes, coord, kinds, is_log, categories, projection='rectilinear'):
     """
     Changes the axes to have the proper tick formatting based on the type of
     component.

--- a/glue/viewers/common/viewer.py
+++ b/glue/viewers/common/viewer.py
@@ -396,6 +396,7 @@ class Viewer(BaseViewer):
                     shell.user_ns.pop(key)
 
     def remove_layer(self, layer):
+        print("remove_layer called", layer, self._layer_artist_container)
         self._layer_artist_container.pop(layer)
 
     @property

--- a/glue/viewers/common/viewer.py
+++ b/glue/viewers/common/viewer.py
@@ -396,7 +396,6 @@ class Viewer(BaseViewer):
                     shell.user_ns.pop(key)
 
     def remove_layer(self, layer):
-        print("remove_layer called", layer, self._layer_artist_container)
         self._layer_artist_container.pop(layer)
 
     @property

--- a/glue/viewers/matplotlib/mpl_axes.py
+++ b/glue/viewers/matplotlib/mpl_axes.py
@@ -34,7 +34,7 @@ def update_appearance_from_settings(axes):
     set_foreground_color(axes, settings.FOREGROUND_COLOR)
 
 
-def init_mpl(figure=None, axes=None, wcs=False, axes_factory=None):
+def init_mpl(figure=None, axes=None, wcs=False, axes_factory=None, projection=None):
 
     if (axes is not None and figure is not None and
             axes.figure is not figure):
@@ -55,7 +55,7 @@ def init_mpl(figure=None, axes=None, wcs=False, axes_factory=None):
             _figure.add_axes(_axes)
         else:
             if axes_factory is None:
-                _axes = _figure.add_subplot(1, 1, 1)
+                _axes = _figure.add_subplot(1, 1, 1, projection=projection)
             else:
                 _axes = axes_factory(_figure)
 

--- a/glue/viewers/matplotlib/qt/data_viewer.py
+++ b/glue/viewers/matplotlib/qt/data_viewer.py
@@ -22,7 +22,7 @@ class MatplotlibDataViewer(MatplotlibViewerMixin, DataViewer):
     tools = ['mpl:home', 'mpl:pan', 'mpl:zoom']
     subtools = {'save': ['mpl:save']}
 
-    def __init__(self, session, parent=None, wcs=None, state=None):
+    def __init__(self, session, parent=None, wcs=None, state=None, projection=None):
 
         super(MatplotlibDataViewer, self).__init__(session, parent=parent, state=state)
 
@@ -33,7 +33,7 @@ class MatplotlibDataViewer(MatplotlibViewerMixin, DataViewer):
         # TODO: shouldn't have to do this
         self.central_widget = self.mpl_widget
 
-        self.figure, self.axes = init_mpl(self.mpl_widget.canvas.fig, wcs=wcs)
+        self.figure, self.axes = init_mpl(self.mpl_widget.canvas.fig, wcs=wcs, projection=projection)
 
         MatplotlibViewerMixin.setup_callbacks(self)
 

--- a/glue/viewers/matplotlib/toolbar_mode.py
+++ b/glue/viewers/matplotlib/toolbar_mode.py
@@ -233,7 +233,8 @@ class RectangleMode(RoiMode):
 
     def __init__(self, viewer, **kwargs):
         super(RectangleMode, self).__init__(viewer, **kwargs)
-        self._roi_tool = roi.MplRectangularROI(self._axes)
+        data_space = not hasattr(viewer.state,'plot_mode') or viewer.state.plot_mode == 'rectilinear'
+        self._roi_tool = roi.MplRectangularROI(self._axes, data_space=data_space)
 
 
 class PathMode(ClickRoiMode):
@@ -264,7 +265,8 @@ class CircleMode(RoiMode):
 
     def __init__(self, viewer, **kwargs):
         super(CircleMode, self).__init__(viewer, **kwargs)
-        self._roi_tool = roi.MplCircularROI(self._axes)
+        data_space = not hasattr(viewer.state,'plot_mode') or viewer.state.plot_mode == 'rectilinear'
+        self._roi_tool = roi.MplCircularROI(self._axes, data_space=data_space)
 
 
 @viewer_tool
@@ -285,7 +287,8 @@ class PolyMode(ClickRoiMode):
 
     def __init__(self, viewer, **kwargs):
         super(PolyMode, self).__init__(viewer, **kwargs)
-        self._roi_tool = roi.MplPolygonalROI(self._axes)
+        data_space = not hasattr(viewer.state,'plot_mode') or viewer.state.plot_mode == 'rectilinear'
+        self._roi_tool = roi.MplPolygonalROI(self._axes, data_space=data_space)
 
 
 @viewer_tool
@@ -304,7 +307,8 @@ class HRangeMode(RoiMode):
 
     def __init__(self, viewer, **kwargs):
         super(HRangeMode, self).__init__(viewer, **kwargs)
-        self._roi_tool = roi.MplXRangeROI(self._axes)
+        data_space = not hasattr(viewer.state,'plot_mode') or viewer.state.plot_mode == 'rectilinear'
+        self._roi_tool = roi.MplXRangeROI(self._axes, data_space=data_space)
 
 
 @viewer_tool
@@ -323,7 +327,8 @@ class VRangeMode(RoiMode):
 
     def __init__(self, viewer, **kwargs):
         super(VRangeMode, self).__init__(viewer, **kwargs)
-        self._roi_tool = roi.MplYRangeROI(self._axes)
+        data_space = not hasattr(viewer.state,'plot_mode') or viewer.state.plot_mode == 'rectilinear'
+        self._roi_tool = roi.MplYRangeROI(self._axes, data_space=data_space)
 
 
 @viewer_tool

--- a/glue/viewers/matplotlib/toolbar_mode.py
+++ b/glue/viewers/matplotlib/toolbar_mode.py
@@ -233,7 +233,7 @@ class RectangleMode(RoiMode):
 
     def __init__(self, viewer, **kwargs):
         super(RectangleMode, self).__init__(viewer, **kwargs)
-        data_space = not hasattr(viewer.state,'plot_mode') or viewer.state.plot_mode == 'rectilinear'
+        data_space = not hasattr(viewer.state, 'plot_mode') or viewer.state.plot_mode == 'rectilinear'
         self._roi_tool = roi.MplRectangularROI(self._axes, data_space=data_space)
 
 
@@ -265,7 +265,7 @@ class CircleMode(RoiMode):
 
     def __init__(self, viewer, **kwargs):
         super(CircleMode, self).__init__(viewer, **kwargs)
-        data_space = not hasattr(viewer.state,'plot_mode') or viewer.state.plot_mode == 'rectilinear'
+        data_space = not hasattr(viewer.state, 'plot_mode') or viewer.state.plot_mode == 'rectilinear'
         self._roi_tool = roi.MplCircularROI(self._axes, data_space=data_space)
 
 
@@ -287,7 +287,7 @@ class PolyMode(ClickRoiMode):
 
     def __init__(self, viewer, **kwargs):
         super(PolyMode, self).__init__(viewer, **kwargs)
-        data_space = not hasattr(viewer.state,'plot_mode') or viewer.state.plot_mode == 'rectilinear'
+        data_space = not hasattr(viewer.state, 'plot_mode') or viewer.state.plot_mode == 'rectilinear'
         self._roi_tool = roi.MplPolygonalROI(self._axes, data_space=data_space)
 
 
@@ -307,7 +307,7 @@ class HRangeMode(RoiMode):
 
     def __init__(self, viewer, **kwargs):
         super(HRangeMode, self).__init__(viewer, **kwargs)
-        data_space = not hasattr(viewer.state,'plot_mode') or viewer.state.plot_mode == 'rectilinear'
+        data_space = not hasattr(viewer.state, 'plot_mode') or viewer.state.plot_mode == 'rectilinear'
         self._roi_tool = roi.MplXRangeROI(self._axes, data_space=data_space)
 
 
@@ -327,7 +327,7 @@ class VRangeMode(RoiMode):
 
     def __init__(self, viewer, **kwargs):
         super(VRangeMode, self).__init__(viewer, **kwargs)
-        data_space = not hasattr(viewer.state,'plot_mode') or viewer.state.plot_mode == 'rectilinear'
+        data_space = not hasattr(viewer.state, 'plot_mode') or viewer.state.plot_mode == 'rectilinear'
         self._roi_tool = roi.MplYRangeROI(self._axes, data_space=data_space)
 
 

--- a/glue/viewers/matplotlib/viewer.py
+++ b/glue/viewers/matplotlib/viewer.py
@@ -14,7 +14,7 @@ __all__ = ['MatplotlibViewerMixin']
 SCRIPT_HEADER = """
 # Initialize figure
 fig = plt.figure()
-ax = fig.add_subplot(1, 1, 1, aspect='{aspect}')
+ax = fig.add_subplot(1, 1, 1, aspect='{aspect}', projection={projection})
 
 # for the legend
 legend_handles = []
@@ -22,14 +22,16 @@ legend_labels = []
 legend_handler_dict = dict()
 """.strip()
 
-SCRIPT_FOOTER = """
+LIMIT_SCRIPT = """
 # Set limits
-ax.set_xlim({x_min}, {x_max})
-ax.set_ylim({y_min}, {y_max})
+ax.set_xlim(left={x_min}, right={x_max})
+ax.set_ylim(bottom={y_min}, top={y_max})
+"""
 
-# Set scale (log or linear)
-ax.set_xscale('{x_log_str}')
-ax.set_yscale('{y_log_str}')
+SCRIPT_FOOTER = """
+{limit_script}
+
+{scale_script}
 
 # Set axis label properties
 ax.set_xlabel('{x_axislabel}', weight='{x_axislabel_weight}', size={x_axislabel_size})
@@ -303,15 +305,24 @@ class MatplotlibViewerMixin(object):
 
     def _script_header(self):
         state_dict = self.state.as_dict()
+        state_dict['projection'] = "None" if not hasattr(self.state, 'plot_mode') else "'"+self.state.plot_mode+"'"
         return ['import matplotlib',
                 "matplotlib.use('Agg')",
                 "# matplotlib.use('qt5Agg')",
                 'import matplotlib.pyplot as plt'], SCRIPT_HEADER.format(**state_dict)
 
     def _script_footer(self):
+        mode = 'rectilinear' if not hasattr(self.state, 'plot_mode') else self.state.plot_mode
         state_dict = self.state.as_dict()
-        state_dict['x_log_str'] = 'log' if self.state.x_log else 'linear'
-        state_dict['y_log_str'] = 'log' if self.state.y_log else 'linear'
+        temp_str = ''
+        if mode not in ['aitoff', 'hammer', 'lambert', 'mollweide', 'polar']:
+            x_log_str = 'log' if self.state.x_log else 'linear'
+            temp_str += "ax.set_xscale('"+x_log_str+"')\n"
+        if mode not in ['aitoff', 'hammer', 'lambert', 'mollweide']:
+            y_log_str = 'log' if self.state.y_log else 'linear'
+            temp_str += "ax.set_yscale('"+y_log_str+"')\n"
+        state_dict['scale_script'] = "# Set scale (log or linear)\n" +temp_str if temp_str else ''
+        state_dict['limit_script'] = '' if mode in ['aitoff', 'hammer', 'lambert', 'mollweide'] else LIMIT_SCRIPT.format(**state_dict)
         return [], SCRIPT_FOOTER.format(**state_dict)
 
     def _script_legend(self):

--- a/glue/viewers/matplotlib/viewer.py
+++ b/glue/viewers/matplotlib/viewer.py
@@ -305,7 +305,8 @@ class MatplotlibViewerMixin(object):
 
     def _script_header(self):
         state_dict = self.state.as_dict()
-        state_dict['projection'] = "None" if not hasattr(self.state, 'plot_mode') else "'"+self.state.plot_mode+"'"
+        proj = "'" + self.state.plot_mode + "'" if hasattr(self.state, 'plot_mode') else "None"
+        state_dict['projection'] = proj
         return ['import matplotlib',
                 "matplotlib.use('Agg')",
                 "# matplotlib.use('qt5Agg')",
@@ -317,12 +318,13 @@ class MatplotlibViewerMixin(object):
         temp_str = ''
         if mode not in ['aitoff', 'hammer', 'lambert', 'mollweide', 'polar']:
             x_log_str = 'log' if self.state.x_log else 'linear'
-            temp_str += "ax.set_xscale('"+x_log_str+"')\n"
+            temp_str += "ax.set_xscale('" + x_log_str + "')\n"
         if mode not in ['aitoff', 'hammer', 'lambert', 'mollweide']:
             y_log_str = 'log' if self.state.y_log else 'linear'
-            temp_str += "ax.set_yscale('"+y_log_str+"')\n"
-        state_dict['scale_script'] = "# Set scale (log or linear)\n" +temp_str if temp_str else ''
-        state_dict['limit_script'] = '' if mode in ['aitoff', 'hammer', 'lambert', 'mollweide'] else LIMIT_SCRIPT.format(**state_dict)
+            temp_str += "ax.set_yscale('" + y_log_str + "')\n"
+        state_dict['scale_script'] = "# Set scale (log or linear)\n" + temp_str if temp_str else ''
+        full_sphere = ['aitoff', 'hammer', 'lambert', 'mollweide']
+        state_dict['limit_script'] = '' if mode in full_sphere else LIMIT_SCRIPT.format(**state_dict)
         return [], SCRIPT_FOOTER.format(**state_dict)
 
     def _script_legend(self):

--- a/glue/viewers/scatter/layer_artist.py
+++ b/glue/viewers/scatter/layer_artist.py
@@ -137,7 +137,7 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
 
         super(ScatterLayerArtist, self).__init__(axes, viewer_state,
                                                  layer_state=layer_state, layer=layer)
-        print(type(axes),id(axes))
+
         # Watch for changes in the viewer state which would require the
         # layers to be redrawn
         self._viewer_state.add_global_callback(self._update_scatter)

--- a/glue/viewers/scatter/layer_artist.py
+++ b/glue/viewers/scatter/layer_artist.py
@@ -229,7 +229,8 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
                 self.scatter_artist.set_offsets(np.zeros((0, 2)))
             else:
                 self.density_artist.set_label(None)
-                if self.state.cmap_mode == 'Fixed' and self.state.size_mode == 'Fixed':
+                if self.state.cmap_mode == 'Fixed' and self.state.size_mode == 'Fixed' \
+                        and not self._viewer_state.plot_mode == 'polar' :
                     # In this case we use Matplotlib's plot function because it has much
                     # better performance than scatter.
                     self.plot_artist.set_data(x, y)
@@ -361,7 +362,8 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
 
             else:
 
-                if self.state.cmap_mode == 'Fixed' and self.state.size_mode == 'Fixed':
+                if self.state.cmap_mode == 'Fixed' and self.state.size_mode == 'Fixed' \
+                        and self._viewer_state.plot_mode != 'polar':
 
                     if force or 'color' in changed or 'fill' in changed:
                         if self.state.fill:

--- a/glue/viewers/scatter/layer_artist.py
+++ b/glue/viewers/scatter/layer_artist.py
@@ -546,7 +546,7 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
                                     color=color)
                     handles.append(handle)  # as placeholder
                 else:
-                    if self.state.cmap_mode == 'Fixed' and self.state.size_mode == 'Fixed':
+                    if self._use_plot_artist():
                         handles.append(self.plot_artist)
                     else:
                         handles.append(self.scatter_artist)

--- a/glue/viewers/scatter/layer_artist.py
+++ b/glue/viewers/scatter/layer_artist.py
@@ -234,9 +234,7 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
                     # In this case we use Matplotlib's plot function because it has much
                     # better performance than scatter.
                     self.plot_artist.set_data(x, y)
-                    self.scatter_artist.set_offsets(np.zeros((0, 2)))
                 else:
-                    self.plot_artist.set_data([], [])
                     offsets = np.vstack((x, y)).transpose()
                     self.scatter_artist.set_offsets(offsets)
         else:
@@ -496,7 +494,10 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
                                        self.state.markers_visible)
                 else:
                     artist.set_visible(self.state.visible)
-
+        if self._use_plot_artist():
+            self.scatter_artist.set_visible(False)
+        else:
+            self.plot_artist.set_visible(False)
         self.redraw()
 
     @defer_draw

--- a/glue/viewers/scatter/layer_artist.py
+++ b/glue/viewers/scatter/layer_artist.py
@@ -137,7 +137,7 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
 
         super(ScatterLayerArtist, self).__init__(axes, viewer_state,
                                                  layer_state=layer_state, layer=layer)
-
+        print(type(axes),id(axes))
         # Watch for changes in the viewer state which would require the
         # layers to be redrawn
         self._viewer_state.add_global_callback(self._update_scatter)

--- a/glue/viewers/scatter/layer_artist.py
+++ b/glue/viewers/scatter/layer_artist.py
@@ -229,8 +229,7 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
                 self.scatter_artist.set_offsets(np.zeros((0, 2)))
             else:
                 self.density_artist.set_label(None)
-                if self.state.cmap_mode == 'Fixed' and self.state.size_mode == 'Fixed' \
-                        and not self._viewer_state.plot_mode == 'polar' :
+                if  self._use_plot_artist():
                     # In this case we use Matplotlib's plot function because it has much
                     # better performance than scatter.
                     self.plot_artist.set_data(x, y)
@@ -362,8 +361,7 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
 
             else:
 
-                if self.state.cmap_mode == 'Fixed' and self.state.size_mode == 'Fixed' \
-                        and self._viewer_state.plot_mode != 'polar':
+                if self._use_plot_artist():
 
                     if force or 'color' in changed or 'fill' in changed:
                         if self.state.fill:
@@ -570,3 +568,7 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
 
         else:
             return None, None, None
+
+    def _use_plot_artist(self):
+        res = self.state.cmap_mode == 'Fixed' and self.state.size_mode == 'Fixed'
+        return res and (not hasattr(self._viewer_state, 'plot_mode') or not self._viewer_state.plot_mode == 'polar')

--- a/glue/viewers/scatter/layer_artist.py
+++ b/glue/viewers/scatter/layer_artist.py
@@ -230,7 +230,7 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
                 self.scatter_artist.set_offsets(np.zeros((0, 2)))
             else:
                 self.density_artist.set_label(None)
-                if  self._use_plot_artist():
+                if self._use_plot_artist():
                     # In this case we use Matplotlib's plot function because it has much
                     # better performance than scatter.
                     self.plot_artist.set_data(x, y)
@@ -572,4 +572,5 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
 
     def _use_plot_artist(self):
         res = self.state.cmap_mode == 'Fixed' and self.state.size_mode == 'Fixed'
-        return res and (not hasattr(self._viewer_state, 'plot_mode') or not self._viewer_state.plot_mode == 'polar')
+        return res and (not hasattr(self._viewer_state, 'plot_mode') or
+                        not self._viewer_state.plot_mode == 'polar')

--- a/glue/viewers/scatter/python_export.py
+++ b/glue/viewers/scatter/python_export.py
@@ -76,7 +76,7 @@ def python_export_scatter_layer(layer, *args):
             script += "           {0}))\n".format(serialize_options(options))
 
         else:
-            if layer.state.cmap_mode == 'Fixed' and layer.state.size_mode == 'Fixed':
+            if layer._use_plot_artist():
                 options = dict(color=layer.state.color,
                                markersize=layer.state.size * layer.state.size_scaling,
                                alpha=layer.state.alpha,

--- a/glue/viewers/scatter/qt/data_viewer.py
+++ b/glue/viewers/scatter/qt/data_viewer.py
@@ -30,7 +30,8 @@ class ScatterViewer(MatplotlibScatterMixin, MatplotlibDataViewer):
              'select:polygon']
 
     def __init__(self, session, parent=None, state=None):
-        MatplotlibDataViewer.__init__(self, session, parent=parent, state=state)
+        proj = None if not state or not state.plot_mode else state.plot_mode
+        MatplotlibDataViewer.__init__(self, session, parent=parent, state=state, projection=proj)
         MatplotlibScatterMixin.setup_callbacks(self)
 
     def limits_to_mpl(self, *args):

--- a/glue/viewers/scatter/qt/data_viewer.py
+++ b/glue/viewers/scatter/qt/data_viewer.py
@@ -49,8 +49,7 @@ class ScatterViewer(MatplotlibScatterMixin, MatplotlibDataViewer):
             self._skip_limits_from_mpl = True
             try:
                 self.axes.set_thetalim(thetamin=rad2deg(x_min), thetamax=rad2deg(x_max))
-                self.axes.set_ylim(y_min, y_max)
-                self.axes.set_rorigin(y_min)
+                self.axes.set_rlim(bottom=y_min, top=y_max)
                 self.axes.figure.canvas.draw_idle()
             finally:
                 self._skip_limits_from_mpl = False

--- a/glue/viewers/scatter/qt/data_viewer.py
+++ b/glue/viewers/scatter/qt/data_viewer.py
@@ -7,10 +7,6 @@ from glue.viewers.scatter.state import ScatterViewerState
 
 from glue.viewers.scatter.viewer import MatplotlibScatterMixin
 
-from echo import delay_callback
-
-
-from numpy import rad2deg, deg2rad, datetime64
 
 __all__ = ['ScatterViewer']
 
@@ -35,53 +31,7 @@ class ScatterViewer(MatplotlibScatterMixin, MatplotlibDataViewer):
         MatplotlibScatterMixin.setup_callbacks(self)
 
     def limits_to_mpl(self, *args):
-        if self.state.plot_mode == 'rectilinear':
-            super().limits_to_mpl(*args)
-        elif self.state.plot_mode == 'polar':
-            x_min, x_max = self.state.x_min, self.state.x_max
-
-            y_min, y_max = self.state.y_min, self.state.y_max
-            if self.state.y_log:
-                if self.state.y_max <= 0:
-                    y_min, y_max = 0.1, 1
-                elif self.state.y_min <= 0:
-                    y_min = y_max / 10
-
-            self._skip_limits_from_mpl = True
-            try:
-                self.axes.set_thetalim(thetamin=rad2deg(x_min), thetamax=rad2deg(x_max))
-                self.axes.set_rlim(bottom=y_min, top=y_max)
-                self.axes.figure.canvas.draw_idle()
-            finally:
-                self._skip_limits_from_mpl = False
-        else:
-            pass
-
-    def mpl_to_limits(self, *args):
-        if self.state.plot_mode == 'rectilinear':
-            super().mpl_to_limits(*args)
-        elif self.state.plot_mode == 'polar':
-            if self._skip_limits_from_mpl:
-                return
-            if isinstance(self.state.x_min, datetime64):
-                x_min = mpl_to_datetime64(self.axes.get_theatmin())
-                x_max = mpl_to_datetime64(self.axes.get_theatmax())
-            else:
-                x_min = self.axes.get_theatmin()
-                x_max = self.axes.get_theatmax()
-
-            if isinstance(self.state.y_min, datetime64):
-                y_min, y_max = [mpl_to_datetime64(y) for y in self.axes.get_ylim()]
-            else:
-                y_min, y_max = self.axes.get_ylim()
-
-            with delay_callback(self.state, 'x_min', 'x_max', 'y_min', 'y_max'):
-
-                self.state.x_min = x_min
-                self.state.x_max = x_max
-                self.state.y_min = y_min
-                self.state.y_max = y_max
-
-        else:
-            pass
-
+        # These projections throw errors if we try to set the limits
+        if self.state.plot_mode in ['aitoff', 'hammer', 'lambert', 'mollweide']:
+            return
+        super().limits_to_mpl(*args)

--- a/glue/viewers/scatter/qt/data_viewer.py
+++ b/glue/viewers/scatter/qt/data_viewer.py
@@ -1,4 +1,4 @@
-from glue.utils import defer_draw, decorate_all_methods
+from glue.utils import defer_draw, decorate_all_methods, mpl_to_datetime64
 from glue.viewers.matplotlib.qt.data_viewer import MatplotlibDataViewer
 from glue.viewers.scatter.qt.layer_style_editor import ScatterLayerStyleEditor
 from glue.viewers.scatter.layer_artist import ScatterLayerArtist
@@ -6,6 +6,11 @@ from glue.viewers.scatter.qt.options_widget import ScatterOptionsWidget
 from glue.viewers.scatter.state import ScatterViewerState
 
 from glue.viewers.scatter.viewer import MatplotlibScatterMixin
+
+from echo import delay_callback
+
+
+from numpy import rad2deg, deg2rad, datetime64
 
 __all__ = ['ScatterViewer']
 
@@ -27,3 +32,56 @@ class ScatterViewer(MatplotlibScatterMixin, MatplotlibDataViewer):
     def __init__(self, session, parent=None, state=None):
         MatplotlibDataViewer.__init__(self, session, parent=parent, state=state)
         MatplotlibScatterMixin.setup_callbacks(self)
+
+    def limits_to_mpl(self, *args):
+        if self.state.plot_mode == 'rectilinear':
+            super().limits_to_mpl(*args)
+        elif self.state.plot_mode == 'polar':
+            x_min, x_max = self.state.x_min, self.state.x_max
+
+            y_min, y_max = self.state.y_min, self.state.y_max
+            if self.state.y_log:
+                if self.state.y_max <= 0:
+                    y_min, y_max = 0.1, 1
+                elif self.state.y_min <= 0:
+                    y_min = y_max / 10
+
+            self._skip_limits_from_mpl = True
+            try:
+                self.axes.set_thetalim(thetamin=rad2deg(x_min), thetamax=rad2deg(x_max))
+                self.axes.set_ylim(y_min, y_max)
+                self.axes.set_rorigin(y_min)
+                self.axes.figure.canvas.draw_idle()
+            finally:
+                self._skip_limits_from_mpl = False
+        else:
+            pass
+
+    def mpl_to_limits(self, *args):
+        if self.state.plot_mode == 'rectilinear':
+            super().mpl_to_limits(*args)
+        elif self.state.plot_mode == 'polar':
+            if self._skip_limits_from_mpl:
+                return
+            if isinstance(self.state.x_min, datetime64):
+                x_min = mpl_to_datetime64(self.axes.get_theatmin())
+                x_max = mpl_to_datetime64(self.axes.get_theatmax())
+            else:
+                x_min = self.axes.get_theatmin()
+                x_max = self.axes.get_theatmax()
+
+            if isinstance(self.state.y_min, datetime64):
+                y_min, y_max = [mpl_to_datetime64(y) for y in self.axes.get_ylim()]
+            else:
+                y_min, y_max = self.axes.get_ylim()
+
+            with delay_callback(self.state, 'x_min', 'x_max', 'y_min', 'y_max'):
+
+                self.state.x_min = x_min
+                self.state.x_max = x_max
+                self.state.y_min = y_min
+                self.state.y_max = y_max
+
+        else:
+            pass
+

--- a/glue/viewers/scatter/qt/data_viewer.py
+++ b/glue/viewers/scatter/qt/data_viewer.py
@@ -1,4 +1,4 @@
-from glue.utils import defer_draw, decorate_all_methods, mpl_to_datetime64
+from glue.utils import defer_draw, decorate_all_methods
 from glue.viewers.matplotlib.qt.data_viewer import MatplotlibDataViewer
 from glue.viewers.scatter.qt.layer_style_editor import ScatterLayerStyleEditor
 from glue.viewers.scatter.layer_artist import ScatterLayerArtist

--- a/glue/viewers/scatter/qt/layer_style_editor.py
+++ b/glue/viewers/scatter/qt/layer_style_editor.py
@@ -49,6 +49,8 @@ class ScatterLayerStyleEditor(QtWidgets.QWidget):
 
         self.layer_state.viewer_state.add_callback('x_att', self._update_checkboxes)
         self.layer_state.viewer_state.add_callback('y_att', self._update_checkboxes)
+        if hasattr(self.layer_state.viewer_state, 'plot_mode'):
+            self.layer_state.viewer_state.add_callback('plot_mode', self._update_vectors_visible)
 
         self.layer_state.add_callback('layer', self._update_warnings)
 
@@ -185,7 +187,9 @@ class ScatterLayerStyleEditor(QtWidgets.QWidget):
         self.ui.combosel_yerr_att.setEnabled(self.layer_state.yerr_visible)
 
     def _update_vectors_visible(self, *args):
-        self.ui.combosel_vector_mode.setEnabled(self.layer_state.vector_visible)
+        viewer_state = self.layer_state.viewer_state
+        is_rect = not hasattr(viewer_state, 'plot_mode') or viewer_state.plot_mode == 'rectilinear'
+        self.ui.combosel_vector_mode.setEnabled(self.layer_state.vector_visible and is_rect)
         self.ui.combosel_vx_att.setEnabled(self.layer_state.vector_visible)
         self.ui.combosel_vy_att.setEnabled(self.layer_state.vector_visible)
         self.ui.value_vector_scaling.setEnabled(self.layer_state.vector_visible)

--- a/glue/viewers/scatter/qt/options_widget.py
+++ b/glue/viewers/scatter/qt/options_widget.py
@@ -19,6 +19,7 @@ def _get_labels(proj):
     else:
         return 'axis 1', 'axis 2'
 
+
 class ScatterOptionsWidget(QtWidgets.QWidget):
 
     def __init__(self, viewer_state, session, parent=None):
@@ -54,9 +55,7 @@ class ScatterOptionsWidget(QtWidgets.QWidget):
 
     def _update_x_attribute(self, *args):
         # If at least one of the components is categorical or a date, disable log button
-        log_enabled = ('categorical' not in self.viewer_state.x_kinds and
-                      self.viewer_state.plot_mode not in ['aitoff', 'hammer',
-                                                          'lambert', 'mollweide', 'polar'])
+        log_enabled = ('categorical' not in self.viewer_state.x_kinds and self.viewer_state.plot_mode not in ['aitoff', 'hammer', 'lambert', 'mollweide', 'polar'])
         self.ui.bool_x_log.setEnabled(log_enabled)
         self.ui.bool_x_log_.setEnabled(log_enabled)
         if not log_enabled:
@@ -65,8 +64,7 @@ class ScatterOptionsWidget(QtWidgets.QWidget):
 
     def _update_y_attribute(self, *args):
         # If at least one of the components is categorical or a date, disable log button
-        log_enabled = ('categorical' not in self.viewer_state.y_kinds and
-                      self.viewer_state.plot_mode  not in ['aitoff', 'hammer', 'lambert', 'mollweide'])
+        log_enabled = ('categorical' not in self.viewer_state.y_kinds and self.viewer_state.plot_mode not in ['aitoff', 'hammer', 'lambert', 'mollweide'])
         self.ui.bool_y_log.setEnabled(log_enabled)
         self.ui.bool_y_log_.setEnabled(log_enabled)
         if not log_enabled:

--- a/glue/viewers/scatter/qt/options_widget.py
+++ b/glue/viewers/scatter/qt/options_widget.py
@@ -41,6 +41,8 @@ class ScatterOptionsWidget(QtWidgets.QWidget):
         viewer_state.add_callback('y_att', self._update_y_attribute)
         viewer_state.add_callback('plot_mode', self._update_plot_mode)
 
+        self.ui.button_full_circle.setVisible(False)
+
         self.session = session
         self.ui.axes_editor.button_apply_all.clicked.connect(self._apply_all_viewers)
 
@@ -75,6 +77,7 @@ class ScatterOptionsWidget(QtWidgets.QWidget):
         self.ui.y_lab.setText(y_label)
         self.ui.y_lab_2.setText(y_label)
         lim_enabled = self.viewer_state.plot_mode not in ['aitoff', 'hammer', 'lambert', 'mollweide']
+        is_polar = self.viewer_state.plot_mode == 'polar'
         self.ui.valuetext_x_min.setEnabled(lim_enabled)
         self.ui.button_flip_x.setEnabled(lim_enabled)
         self.ui.valuetext_x_max.setEnabled(lim_enabled)
@@ -82,4 +85,7 @@ class ScatterOptionsWidget(QtWidgets.QWidget):
         self.ui.button_flip_y.setEnabled(lim_enabled)
         self.ui.valuetext_y_max.setEnabled(lim_enabled)
         self.ui.bool_y_log.setEnabled(lim_enabled)
-        self.ui.bool_x_log.setEnabled(lim_enabled or self.viewer_state.plot_mode == 'polar')
+        self.ui.bool_y_log_.setEnabled(lim_enabled)
+        self.ui.bool_x_log.setEnabled(lim_enabled and not is_polar)
+        self.ui.bool_x_log_.setEnabled(lim_enabled and not is_polar)
+        self.ui.button_full_circle.setVisible(is_polar)

--- a/glue/viewers/scatter/qt/options_widget.py
+++ b/glue/viewers/scatter/qt/options_widget.py
@@ -74,3 +74,12 @@ class ScatterOptionsWidget(QtWidgets.QWidget):
         self.ui.x_lab_2.setText(x_label)
         self.ui.y_lab.setText(y_label)
         self.ui.y_lab_2.setText(y_label)
+        lim_enabled = self.viewer_state.plot_mode not in ['aitoff', 'hammer', 'lambert', 'mollweide']
+        self.ui.valuetext_x_min.setEnabled(lim_enabled)
+        self.ui.button_flip_x.setEnabled(lim_enabled)
+        self.ui.valuetext_x_max.setEnabled(lim_enabled)
+        self.ui.valuetext_y_min.setEnabled(lim_enabled)
+        self.ui.button_flip_y.setEnabled(lim_enabled)
+        self.ui.valuetext_y_max.setEnabled(lim_enabled)
+        self.ui.bool_y_log.setEnabled(lim_enabled)
+        self.ui.bool_x_log.setEnabled(lim_enabled or self.viewer_state.plot_mode == 'polar')

--- a/glue/viewers/scatter/qt/options_widget.py
+++ b/glue/viewers/scatter/qt/options_widget.py
@@ -9,6 +9,16 @@ from glue.viewers.matplotlib.state import MatplotlibDataViewerState
 __all__ = ['ScatterOptionsWidget']
 
 
+def _get_labels(proj):
+    if proj == 'rectilinear':
+        return 'x_axis', 'y_axis'
+    elif proj == 'polar':
+        return 'theta (rad)', 'radius'
+    elif proj in ['aitoff', 'hammer', 'lambert', 'mollweide']:
+        return 'longitude (rad)', 'latitude (rad)'
+    else:
+        return 'axis 1', 'axis 2'
+
 class ScatterOptionsWidget(QtWidgets.QWidget):
 
     def __init__(self, viewer_state, session, parent=None):
@@ -29,6 +39,7 @@ class ScatterOptionsWidget(QtWidgets.QWidget):
 
         viewer_state.add_callback('x_att', self._update_x_attribute)
         viewer_state.add_callback('y_att', self._update_y_attribute)
+        viewer_state.add_callback('plot_mode', self._update_plot_mode)
 
         self.session = session
         self.ui.axes_editor.button_apply_all.clicked.connect(self._apply_all_viewers)
@@ -56,3 +67,10 @@ class ScatterOptionsWidget(QtWidgets.QWidget):
         if not log_enabled:
             self.ui.bool_y_log.setChecked(False)
             self.ui.bool_y_log_.setChecked(False)
+
+    def _update_plot_mode(self, *args):
+        x_label, y_label = _get_labels(self.viewer_state.plot_mode)
+        self.ui.x_lab.setText(x_label)
+        self.ui.x_lab_2.setText(x_label)
+        self.ui.y_lab.setText(y_label)
+        self.ui.y_lab_2.setText(y_label)

--- a/glue/viewers/scatter/qt/options_widget.py
+++ b/glue/viewers/scatter/qt/options_widget.py
@@ -11,11 +11,11 @@ __all__ = ['ScatterOptionsWidget']
 
 def _get_labels(proj):
     if proj == 'rectilinear':
-        return 'x_axis', 'y_axis'
+        return 'x axis', 'y axis'
     elif proj == 'polar':
         return 'theta (rad)', 'radius'
     elif proj in ['aitoff', 'hammer', 'lambert', 'mollweide']:
-        return 'longitude (rad)', 'latitude (rad)'
+        return 'long (rad)', 'lat (rad)'
     else:
         return 'axis 1', 'axis 2'
 
@@ -54,7 +54,9 @@ class ScatterOptionsWidget(QtWidgets.QWidget):
 
     def _update_x_attribute(self, *args):
         # If at least one of the components is categorical or a date, disable log button
-        log_enabled = 'categorical' not in self.viewer_state.x_kinds
+        log_enabled = ('categorical' not in self.viewer_state.x_kinds and
+                      self.viewer_state.plot_mode not in ['aitoff', 'hammer',
+                                                          'lambert', 'mollweide', 'polar'])
         self.ui.bool_x_log.setEnabled(log_enabled)
         self.ui.bool_x_log_.setEnabled(log_enabled)
         if not log_enabled:
@@ -63,7 +65,8 @@ class ScatterOptionsWidget(QtWidgets.QWidget):
 
     def _update_y_attribute(self, *args):
         # If at least one of the components is categorical or a date, disable log button
-        log_enabled = 'categorical' not in self.viewer_state.y_kinds
+        log_enabled = ('categorical' not in self.viewer_state.y_kinds and
+                      self.viewer_state.plot_mode  not in ['aitoff', 'hammer', 'lambert', 'mollweide'])
         self.ui.bool_y_log.setEnabled(log_enabled)
         self.ui.bool_y_log_.setEnabled(log_enabled)
         if not log_enabled:
@@ -84,8 +87,6 @@ class ScatterOptionsWidget(QtWidgets.QWidget):
         self.ui.valuetext_y_min.setEnabled(lim_enabled)
         self.ui.button_flip_y.setEnabled(lim_enabled)
         self.ui.valuetext_y_max.setEnabled(lim_enabled)
-        self.ui.bool_y_log.setEnabled(lim_enabled)
-        self.ui.bool_y_log_.setEnabled(lim_enabled)
-        self.ui.bool_x_log.setEnabled(lim_enabled and not is_polar)
-        self.ui.bool_x_log_.setEnabled(lim_enabled and not is_polar)
         self.ui.button_full_circle.setVisible(is_polar)
+        self._update_x_attribute()
+        self._update_y_attribute()

--- a/glue/viewers/scatter/qt/options_widget.ui
+++ b/glue/viewers/scatter/qt/options_widget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>332</width>
+    <width>347</width>
     <height>152</height>
    </rect>
   </property>
@@ -296,16 +296,6 @@
        <item row="1" column="2">
         <widget class="QLineEdit" name="valuetext_x_min"/>
        </item>
-       <item row="1" column="6">
-        <widget class="QPushButton" name="button_full_circle">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-         <property name="text">
-          <string>full circle</string>
-         </property>
-        </widget>
-       </item>
        <item row="4" column="2" colspan="5">
         <spacer name="horizontalSpacer_2">
          <property name="orientation">
@@ -318,6 +308,16 @@
           </size>
          </property>
         </spacer>
+       </item>
+       <item row="2" column="2">
+        <widget class="QPushButton" name="button_full_circle">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="text">
+          <string>full circle</string>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>

--- a/glue/viewers/scatter/qt/options_widget.ui
+++ b/glue/viewers/scatter/qt/options_widget.ui
@@ -72,22 +72,15 @@
        <property name="verticalSpacing">
         <number>5</number>
        </property>
-       <item row="0" column="1">
-        <widget class="QComboBox" name="combosel_x_att">
-         <property name="sizeAdjustPolicy">
-          <enum>QComboBox::AdjustToMinimumContentsLength</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="1">
-        <spacer name="horizontalSpacer">
+       <item row="4" column="1">
+        <spacer name="verticalSpacer_2">
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
-           <width>40</width>
-           <height>5</height>
+           <width>20</width>
+           <height>40</height>
           </size>
          </property>
         </spacer>
@@ -105,26 +98,6 @@
          </property>
         </widget>
        </item>
-       <item row="3" column="1">
-        <spacer name="verticalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="1" column="1">
-        <widget class="QComboBox" name="combosel_y_att">
-         <property name="sizeAdjustPolicy">
-          <enum>QComboBox::AdjustToMinimumContentsLength</enum>
-         </property>
-        </widget>
-       </item>
        <item row="1" column="0">
         <widget class="QLabel" name="x_lab">
          <property name="font">
@@ -138,6 +111,13 @@
          </property>
         </widget>
        </item>
+       <item row="1" column="1">
+        <widget class="QComboBox" name="combosel_y_att">
+         <property name="sizeAdjustPolicy">
+          <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+         </property>
+        </widget>
+       </item>
        <item row="0" column="2">
         <widget class="QToolButton" name="bool_x_log_">
          <property name="text">
@@ -148,6 +128,26 @@
          </property>
         </widget>
        </item>
+       <item row="3" column="1">
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>5</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="0" column="1">
+        <widget class="QComboBox" name="combosel_x_att">
+         <property name="sizeAdjustPolicy">
+          <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+         </property>
+        </widget>
+       </item>
        <item row="1" column="2">
         <widget class="QToolButton" name="bool_y_log_">
          <property name="text">
@@ -155,6 +155,22 @@
          </property>
          <property name="checkable">
           <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QComboBox" name="combosel_plot_mode"/>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="type_lab">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>type</string>
          </property>
         </widget>
        </item>

--- a/glue/viewers/scatter/qt/options_widget.ui
+++ b/glue/viewers/scatter/qt/options_widget.ui
@@ -35,7 +35,7 @@
       <enum>QTabWidget::North</enum>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <property name="usesScrollButtons">
       <bool>false</bool>
@@ -99,7 +99,7 @@
         </widget>
        </item>
        <item row="1" column="0">
-        <widget class="QLabel" name="x_lab">
+        <widget class="QLabel" name="y_lab">
          <property name="font">
           <font>
            <weight>75</weight>
@@ -249,7 +249,7 @@
         <widget class="QLineEdit" name="valuetext_x_max"/>
        </item>
        <item row="1" column="1">
-        <widget class="QLabel" name="label_2">
+        <widget class="QLabel" name="x_lab_2">
          <property name="font">
           <font>
            <weight>75</weight>
@@ -265,7 +265,7 @@
         </widget>
        </item>
        <item row="2" column="1">
-        <widget class="QLabel" name="label_2">
+        <widget class="QLabel" name="y_lab_2">
          <property name="font">
           <font>
            <weight>75</weight>

--- a/glue/viewers/scatter/qt/options_widget.ui
+++ b/glue/viewers/scatter/qt/options_widget.ui
@@ -199,7 +199,39 @@
        <property name="verticalSpacing">
         <number>5</number>
        </property>
-       <item row="2" column="5">
+       <item row="1" column="1">
+        <widget class="QLabel" name="x_lab_2">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>x axis</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="4">
+        <widget class="QLineEdit" name="valuetext_y_max"/>
+       </item>
+       <item row="5" column="2">
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="3" column="5">
         <widget class="QToolButton" name="bool_y_log">
          <property name="text">
           <string>log</string>
@@ -209,20 +241,26 @@
          </property>
         </widget>
        </item>
-       <item row="1" column="5">
-        <widget class="QToolButton" name="bool_x_log">
-         <property name="text">
-          <string>log</string>
+       <item row="1" column="4">
+        <widget class="QLineEdit" name="valuetext_x_max"/>
+       </item>
+       <item row="3" column="1">
+        <widget class="QLabel" name="y_lab_2">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
          </property>
-         <property name="checkable">
-          <bool>true</bool>
+         <property name="text">
+          <string>y axis</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
          </property>
         </widget>
        </item>
-       <item row="2" column="4">
-        <widget class="QLineEdit" name="valuetext_y_max"/>
-       </item>
-       <item row="2" column="3">
+       <item row="3" column="3">
         <widget class="QToolButton" name="button_flip_y">
          <property name="styleSheet">
           <string notr="true">padding: 0px</string>
@@ -242,48 +280,33 @@
          </property>
         </widget>
        </item>
-       <item row="2" column="2">
+       <item row="1" column="5">
+        <widget class="QToolButton" name="bool_x_log">
+         <property name="text">
+          <string>log</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="2">
         <widget class="QLineEdit" name="valuetext_y_min"/>
-       </item>
-       <item row="1" column="4">
-        <widget class="QLineEdit" name="valuetext_x_max"/>
-       </item>
-       <item row="1" column="1">
-        <widget class="QLabel" name="x_lab_2">
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>x axis</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="1">
-        <widget class="QLabel" name="y_lab_2">
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>y axis</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-        </widget>
        </item>
        <item row="1" column="2">
         <widget class="QLineEdit" name="valuetext_x_min"/>
        </item>
-       <item row="3" column="2" colspan="4">
+       <item row="1" column="6">
+        <widget class="QPushButton" name="button_full_circle">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="text">
+          <string>full circle</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="2" colspan="5">
         <spacer name="horizontalSpacer_2">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
@@ -292,19 +315,6 @@
           <size>
            <width>40</width>
            <height>5</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="4" column="2">
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
           </size>
          </property>
         </spacer>

--- a/glue/viewers/scatter/qt/options_widget.ui
+++ b/glue/viewers/scatter/qt/options_widget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>347</width>
+    <width>332</width>
     <height>152</height>
    </rect>
   </property>
@@ -35,7 +35,7 @@
       <enum>QTabWidget::North</enum>
      </property>
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <property name="usesScrollButtons">
       <bool>false</bool>

--- a/glue/viewers/scatter/qt/tests/test_data_viewer.py
+++ b/glue/viewers/scatter/qt/tests/test_data_viewer.py
@@ -740,9 +740,9 @@ class TestScatterViewer(object):
         assert_allclose(viewer_state.x_min, -np.pi)
         assert_allclose(viewer_state.x_max, np.pi)
         assert_allclose(self.viewer.axes.get_xlim(), [-np.pi, np.pi])
-        assert_allclose(viewer_state.y_min, -np.pi/2)
-        assert_allclose(viewer_state.y_max, np.pi/2)
-        assert_allclose(self.viewer.axes.get_ylim(), [-np.pi/2, np.pi/2])
+        assert_allclose(viewer_state.y_min, -np.pi / 2)
+        assert_allclose(viewer_state.y_max, np.pi / 2)
+        assert_allclose(self.viewer.axes.get_ylim(), [-np.pi / 2, np.pi / 2])
 
         viewer_state.plot_mode = 'rectilinear'
         assert_allclose(viewer_state.x_min, old_xmin)
@@ -756,24 +756,24 @@ class TestScatterViewer(object):
         assert_allclose(viewer_state.x_min, -np.pi)
         assert_allclose(viewer_state.x_max, np.pi)
         assert_allclose(self.viewer.axes.get_xlim(), [-np.pi, np.pi])
-        assert_allclose(viewer_state.y_min, -np.pi/2)
-        assert_allclose(viewer_state.y_max, np.pi/2)
-        assert_allclose(self.viewer.axes.get_ylim(), [-np.pi/2, np.pi/2])
+        assert_allclose(viewer_state.y_min, -np.pi / 2)
+        assert_allclose(viewer_state.y_max, np.pi / 2)
+        assert_allclose(self.viewer.axes.get_ylim(), [-np.pi / 2, np.pi / 2])
 
         viewer_state.plot_mode = 'rectilinear'
         viewer_state.plot_mode = 'lambert'
         assert_allclose(viewer_state.x_min, -np.pi)
         assert_allclose(viewer_state.x_max, np.pi)
         assert_allclose(self.viewer.axes.get_xlim(), [-np.pi, np.pi])
-        assert_allclose(viewer_state.y_min, -np.pi/2)
-        assert_allclose(viewer_state.y_max, np.pi/2)
-        assert_allclose(self.viewer.axes.get_ylim(), [-np.pi/2, np.pi/2])
+        assert_allclose(viewer_state.y_min, -np.pi / 2)
+        assert_allclose(viewer_state.y_max, np.pi / 2)
+        assert_allclose(self.viewer.axes.get_ylim(), [-np.pi / 2, np.pi / 2])
 
         viewer_state.plot_mode = 'rectilinear'
         viewer_state.plot_mode = 'mollweide'
         assert_allclose(viewer_state.x_min, -np.pi)
         assert_allclose(viewer_state.x_max, np.pi)
         assert_allclose(self.viewer.axes.get_xlim(), [-np.pi, np.pi])
-        assert_allclose(viewer_state.y_min, -np.pi/2)
-        assert_allclose(viewer_state.y_max, np.pi/2)
-        assert_allclose(self.viewer.axes.get_ylim(), [-np.pi/2, np.pi/2])
+        assert_allclose(viewer_state.y_min, -np.pi / 2)
+        assert_allclose(viewer_state.y_max, np.pi / 2)
+        assert_allclose(self.viewer.axes.get_ylim(), [-np.pi / 2, np.pi / 2])

--- a/glue/viewers/scatter/qt/tests/test_data_viewer.py
+++ b/glue/viewers/scatter/qt/tests/test_data_viewer.py
@@ -31,6 +31,7 @@ class TestScatterCommon(BaseTestMatplotlibDataViewer):
         return Data(label='d1', x=[3.4, 2.3, -1.1, 0.3], y=['a', 'b', 'c', 'a'])
     viewer_cls = ScatterViewer
 
+fullsphere_projections = ['aitoff', 'hammer', 'lambert', 'mollweide']
 
 class TestScatterViewer(object):
 
@@ -736,14 +737,6 @@ class TestScatterViewer(object):
         assert_allclose(viewer_state.y_max, old_ymax)
         assert_allclose(self.viewer.axes.get_ylim(), [old_ymin, old_ymax])
 
-        viewer_state.plot_mode = 'aitoff'
-        assert_allclose(viewer_state.x_min, -np.pi)
-        assert_allclose(viewer_state.x_max, np.pi)
-        assert_allclose(self.viewer.axes.get_xlim(), [-np.pi, np.pi])
-        assert_allclose(viewer_state.y_min, -np.pi / 2)
-        assert_allclose(viewer_state.y_max, np.pi / 2)
-        assert_allclose(self.viewer.axes.get_ylim(), [-np.pi / 2, np.pi / 2])
-
         viewer_state.plot_mode = 'rectilinear'
         assert_allclose(viewer_state.x_min, old_xmin)
         assert_allclose(viewer_state.x_max, old_xmax)
@@ -752,28 +745,47 @@ class TestScatterViewer(object):
         assert_allclose(viewer_state.y_max, old_ymax)
         assert_allclose(self.viewer.axes.get_ylim(), [old_ymin, old_ymax])
 
-        viewer_state.plot_mode = 'hammer'
-        assert_allclose(viewer_state.x_min, -np.pi)
-        assert_allclose(viewer_state.x_max, np.pi)
-        assert_allclose(self.viewer.axes.get_xlim(), [-np.pi, np.pi])
-        assert_allclose(viewer_state.y_min, -np.pi / 2)
-        assert_allclose(viewer_state.y_max, np.pi / 2)
-        assert_allclose(self.viewer.axes.get_ylim(), [-np.pi / 2, np.pi / 2])
+        for proj in fullsphere_projections:
+            viewer_state.plot_mode = 'rectilinear'
+            viewer_state.plot_mode = proj
+            error_msg = "Issue with {} projection".format(proj)
+            assert_allclose(viewer_state.x_min, -np.pi)
+            assert_allclose(viewer_state.x_max, np.pi)
+            assert_allclose(self.viewer.axes.get_xlim(), [-np.pi, np.pi], err_msg=error_msg)
+            assert_allclose(viewer_state.y_min, -np.pi / 2)
+            assert_allclose(viewer_state.y_max, np.pi / 2)
+            assert_allclose(self.viewer.axes.get_ylim(), [-np.pi / 2, np.pi / 2], err_msg=error_msg)
 
-        viewer_state.plot_mode = 'rectilinear'
-        viewer_state.plot_mode = 'lambert'
-        assert_allclose(viewer_state.x_min, -np.pi)
-        assert_allclose(viewer_state.x_max, np.pi)
-        assert_allclose(self.viewer.axes.get_xlim(), [-np.pi, np.pi])
-        assert_allclose(viewer_state.y_min, -np.pi / 2)
-        assert_allclose(viewer_state.y_max, np.pi / 2)
-        assert_allclose(self.viewer.axes.get_ylim(), [-np.pi / 2, np.pi / 2])
 
-        viewer_state.plot_mode = 'rectilinear'
-        viewer_state.plot_mode = 'mollweide'
-        assert_allclose(viewer_state.x_min, -np.pi)
-        assert_allclose(viewer_state.x_max, np.pi)
-        assert_allclose(self.viewer.axes.get_xlim(), [-np.pi, np.pi])
-        assert_allclose(viewer_state.y_min, -np.pi / 2)
-        assert_allclose(viewer_state.y_max, np.pi / 2)
-        assert_allclose(self.viewer.axes.get_ylim(), [-np.pi / 2, np.pi / 2])
+    def test_limit_log_set_polar(self):
+        self.viewer.add_data(self.data)
+        viewer_state = self.viewer.state
+        viewer_state.plot_mode = "polar"
+        axes = self.viewer.axes
+
+        viewer_state.x_min = 0.5
+        viewer_state.x_max = 1.5
+        assert_allclose(axes.get_xlim(),[0.5, 1.5])
+
+        viewer_state.y_min = -2.5
+        viewer_state.y_max = 2.5
+        assert_allclose(axes.get_ylim(), [-2.5, 2.5])
+
+        viewer_state.y_log = True
+        assert axes.get_yscale() == 'log'
+
+    def test_limit_set_fullsphere(self):
+        # Make sure that the full-sphere projections ignore instead of throwing exceptions
+        self.viewer.add_data(self.data)
+        viewer_state = self.viewer.state
+
+        for proj in fullsphere_projections:
+            viewer_state.plot_mode = proj
+            error_msg = "Issue with {} projection".format(proj)
+            axes = self.viewer.axes
+            viewer_state.x_min = 0.5
+            viewer_state.x_max = 1.5
+            viewer_state.y_min = -2.5
+            viewer_state.y_max = 2.5
+            assert_allclose(axes.get_xlim(), [-np.pi, np.pi], err_msg=error_msg)
+            assert_allclose(axes.get_ylim(), [-np.pi / 2, np.pi / 2], err_msg=error_msg)

--- a/glue/viewers/scatter/qt/tests/test_data_viewer.py
+++ b/glue/viewers/scatter/qt/tests/test_data_viewer.py
@@ -706,3 +706,74 @@ class TestScatterViewer(object):
         # 'd2' is not enabled (no linked component)
         handles, labels, handler_dict = self.viewer.get_handles_legend()
         assert len(handles) == 2
+
+    def test_changing_plot_modes(self):
+        viewer_state = self.viewer.state
+        viewer_state.plot_mode = 'polar'
+        assert 'polar' in str(type(self.viewer.axes)).lower()
+        viewer_state.plot_mode = 'aitoff'
+        assert 'aitoff' in str(type(self.viewer.axes)).lower()
+        viewer_state.plot_mode = 'hammer'
+        assert 'hammer' in str(type(self.viewer.axes)).lower()
+        viewer_state.plot_mode = 'lambert'
+        assert 'lambert' in str(type(self.viewer.axes)).lower()
+        viewer_state.plot_mode = 'mollweide'
+        assert 'mollweide' in str(type(self.viewer.axes)).lower()
+
+    def test_chaning_mode_limits(self):
+        self.viewer.add_data(self.data)
+        viewer_state = self.viewer.state
+        old_xmin = viewer_state.x_min
+        old_xmax = viewer_state.x_max
+        old_ymin = viewer_state.y_min
+        old_ymax = viewer_state.y_max
+
+        viewer_state.plot_mode = 'polar'
+        assert_allclose(viewer_state.x_min, old_xmin)
+        assert_allclose(viewer_state.x_max, old_xmax)
+        assert_allclose(self.viewer.axes.get_xlim(), [old_xmin, old_xmax])
+        assert_allclose(viewer_state.y_min, old_ymin)
+        assert_allclose(viewer_state.y_max, old_ymax)
+        assert_allclose(self.viewer.axes.get_ylim(), [old_ymin, old_ymax])
+
+        viewer_state.plot_mode = 'aitoff'
+        assert_allclose(viewer_state.x_min, -np.pi)
+        assert_allclose(viewer_state.x_max, np.pi)
+        assert_allclose(self.viewer.axes.get_xlim(), [-np.pi, np.pi])
+        assert_allclose(viewer_state.y_min, -np.pi/2)
+        assert_allclose(viewer_state.y_max, np.pi/2)
+        assert_allclose(self.viewer.axes.get_ylim(), [-np.pi/2, np.pi/2])
+
+        viewer_state.plot_mode = 'rectilinear'
+        assert_allclose(viewer_state.x_min, old_xmin)
+        assert_allclose(viewer_state.x_max, old_xmax)
+        assert_allclose(self.viewer.axes.get_xlim(), [old_xmin, old_xmax])
+        assert_allclose(viewer_state.y_min, old_ymin)
+        assert_allclose(viewer_state.y_max, old_ymax)
+        assert_allclose(self.viewer.axes.get_ylim(), [old_ymin, old_ymax])
+
+        viewer_state.plot_mode = 'hammer'
+        assert_allclose(viewer_state.x_min, -np.pi)
+        assert_allclose(viewer_state.x_max, np.pi)
+        assert_allclose(self.viewer.axes.get_xlim(), [-np.pi, np.pi])
+        assert_allclose(viewer_state.y_min, -np.pi/2)
+        assert_allclose(viewer_state.y_max, np.pi/2)
+        assert_allclose(self.viewer.axes.get_ylim(), [-np.pi/2, np.pi/2])
+
+        viewer_state.plot_mode = 'rectilinear'
+        viewer_state.plot_mode = 'lambert'
+        assert_allclose(viewer_state.x_min, -np.pi)
+        assert_allclose(viewer_state.x_max, np.pi)
+        assert_allclose(self.viewer.axes.get_xlim(), [-np.pi, np.pi])
+        assert_allclose(viewer_state.y_min, -np.pi/2)
+        assert_allclose(viewer_state.y_max, np.pi/2)
+        assert_allclose(self.viewer.axes.get_ylim(), [-np.pi/2, np.pi/2])
+
+        viewer_state.plot_mode = 'rectilinear'
+        viewer_state.plot_mode = 'mollweide'
+        assert_allclose(viewer_state.x_min, -np.pi)
+        assert_allclose(viewer_state.x_max, np.pi)
+        assert_allclose(self.viewer.axes.get_xlim(), [-np.pi, np.pi])
+        assert_allclose(viewer_state.y_min, -np.pi/2)
+        assert_allclose(viewer_state.y_max, np.pi/2)
+        assert_allclose(self.viewer.axes.get_ylim(), [-np.pi/2, np.pi/2])

--- a/glue/viewers/scatter/qt/tests/test_data_viewer.py
+++ b/glue/viewers/scatter/qt/tests/test_data_viewer.py
@@ -12,6 +12,7 @@ from glue.config import colormaps
 from glue.core.message import SubsetUpdateMessage
 from glue.core import HubListener, Data
 from glue.core.roi import XRangeROI, RectangularROI, CircularROI
+from glue.core.roi_pretransforms import ProjectionMplTransform
 from glue.core.subset import RoiSubsetState, AndState
 from glue import core
 from glue.core.component_id import ComponentID
@@ -907,3 +908,65 @@ class TestScatterViewer(object):
             assert ui.button_flip_y.isEnabled()
             assert ui.valuetext_y_max.isEnabled()
             assert ui.button_full_circle.isHidden()
+
+    def test_apply_roi_polar(self):
+        self.viewer.add_data(self.data)
+        viewer_state = self.viewer.state
+        roi = RectangularROI(0, 0.5, 0, 0.5)
+        viewer_state.plot_mode = 'polar'
+        viewer_state.full_circle()
+        assert len(self.viewer.layers) == 1
+
+        self.viewer.apply_roi(roi)
+
+        assert len(self.viewer.layers) == 2
+        assert len(self.data.subsets) == 1
+
+        assert_allclose(self.data.subsets[0].to_mask(), [1, 0, 0, 0])
+
+        state = self.data.subsets[0].subset_state
+        assert isinstance(state, RoiSubsetState)
+        assert state.pretransform
+        pretrans = state.pretransform
+        assert isinstance(pretrans, ProjectionMplTransform)
+        assert pretrans._state['projection'] == 'polar'
+        assert_allclose(pretrans._state['x_lim'], [viewer_state.x_min, viewer_state.x_max])
+        assert_allclose(pretrans._state['y_lim'], [viewer_state.y_min, viewer_state.y_max])
+        assert pretrans._state['x_scale'] == 'linear'
+        assert pretrans._state['y_scale'] == 'linear'
+        self.data.subsets[0].delete()
+
+        viewer_state.y_log = True
+        self.viewer.apply_roi(roi)
+        state = self.data.subsets[0].subset_state
+        assert state.pretransform
+        pretrans = state.pretransform
+        assert isinstance(pretrans, ProjectionMplTransform)
+        assert pretrans._state['y_scale'] == 'log'
+
+    def test_apply_roi_fullsphere(self):
+        self.viewer.add_data(self.data)
+        viewer_state = self.viewer.state
+        roi = RectangularROI(0, 0.5, 0, 0.5)
+
+        for proj in fullsphere_projections:
+            viewer_state.plot_mode = proj
+            assert len(self.viewer.layers) == 1
+
+            self.viewer.apply_roi(roi)
+
+            assert len(self.viewer.layers) == 2
+            assert len(self.data.subsets) == 1
+
+            subset = self.data.subsets[0]
+            state = subset.subset_state
+            assert isinstance(state, RoiSubsetState)
+            assert state.pretransform
+            pretrans = state.pretransform
+            assert isinstance(pretrans, ProjectionMplTransform)
+            assert pretrans._state['projection'] == proj
+            assert_allclose(pretrans._state['x_lim'], [viewer_state.x_min, viewer_state.x_max])
+            assert_allclose(pretrans._state['y_lim'], [viewer_state.y_min, viewer_state.y_max])
+            assert pretrans._state['x_scale'] == 'linear'
+            assert pretrans._state['y_scale'] == 'linear'
+            subset.delete()

--- a/glue/viewers/scatter/qt/tests/test_data_viewer.py
+++ b/glue/viewers/scatter/qt/tests/test_data_viewer.py
@@ -822,3 +822,88 @@ class TestScatterViewer(object):
             assert not viewer_state.y_log, error_msg
             assert self.viewer.axes.get_xscale() == 'linear', error_msg
             assert self.viewer.axes.get_yscale() == 'linear', error_msg
+
+    def test_full_circle_utility(self):
+        # Make sure that the full circle function behaves well
+        self.viewer.add_data(self.data)
+        viewer_state = self.viewer.state
+        old_xmin = viewer_state.x_min
+        old_xmax = viewer_state.x_max
+        old_ymin = viewer_state.y_min
+        old_ymax = viewer_state.y_max
+        viewer_state.full_circle()
+        assert_allclose([viewer_state.x_min, viewer_state.x_max], [old_xmin, old_xmax])
+        assert_allclose([viewer_state.y_min, viewer_state.y_max], [old_ymin, old_ymax])
+
+        viewer_state.plot_mode = 'polar'
+        viewer_state.full_circle()
+        assert_allclose([viewer_state.x_min, viewer_state.x_max], [0, 2 * np.pi])
+        assert_allclose([viewer_state.y_min, viewer_state.y_max], [old_ymin, old_ymax])
+
+        for proj in fullsphere_projections:
+            error_msg = 'Issue with {} projection'.format(proj)
+            viewer_state.plot_mode = proj
+            viewer_state.full_circle()
+            assert_allclose([viewer_state.x_min, viewer_state.x_max], [-np.pi, np.pi], err_msg=error_msg)
+            assert_allclose([viewer_state.y_min, viewer_state.y_max], [-np.pi / 2, np.pi /2], err_msg=error_msg)
+
+    def test_limits_log_widget_polar_cartesian(self):
+        ui = self.viewer.options_widget().ui
+        viewer_state = self.viewer.state
+        viewer_state.plot_mode = 'polar'
+        assert not ui.bool_x_log.isEnabled()
+        assert not ui.bool_x_log_.isEnabled()
+        assert ui.bool_y_log.isEnabled()
+        assert ui.bool_y_log_.isEnabled()
+        assert ui.valuetext_x_min.isEnabled()
+        assert ui.button_flip_x.isEnabled()
+        assert ui.valuetext_x_max.isEnabled()
+        assert ui.valuetext_y_min.isEnabled()
+        assert ui.button_flip_y.isEnabled()
+        assert ui.valuetext_y_max.isEnabled()
+        assert not ui.button_full_circle.isHidden()
+
+        viewer_state.plot_mode = 'rectilinear'
+        assert ui.bool_x_log.isEnabled()
+        assert ui.bool_x_log_.isEnabled()
+        assert ui.bool_y_log.isEnabled()
+        assert ui.bool_y_log_.isEnabled()
+        assert ui.valuetext_x_min.isEnabled()
+        assert ui.button_flip_x.isEnabled()
+        assert ui.valuetext_x_max.isEnabled()
+        assert ui.valuetext_y_min.isEnabled()
+        assert ui.button_flip_y.isEnabled()
+        assert ui.valuetext_y_max.isEnabled()
+        assert ui.button_full_circle.isHidden()
+        assert ui.button_full_circle.isHidden()
+
+    def test_limits_log_widget_fullsphere(self):
+        ui = self.viewer.options_widget().ui
+        viewer_state = self.viewer.state
+        for proj in fullsphere_projections:
+            error_msg = 'Issue with {} projection'.format(proj)
+            viewer_state.plot_mode = proj
+            not ui.bool_x_log.isEnabled()
+            assert not ui.bool_x_log_.isEnabled(), error_msg
+            assert not ui.bool_y_log.isEnabled(), error_msg
+            assert not ui.bool_y_log_.isEnabled(), error_msg
+            assert not ui.valuetext_x_min.isEnabled(), error_msg
+            assert not ui.button_flip_x.isEnabled(), error_msg
+            assert not ui.valuetext_x_max.isEnabled(), error_msg
+            assert not ui.valuetext_y_min.isEnabled(), error_msg
+            assert not ui.button_flip_y.isEnabled(), error_msg
+            assert not ui.valuetext_y_max.isEnabled(), error_msg
+            assert ui.button_full_circle.isHidden(), error_msg
+
+            viewer_state.plot_mode = 'rectilinear'
+            assert ui.bool_x_log.isEnabled()
+            assert ui.bool_x_log_.isEnabled()
+            assert ui.bool_y_log.isEnabled()
+            assert ui.bool_y_log_.isEnabled()
+            assert ui.valuetext_x_min.isEnabled()
+            assert ui.button_flip_x.isEnabled()
+            assert ui.valuetext_x_max.isEnabled()
+            assert ui.valuetext_y_min.isEnabled()
+            assert ui.button_flip_y.isEnabled()
+            assert ui.valuetext_y_max.isEnabled()
+            assert ui.button_full_circle.isHidden()

--- a/glue/viewers/scatter/qt/tests/test_data_viewer.py
+++ b/glue/viewers/scatter/qt/tests/test_data_viewer.py
@@ -721,41 +721,6 @@ class TestScatterViewer(object):
         viewer_state.plot_mode = 'mollweide'
         assert 'mollweide' in str(type(self.viewer.axes)).lower()
 
-    def test_chaning_mode_limits(self):
-        self.viewer.add_data(self.data)
-        viewer_state = self.viewer.state
-        old_xmin = viewer_state.x_min
-        old_xmax = viewer_state.x_max
-        old_ymin = viewer_state.y_min
-        old_ymax = viewer_state.y_max
-
-        viewer_state.plot_mode = 'polar'
-        assert_allclose(viewer_state.x_min, old_xmin)
-        assert_allclose(viewer_state.x_max, old_xmax)
-        assert_allclose(self.viewer.axes.get_xlim(), [old_xmin, old_xmax])
-        assert_allclose(viewer_state.y_min, old_ymin)
-        assert_allclose(viewer_state.y_max, old_ymax)
-        assert_allclose(self.viewer.axes.get_ylim(), [old_ymin, old_ymax])
-
-        viewer_state.plot_mode = 'rectilinear'
-        assert_allclose(viewer_state.x_min, old_xmin)
-        assert_allclose(viewer_state.x_max, old_xmax)
-        assert_allclose(self.viewer.axes.get_xlim(), [old_xmin, old_xmax])
-        assert_allclose(viewer_state.y_min, old_ymin)
-        assert_allclose(viewer_state.y_max, old_ymax)
-        assert_allclose(self.viewer.axes.get_ylim(), [old_ymin, old_ymax])
-
-        for proj in fullsphere_projections:
-            viewer_state.plot_mode = 'rectilinear'
-            viewer_state.plot_mode = proj
-            error_msg = "Issue with {} projection".format(proj)
-            assert_allclose(viewer_state.x_min, -np.pi)
-            assert_allclose(viewer_state.x_max, np.pi)
-            assert_allclose(self.viewer.axes.get_xlim(), [-np.pi, np.pi], err_msg=error_msg)
-            assert_allclose(viewer_state.y_min, -np.pi / 2)
-            assert_allclose(viewer_state.y_max, np.pi / 2)
-            assert_allclose(self.viewer.axes.get_ylim(), [-np.pi / 2, np.pi / 2], err_msg=error_msg)
-
 
     def test_limit_log_set_polar(self):
         self.viewer.add_data(self.data)
@@ -781,7 +746,7 @@ class TestScatterViewer(object):
 
         for proj in fullsphere_projections:
             viewer_state.plot_mode = proj
-            error_msg = "Issue with {} projection".format(proj)
+            error_msg = 'Issue with {} projection'.format(proj)
             axes = self.viewer.axes
             viewer_state.x_min = 0.5
             viewer_state.x_max = 1.5
@@ -789,3 +754,71 @@ class TestScatterViewer(object):
             viewer_state.y_max = 2.5
             assert_allclose(axes.get_xlim(), [-np.pi, np.pi], err_msg=error_msg)
             assert_allclose(axes.get_ylim(), [-np.pi / 2, np.pi / 2], err_msg=error_msg)
+
+    def test_changing_mode_limits(self):
+        self.viewer.add_data(self.data)
+        viewer_state = self.viewer.state
+        old_xmin = viewer_state.x_min
+        old_xmax = viewer_state.x_max
+        old_ymin = viewer_state.y_min
+        old_ymax = viewer_state.y_max
+        # Make sure limits are reset first
+        viewer_state.x_max += 3
+
+        viewer_state.plot_mode = 'polar'
+        assert_allclose(viewer_state.x_min, old_xmin)
+        assert_allclose(viewer_state.x_max, old_xmax)
+        assert_allclose(self.viewer.axes.get_xlim(), [old_xmin, old_xmax])
+        assert_allclose(viewer_state.y_min, old_ymin)
+        assert_allclose(viewer_state.y_max, old_ymax)
+        assert_allclose(self.viewer.axes.get_ylim(), [old_ymin, old_ymax])
+
+        viewer_state.plot_mode = 'rectilinear'
+        assert_allclose(viewer_state.x_min, old_xmin)
+        assert_allclose(viewer_state.x_max, old_xmax)
+        assert_allclose(self.viewer.axes.get_xlim(), [old_xmin, old_xmax])
+        assert_allclose(viewer_state.y_min, old_ymin)
+        assert_allclose(viewer_state.y_max, old_ymax)
+        assert_allclose(self.viewer.axes.get_ylim(), [old_ymin, old_ymax])
+
+        for proj in fullsphere_projections:
+            viewer_state.plot_mode = 'rectilinear'
+            viewer_state.plot_mode = proj
+            error_msg = 'Issue with {} projection'.format(proj)
+            assert_allclose(viewer_state.x_min, -np.pi)
+            assert_allclose(viewer_state.x_max, np.pi)
+            assert_allclose(self.viewer.axes.get_xlim(), [-np.pi, np.pi], err_msg=error_msg)
+            assert_allclose(viewer_state.y_min, -np.pi / 2)
+            assert_allclose(viewer_state.y_max, np.pi / 2)
+            assert_allclose(self.viewer.axes.get_ylim(), [-np.pi / 2, np.pi / 2], err_msg=error_msg)
+
+    def test_changing_mode_log(self):
+        # Test to make sure we reset the log axes to false when changing modes to prevent problems
+        self.viewer.add_data(self.data)
+        viewer_state = self.viewer.state
+        viewer_state.x_log = True
+        viewer_state.y_log = True
+
+        viewer_state.plot_mode = 'polar'
+        assert not viewer_state.x_log
+        assert not viewer_state.y_log
+        assert self.viewer.axes.get_xscale() == 'linear'
+        assert self.viewer.axes.get_yscale() == 'linear'
+        viewer_state.y_log = True
+
+        viewer_state.plot_mode = 'rectilinear'
+        assert not viewer_state.x_log
+        assert not viewer_state.y_log
+        assert self.viewer.axes.get_xscale() == 'linear'
+        assert self.viewer.axes.get_yscale() == 'linear'
+
+        for proj in fullsphere_projections:
+            viewer_state.plot_mode = 'rectilinear'
+            viewer_state.x_log = True
+            viewer_state.y_log = True
+            viewer_state.plot_mode = proj
+            error_msg = 'Issue with {} projection'.format(proj)
+            assert not viewer_state.x_log, error_msg
+            assert not viewer_state.y_log, error_msg
+            assert self.viewer.axes.get_xscale() == 'linear', error_msg
+            assert self.viewer.axes.get_yscale() == 'linear', error_msg

--- a/glue/viewers/scatter/qt/tests/test_data_viewer.py
+++ b/glue/viewers/scatter/qt/tests/test_data_viewer.py
@@ -26,13 +26,14 @@ from ..data_viewer import ScatterViewer
 
 DATA = os.path.join(os.path.dirname(__file__), 'data')
 
+fullsphere_projections = ['aitoff', 'hammer', 'lambert', 'mollweide']
+
 
 class TestScatterCommon(BaseTestMatplotlibDataViewer):
     def init_data(self):
         return Data(label='d1', x=[3.4, 2.3, -1.1, 0.3], y=['a', 'b', 'c', 'a'])
     viewer_cls = ScatterViewer
 
-fullsphere_projections = ['aitoff', 'hammer', 'lambert', 'mollweide']
 
 class TestScatterViewer(object):
 
@@ -722,7 +723,6 @@ class TestScatterViewer(object):
         viewer_state.plot_mode = 'mollweide'
         assert 'mollweide' in str(type(self.viewer.axes)).lower()
 
-
     def test_limit_log_set_polar(self):
         self.viewer.add_data(self.data)
         viewer_state = self.viewer.state
@@ -731,7 +731,7 @@ class TestScatterViewer(object):
 
         viewer_state.x_min = 0.5
         viewer_state.x_max = 1.5
-        assert_allclose(axes.get_xlim(),[0.5, 1.5])
+        assert_allclose(axes.get_xlim(), [0.5, 1.5])
 
         viewer_state.y_min = -2.5
         viewer_state.y_max = 2.5
@@ -846,7 +846,7 @@ class TestScatterViewer(object):
             viewer_state.plot_mode = proj
             viewer_state.full_circle()
             assert_allclose([viewer_state.x_min, viewer_state.x_max], [-np.pi, np.pi], err_msg=error_msg)
-            assert_allclose([viewer_state.y_min, viewer_state.y_max], [-np.pi / 2, np.pi /2], err_msg=error_msg)
+            assert_allclose([viewer_state.y_min, viewer_state.y_max], [-np.pi / 2, np.pi / 2], err_msg=error_msg)
 
     def test_limits_log_widget_polar_cartesian(self):
         ui = self.viewer.options_widget().ui

--- a/glue/viewers/scatter/qt/tests/test_python_export.py
+++ b/glue/viewers/scatter/qt/tests/test_python_export.py
@@ -251,3 +251,10 @@ class TestExportPython(BaseTestExportPython):
         self.viewer.state.x_att = self.data.id['a']
         self.viewer.state.y_att = self.data.id['b']
         self.assert_same(tmpdir)
+
+    def test_cmap_size_noncartesian(self, tmpdir):
+        self.viewer.state.layers[0].size_mode = 'Linear'
+        self.viewer.state.layers[0].cmap_mode = 'Linear'
+        for proj in ['polar', 'aitoff', 'hammer', 'lambert', 'mollweide']:
+            self.viewer.state.plot_mode = proj
+            self.assert_same(tmpdir)

--- a/glue/viewers/scatter/qt/tests/test_python_export.py
+++ b/glue/viewers/scatter/qt/tests/test_python_export.py
@@ -227,3 +227,27 @@ class TestExportPython(BaseTestExportPython):
         self.viewer.state.layers[0].cmap = plt.cm.BuGn
         self.viewer.state.layers[0].density_map = False
         self.assert_same(tmpdir)
+
+    def test_simple_polar_plot(self, tmpdir):
+        self.viewer.state.plot_mode = 'polar'
+        self.viewer.state.x_att = self.data.id['c']
+        self.viewer.state.y_att = self.data.id['d']
+        self.assert_same(tmpdir)
+
+    def test_full_sphere(self, tmpdir):
+        self.viewer.state.plot_mode = 'aitoff'
+        self.viewer.state.x_att = self.data.id['c']
+        self.viewer.state.y_att = self.data.id['d']
+        self.assert_same(tmpdir)
+        self.viewer.state.plot_mode = 'hammer'
+        self.viewer.state.x_att = self.data.id['e']
+        self.viewer.state.y_att = self.data.id['f']
+        self.assert_same(tmpdir)
+        self.viewer.state.plot_mode = 'lambert'
+        self.viewer.state.x_att = self.data.id['g']
+        self.viewer.state.y_att = self.data.id['h']
+        self.assert_same(tmpdir)
+        self.viewer.state.plot_mode = 'mollweide'
+        self.viewer.state.x_att = self.data.id['a']
+        self.viewer.state.y_att = self.data.id['b']
+        self.assert_same(tmpdir)

--- a/glue/viewers/scatter/qt/tests/test_python_export.py
+++ b/glue/viewers/scatter/qt/tests/test_python_export.py
@@ -258,3 +258,19 @@ class TestExportPython(BaseTestExportPython):
         for proj in ['polar', 'aitoff', 'hammer', 'lambert', 'mollweide']:
             self.viewer.state.plot_mode = proj
             self.assert_same(tmpdir)
+
+    def test_vectors_noncartesian(self, tmpdir):
+        for proj in ['polar', 'aitoff', 'hammer', 'lambert', 'mollweide']:
+            self.viewer.state.plot_mode = proj
+            self._vector_common(tmpdir)
+
+    def test_errorbarxy_noncartesian(self, tmpdir):
+        self.viewer.state.layers[0].xerr_visible = True
+        self.viewer.state.layers[0].xerr_att = self.data.id['e']
+        self.viewer.state.layers[0].yerr_visible = True
+        self.viewer.state.layers[0].yerr_att = self.data.id['f']
+        self.viewer.state.layers[0].color = 'purple'
+        self.viewer.state.layers[0].alpha = 0.5
+        for proj in ['polar', 'aitoff', 'hammer', 'lambert', 'mollweide']:
+            self.viewer.state.plot_mode = proj
+            self.assert_same(tmpdir)

--- a/glue/viewers/scatter/state.py
+++ b/glue/viewers/scatter/state.py
@@ -87,6 +87,12 @@ class ScatterViewerState(MatplotlibDataViewerState):
         """
         self.y_lim_helper.flip_limits()
 
+    def full_circle(self):
+        if not self.plot_mode == 'polar':
+            return
+        self.x_min = 0
+        self.x_max = 2*np.pi
+
     @property
     def x_categories(self):
         return self._categories(self.x_att)

--- a/glue/viewers/scatter/state.py
+++ b/glue/viewers/scatter/state.py
@@ -27,7 +27,7 @@ class ScatterViewerState(MatplotlibDataViewerState):
     x_att = DDSCProperty(docstring='The attribute to show on the x-axis', default_index=0)
     y_att = DDSCProperty(docstring='The attribute to show on the y-axis', default_index=1)
     dpi = DDCProperty(72, docstring='The resolution (in dots per inch) of density maps, if present')
-    plot_mode = DDSCProperty(docstring="Whether to plot the data in cartesian or polar mode")
+    plot_mode = DDSCProperty(docstring="Whether to plot the data in cartesian, polar or another projection")
 
     def __init__(self, **kwargs):
 

--- a/glue/viewers/scatter/state.py
+++ b/glue/viewers/scatter/state.py
@@ -51,7 +51,7 @@ class ScatterViewerState(MatplotlibDataViewerState):
         self.y_att_helper = ComponentIDComboHelper(self, 'y_att', pixel_coord=True, world_coord=True)
 
         self.plot_mode_helper = ComboHelper(self, 'plot_mode')
-        self.plot_mode_helper.choices = get_projection_names()
+        self.plot_mode_helper.choices = [proj for proj in get_projection_names() if proj not in ['3d', 'scatter_density']]
         self.plot_mode_helper.selection = 'rectilinear'
 
         self.update_from_dict(kwargs)

--- a/glue/viewers/scatter/state.py
+++ b/glue/viewers/scatter/state.py
@@ -11,8 +11,10 @@ from glue.viewers.matplotlib.state import (MatplotlibDataViewerState,
                                            DeferredDrawSelectionCallbackProperty as DDSCProperty)
 from glue.core.state_objects import StateAttributeLimitsHelper
 from echo import keep_in_sync, delay_callback
-from glue.core.data_combo_helper import ComponentIDComboHelper
+from glue.core.data_combo_helper import ComponentIDComboHelper, ComboHelper
 from glue.core.exceptions import IncompatibleAttribute
+
+from matplotlib.projections import get_projection_names
 
 __all__ = ['ScatterViewerState', 'ScatterLayerState']
 
@@ -25,6 +27,7 @@ class ScatterViewerState(MatplotlibDataViewerState):
     x_att = DDSCProperty(docstring='The attribute to show on the x-axis', default_index=0)
     y_att = DDSCProperty(docstring='The attribute to show on the y-axis', default_index=1)
     dpi = DDCProperty(72, docstring='The resolution (in dots per inch) of density maps, if present')
+    plot_mode = DDSCProperty(docstring="Whether to plot the data in cartesian or polar mode")
 
     def __init__(self, **kwargs):
 
@@ -46,6 +49,10 @@ class ScatterViewerState(MatplotlibDataViewerState):
 
         self.x_att_helper = ComponentIDComboHelper(self, 'x_att', pixel_coord=True, world_coord=True)
         self.y_att_helper = ComponentIDComboHelper(self, 'y_att', pixel_coord=True, world_coord=True)
+
+        self.plot_mode_helper = ComboHelper(self, 'plot_mode')
+        self.plot_mode_helper.choices = get_projection_names()
+        self.plot_mode_helper.selection = 'rectilinear'
 
         self.update_from_dict(kwargs)
 

--- a/glue/viewers/scatter/state.py
+++ b/glue/viewers/scatter/state.py
@@ -91,7 +91,7 @@ class ScatterViewerState(MatplotlibDataViewerState):
         if not self.plot_mode == 'polar':
             return
         self.x_min = 0
-        self.x_max = 2*np.pi
+        self.x_max = 2 * np.pi
 
     @property
     def x_categories(self):

--- a/glue/viewers/scatter/viewer.py
+++ b/glue/viewers/scatter/viewer.py
@@ -6,9 +6,6 @@ from glue.utils import mpl_to_datetime64
 from glue.viewers.scatter.compat import update_scatter_viewer_state
 from glue.viewers.matplotlib.mpl_axes import init_mpl
 
-from matplotlib.figure import Figure
-import numpy as np
-
 
 __all__ = ['MatplotlibScatterMixin']
 

--- a/glue/viewers/scatter/viewer.py
+++ b/glue/viewers/scatter/viewer.py
@@ -54,6 +54,7 @@ class MatplotlibScatterMixin(object):
         _, self.axes = init_mpl(self.figure, projection=self.state.plot_mode)
         for layer in old_layers:
             layer._set_axes(self.axes)
+            layer.state.vector_mode = 'Cartesian'
             layer.update()
         self.axes.callbacks.connect('xlim_changed', self.limits_from_mpl)
         self.axes.callbacks.connect('ylim_changed', self.limits_from_mpl)

--- a/glue/viewers/scatter/viewer.py
+++ b/glue/viewers/scatter/viewer.py
@@ -51,12 +51,8 @@ class MatplotlibScatterMixin(object):
         self.figure.delaxes(self.axes)
         _, self.axes = init_mpl(self.figure, projection=self.state.plot_mode)
         for layer in old_layers:
-            z_order = layer.zorder
-            new_layer = ScatterLayerArtist(self.axes, self.state,
-                                           layer_state=layer.state, layer=layer.layer)
-            self._layer_artist_container.append(new_layer)
-            self._layer_artist_container.remove(layer)
-            new_layer.zorder = z_order
+            layer._set_axes(self.axes)
+            layer.update()
         self.axes.callbacks.connect('xlim_changed', self.limits_from_mpl)
         self.axes.callbacks.connect('ylim_changed', self.limits_from_mpl)
         self.limits_from_mpl()

--- a/glue/viewers/scatter/viewer.py
+++ b/glue/viewers/scatter/viewer.py
@@ -65,6 +65,7 @@ class MatplotlibScatterMixin(object):
         self.update_y_ticklabel()
 
         # Reset and roundtrip the limits to have reasonable and synced limits when changing
+        self.state.x_log = self.state.y_log = False
         self.state.reset_limits()
         self.limits_to_mpl()
         self.limits_from_mpl()

--- a/glue/viewers/scatter/viewer.py
+++ b/glue/viewers/scatter/viewer.py
@@ -55,6 +55,9 @@ class MatplotlibScatterMixin(object):
                                                                    layer_state=layer.state,
                                                                    layer=layer.layer))
             self._layer_artist_container.remove(layer)
+        self.axes.callbacks.connect('xlim_changed', self.limits_from_mpl)
+        self.axes.callbacks.connect('ylim_changed', self.limits_from_mpl)
+        self.limits_from_mpl()
         self.figure.canvas.draw_idle()
 
     def apply_roi(self, roi, override_mode=None):

--- a/glue/viewers/scatter/viewer.py
+++ b/glue/viewers/scatter/viewer.py
@@ -48,11 +48,9 @@ class MatplotlibScatterMixin(object):
 
     def _update_projection(self, *args):
 
-        old_layers = self.layers
-
         self.figure.delaxes(self.axes)
         _, self.axes = init_mpl(self.figure, projection=self.state.plot_mode)
-        for layer in old_layers:
+        for layer in self.layers:
             layer._set_axes(self.axes)
             layer.state.vector_mode = 'Cartesian'
             layer.update()

--- a/glue/viewers/scatter/viewer.py
+++ b/glue/viewers/scatter/viewer.py
@@ -26,7 +26,7 @@ class MatplotlibScatterMixin(object):
 
             # Update ticks, which sets the labels to categories if components are categorical
             update_ticks(self.axes, 'x', self.state.x_kinds, self.state.x_log,
-                         self.state.x_categories, projection = self.state.plot_mode)
+                         self.state.x_categories, projection=self.state.plot_mode)
 
             if self.state.x_log:
                 self.state.x_axislabel = 'Log ' + self.state.x_att.label
@@ -37,7 +37,7 @@ class MatplotlibScatterMixin(object):
 
             # Update ticks, which sets the labels to categories if components are categorical
             update_ticks(self.axes, 'y', self.state.y_kinds, self.state.y_log,
-                         self.state.y_categories, projection = self.state.plot_mode)
+                         self.state.y_categories, projection=self.state.plot_mode)
 
             if self.state.y_log:
                 self.state.y_axislabel = 'Log ' + self.state.y_att.label
@@ -94,7 +94,7 @@ class MatplotlibScatterMixin(object):
         subset_state = roi_to_subset_state(roi,
                                            x_att=self.state.x_att, x_categories=self.state.x_categories,
                                            y_att=self.state.y_att, y_categories=self.state.y_categories,
-                                           use_pretransform = use_transform)
+                                           use_pretransform=use_transform)
         if use_transform:
             subset_state.pretransform = ProjectionMplTransform(self.state.plot_mode,
                                                                self.axes.get_xlim(),

--- a/glue/viewers/scatter/viewer.py
+++ b/glue/viewers/scatter/viewer.py
@@ -51,10 +51,12 @@ class MatplotlibScatterMixin(object):
         self.figure.delaxes(self.axes)
         _, self.axes = init_mpl(self.figure, projection=self.state.plot_mode)
         for layer in old_layers:
-            self._layer_artist_container.append(ScatterLayerArtist(self.axes, self.state,
-                                                                   layer_state=layer.state,
-                                                                   layer=layer.layer))
+            z_order = layer.zorder
+            new_layer = ScatterLayerArtist(self.axes, self.state,
+                                           layer_state=layer.state, layer=layer.layer)
+            self._layer_artist_container.append(new_layer)
             self._layer_artist_container.remove(layer)
+            new_layer.zorder = z_order
         self.axes.callbacks.connect('xlim_changed', self.limits_from_mpl)
         self.axes.callbacks.connect('ylim_changed', self.limits_from_mpl)
         self.limits_from_mpl()

--- a/glue/viewers/scatter/viewer.py
+++ b/glue/viewers/scatter/viewer.py
@@ -1,11 +1,9 @@
 from glue.core.subset import roi_to_subset_state
 from glue.core.util import update_ticks
-from glue.core import glue_pickle as gp
 
 from glue.utils import mpl_to_datetime64
 from glue.viewers.scatter.compat import update_scatter_viewer_state
 from glue.viewers.matplotlib.mpl_axes import init_mpl
-from glue.viewers.scatter.layer_artist import ScatterLayerArtist
 
 from matplotlib.figure import Figure
 import numpy as np
@@ -92,6 +90,10 @@ class MatplotlibScatterMixin(object):
         self.limits_from_mpl()
         self.removeToolBar(self.toolbar)
         self.initialize_toolbar()
+        self.update_x_axislabel()
+        self.update_y_axislabel()
+        self.update_x_ticklabel()
+        self.update_y_ticklabel()
         self.figure.canvas.draw_idle()
 
     def apply_roi(self, roi, override_mode=None):

--- a/glue/viewers/scatter/viewer.py
+++ b/glue/viewers/scatter/viewer.py
@@ -6,6 +6,8 @@ from glue.utils import mpl_to_datetime64
 from glue.viewers.scatter.compat import update_scatter_viewer_state
 from glue.viewers.matplotlib.mpl_axes import init_mpl
 from glue.viewers.scatter.layer_artist import ScatterLayerArtist
+
+from matplotlib.figure import Figure
 import numpy as np
 
 
@@ -13,8 +15,16 @@ __all__ = ['MatplotlibScatterMixin']
 
 
 class MplProjectionTransform(object):
-    def __init__(self, axes):
-        self._transform = (axes.transData + axes.transAxes.inverted()).frozen() if axes else None
+    def __init__(self, projection, x_lim, y_lim, x_scale, y_scale):
+        self._state = {'projection': projection, 'x_lim': x_lim,'y_lim': y_lim,
+                       'x_scale': x_scale, 'y_scale': y_scale}
+        _, axes = init_mpl(Figure(), projection=self._state['projection'])
+        axes.set_xscale(self._state['x_scale'])
+        axes.set_yscale(self._state['y_scale'])
+        if self._state['projection'] not in ['aitoff', 'hammer', 'lambert', 'mollweide']:
+            axes.set_xlim(self._state['x_lim'])
+            axes.set_ylim(self._state['y_lim'])
+        self._transform = (axes.transData + axes.transAxes.inverted()).frozen()
 
     def __call__(self, x,y):
         assert self._transform is not None
@@ -25,13 +35,12 @@ class MplProjectionTransform(object):
         return out[0].reshape(x.shape), out[1].reshape(y.shape)
 
     def __gluestate__(self, context):
-        return dict(transform=context.id(self._transform))
+        return dict(state=context.id(self._state))
 
     @classmethod
     def __setgluestate__(cls, rec, context):
-        obj = cls()
-        obj._transform = context.object(rec['transform'])
-        return obj
+        state = context.object(rec['state'])
+        return cls(state['projection'], state['x_lim'], state['y_lim'], state['x_scale'], state['y_scale'])
 
 class MatplotlibScatterMixin(object):
 
@@ -108,7 +117,11 @@ class MatplotlibScatterMixin(object):
                                            y_att=self.state.y_att, y_categories=self.state.y_categories,
                                            use_pretransform = use_transform)
         if use_transform:
-            subset_state.pretransform = MplProjectionTransform(self.axes)
+            subset_state.pretransform = MplProjectionTransform(self.state.plot_mode,
+                                                               self.axes.get_xlim(),
+                                                               self.axes.get_ylim(),
+                                                               self.axes.get_xscale(),
+                                                               self.axes.get_yscale())
 
         self.apply_subset_state(subset_state, override_mode=override_mode)
 

--- a/glue/viewers/scatter/viewer.py
+++ b/glue/viewers/scatter/viewer.py
@@ -87,13 +87,18 @@ class MatplotlibScatterMixin(object):
             layer.update()
         self.axes.callbacks.connect('xlim_changed', self.limits_from_mpl)
         self.axes.callbacks.connect('ylim_changed', self.limits_from_mpl)
-        self.limits_from_mpl()
         self.removeToolBar(self.toolbar)
         self.initialize_toolbar()
         self.update_x_axislabel()
         self.update_y_axislabel()
         self.update_x_ticklabel()
         self.update_y_ticklabel()
+
+        # Reset and roundtrip the limits to have reasonable and synced limits when changing
+        self.state.reset_limits()
+        self.limits_to_mpl()
+        self.limits_from_mpl()
+        
         self.figure.canvas.draw_idle()
 
     def apply_roi(self, roi, override_mode=None):

--- a/glue/viewers/scatter/viewer.py
+++ b/glue/viewers/scatter/viewer.py
@@ -57,7 +57,8 @@ class MatplotlibScatterMixin(object):
         if self.state.x_att is not None:
 
             # Update ticks, which sets the labels to categories if components are categorical
-            update_ticks(self.axes, 'x', self.state.x_kinds, self.state.x_log, self.state.x_categories)
+            update_ticks(self.axes, 'x', self.state.x_kinds, self.state.x_log,
+                         self.state.x_categories, projection = self.state.plot_mode)
 
             if self.state.x_log:
                 self.state.x_axislabel = 'Log ' + self.state.x_att.label
@@ -67,7 +68,8 @@ class MatplotlibScatterMixin(object):
         if self.state.y_att is not None:
 
             # Update ticks, which sets the labels to categories if components are categorical
-            update_ticks(self.axes, 'y', self.state.y_kinds, self.state.y_log, self.state.y_categories)
+            update_ticks(self.axes, 'y', self.state.y_kinds, self.state.y_log,
+                         self.state.y_categories, projection = self.state.plot_mode)
 
             if self.state.y_log:
                 self.state.y_axislabel = 'Log ' + self.state.y_att.label


### PR DESCRIPTION
This PR adds the ability to change the projection of the Matplotlib 2D scatter plot. To make sure that selecting ROIs on the various projections, this PR also adds the ability for ROI subset states to apply an arbitrary transform before testing for inclusion in the ROI. There are also lots of tweaks and changes to the scatter code to make sure that things like script export, color-maps, scaling, vectors, error bars, limits, log, tick formatting, etc. behave when using the different projections. A number of tests are added as well. Some future improvements that can be made to this include:

* Curving the theta error bars when using a polar projection.
* Being smarter about units when axes are inherently angular. Currently the code naively assumes that the values of angular axis are in radians. However, if the selected attribute has an attached angular unit, we could convert it before plotting and ROI selection.
	