### PR TITLE
feat: support for Voila v0.2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     ipython>=4.0
     ipykernel>=4.0,!=5.0.0,!=5.1.0
     qtconsole>=4.3
-    jupyter_client<6
+    jupyter_client<7
     dill>=0.2
     xlrd>=1.2
     h5py>=2.10

--- a/tox.ini
+++ b/tox.ini
@@ -37,8 +37,8 @@ deps =
     legacy: astropy==4.0.*
     legacy: setuptools==30.3.*
     legacy: qtpy==1.9.*
-    legacy: ipython==4.0.*
-    legacy: ipykernel==4.0.*
+    legacy: ipython==7.16.*
+    legacy: ipykernel==5.3.*
     legacy: qtconsole==4.3.*
     legacy: dill==0.2.*
     legacy: xlrd==1.2.*


### PR DESCRIPTION
Voila v0.2 has a dependency on jupyter-client>6. The current pinning of <6 is not necessary any more (see #2174).

Closes #2174.