### PR TITLE
DOC: Fix outdated FITS tutorial

### DIFF
--- a/doc/python_guide/data_tutorial.rst
+++ b/doc/python_guide/data_tutorial.rst
@@ -276,9 +276,9 @@ In the above examples, we have assumed that the data objects were loaded via
 the Glue application. The readers/writers in Glue can also be accessed using
 the functions in :mod:`glue.core.data_factories`::
 
-    >>> from glue.core.data_factores import (load_data, gridded_data,
-    ...                                      tabular_data)
-    >>> load_data('image.fits', factory=gridded_data)  # reads a FITS image
+    >>> from glue.core.data_factories import (load_data, fits_reader,
+    ...                                       tabular_data)
+    >>> fits_reader('image.fits')  # reads a FITS image
     >>> load_data('catalog.csv', factory=tabular_data) # reads a catalog
     >>> load_data('catalog.csv')  # guesses format
 


### PR DESCRIPTION
## Description

Current http://docs.glueviz.org/en/latest/python_guide/data_tutorial.html#creating-a-data-object has a typo in the import and also the FITS reader instruction is broken.

cc @astrofrog 