### PR TITLE
Prioritise pandas over astropy for reading tables

### DIFF
--- a/glue/core/data_factories/tables.py
+++ b/glue/core/data_factories/tables.py
@@ -13,7 +13,8 @@ __all__ = ['tabular_data']
 def tabular_data(path, **kwargs):
     from glue.core.data_factories.astropy_table import astropy_tabular_data
     from glue.core.data_factories.pandas import pandas_read_table
-    for fac in [astropy_tabular_data, pandas_read_table]:
+    # Try pandas first, as it is an order of mangitude faster than astropy
+    for fac in [pandas_read_table, astropy_tabular_data]:
         try:
             return fac(path, **kwargs)
         except Exception:


### PR DESCRIPTION
# Pull Request Template

## Description
As reported in https://github.com/glue-viz/glue/issues/2183, some basic benchmarking I've done shows that `astropy` is an order of magnitude slower reading tables when compared to `pandas`. In my particular case, the difference is 90 seconds vs. 4 seconds.

Given this large difference, I think it makes sense to try and use pandas where possible, and only fallback on astropy when that doesn't work.

