### PR TITLE
Fix FutureWarning in compute_statistic

### DIFF
--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -1800,7 +1800,7 @@ class Data(BaseCartesianData):
             full_shape = [self.shape[idim] for idim in range(self.ndim) if idim not in axis]
             full_result = np.zeros(full_shape) * np.nan
             result_slices = [subarray_slices[idim] for idim in range(self.ndim) if idim not in axis]
-            full_result[result_slices] = result
+            full_result[tuple(result_slices)] = result
             return full_result
 
     def compute_histogram(self, cids, weights=None, range=None, bins=None, log=None, subset_state=None):


### PR DESCRIPTION
# Pull Request Template

## Description

Resolves a `FutureWarning` thrown in `compute_statistic` (copied below):

```
/Users/pogle/miniconda3/envs/jdaviz1.1/lib/python3.9/site-packages/glue/core/data.py:1803: FutureWarning: 
Using a non-tuple sequence for multidimensional indexing is deprecated; use `arr[tuple(seq)]` instead of 
`arr[seq]`. In the future this will be interpreted as an array index, `arr[np.array(seq)]`, which will result 
either in an error or a different result.
  full_result[result_slices] = result
```
