### PR TITLE
Define fileno() on GlueLogger for ipykernel 6+

### DIFF
--- a/glue/app/qt/application.py
+++ b/glue/app/qt/application.py
@@ -134,6 +134,9 @@ class GlueLogger(QtWidgets.QWidget):
 
         self.setLayout(l)
 
+    def fileno(self):
+        return self._stderr_original.fileno()
+
     def _set_console_button(self, attention):
         if attention:
             style = 'color: red; text-decoration: underline;'


### PR DESCRIPTION
Fixes compatibility with ipykernel 6+ (see https://github.com/ipython/ipykernel/pull/630)