### PR TITLE
BUG: Fix wcs_autolink to work with GWCS

### DIFF
--- a/glue/plugins/wcs_autolinking/wcs_autolinking.py
+++ b/glue/plugins/wcs_autolinking/wcs_autolinking.py
@@ -1,8 +1,7 @@
 import copy
 
-from astropy.wcs import WCS
 from astropy.wcs.utils import pixel_to_pixel
-from astropy.wcs.wcsapi import SlicedLowLevelWCS, HighLevelWCSWrapper
+from astropy.wcs.wcsapi import BaseHighLevelWCS, SlicedLowLevelWCS, HighLevelWCSWrapper
 from glue.config import autolinker, link_helper
 from glue.core.link_helpers import MultiLink
 
@@ -183,7 +182,7 @@ def wcs_autolink(data_collection):
 
     # Find subset of datasets with WCS coordinates
     wcs_datasets = [data for data in data_collection
-                    if hasattr(data, 'coords') and isinstance(data.coords, WCS)]
+                    if hasattr(data, 'coords') and isinstance(data.coords, BaseHighLevelWCS)]
 
     # Only continue if there are at least two such datasets
     if len(wcs_datasets) < 2:


### PR DESCRIPTION
# Pull Request Template

## Description

This is so `wcs_autolink` works when `Data.coords` contains GWCS. cc @astrofrog 