### PR TITLE
Fix deprecation warnings with recent versions of astropy

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ v1.1.0 (unreleased)
 
 * Fixed compatibility with recent releases of Matplotlib. [#2196]
 
+* Avoid warnings with recent releases of astropy. [#2212]
+
 v1.0.1 (2020-11-10)
 -------------------
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -35,7 +35,6 @@ if os.environ.get('READTHEDOCS') == 'True':
 
 intersphinx_cache_limit = 10     # days to keep the cached inventories
 intersphinx_mapping = {
-    'sphinx': ('https://www.sphinx-doc.org/en/3.x/', None),
     'python': ('https://docs.python.org/3.7', None),
     'matplotlib': ('https://matplotlib.org', None),
     'numpy': ('https://docs.scipy.org/doc/numpy', None),
@@ -175,6 +174,7 @@ nitpick_ignore = [('py:class', 'object'), ('py:class', 'str'),
                   ('py:class', 'QStyle'),
                   ('py:class', 'QToolBar'),
                   ('py:class', 'QThread'),
+                  ('py:class', 'QScreen'),
                   ('py:class', 'QWidget'),
                   ('py:class', 'QWidget.RenderFlag'),
                   ('py:class', 'QWidget.RenderFlags'),

--- a/glue/plugins/coordinate_helpers/deprecated.py
+++ b/glue/plugins/coordinate_helpers/deprecated.py
@@ -4,13 +4,13 @@ from astropy.coordinates import FK5, Galactic
 
 def fk52gal(ra, dec):
     c = FK5(ra * u.deg, dec * u.deg)
-    out = c.transform_to(Galactic)
+    out = c.transform_to(Galactic())
     return out.l.degree, out.b.degree
 
 
 def gal2fk5(l, b):
     c = Galactic(l * u.deg, b * u.deg)
-    out = c.transform_to(FK5)
+    out = c.transform_to(FK5())
     return out.ra.degree, out.dec.degree
 
 

--- a/glue/plugins/coordinate_helpers/link_helpers.py
+++ b/glue/plugins/coordinate_helpers/link_helpers.py
@@ -104,10 +104,10 @@ class GalactocentricToGalactic(BaseMultiLink):
 
     def forwards(self, x_kpc, y_kpc, z_kpc):
         with galactocentric_frame_defaults.set('pre-v4.0'):
-            gal = Galactocentric(x=x_kpc * u.kpc, y=y_kpc * u.kpc, z=z_kpc * u.kpc).transform_to(Galactic)
+            gal = Galactocentric(x=x_kpc * u.kpc, y=y_kpc * u.kpc, z=z_kpc * u.kpc).transform_to(Galactic())
         return gal.l.degree, gal.b.degree, gal.distance.to(u.kpc).value
 
     def backwards(self, l_deg, b_deg, d_kpc):
         with galactocentric_frame_defaults.set('pre-v4.0'):
-            gal = Galactic(l=l_deg * u.deg, b=b_deg * u.deg, distance=d_kpc * u.kpc).transform_to(Galactocentric)
+            gal = Galactic(l=l_deg * u.deg, b=b_deg * u.deg, distance=d_kpc * u.kpc).transform_to(Galactocentric())
         return gal.x.to(u.kpc).value, gal.y.to(u.kpc).value, gal.z.to(u.kpc).value


### PR DESCRIPTION
Just a small change to avoid deprecation warnings with recent versions of astropy