### PR TITLE
DOC: Fix typo in link_manager module docstring

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 Full changelog
 ==============
 
-v1.1.0 (unreleased)
+v1.1.0 (2021-07-21)
 -------------------
 
 * Fix compatibility with xlrd 2.0 and require openpyxl for .xlsx input. [#2196]
@@ -11,6 +11,8 @@ v1.1.0 (unreleased)
 * Fixed compatibility with recent releases of Matplotlib. [#2196]
 
 * Avoid warnings with recent releases of astropy. [#2212]
+
+* Fixed compatibility of auto-linking with all APE 14 WCSes. [#2209]
 
 v1.0.1 (2020-11-10)
 -------------------

--- a/doc/installation/conda.rst
+++ b/doc/installation/conda.rst
@@ -28,7 +28,7 @@ First, make sure that your conda command is up to date::
 
 then install glue with::
 
-    conda install -c glueviz glueviz=1.0
+    conda install -c glueviz glueviz=1.1
 
 This will install the latest version of glue from the ``glueviz`` conda channel.
 

--- a/doc/whatsnew/whatsnew.rst
+++ b/doc/whatsnew/whatsnew.rst
@@ -15,7 +15,7 @@ interested.
 Before we get started, here's a reminder on how to install/update glue. You can
 easily update glue if you are using Anaconda/Miniconda by doing::
 
-    conda install -c glueviz glueviz=1.0
+    conda install -c glueviz glueviz=1.1
 
 If instead you installed glue with pip, you can update with::
 
@@ -25,6 +25,15 @@ If you have any questions about any of the functionality described below or
 about glue in general, you can find information :ref:`here
 <help>` about contacting us and/or
 reporting issues.
+
+.. _whatsnew_110:
+
+What's new in glue v1.1.0?
+==========================
+
+Glue v1.1.0 is a maintenance release that fixes support with recent versions of
+dependencies and drops support for Python 3.6. Python 3.7 or later is now required
+to run glue.
 
 .. _whatsnew_100:
 

--- a/glue/core/link_manager.py
+++ b/glue/core/link_manager.py
@@ -1,5 +1,5 @@
 """
-The LinkManager class is responsible for maintaining the conistency
+The LinkManager class is responsible for maintaining the consistency
 of the "web of links" in a DataCollection. It discovers how to
 combine ComponentLinks together to discover all of the ComponentIDs
 that a Data object can derive,


### PR DESCRIPTION
Noticed a typo.