### PR TITLE
Add WCSLink.as_affine method to return affine approximation to WCSLink

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 Full changelog
 ==============
 
+v1.2.0 (unreleased)
+-------------------
+
+* Added a new ``WCSLink.as_affine_link`` method which can be used to find
+  an affine approximation to a WCSLink. [#2219]
+
 v1.1.0 (2021-07-21)
 -------------------
 

--- a/glue/core/coordinates.py
+++ b/glue/core/coordinates.py
@@ -194,7 +194,7 @@ class AffineCoordinates(Coordinates):
 WCSCoordinates = WCS
 
 
-def coordinates_from_header(header):
+def coordinates_from_header(header, hdulist=None):
     """
     Convert a FITS header into a glue Coordinates object.
 
@@ -216,7 +216,7 @@ def coordinates_from_header(header):
 
     if isinstance(header, Header) and 'CRVAL1' in header:
         try:
-            return WCSCoordinates(header)
+            return WCSCoordinates(header, hdulist)
         except Exception as e:
             logging.getLogger(__name__).warn(
                 "\n\n*******************************\n"

--- a/glue/core/data_factories/fits.py
+++ b/glue/core/data_factories/fits.py
@@ -128,7 +128,7 @@ def fits_reader(source, auto_merge=False, exclude_exts=None, label=None):
                 extnum not in exclude_exts):
             if is_image_hdu(hdu):
                 shape = hdu.data.shape
-                coords = coordinates_from_header(hdu.header)
+                coords = coordinates_from_header(hdu.header, hdulist)
                 units = hdu.header.get('BUNIT')
                 if not auto_merge or has_wcs(coords):
                     data = new_data(suffix=len(hdulist) > 1)
@@ -220,7 +220,7 @@ def casalike_cube(filename, **kwargs):
     with fits.open(filename, mode='denywrite', **kwargs) as hdulist:
         array = hdulist[0].data
         header = hdulist[0].header
-    result.coords = coordinates_from_header(header)
+        result.coords = coordinates_from_header(header, hdulist)
     for i in range(array.shape[0]):
         units = header.get('BUNIT')
         component = Component.autotyped(array[[i]], units=units)

--- a/glue/plugins/wcs_autolinking/wcs_autolinking.py
+++ b/glue/plugins/wcs_autolinking/wcs_autolinking.py
@@ -8,12 +8,12 @@ from glue.config import autolinker, link_helper
 from glue.core.link_helpers import MultiLink
 
 
-__all__ = ['IncompatibleWCS', 'WCSLink', 'wcs_autolink']
+__all__ = ['IncompatibleWCS', 'WCSLink', 'wcs_autolink', 'AffineLink']
 
 
 class AffineLink(MultiLink):
 
-    def __init__(self, cids1=None, cids2=None, matrix=None):
+    def __init__(self, data1=None, data2=None, cids1=None, cids2=None, matrix=None):
 
         if matrix.ndim != 2:
             raise ValueError("Affine matrix should be two-dimensional")
@@ -26,6 +26,9 @@ class AffineLink(MultiLink):
 
         self._matrix = matrix
         self._matrix_inv = np.linalg.inv(matrix)
+
+        self.data1 = data1
+        self.data2 = data2
 
         super(AffineLink, self).__init__(cids1, cids2,
                                          forwards=self.forwards,
@@ -251,7 +254,8 @@ class WCSLink(MultiLink):
 
         matrix = np.vstack([best.reshape((2, 3)), [[0, 0, 1]]])
 
-        return AffineLink(cids1=self.cids1, cids2=self.cids2, matrix=matrix)
+        return AffineLink(data1=self.data1, data2=self.data2,
+                          cids1=self.cids1, cids2=self.cids2, matrix=matrix)
 
 
 @autolinker('Astronomy WCS')

--- a/glue/plugins/wcs_autolinking/wcs_autolinking.py
+++ b/glue/plugins/wcs_autolinking/wcs_autolinking.py
@@ -8,7 +8,12 @@ from glue.config import autolinker, link_helper
 from glue.core.link_helpers import MultiLink
 
 
-__all__ = ['IncompatibleWCS', 'WCSLink', 'wcs_autolink', 'AffineLink']
+__all__ = ['IncompatibleWCS', 'WCSLink', 'wcs_autolink', 'AffineLink', 'OffsetLink',
+           'NoAffineApproximation']
+
+
+class NoAffineApproximation(Exception):
+    pass
 
 
 class OffsetLink(MultiLink):
@@ -281,8 +286,8 @@ class WCSLink(MultiLink):
         max_deviation = np.max(transform_affine(best))
 
         if max_deviation > tolerance:
-            raise ValueError(f'Could not find a good affine approximation to '
-                             f'WCSLink with tolerance={tolerance}')
+            raise NoAffineApproximation(f'Could not find a good affine approximation to '
+                                        f'WCSLink with tolerance={tolerance}')
 
         matrix = np.vstack([best.reshape((2, 3)), [[0, 0, 1]]])
 


### PR DESCRIPTION
While investigating performance issues in jdaviz it hit me that in many cases we could speed things up a **lot** by approximating the pixel to pixel transformation between datasets as an affine transform. This PR adds a new method to do this approximation, though I still need to think about how to expose it in the Qt glue GUI (could be done in a follow-up PR).

Needs:
* [x] Unit test(s)
* [x] Changelog entry