### PR TITLE
Speed up adding of layers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@ v1.2.0 (unreleased)
 * Added a new ``WCSLink.as_affine_link`` method which can be used to find
   an affine approximation to a WCSLink. [#2219]
 
+* Avoid duplicate update of layer artist when creating a new layer. [#2220]
+
 v1.1.0 (2021-07-21)
 -------------------
 

--- a/glue/viewers/common/viewer.py
+++ b/glue/viewers/common/viewer.py
@@ -12,7 +12,7 @@ from glue.core.state import save
 from glue.core import message as msg
 from glue.core.exceptions import IncompatibleDataException
 from glue.core.state import lookup_class_with_patches
-from echo import delay_callback
+from echo import delay_callback, ignore_callback
 from glue.core.layer_artist import LayerArtistContainer
 
 from glue.viewers.common.state import ViewerState
@@ -250,7 +250,12 @@ class Viewer(BaseViewer):
         if layer is None:
             return False
 
-        self._layer_artist_container.append(layer)
+        # When adding a layer artist to the layer artist container, zorder
+        # gets set automatically - however since we call a forced update of the
+        # layer after adding it to the container we can ignore any callbacks
+        # related to zorder.
+        with ignore_callback(layer.state, 'zorder'):
+            self._layer_artist_container.append(layer)
         layer.update()
 
         return True

--- a/glue/viewers/common/viewer.py
+++ b/glue/viewers/common/viewer.py
@@ -209,8 +209,16 @@ class Viewer(BaseViewer):
         if layer is None:
             return False
 
-        self._layer_artist_container.append(layer)
+        # When adding a layer artist to the layer artist container, zorder
+        # gets set automatically - however since we call a forced update of the
+        # layer after adding it to the container we can ignore any callbacks
+        # related to zorder. We also then need to set layer.state.zorder manually.
+        with ignore_callback(layer, 'zorder'):
+            with ignore_callback(layer.state, 'zorder'):
+                self._layer_artist_container.append(layer)
+                layer.state.zorder = layer.zorder
         layer.update()
+        self.draw_legend()  # need to be called here because callbacks are ignored in previous step
 
         # Add existing subsets to viewer
         for subset in data.subsets:
@@ -253,10 +261,13 @@ class Viewer(BaseViewer):
         # When adding a layer artist to the layer artist container, zorder
         # gets set automatically - however since we call a forced update of the
         # layer after adding it to the container we can ignore any callbacks
-        # related to zorder.
-        with ignore_callback(layer.state, 'zorder'):
-            self._layer_artist_container.append(layer)
+        # related to zorder. We also then need to set layer.state.zorder manually.
+        with ignore_callback(layer, 'zorder'):
+            with ignore_callback(layer.state, 'zorder'):
+                self._layer_artist_container.append(layer)
+                layer.state.zorder = layer.zorder
         layer.update()
+        self.draw_legend()  # need to be called here because callbacks are ignored in previous step
 
         return True
 


### PR DESCRIPTION
This is a small performance improvement - avoid triggering a layer update twice when adding a layer to the layer collection (due to setting zorder automatically)