### PR TITLE
Fix assumption that all layer artists have a zorder

### DIFF
--- a/glue/app/qt/layer_tree_widget.py
+++ b/glue/app/qt/layer_tree_widget.py
@@ -266,7 +266,6 @@ class ArithmeticAction(LayerAction):
     def _do_action(self):
         assert self._can_trigger()
         data = self.selected_layers()[0]
-        print(data.label)
         dialog = ArithmeticEditorWidget(self._layer_tree.data_collection,
                                         initial_data=data)
         dialog.exec_()
@@ -283,7 +282,6 @@ class ManageComponentsAction(LayerAction):
     def _do_action(self):
         assert self._can_trigger()
         data = self.selected_layers()[0]
-        print(data.label)
         dialog = ComponentManagerWidget(self._layer_tree.data_collection,
                                         initial_data=data)
         dialog.exec_()

--- a/glue/core/tests/test_component.py
+++ b/glue/core/tests/test_component.py
@@ -112,7 +112,6 @@ class TestCategoricalComponent(object):
         from pandas import DataFrame
         df = DataFrame()
         df['a'] = ['a', 'b', 'c']
-        print(df['a'].fillna(''), type)
         CategoricalComponent(df['a'].fillna(''))
 
     def test_accepts_list(self):

--- a/glue/viewers/common/viewer.py
+++ b/glue/viewers/common/viewer.py
@@ -213,10 +213,8 @@ class Viewer(BaseViewer):
         # gets set automatically - however since we call a forced update of the
         # layer after adding it to the container we can ignore any callbacks
         # related to zorder. We also then need to set layer.state.zorder manually.
-        with ignore_callback(layer, 'zorder'):
-            with ignore_callback(layer.state, 'zorder'):
-                self._layer_artist_container.append(layer)
-                layer.state.zorder = layer.zorder
+        with ignore_callback(layer.state, 'zorder'):
+            self._layer_artist_container.append(layer)
         layer.update()
         self.draw_legend()  # need to be called here because callbacks are ignored in previous step
 


### PR DESCRIPTION
I think it is sufficient to ignore the callback on state.zorder which should exist.