### PR TITLE
Added WCS autolinking to API docs

### DIFF
--- a/doc/developer_guide/api.rst
+++ b/doc/developer_guide/api.rst
@@ -213,3 +213,8 @@ Utilities
 .. automodapi:: glue.utils.qt.widget_properties
    :no-inheritance-diagram:
 
+Plugins
+=======
+
+.. automodapi:: glue.plugins.wcs_autolinking.wcs_autolinking
+   :no-inheritance-diagram:


### PR DESCRIPTION
Just noticed this was missing but I would like to link to these classes in the jdaviz docs.