### PR TITLE
Prevent resetting of WCS in image if data does not change

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 Full changelog
 ==============
 
+v1.2.2 (unreleased)
+-------------------
+
+* Prevent resetting of image viewer limits when adding a dataset to the
+  viewer. [#2232]
+
 v1.2.1 (2021-08-24)
 -------------------
 

--- a/glue/viewers/image/qt/tests/test_data_viewer.py
+++ b/glue/viewers/image/qt/tests/test_data_viewer.py
@@ -740,6 +740,34 @@ class TestImageViewer(object):
 
         assert to_hex(handles[1].get_facecolor()) == viewer_state.layers[1].color
 
+    def test_limit_resetting(self):
+
+        # Test to make sure that the limits only change if the reference data
+        # is changed
+
+        self.viewer.state.aspect = 'auto'
+
+        self.viewer.add_data(self.image1)
+
+        self.viewer.state.x_min = 0.2
+        self.viewer.state.x_max = 0.4
+        self.viewer.state.y_min = 0.3
+        self.viewer.state.y_max = 0.5
+
+        self.viewer.add_data(self.image2)
+
+        assert self.viewer.state.x_min == 0.2
+        assert self.viewer.state.x_max == 0.4
+        assert self.viewer.state.y_min == 0.3
+        assert self.viewer.state.y_max == 0.5
+
+        self.viewer.state.reference_data = self.image2
+
+        assert self.viewer.state.x_min == -0.5
+        assert self.viewer.state.x_max == 1.5
+        assert self.viewer.state.y_min == -0.5
+        assert self.viewer.state.y_max == 1.5
+
 
 class TestSessions(object):
 

--- a/glue/viewers/image/viewer.py
+++ b/glue/viewers/image/viewer.py
@@ -44,7 +44,7 @@ class MatplotlibImageMixin(object):
         self.state.add_callback('x_att', self._set_wcs)
         self.state.add_callback('y_att', self._set_wcs)
         self.state.add_callback('slices', self._on_slice_change)
-        self.state.add_callback('reference_data', self._set_wcs)
+        self.state.add_callback('reference_data', self._set_wcs, echo_old=True)
         self.axes._composite = CompositeArray()
         self.axes._composite_image = imshow(self.axes, self.axes._composite, aspect='auto',
                                             origin='lower', interpolation='nearest')
@@ -90,7 +90,13 @@ class MatplotlibImageMixin(object):
         if self._changing_slice_requires_wcs_update:
             self._set_wcs(event=event, relim=False)
 
-    def _set_wcs(self, event=None, relim=True):
+    def _set_wcs(self, before=None, after=None, relim=True):
+
+        # A callback event for reference_data is triggered if the choices change
+        # but the actual selection doesn't - so we avoid resetting the WCS in
+        # this case.
+        if before is after:
+            return
 
         if self.state.x_att is None or self.state.y_att is None or self.state.reference_data is None:
             return

--- a/glue/viewers/image/viewer.py
+++ b/glue/viewers/image/viewer.py
@@ -95,7 +95,10 @@ class MatplotlibImageMixin(object):
         # A callback event for reference_data is triggered if the choices change
         # but the actual selection doesn't - so we avoid resetting the WCS in
         # this case.
+
         if before is after:
+            if relim:
+                self.state.reset_limits()
             return
 
         if self.state.x_att is None or self.state.y_att is None or self.state.reference_data is None:

--- a/glue/viewers/image/viewer.py
+++ b/glue/viewers/image/viewer.py
@@ -88,20 +88,17 @@ class MatplotlibImageMixin(object):
 
     def _on_slice_change(self, event=None):
         if self._changing_slice_requires_wcs_update:
-            self._set_wcs(event=event, relim=False)
+            self._set_wcs(relim=False)
 
     def _set_wcs(self, before=None, after=None, relim=True):
+
+        if self.state.x_att is None or self.state.y_att is None or self.state.reference_data is None:
+            return
 
         # A callback event for reference_data is triggered if the choices change
         # but the actual selection doesn't - so we avoid resetting the WCS in
         # this case.
-
-        if before is after:
-            if relim:
-                self.state.reset_limits()
-            return
-
-        if self.state.x_att is None or self.state.y_att is None or self.state.reference_data is None:
+        if after is not None and before is after:
             return
 
         ref_coords = getattr(self.state.reference_data, 'coords', None)


### PR DESCRIPTION
This should prevent the issue of the image viewer limits resetting when markers or another image are added to the viewer