### PR TITLE
np.int and np.object are deprecated (subset.py, array.py, component.py)

### DIFF
--- a/glue/core/component.py
+++ b/glue/core/component.py
@@ -452,7 +452,7 @@ class CategoricalComponent(Component):
         :return: pandas.Series
         """
 
-        return pd.Series(self.labels, dtype=np.object, **kwargs)
+        return pd.Series(self.labels, dtype=object, **kwargs)
 
 
 class DateTimeComponent(Component):

--- a/glue/core/subset.py
+++ b/glue/core/subset.py
@@ -1218,7 +1218,7 @@ class MaskSubsetState(SubsetState):
             return self.mask[view].copy()
 
         # locate each element of data in the coordinate system of the mask
-        vals = [data[c, view].astype(np.int) for c in self.cids]
+        vals = [data[c, view].astype(int) for c in self.cids]
         result = self.mask[tuple(vals)]
 
         for v, n in zip(vals, data.shape):

--- a/glue/utils/array.py
+++ b/glue/utils/array.py
@@ -126,7 +126,7 @@ def coerce_numeric(arr):
 
     # Convert booleans to integers
     if np.issubdtype(arr.dtype, np.bool_):
-        return arr.astype(np.int)
+        return arr.astype(int)
 
     # a string dtype, or anything else
     try:


### PR DESCRIPTION
## Description

glue/core/subset.py:1221: DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`.
To silence this warning, use `int` by itself. Doing this will not modify any behavior and is safe.
When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision.
If you wish to review your current use, check the release note link for additional information.

(and so on...)

Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations