### PR TITLE
Get mask in compute_histogram with call that also tries join_on_key

### DIFF
--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -1848,7 +1848,7 @@ class Data(BaseCartesianData):
             w = None
 
         if subset_state is not None:
-            mask = subset_state.to_mask(self)
+            mask = self.get_mask(subset_state)
             if DASK_INSTALLED and isinstance(x, da.Array) and not isinstance(mask, da.Array):
                 x = x[da.asarray(mask)]
             else:


### PR DESCRIPTION
# Pull Request Template

## Description

This is a single-line change to use a method that also tries `join_on_key` inside `compute_histogram`. Without this change, 2D scatter plots that are in density_map mode will not show selections that _should_ propagate through `join_on_key` type connections. `compute_statistic` in `data.py` might also not working correctly with `join_on_key` because it calls `subset_state.to_mask(self, view)`-- but it also calls `subset_state.to_array(self, cid)` and so this would be a larger fix (if it even is a problem).
