### PR TITLE
Fix polar scatter serialization issue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,9 @@ v1.2.3 (unreleased)
 * Remove bottleneck dependency as it is no longer maintained. Certain
   array operations may be slower as a result. [#2258]
 
+* Fixed a bug which prevented serialization for polar plots in degree
+  mode. [#2259]
+
 v1.2.2 (2021-09-16)
 -------------------
 

--- a/glue/core/roi_pretransforms.py
+++ b/glue/core/roi_pretransforms.py
@@ -30,3 +30,26 @@ class ProjectionMplTransform(object):
         state = context.object(rec['state'])
         return cls(state['projection'], state['x_lim'], state['y_lim'],
                    state['x_scale'], state['y_scale'])
+
+
+class RadianTransform(object):
+    # We define 'next_transform' so that this pre-transform can
+    # be chained together with another transformation, if desired
+    def __init__(self, next_transform=None):
+        self._next_transform = next_transform
+        self._state = {"next_transform": next_transform}
+
+    def __call__(self, x, y):
+        x = np.deg2rad(x)
+        if self._next_transform is not None:
+            return self._next_transform(x, y)
+        else:
+            return x, y
+
+    def __gluestate__(self, context):
+        return dict(state=context.do(self._state))
+
+    @classmethod
+    def __setgluestate__(cls, rec, context):
+        state = context.object(rec['state'])
+        return cls(state['next_transform'])

--- a/glue/viewers/scatter/viewer.py
+++ b/glue/viewers/scatter/viewer.py
@@ -1,13 +1,11 @@
 from glue.core.subset import roi_to_subset_state
 from glue.core.util import update_ticks
-from glue.core.roi_pretransforms import ProjectionMplTransform
+from glue.core.roi_pretransforms import ProjectionMplTransform, RadianTransform
 
 from glue.utils import mpl_to_datetime64
 from glue.viewers.scatter.compat import update_scatter_viewer_state
 from glue.viewers.matplotlib.mpl_axes import init_mpl
 
-import numpy as np
-from functools import partial
 
 __all__ = ['MatplotlibScatterMixin']
 
@@ -113,11 +111,6 @@ class MatplotlibScatterMixin(object):
                              labelpad=labelpad)
         self.redraw()
 
-    @staticmethod
-    def _radian_pretransform(x, y, transform):
-        x = np.deg2rad(x)
-        return transform(x, y)
-
     def apply_roi(self, roi, override_mode=None):
 
         # Force redraw to get rid of ROI. We do this because applying the
@@ -151,7 +144,7 @@ class MatplotlibScatterMixin(object):
 
             # If we're using degrees, we need to staple on the degrees -> radians conversion beforehand
             if self.using_polar() and self.state.angle_unit == 'degrees':
-                transform = partial(MatplotlibScatterMixin._radian_pretransform, transform=transform)
+                transform = RadianTransform(next_transform=transform)
             subset_state.pretransform = transform
 
         self.apply_subset_state(subset_state, override_mode=override_mode)


### PR DESCRIPTION
This PR fixes an issue with saving glue sessions that have polar plots in degree mode. This is accomplished by creating the `RadianTransform` class in `roi_pretransforms.py`, which is glue-serializable. This replaces the previous transform that was applying the conversion to degrees (an instance of `functools.partial`), which glue does not know how to serialize.