### PR TITLE
Remove pin on jupyter_client

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,6 @@ install_requires =
     ipython>=4.0
     ipykernel>=4.0,!=5.0.0,!=5.1.0
     qtconsole>=4.3
-    jupyter_client<7
     dill>=0.2
     xlrd>=1.2
     openpyxl>=3.0


### PR DESCRIPTION
This PR removes the `jupyter_client<7` pin in `setup.cfg`. This pin no longer seems necessary, and `jupyter_client >= 7` is needed for `wwt_kernel_data_relay`, which is necessary for using the newest pywwt release in a Jupyter context. Currently this is needed for Cosmic Data Stories, and glue-wwt going forward.
