### PR TITLE
Allow selection after projection has been changed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,9 @@ v1.2.3 (unreleased)
 * Remove bottleneck dependency as it is no longer maintained. Certain
   array operations may be slower as a result. [#2258]
 
+* Fixed a bug that caused selections to no longer work
+  in a scatter viewer once its projection had been changed. [#2262]
+
 v1.2.2 (2021-09-16)
 -------------------
 

--- a/glue/viewers/common/qt/data_viewer.py
+++ b/glue/viewers/common/qt/data_viewer.py
@@ -136,6 +136,15 @@ class DataViewer(Viewer, BaseQtViewerWidget,
         self._toolbars.append(tb)
         self._tb_vis[tb] = True
 
+    def remove_toolbar(self, tb):
+        self._toolbars.remove(tb)
+        self._tb_vis.pop(tb, None)
+        super(DataViewer, self).removeToolBar(tb)
+
+    def remove_all_toolbars(self):
+        for tb in reversed(self._toolbars):
+            self.remove_toolbar(tb)
+
     def initialize_toolbar(self):
 
         from glue.config import viewer_tool

--- a/glue/viewers/scatter/viewer.py
+++ b/glue/viewers/scatter/viewer.py
@@ -62,6 +62,8 @@ class MatplotlibScatterMixin(object):
     def _update_projection(self, *args):
         self.figure.delaxes(self.axes)
         _, self.axes = init_mpl(self.figure, projection=self.state.plot_mode)
+        self.remove_all_toolbars()
+        self.initialize_toolbar()
         for layer in self.layers:
             layer._set_axes(self.axes)
             layer.state.vector_mode = 'Cartesian'


### PR DESCRIPTION
Currently, in the scatter viewer, as soon as one changes the projection of the viewer, the selection tools no longer work for that viewer. This effect is independent of both the initial and final projections in the change.

The reason for this is [here](https://github.com/glue-viz/glue/blob/main/glue/viewers/scatter/viewer.py#L64). When the projection is updated, the `axes` property of the viewer is updated with the axes for the new projection. However, the toolbar items, and any associated ROI tools, are still referencing the original viewer axes. This stale reference causes the selection tools to no longer work.

This PR fixes the issue by adding `remove_toolbar` and `remove_all_toolbars` methods to the Qt `DataViewer` class, and using these to remove and recreate the toolbar when the scatter projection is changed. I don't believe there are any other viewers that can change axes, but if there are, they will require the same type of update.

The alternative to this would be to update the reference to the axes in each toolbar item/ROI tool as appropriate, but this fix seems more straightforward to me.