### PR TITLE
Fix Splash Screen Bug under Python  3.10: `QProgressBar.setValue` needs `int` argument

### DIFF
--- a/glue/app/qt/splash_screen.py
+++ b/glue/app/qt/splash_screen.py
@@ -28,7 +28,7 @@ class QtSplashScreen(QtWidgets.QWidget):
         self.image = QtGui.QPixmap(pth)
 
     def set_progress(self, value):
-        self.progress.setValue(value)
+        self.progress.setValue(int(value))
         QtWidgets.QApplication.processEvents()  # update progress bar
 
     def paintEvent(self, event):


### PR DESCRIPTION
## Description
Launching the app under Python 3.10 fails with an exception on the Splash Screen:
```python
  File "/Users/derek/opt/lib/python3.10/site-packages/glue/app/qt/splash_screen.py", line 31, in set_progress
    self.progress.setValue(value)
TypeError: setValue(self, int): argument 1 has unexpected type 'float'
```
`QProgressBar.value` is type `int`, but up to 3.9 downcasting was apparently tolerated (with QtPy 2.0.0 in both cases).
Looked around for similar `setValue` calls, but they already seem to explicitly cast to `int`.