### PR TITLE
Modifications to polar graphs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@ Full changelog
 v1.3.0 (unreleased)
 -------------------
 
+* Modify scatter viewer so that axis labels are shown in tick marks
+  when in polar mode. [#2267]
+
 * Remove bundled version of pvextractor and include it as a proper
   dependency. [#2252]
 

--- a/glue/core/util.py
+++ b/glue/core/util.py
@@ -435,7 +435,7 @@ def tick_linker(all_categories, pos, *args):
             return ''
 
 
-def _polar_tick_alignment(value, radians):
+def polar_tick_alignment(value, radians):
     if radians:
         value = value * 180 / np.pi
 
@@ -505,7 +505,7 @@ def update_ticks(axes, coord, kinds, is_log, categories, projection='rectilinear
             formatter_type = ThetaRadianFormatter if radians else ThetaDegreeFormatter
             axis.set_major_formatter(formatter_type(label))
             for lbl, loc in zip(axis.get_majorticklabels(), axis.get_majorticklocs()):
-                lbl.set_horizontalalignment(_polar_tick_alignment(loc, radians))
+                lbl.set_horizontalalignment(polar_tick_alignment(loc, radians))
         else:
             axis.set_major_locator(AutoLocator())
             axis.set_major_formatter(PolarRadiusFormatter(label))

--- a/glue/core/util.py
+++ b/glue/core/util.py
@@ -110,6 +110,7 @@ class PolarRadiusFormatter(ScalarFormatter):
             ticks[index] = "{label}={value}".format(label=self.axis_label, value=ticks[index])
         return ticks
 
+
 def relim(lo, hi, log=False):
     logging.getLogger(__name__).debug("Inputs to relim: %r %r", lo, hi)
     x, y = lo, hi
@@ -426,6 +427,18 @@ def tick_linker(all_categories, pos, *args):
             return ''
 
 
+def _polar_tick_alignment(value, radians):
+    if radians:
+        value = value * 180 / np.pi
+
+    if value < 90 or 270 < value:
+        return "left"
+    elif 90 < value < 270:
+        return "right"
+    else:
+        return "center"
+
+
 def update_ticks(axes, coord, kinds, is_log, categories, projection='rectilinear', radians=True, label=None):
     """
     Changes the axes to have the proper tick formatting based on the type of
@@ -483,6 +496,8 @@ def update_ticks(axes, coord, kinds, is_log, categories, projection='rectilinear
             axis.set_major_locator(ThetaLocator(AutoLocator()))
             formatter_type = ThetaRadianFormatter if radians else ThetaDegreeFormatter
             axis.set_major_formatter(formatter_type(label))
+            for lbl, loc in zip(axis.get_majorticklabels(), axis.get_majorticklocs()):
+                lbl.set_horizontalalignment(_polar_tick_alignment(loc, radians))
         else:
             axis.set_major_locator(AutoLocator())
             axis.set_major_formatter(PolarRadiusFormatter(label))

--- a/glue/core/util.py
+++ b/glue/core/util.py
@@ -490,7 +490,7 @@ def update_ticks(axes, coord, kinds, is_log, categories, projection='rectilinear
         formatter = FuncFormatter(format_func)
         axis.set_major_locator(locator)
         axis.set_major_formatter(formatter)
-    # Have to treat the theta axis of polar plots differently
+    # Have to treat the axes for polar plots differently
     elif projection == 'polar':
         if coord == 'x':
             axis.set_major_locator(ThetaLocator(AutoLocator()))
@@ -501,6 +501,8 @@ def update_ticks(axes, coord, kinds, is_log, categories, projection='rectilinear
         else:
             axis.set_major_locator(AutoLocator())
             axis.set_major_formatter(PolarRadiusFormatter(label))
+            for lbl in axis.get_majorticklabels():
+                lbl.set_fontstyle("italic")
     else:
         axis.set_major_locator(AutoLocator())
         axis.set_major_formatter(ScalarFormatter())

--- a/glue/core/util.py
+++ b/glue/core/util.py
@@ -109,10 +109,14 @@ class PolarRadiusFormatter(ScalarFormatter):
         forwards = vmax > vmin
         if forwards:
             delta, index = -1, -1
-            def test(idx): return values[idx] > vmax and idx >= -len(values)
+
+            def test(idx):
+                return values[idx] > vmax and idx >= -len(values)
         else:
             delta, index = 1, 0
-            def test(idx): return values[idx] < vmax and idx < len(values)
+
+            def test(idx):
+                return values[idx] < vmax and idx < len(values)
         while test(index):
             index += delta
         if self.axis_label:

--- a/glue/viewers/matplotlib/viewer.py
+++ b/glue/viewers/matplotlib/viewer.py
@@ -319,9 +319,12 @@ class MatplotlibViewerMixin(object):
         if mode not in ['aitoff', 'hammer', 'lambert', 'mollweide', 'polar']:
             x_log_str = 'log' if self.state.x_log else 'linear'
             temp_str += "ax.set_xscale('" + x_log_str + "')\n"
-        if mode not in ['aitoff', 'hammer', 'lambert', 'mollweide']:
+        if mode not in ['aitoff', 'hammer', 'lambert', 'mollweide', 'polar']:
             y_log_str = 'log' if self.state.y_log else 'linear'
             temp_str += "ax.set_yscale('" + y_log_str + "')\n"
+        if mode == 'polar':
+            state_dict['x_axislabel'] = ''
+            state_dict['y_axislabel'] = ''
         state_dict['scale_script'] = "# Set scale (log or linear)\n" + temp_str if temp_str else ''
         full_sphere = ['aitoff', 'hammer', 'lambert', 'mollweide']
         state_dict['limit_script'] = '' if mode in full_sphere else LIMIT_SCRIPT.format(**state_dict)

--- a/glue/viewers/scatter/qt/options_widget.py
+++ b/glue/viewers/scatter/qt/options_widget.py
@@ -110,6 +110,8 @@ class ScatterOptionsWidget(QtWidgets.QWidget):
         axes_ui.value_y_axislabel_size.setVisible(not is_polar)
         axes_ui.combosel_x_axislabel_weight.setVisible(not is_polar)
         axes_ui.combosel_y_axislabel_weight.setVisible(not is_polar)
+        axes_ui.label_2.setText("Θlabel" if is_polar else "xlabel")
+        axes_ui.label_6.setText("rlabel" if is_polar else "ylabel")
 
         self._update_x_attribute()
         self._update_y_attribute()

--- a/glue/viewers/scatter/qt/options_widget.py
+++ b/glue/viewers/scatter/qt/options_widget.py
@@ -100,5 +100,16 @@ class ScatterOptionsWidget(QtWidgets.QWidget):
         self.ui.button_flip_x.setVisible(not is_polar)
         self.ui.valuetext_x_max.setVisible(not is_polar)
         self.ui.bool_x_log.setVisible(not is_polar)
+
+        # In polar mode, the axis labels are shown in ticks rather than using the plot axis
+        # so we adjust the axes editor to account for this
+        axes_ui = self.ui.axes_editor.ui
+        axes_ui.label_3.setVisible(not is_polar)
+        axes_ui.label_4.setVisible(not is_polar)
+        axes_ui.value_x_axislabel_size.setVisible(not is_polar)
+        axes_ui.value_y_axislabel_size.setVisible(not is_polar)
+        axes_ui.combosel_x_axislabel_weight.setVisible(not is_polar)
+        axes_ui.combosel_y_axislabel_weight.setVisible(not is_polar)
+
         self._update_x_attribute()
         self._update_y_attribute()

--- a/glue/viewers/scatter/qt/options_widget.py
+++ b/glue/viewers/scatter/qt/options_widget.py
@@ -112,6 +112,8 @@ class ScatterOptionsWidget(QtWidgets.QWidget):
         axes_ui.combosel_y_axislabel_weight.setVisible(not is_polar)
         axes_ui.label_2.setText("Θlabel" if is_polar else "xlabel")
         axes_ui.label_6.setText("rlabel" if is_polar else "ylabel")
+        axes_ui.label.setText("Θ" if is_polar else "x")
+        axes_ui.label_10.setText("r" if is_polar else "y")
 
         self._update_x_attribute()
         self._update_y_attribute()

--- a/glue/viewers/scatter/viewer.py
+++ b/glue/viewers/scatter/viewer.py
@@ -49,8 +49,6 @@ class MatplotlibScatterMixin(object):
 
             if self.state.x_log:
                 self.state.x_axislabel = 'Log ' + self.state.x_att.label
-            # elif self.using_polar():
-            #     self.state.x_axislabel = ""
             else:
                 self.state.x_axislabel = self.state.x_att.label
 
@@ -58,8 +56,6 @@ class MatplotlibScatterMixin(object):
 
             if self.state.y_log:
                 self.state.y_axislabel = 'Log ' + self.state.y_att.label
-            # elif self.using_polar():
-            #     self.state.y_axislabel = ""
             else:
                 self.state.y_axislabel = self.state.y_att.label
 
@@ -129,9 +125,9 @@ class MatplotlibScatterMixin(object):
             self.axes.set_ylabel("")
         else:
             self.axes.set_ylabel(self.state.y_axislabel,
-                             weight=self.state.y_axislabel_weight,
-                             size=self.state.y_axislabel_size,
-                             labelpad=None)
+                                 weight=self.state.y_axislabel_weight,
+                                 size=self.state.y_axislabel_size,
+                                 labelpad=None)
         self.redraw()
 
     def apply_roi(self, roi, override_mode=None):

--- a/glue/viewers/scatter/viewer.py
+++ b/glue/viewers/scatter/viewer.py
@@ -33,12 +33,12 @@ class MatplotlibScatterMixin(object):
             # Update ticks, which sets the labels to categories if components are categorical
             radians = hasattr(self.state, 'angle_unit') and self.state.angle_unit == 'radians'
             update_ticks(self.axes, 'x', self.state.x_kinds, self.state.x_log,
-                         self.state.x_categories, projection=self.state.plot_mode, radians=radians)
+                         self.state.x_categories, projection=self.state.plot_mode, radians=radians, label=self.state.x_axislabel)
 
             if self.state.x_log:
                 self.state.x_axislabel = 'Log ' + self.state.x_att.label
-            elif self.using_polar():
-                self.state.x_axislabel = ""
+            # elif self.using_polar():
+            #     self.state.x_axislabel = ""
             else:
                 self.state.x_axislabel = self.state.x_att.label
 
@@ -46,12 +46,12 @@ class MatplotlibScatterMixin(object):
 
             # Update ticks, which sets the labels to categories if components are categorical
             update_ticks(self.axes, 'y', self.state.y_kinds, self.state.y_log,
-                         self.state.y_categories, projection=self.state.plot_mode)
+                         self.state.y_categories, projection=self.state.plot_mode, label=self.state.y_axislabel)
 
             if self.state.y_log:
                 self.state.y_axislabel = 'Log ' + self.state.y_att.label
-            elif self.using_polar():
-                self.state.y_axislabel = ""
+            # elif self.using_polar():
+            #     self.state.y_axislabel = ""
             else:
                 self.state.y_axislabel = self.state.y_att.label
 
@@ -103,14 +103,22 @@ class MatplotlibScatterMixin(object):
             self.state.full_circle()
         self.limits_to_mpl()
 
+    def update_x_axislabel(self, *event):
+        if self.using_polar():
+            self.axes.set_xlabel("")
+        else:
+            super().update_x_axislabel()
+
     # Because of how the polar plot is drawn, we need to give the y-axis label more padding
     # Since this mixin is first in the MRO, we can 'override' the MatplotlibDataViewer method
     def update_y_axislabel(self, *event):
-        labelpad = 25 if self.using_polar() else None
-        self.axes.set_ylabel(self.state.y_axislabel,
+        if self.using_polar():
+            self.axes.set_ylabel("")
+        else:
+            self.axes.set_ylabel(self.state.y_axislabel,
                              weight=self.state.y_axislabel_weight,
                              size=self.state.y_axislabel_size,
-                             labelpad=labelpad)
+                             labelpad=None)
         self.redraw()
 
     def apply_roi(self, roi, override_mode=None):

--- a/glue/viewers/scatter/viewer.py
+++ b/glue/viewers/scatter/viewer.py
@@ -24,16 +24,28 @@ class MatplotlibScatterMixin(object):
         self.state.add_callback('x_max', self._x_limits_to_mpl)
         self.state.add_callback('y_min', self.limits_to_mpl)
         self.state.add_callback('y_max', self.limits_to_mpl)
+        self.state.add_callback('x_axislabel', self._update_polar_ticks)
+        self.state.add_callback('y_axislabel', self._update_polar_ticks)
         self._update_axes()
 
-    def _update_axes(self, *args):
-
+    def _update_ticks(self, *args):
         if self.state.x_att is not None:
-
             # Update ticks, which sets the labels to categories if components are categorical
             radians = hasattr(self.state, 'angle_unit') and self.state.angle_unit == 'radians'
             update_ticks(self.axes, 'x', self.state.x_kinds, self.state.x_log,
-                         self.state.x_categories, projection=self.state.plot_mode, radians=radians, label=self.state.x_axislabel)
+                         self.state.x_categories, projection=self.state.plot_mode, radians=radians,
+                         label=self.state.x_axislabel)
+
+        if self.state.y_att is not None:
+            # Update ticks, which sets the labels to categories if components are categorical
+            update_ticks(self.axes, 'y', self.state.y_kinds, self.state.y_log,
+                         self.state.y_categories, projection=self.state.plot_mode, label=self.state.y_axislabel)
+
+    def _update_axes(self, *args):
+
+        self._update_ticks(args)
+
+        if self.state.x_att is not None:
 
             if self.state.x_log:
                 self.state.x_axislabel = 'Log ' + self.state.x_att.label
@@ -44,10 +56,6 @@ class MatplotlibScatterMixin(object):
 
         if self.state.y_att is not None:
 
-            # Update ticks, which sets the labels to categories if components are categorical
-            update_ticks(self.axes, 'y', self.state.y_kinds, self.state.y_log,
-                         self.state.y_categories, projection=self.state.plot_mode, label=self.state.y_axislabel)
-
             if self.state.y_log:
                 self.state.y_axislabel = 'Log ' + self.state.y_att.label
             # elif self.using_polar():
@@ -56,6 +64,11 @@ class MatplotlibScatterMixin(object):
                 self.state.y_axislabel = self.state.y_att.label
 
         self.axes.figure.canvas.draw_idle()
+
+    def _update_polar_ticks(self, *args):
+        if self.using_polar():
+            self._update_ticks(args)
+            self.axes.figure.canvas.draw_idle()
 
     def _update_projection(self, *args):
         self.figure.delaxes(self.axes)


### PR DESCRIPTION
This PR implements the changes to polar scatterplot styling discussed at the glue meeting on 1/13/2022. In particular, these changes are:

Rather than display axis labels along the bottom and side of the plot (which doesn't really make sense for a polar plot), the axis labels are included in the angular and radial tick marks. In particular, the angular tick at zero angle is of the form `label=0`, while the outermost radial tick has the form `label=<value>`. Additionally, the radial tick marks are italicized to make the two sets of ticks clearly distinct.
![polar_plot](https://user-images.githubusercontent.com/14281631/152288871-ee0d5906-7015-4087-9515-e3835c58eb72.png)

If the label is an empty string, the equals is omitted:
![polar_plot_empty_label](https://user-images.githubusercontent.com/14281631/152288892-c64e98cf-2b80-415d-8bea-0ee560247379.png)

When in polar mode, the axis widget is adjusted accordingly:
![axes_options](https://user-images.githubusercontent.com/14281631/152288905-a7c374e8-96a8-40f0-aceb-87f2c709390e.png)

