### PR TITLE
Disable CI builds that fail systematically

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,25 +33,30 @@ jobs:
     - linux: py37-test-pyqt512
     - linux: py37-test-pyqt513-all
     - linux: py38-test-pyqt514
-    - linux: py39-test-pyqt515
-    - linux: py310-test-pyqt515
-    - linux: py36-test-pyside512
-    - linux: py37-test-pyside513-all
-    - linux: py38-test-pyside514
+
+    # TODO: The PyQt 5.15 builds have never passed, need to investigate why
+    # - linux: py39-test-pyqt515
+    # - linux: py310-test-pyqt515
+    # FIXME: The PySide builds are broken, needs investigating
+    # - linux: py36-test-pyside512
+    # - linux: py37-test-pyside513-all
+    # - linux: py38-test-pyside514
 
     # Test against latest developer versions of some packages
-    - linux: py37-test-pyside513-dev-all
+    - linux: py37-test-pyqt512-dev-all
 
     # Test a few configurations on MacOS X
     - macos: py37-test-pyqt513
     - macos: py38-test-pyqt514-all
-    - macos: py37-test-pyside513
+    # FIXME: The PySide builds are broken, needs investigating
+    # - macos: py37-test-pyside513
 
     # Test a few configurations on Windows
     - windows: py37-test-pyqt510
-    # The following fails due to https://github.com/jupyter/qtconsole/issues/400
+    # FIXME: The following fails due to https://github.com/jupyter/qtconsole/issues/400
     # - windows: py38-test-pyqt514-all
-    - windows: py37-test-pyside513-all
+    # FIXME: The PySide builds are broken, needs investigating
+    # - windows: py37-test-pyside513-all
 
     # Try out documentation build on Linux and Windows
     - linux: py37-docs-pyqt513

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,7 +43,7 @@ jobs:
     # - linux: py38-test-pyside514
 
     # Test against latest developer versions of some packages
-    - linux: py37-test-pyqt512-dev-all
+    - linux: py310-test-pyqt514-dev-all
 
     # Test a few configurations on MacOS X
     - macos: py37-test-pyqt513


### PR DESCRIPTION
Some of the CI builds always fail, and make it hard to see if a given PR is otherwise passing, so I am disabling those builds for now.