### PR TITLE
Enable PyQt 5.15 tests on macOS + Windows

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,13 +48,19 @@ jobs:
     # Test a few configurations on MacOS X
     - macos: py37-test-pyqt513
     - macos: py38-test-pyqt514-all
+    # PyQt 5.15 failing on Linux possibly due to X11-related problems (X11/lib/libxcb)
+    # - let's try on macOS
+    - macos: py39-test-pyqt515
     # FIXME: The PySide builds are broken, needs investigating
     # - macos: py37-test-pyside513
 
     # Test a few configurations on Windows
     - windows: py37-test-pyqt510
-    # FIXME: The following fails due to https://github.com/jupyter/qtconsole/issues/400
-    # - windows: py38-test-pyqt514-all
+    # The following failed due to https://github.com/jupyter/qtconsole/issues/400 - should be fixed upstream
+    - windows: py38-test-pyqt514-all
+    # PyQt 5.15 failing on Linux possibly due to X11-related problems (X11/lib/libxcb)
+    # - let's try on Windows
+    - windows: py39-test-pyqt515
     # FIXME: The PySide builds are broken, needs investigating
     # - windows: py37-test-pyside513-all
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,10 @@ jobs:
     coverage: codecov
     libraries:
       apt:
+        - libxcb.*-dev
         - libxkbcommon-x11-0
+        - libxkbcommon-x11-dev
+        - libxkbcommon-dev
       brew:
         - enchant
 
@@ -51,20 +54,17 @@ jobs:
     # - macos: py38-test-pyqt514-all
     # PyQt 5.15 failing on Linux possibly due to X11-related problems (X11/lib/libxcb)
     # - let's try on macOS
-    - macos: py38-test-pyqt515
-    - macos: py39-test-pyqt515
-    - macos: py310-test-pyqt515
+    # - macos: py37-test-pyqt515
     # FIXME: The PySide builds are broken, needs investigating
     # - macos: py37-test-pyside513
 
     # Test a few configurations on Windows
     # - windows: py37-test-pyqt510
     # The following failed due to https://github.com/jupyter/qtconsole/issues/400 - should be fixed upstream
-    - windows: py38-test-pyqt514-all
+    # - windows: py38-test-pyqt514-all
     # PyQt 5.15 failing on Linux possibly due to X11-related problems (X11/lib/libxcb)
     # - let's try on Windows
-    - windows: py39-test-pyqt515
-    - windows: py310-test-pyqt515
+    # - windows: py38-test-pyqt515
     # FIXME: The PySide builds are broken, needs investigating
     # - windows: py37-test-pyside513-all
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,12 +13,12 @@ jobs:
 
     xvfb: true
     coverage: codecov
+
+    # The Linux PyQt 5.15 installation requires apt-getting its xcb deps
     libraries:
       apt:
         - libxcb.*-dev
-        - libxkbcommon-x11-0
         - libxkbcommon-x11-dev
-        - libxkbcommon-dev
       brew:
         - enchant
 
@@ -30,14 +30,12 @@ jobs:
       coverage: 'false'
 
     # Linux builds - test on all supported PyQt5 versions, and include all dependencies in some builds
-    # - linux: py37-test-pyqt59-legacy
-    # - linux: py37-test-pyqt510
-    # - linux: py37-test-pyqt511-all
-    # - linux: py37-test-pyqt512
-    # - linux: py37-test-pyqt513-all
-    # - linux: py38-test-pyqt514
-
-    # TODO: The PyQt 5.15 builds have never passed, need to investigate why
+    - linux: py37-test-pyqt59-legacy
+    - linux: py37-test-pyqt510
+    - linux: py37-test-pyqt511-all
+    - linux: py37-test-pyqt512
+    - linux: py37-test-pyqt513-all
+    - linux: py38-test-pyqt514
     - linux: py38-test-pyqt515
     - linux: py39-test-pyqt515
     - linux: py310-test-pyqt515
@@ -47,28 +45,27 @@ jobs:
     # - linux: py38-test-pyside514
 
     # Test against latest developer versions of some packages
-    # - linux: py310-test-pyqt514-dev-all
+    - linux: py310-test-pyqt514-dev-all
 
     # Test a few configurations on MacOS X
-    # - macos: py37-test-pyqt513
-    # - macos: py38-test-pyqt514-all
-    # PyQt 5.15 failing on Linux possibly due to X11-related problems (X11/lib/libxcb)
-    # - let's try on macOS
-    # - macos: py37-test-pyqt515
+    - macos: py37-test-pyqt513
+    - macos: py38-test-pyqt514-all
+    - macos: py39-test-pyqt515
+    - macos: py310-test-pyqt515-all
     # FIXME: The PySide builds are broken, needs investigating
     # - macos: py37-test-pyside513
 
     # Test a few configurations on Windows
-    # - windows: py37-test-pyqt510
+    - windows: py37-test-pyqt510
     # The following failed due to https://github.com/jupyter/qtconsole/issues/400 - should be fixed upstream
-    # - windows: py38-test-pyqt514-all
-    # PyQt 5.15 failing on Linux possibly due to X11-related problems (X11/lib/libxcb)
-    # - let's try on Windows
-    # - windows: py38-test-pyqt515
+    - windows: py38-test-pyqt514-all
+    - windows: py38-test-pyqt515
+    - windows: py39-test-pyqt515
+    - windows: py310-test-pyqt515-all
     # FIXME: The PySide builds are broken, needs investigating
     # - windows: py37-test-pyside513-all
 
     # Try out documentation build on Linux and Windows
-    # - linux: py37-docs-pyqt513
-    # - macos: py37-docs-pyqt513
-    # - windows: py38-docs-pyqt513
+    - linux: py37-docs-pyqt513
+    - macos: py37-docs-pyqt513
+    - windows: py38-docs-pyqt513

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,32 +36,27 @@ jobs:
     - linux: py37-test-pyqt512
     - linux: py37-test-pyqt513-all
     - linux: py38-test-pyqt514
-    - linux: py38-test-pyqt515
     - linux: py39-test-pyqt515
-    - linux: py310-test-pyqt515
     # FIXME: The PySide builds are broken, needs investigating
     # - linux: py36-test-pyside512
     # - linux: py37-test-pyside513-all
     # - linux: py38-test-pyside514
 
     # Test against latest developer versions of some packages
-    - linux: py310-test-pyqt514-dev-all
+    - linux: py310-test-pyqt515-dev-all
 
     # Test a few configurations on MacOS X
     - macos: py37-test-pyqt513
     - macos: py38-test-pyqt514-all
-    - macos: py39-test-pyqt515
     - macos: py310-test-pyqt515-all
     # FIXME: The PySide builds are broken, needs investigating
     # - macos: py37-test-pyside513
 
     # Test a few configurations on Windows
     - windows: py37-test-pyqt510
-    # The following failed due to https://github.com/jupyter/qtconsole/issues/400 - should be fixed upstream
+    # The following failed due to https://github.com/jupyter/qtconsole/issues/400 - fixed upstream
     - windows: py38-test-pyqt514-all
-    - windows: py38-test-pyqt515
-    - windows: py39-test-pyqt515
-    - windows: py310-test-pyqt515-all
+    - windows: py310-test-pyqt515
     # FIXME: The PySide builds are broken, needs investigating
     # - windows: py37-test-pyside513-all
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,44 +27,48 @@ jobs:
       coverage: 'false'
 
     # Linux builds - test on all supported PyQt5 versions, and include all dependencies in some builds
-    - linux: py37-test-pyqt59-legacy
-    - linux: py37-test-pyqt510
-    - linux: py37-test-pyqt511-all
-    - linux: py37-test-pyqt512
-    - linux: py37-test-pyqt513-all
-    - linux: py38-test-pyqt514
+    # - linux: py37-test-pyqt59-legacy
+    # - linux: py37-test-pyqt510
+    # - linux: py37-test-pyqt511-all
+    # - linux: py37-test-pyqt512
+    # - linux: py37-test-pyqt513-all
+    # - linux: py38-test-pyqt514
 
     # TODO: The PyQt 5.15 builds have never passed, need to investigate why
-    # - linux: py39-test-pyqt515
-    # - linux: py310-test-pyqt515
+    - linux: py38-test-pyqt515
+    - linux: py39-test-pyqt515
+    - linux: py310-test-pyqt515
     # FIXME: The PySide builds are broken, needs investigating
     # - linux: py36-test-pyside512
     # - linux: py37-test-pyside513-all
     # - linux: py38-test-pyside514
 
     # Test against latest developer versions of some packages
-    - linux: py310-test-pyqt514-dev-all
+    # - linux: py310-test-pyqt514-dev-all
 
     # Test a few configurations on MacOS X
-    - macos: py37-test-pyqt513
-    - macos: py38-test-pyqt514-all
+    # - macos: py37-test-pyqt513
+    # - macos: py38-test-pyqt514-all
     # PyQt 5.15 failing on Linux possibly due to X11-related problems (X11/lib/libxcb)
     # - let's try on macOS
+    - macos: py38-test-pyqt515
     - macos: py39-test-pyqt515
+    - macos: py310-test-pyqt515
     # FIXME: The PySide builds are broken, needs investigating
     # - macos: py37-test-pyside513
 
     # Test a few configurations on Windows
-    - windows: py37-test-pyqt510
+    # - windows: py37-test-pyqt510
     # The following failed due to https://github.com/jupyter/qtconsole/issues/400 - should be fixed upstream
     - windows: py38-test-pyqt514-all
     # PyQt 5.15 failing on Linux possibly due to X11-related problems (X11/lib/libxcb)
     # - let's try on Windows
     - windows: py39-test-pyqt515
+    - windows: py310-test-pyqt515
     # FIXME: The PySide builds are broken, needs investigating
     # - windows: py37-test-pyside513-all
 
     # Try out documentation build on Linux and Windows
-    - linux: py37-docs-pyqt513
-    - macos: py37-docs-pyqt513
-    - windows: py38-docs-pyqt513
+    # - linux: py37-docs-pyqt513
+    # - macos: py37-docs-pyqt513
+    # - windows: py38-docs-pyqt513


### PR DESCRIPTION
## Description

Experiment to investigate the failing tests from #2269; on Linux may be X11 related.
The collection error
```
qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

Available platform plugins are: eglfs, linuxfb, minimal, minimalegl, offscreen, vnc, wayland-egl, wayland, wayland-xcomposite-egl, wayland-xcomposite-glx, webgl, xcb.
```
appears to be Linux only.