### PR TITLE
Try to fix PySide2 tests using `hookwrapper` fixture

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,9 +38,10 @@ jobs:
     - linux: py38-test-pyqt514
     - linux: py39-test-pyqt515
     # FIXME: The PySide builds are broken, needs investigating
-    # - linux: py36-test-pyside512
-    # - linux: py37-test-pyside513-all
-    # - linux: py38-test-pyside514
+    - linux: py36-test-pyside512
+    - linux: py37-test-pyside513-all
+    - linux: py38-test-pyside514
+    - linux: py310-test-pyside515-all
 
     # Test against latest developer versions of some packages
     - linux: py310-test-pyqt515-dev-all
@@ -50,7 +51,8 @@ jobs:
     - macos: py38-test-pyqt514-all
     - macos: py310-test-pyqt515-all
     # FIXME: The PySide builds are broken, needs investigating
-    # - macos: py37-test-pyside513
+    - macos: py37-test-pyside513
+    - macos: py310-test-pyside515
 
     # Test a few configurations on Windows
     - windows: py37-test-pyqt510
@@ -58,9 +60,10 @@ jobs:
     - windows: py38-test-pyqt514-all
     - windows: py310-test-pyqt515
     # FIXME: The PySide builds are broken, needs investigating
-    # - windows: py37-test-pyside513-all
+    - windows: py37-test-pyside513-all
+    - windows: py39-test-pyside515
 
     # Try out documentation build on Linux and Windows
-    - linux: py37-docs-pyqt513
-    - macos: py37-docs-pyqt513
-    - windows: py38-docs-pyqt513
+    # - linux: py37-docs-pyqt513
+    # - macos: py37-docs-pyqt513
+    # - windows: py38-docs-pyqt513

--- a/glue/conftest.py
+++ b/glue/conftest.py
@@ -122,9 +122,10 @@ def pytest_unconfigure(config):
 
 if PYSIDE2:
 
-    def pytest_runtest_call(__multicall__):
+    @pytest.hookimpl(hookwrapper=True)
+    def pytest_runtest_call():
         try:
-            __multicall__.execute()
+            outcome = yield
         except AttributeError as exc:
             if 'PySide2.QtGui.QStandardItem' in str(exc):
                 pytest.xfail()


### PR DESCRIPTION
## Description

Another experiment to replace the deprecated (and apparently now removed `__multicall__` fixture with `hookwrapper` as suggested on https://docs.pytest.org/en/stable/example/simple.html#post-process-test-reports-failures .