### PR TITLE
Fix vector directions when overlaid on image

### DIFF
--- a/glue/viewers/scatter/layer_artist.py
+++ b/glue/viewers/scatter/layer_artist.py
@@ -277,6 +277,18 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
                 vx = ensure_numerical(self.layer[self.state.vx_att].ravel())
                 vy = ensure_numerical(self.layer[self.state.vy_att].ravel())
 
+                # If this is being overlaid on an image viewer with a WCS,
+                # we need to check the relative orientations of the pixel/world axes
+                if getattr(self.axes, 'wcs', None) is not None:
+                    cdelt = self.axes.wcs.wcs.get_cdelt()
+                    ndim = self._viewer_state.reference_data.ndim
+                    x_index = ndim - self._viewer_state.x_att.axis - 1
+                    y_index = ndim - self._viewer_state.y_att.axis - 1
+                    if cdelt[x_index] < 0:
+                        vx = np.negative(vx)
+                    if cdelt[y_index] < 0:
+                        vy = np.negative(vy)
+
                 if self.state.vector_mode == 'Polar':
                     ang = vx
                     length = vy


### PR DESCRIPTION
When a scatter layer is overlaid on an image, vectors will have the wrong orientation if one (or both) of the axes have different pixel and world coordinate orientations. To fix this issue, this PR looks at the signs of the relevant entry of the cdelt coordinate increments. If they're opposite, it negates the corresponding vector components. The relation between x/y attributes and the wcs coordinate indices is the same one used [here](https://github.com/glue-viz/glue/blob/main/glue/viewers/image/viewer.py#L56).

I would be curious to know if @astrofrog or @catherinezucker (or anyone who's knowledgeable about WCS) has any additional thoughts/suggestions.