### PR TITLE
Profile viewer: reset y limits when changing collapse function

### DIFF
--- a/glue/viewers/profile/qt/tests/test_python_export.py
+++ b/glue/viewers/profile/qt/tests/test_python_export.py
@@ -20,6 +20,8 @@ class TestExportPython(BaseTestExportPython):
         self.app = GlueApplication(self.data_collection)
         self.viewer = self.app.new_data_viewer(ProfileViewer)
         self.viewer.add_data(self.data)
+        # Make legend location deterministic
+        self.viewer.state.legend.location = 'lower left'
 
     def teardown_method(self, method):
         self.viewer.close()

--- a/glue/viewers/profile/state.py
+++ b/glue/viewers/profile/state.py
@@ -56,6 +56,7 @@ class ProfileViewerState(MatplotlibDataViewerState):
         self.add_callback('reference_data', self._reference_data_changed, echo_old=True)
         self.add_callback('x_att', self._update_att)
         self.add_callback('normalize', self._reset_y_limits)
+        self.add_callback('function', self._reset_y_limits)
 
         self.x_att_helper = ComponentIDComboHelper(self, 'x_att',
                                                    numeric=False, datetime=False, categorical=False,

--- a/glue/viewers/profile/tests/test_state.py
+++ b/glue/viewers/profile/tests/test_state.py
@@ -1,3 +1,4 @@
+from glue.core.data_collection import DataCollection
 import numpy as np
 
 from numpy.testing import assert_allclose
@@ -30,9 +31,13 @@ class SimpleCoordinates(Coordinates):
 class TestProfileViewerState:
 
     def setup_method(self, method):
+
         self.data = Data(label='d1')
         self.data.coords = SimpleCoordinates()
         self.data['x'] = np.arange(24).reshape((3, 4, 2)).astype(float)
+
+        self.data_collection = DataCollection([self.data])
+
         self.viewer_state = ProfileViewerState()
         self.layer_state = ProfileLayerState(viewer_state=self.viewer_state,
                                              layer=self.data)
@@ -101,9 +106,6 @@ class TestProfileViewerState:
         assert_allclose(y, [np.nan, 13., 19.5])
 
         subset.subset_state = self.data.id['x'] > 100
-
-        # TODO: the fact we have to call this isn't ideal
-        self.layer_state.reset_cache()
 
         x, y = self.layer_state.profile
         assert len(x) == 0


### PR DESCRIPTION
## Description

This PR resets the y-limits of a profile viewer when the collapse function is changed (similar to what is currently done for normalize - the plotted data have changed in y, so the existing y-limits are meaningless).
