### PR TITLE
Ellipse: Do not throw error for theta=0

### DIFF
--- a/glue/core/roi.py
+++ b/glue/core/roi.py
@@ -476,7 +476,7 @@ class EllipticalROI(Roi):
 
     def __init__(self, xc=None, yc=None, radius_x=None, radius_y=None, theta=None):
         super(EllipticalROI, self).__init__()
-        if theta is not None:
+        if theta is not None and theta != 0:
             raise NotImplementedError("Rotated ellipses are not yet supported")
         self.xc = xc
         self.yc = yc


### PR DESCRIPTION
## Description

`theta=0` is the same as no rotation, so throwing `NotImplementedError` for that case is confusing.