### PR TITLE
Fix typo in super setData call of PythonListModel

### DIFF
--- a/glue/utils/qt/python_list_model.py
+++ b/glue/utils/qt/python_list_model.py
@@ -72,7 +72,7 @@ class PythonListModel(QtCore.QAbstractListModel):
             self.dataChanged.emit(index, index)
             return True
 
-        return super(PythonListModel, self).setDdata(index, value, role)
+        return super(PythonListModel, self).setData(index, value, role)
 
     def removeRow(self, row, parent=None):
         """


### PR DESCRIPTION
Hi,

I was just browsing through your code base while researching some pyqt stuff, and I stumbled over a typo in one of your utility classes (`PythonListModel`). I thought I should at least bring it to your attention.

Cheers