### PR TITLE
Set disabled TableLayerArtists to be not visible

### DIFF
--- a/glue/tests/helpers.py
+++ b/glue/tests/helpers.py
@@ -61,7 +61,6 @@ H5PY_INSTALLED, requires_h5py = make_skipper('h5py')
 PYQT5_INSTALLED, requires_pyqt5 = make_skipper('PyQt5')
 PYSIDE2_INSTALLED, requires_pyside2 = make_skipper('PySide2')
 
-
 HYPOTHESIS_INSTALLED, requires_hypothesis = make_skipper('hypothesis')
 
 QT_INSTALLED = PYQT5_INSTALLED or PYSIDE2_INSTALLED

--- a/glue/tests/helpers.py
+++ b/glue/tests/helpers.py
@@ -12,9 +12,14 @@ import pytest
 def make_skipper(module, label=None, version=None):
     label = label or module
     try:
-        mod = __import__(module)
+        if label == 'PyQt5':  # PyQt5 does not use __version__
+            from PyQt5 import QtCore
+            version_installed = QtCore.PYQT_VERSION_STR
+        else:
+            mod = __import__(module)
+            version_installed = mod.__version__
         if version:
-            assert LooseVersion(mod.__version__) >= LooseVersion(version)
+            assert LooseVersion(version_installed) >= LooseVersion(version)
         installed = True
     except (ImportError, AssertionError):
         installed = False
@@ -56,6 +61,7 @@ H5PY_INSTALLED, requires_h5py = make_skipper('h5py')
 PYQT5_INSTALLED, requires_pyqt5 = make_skipper('PyQt5')
 PYSIDE2_INSTALLED, requires_pyside2 = make_skipper('PySide2')
 
+
 HYPOTHESIS_INSTALLED, requires_hypothesis = make_skipper('hypothesis')
 
 QT_INSTALLED = PYQT5_INSTALLED or PYSIDE2_INSTALLED
@@ -65,6 +71,12 @@ SPECTRAL_CUBE_INSTALLED, requires_spectral_cube = make_skipper('spectral_cube',
 
 requires_qt = pytest.mark.skipif(str(not QT_INSTALLED),
                                  reason='An installation of Qt is required')
+
+PYQT_GT_59, _ = make_skipper('PyQt5', version='5.9')
+
+REQUIRES_PYQT_GT_59 = PYQT_GT_59 and not PYSIDE2_INSTALLED
+
+requires_pyqt_gt_59 = pytest.mark.skipif(str(not REQUIRES_PYQT_GT_59), reason='Requires PyQt >= 5.9')
 
 
 @contextmanager

--- a/glue/tests/helpers.py
+++ b/glue/tests/helpers.py
@@ -73,9 +73,8 @@ requires_qt = pytest.mark.skipif(str(not QT_INSTALLED),
 
 PYQT_GT_59, _ = make_skipper('PyQt5', version='5.10')
 
-REQUIRES_PYQT_GT_59 = PYQT_GT_59 and not PYSIDE2_INSTALLED
-
-requires_pyqt_gt_59 = pytest.mark.skipif(str(not REQUIRES_PYQT_GT_59), reason='Requires PyQt > 5.9')
+requires_pyqt_gt_59_or_pyside2 = pytest.mark.skipif(str(not PYQT_GT_59 and not PYSIDE2_INSTALLED),
+                                                    reason='Requires PyQt > 5.9 or PySide2')
 
 
 @contextmanager

--- a/glue/tests/helpers.py
+++ b/glue/tests/helpers.py
@@ -72,11 +72,11 @@ SPECTRAL_CUBE_INSTALLED, requires_spectral_cube = make_skipper('spectral_cube',
 requires_qt = pytest.mark.skipif(str(not QT_INSTALLED),
                                  reason='An installation of Qt is required')
 
-PYQT_GT_59, _ = make_skipper('PyQt5', version='5.9')
+PYQT_GT_59, _ = make_skipper('PyQt5', version='5.10')
 
 REQUIRES_PYQT_GT_59 = PYQT_GT_59 and not PYSIDE2_INSTALLED
 
-requires_pyqt_gt_59 = pytest.mark.skipif(str(not REQUIRES_PYQT_GT_59), reason='Requires PyQt >= 5.9')
+requires_pyqt_gt_59 = pytest.mark.skipif(str(not REQUIRES_PYQT_GT_59), reason='Requires PyQt > 5.9')
 
 
 @contextmanager

--- a/glue/viewers/table/qt/data_viewer.py
+++ b/glue/viewers/table/qt/data_viewer.py
@@ -126,8 +126,10 @@ class DataTableModel(QtCore.QAbstractTableModel):
                         # Only disable the layer if enabled, as otherwise we
                         # will recursively call clear and _refresh, causing
                         # an infinite loop and performance issues.
+                        # Also make sure that a disabled layer is not visible
                         if layer_artist.enabled:
                             layer_artist.disable_invalid_attributes(*exc.args)
+                            layer_artist.visible = False
                     else:
                         layer_artist.enabled = True
 

--- a/glue/viewers/table/qt/tests/test_data_viewer.py
+++ b/glue/viewers/table/qt/tests/test_data_viewer.py
@@ -479,25 +479,25 @@ def test_table_incompatible_attribute():
     #This subset should not be shown in the viewer
     sg1 = dc.new_subset_group('invalid', d1.id['x'] <= 3)
 
-    assert len(viewer.state.layers) == 2
-    assert not viewer.state.layers[1].visible
-    assert viewer.state.layers[0].visible
+    assert len(viewer.layers) == 2
+    assert not viewer.layers[1].visible
+    assert viewer.layers[0].visible
 
     #This subset can be shown in the viewer
     sg2 = dc.new_subset_group('valid', d2.id['a'] == 'a')
 
-    assert len(viewer.state.layers) == 3
-    assert viewer.state.layers[2].visible
-    assert not viewer.state.layers[1].visible
-    assert viewer.state.layers[0].visible
+    assert len(viewer.layers) == 3
+    assert viewer.layers[2].visible
+    assert not viewer.layers[1].visible
+    assert viewer.layers[0].visible
 
     # The original IncompatibleAttribute was thrown
     # here as making the data layer invisible made
     # DataTableModel._update_visible() try and draw
     # the invalid subset
-    viewer.state.layers[0].visible = False
-    assert viewer.state.layers[2].visible
-    assert not viewer.state.layers[1].visible
+    viewer.layers[0].visible = False
+    assert viewer.layers[2].visible
+    assert not viewer.layers[1].visible
 
 
 def test_table_with_dask_column():

--- a/glue/viewers/table/qt/tests/test_data_viewer.py
+++ b/glue/viewers/table/qt/tests/test_data_viewer.py
@@ -463,20 +463,22 @@ def test_incompatible_subset():
 def test_table_incompatible_attribute():
     """
     Regression test for a bug where the table viewer generates an
-    uncaught IncompatibleAttribute error if one toggles the
-    visibility of a dataset iff an invalid subset exists. This
-    occurred because disabled layer_artists were still showing
-    as visible.
+    uncaught IncompatibleAttribute error in _update_visible() if
+    the dataset is not visible and an invalid subset exists at all.
+    This occurred because layer_artists depending on
+    invalid attributes were only being disabled (but were still
+    visible) and the viewer attempts to compute a mask for
+    all visible subsets if the underlying dataset is not visible.
     """
     app = get_qapp()
-    d1 = Data(x=[1,2,3,4],y=[5,6,7,8],label='d1')
-    d2 = Data(a=['a','b','c'],b=['x','y','z'],label='d2')
-    dc = DataCollection([d1,d2])
+    d1 = Data(x=[1, 2, 3, 4], y=[5, 6, 7, 8], label='d1')
+    d2 = Data(a=['a', 'b', 'c'], b=['x', 'y', 'z'], label='d2')
+    dc = DataCollection([d1, d2])
     gapp = GlueApplication(dc)
     viewer = gapp.new_data_viewer(TableViewer)
     viewer.add_data(d2)
 
-    #This subset should not be shown in the viewer
+    # This subset should not be shown in the viewer
     sg1 = dc.new_subset_group('invalid', d1.id['x'] <= 3)
 
     gapp.show()
@@ -486,7 +488,7 @@ def test_table_incompatible_attribute():
     assert not viewer.layers[1].visible
     assert viewer.layers[0].visible
 
-    #This subset can be shown in the viewer
+    # This subset can be shown in the viewer
     sg2 = dc.new_subset_group('valid', d2.id['a'] == 'a')
 
     assert len(viewer.layers) == 3

--- a/glue/viewers/table/qt/tests/test_data_viewer.py
+++ b/glue/viewers/table/qt/tests/test_data_viewer.py
@@ -479,6 +479,9 @@ def test_table_incompatible_attribute():
     #This subset should not be shown in the viewer
     sg1 = dc.new_subset_group('invalid', d1.id['x'] <= 3)
 
+    gapp.show()
+    process_events()
+
     assert len(viewer.layers) == 2
     assert not viewer.layers[1].visible
     assert viewer.layers[0].visible

--- a/glue/viewers/table/qt/tests/test_data_viewer.py
+++ b/glue/viewers/table/qt/tests/test_data_viewer.py
@@ -461,7 +461,7 @@ def test_incompatible_subset():
     assert refresh2.call_count == 0
 
 
-@requires_pyqt_gt_59
+@requires_pyqt_gt_59_or_pyside2
 def test_table_incompatible_attribute():
     """
     Regression test for a bug where the table viewer generates an

--- a/glue/viewers/table/qt/tests/test_data_viewer.py
+++ b/glue/viewers/table/qt/tests/test_data_viewer.py
@@ -13,6 +13,7 @@ from glue.app.qt import GlueApplication
 from ..data_viewer import DataTableModel, TableViewer
 
 from glue.core.edit_subset_mode import AndNotMode, OrMode, ReplaceMode
+from glue.tests.helpers import requires_pyqt_gt_59
 
 
 class TestDataTableModel():
@@ -460,6 +461,7 @@ def test_incompatible_subset():
     assert refresh2.call_count == 0
 
 
+@requires_pyqt_gt_59
 def test_table_incompatible_attribute():
     """
     Regression test for a bug where the table viewer generates an

--- a/glue/viewers/table/qt/tests/test_data_viewer.py
+++ b/glue/viewers/table/qt/tests/test_data_viewer.py
@@ -13,7 +13,7 @@ from glue.app.qt import GlueApplication
 from ..data_viewer import DataTableModel, TableViewer
 
 from glue.core.edit_subset_mode import AndNotMode, OrMode, ReplaceMode
-from glue.tests.helpers import requires_pyqt_gt_59
+from glue.tests.helpers import requires_pyqt_gt_59_or_pyside2
 
 
 class TestDataTableModel():


### PR DESCRIPTION
# Pull Request Template

## Description

A fix for #2285, making sure that disabled TableLayerArtists are not visible, as the viewer will sometimes try to draw visible (but disabled) layers and throw an IncompatibleAttribute Error when it tries to do so. A regression test for this behavior is included.