### PR TITLE
Remove use of deprecated `np.float` dtype

### DIFF
--- a/glue/core/data_factories/tests/test_data_factories.py
+++ b/glue/core/data_factories/tests/test_data_factories.py
@@ -106,7 +106,7 @@ def test_csv_pandas_factory():
     with make_file(data, '.csv') as fname:
         d = df.load_data(fname, factory=df.pandas_read_table)
     assert d['a'].dtype == np.int64
-    assert d['b'].dtype == np.float
+    assert d['b'].dtype == float
     assert d['c'].dtype.kind == 'U'
     cat_comp = d.find_component_id('c')
     assert isinstance(d.get_component(cat_comp), CategoricalComponent)
@@ -129,7 +129,7 @@ def test_dtype_float():
     data = b'# a, b\n1., 1 \n2, 2 \n3, 3'
     with make_file(data, '.csv') as fname:
         d = df.load_data(fname)
-    assert d['a'].dtype == np.float
+    assert d['a'].dtype == float
 
 
 def test_dtype_str_on_categorical():
@@ -143,7 +143,7 @@ def test_dtype_badtext():
     data = b'# a, b\nlabel1, 1 \n2, 2 \n3, 3\n4, 4\n5, 5\n6, 6'
     with make_file(data, '.csv') as fname:
         d = df.load_data(fname)
-    assert d['a'].dtype == np.float
+    assert d['a'].dtype == float
     assert_array_equal(d['a'], [np.nan, 2, 3, 4, 5, 6])
 
 
@@ -151,7 +151,7 @@ def test_dtype_missing_data_col2():
     data = b'# a, b\n1 , 1 \n2,  \n3, 3.0'
     with make_file(data, '.csv') as fname:
         d = df.load_data(fname)
-    assert d['b'].dtype == np.float
+    assert d['b'].dtype == float
     assert_array_equal(d['b'], [1, np.nan, 3])
 
 
@@ -159,7 +159,7 @@ def test_dtype_missing_data_col1():
     data = b'# a, b\n1.0, 1 \n , 2 \n3, 3'
     with make_file(data, '.csv') as fname:
         d = df.load_data(fname)
-    assert d['a'].dtype == np.float
+    assert d['a'].dtype == float
     assert_array_equal(d['a'], [1, np.nan, 3])
 
 
@@ -167,7 +167,7 @@ def test_column_spaces():
     data = b'#a, b\nhere I go, 1\n2, 3\n3, 4\n5, 6\n7, 8'
     with make_file(data, '.csv') as fname:
         d = df.load_data(fname)
-    assert d['a'].dtype == np.float
+    assert d['a'].dtype == float
     assert_array_equal(d['a'], [np.nan, 2, 3, 5, 7])
 
 

--- a/glue/core/tests/test_component.py
+++ b/glue/core/tests/test_component.py
@@ -130,7 +130,7 @@ class TestCategoricalComponent(object):
         cat_comp = CategoricalComponent(self.array_data)
         np.testing.assert_equal(cat_comp.categories, np.asarray(['a', 'b']))
         np.testing.assert_equal(cat_comp.codes, np.array([0, 0, 1, 1]))
-        assert cat_comp.codes.dtype == np.float
+        assert cat_comp.codes.dtype == float
 
     def test_accepts_provided_grouping(self):
         ncategories = ['b', 'c']

--- a/glue/external/modest_image.py
+++ b/glue/external/modest_image.py
@@ -84,8 +84,7 @@ class ModestImage(mi.AxesImage):
         self._full_res = A
         self._A = A
 
-        if self._A.dtype != np.uint8 and not np.can_cast(self._A.dtype,
-                                                         np.float):
+        if self._A.dtype != np.uint8 and not np.can_cast(self._A.dtype, float):
             raise TypeError("Image data can not convert to float")
 
         if (self._A.ndim not in (2, 3) or

--- a/glue/viewers/image/composite_array.py
+++ b/glue/viewers/image/composite_array.py
@@ -161,7 +161,7 @@ class CompositeArray(object):
 
     @property
     def dtype(self):
-        return np.float
+        return np.dtype(float)
 
     @property
     def ndim(self):

--- a/glue/viewers/image/tests/test_composite_array.py
+++ b/glue/viewers/image/tests/test_composite_array.py
@@ -21,7 +21,7 @@ class TestCompositeArray(object):
         assert self.composite.shape is None
         assert self.composite.size is None
         assert self.composite.ndim == 2  # for now, this is hard-coded
-        assert self.composite.dtype is np.float  # for now, this is hard-coded
+        assert self.composite.dtype is float  # for now, this is hard-coded
 
         self.composite.allocate('a')
         self.composite.set('a', array=self.array1)
@@ -29,7 +29,7 @@ class TestCompositeArray(object):
         assert self.composite.shape == (2, 2)
         assert self.composite.size == 4
         assert self.composite.ndim == 2
-        assert self.composite.dtype is np.float
+        assert self.composite.dtype is float
 
     def test_shape_function(self):
 

--- a/glue/viewers/image/tests/test_composite_array.py
+++ b/glue/viewers/image/tests/test_composite_array.py
@@ -21,7 +21,7 @@ class TestCompositeArray(object):
         assert self.composite.shape is None
         assert self.composite.size is None
         assert self.composite.ndim == 2  # for now, this is hard-coded
-        assert self.composite.dtype is float  # for now, this is hard-coded
+        assert self.composite.dtype is np.dtype(float)  # for now, this is hard-coded
 
         self.composite.allocate('a')
         self.composite.set('a', array=self.array1)
@@ -29,7 +29,7 @@ class TestCompositeArray(object):
         assert self.composite.shape == (2, 2)
         assert self.composite.size == 4
         assert self.composite.ndim == 2
-        assert self.composite.dtype is float
+        assert self.composite.dtype is np.dtype(float)
 
     def test_shape_function(self):
 

--- a/glue/viewers/image/tests/test_pixel_selection_subset_state.py
+++ b/glue/viewers/image/tests/test_pixel_selection_subset_state.py
@@ -41,7 +41,7 @@ def test_pixel_selection_subset_state():
         for state in states:
             cid = data.main_components[0]
             if data is data1:
-                assert_array_equal(state.to_array(data, cid), data[cid][state.slices])
+                assert_array_equal(state.to_array(data, cid), data[cid][tuple(state.slices)])
             else:
                 with pytest.raises(IncompatibleAttribute):
                     state.to_array(data, cid)


### PR DESCRIPTION
## Description
The `np.float` alias has been deprecated in 1.20; tested alternative use of the builtin `float` with numpy 1.16/Python 3.6.