### PR TITLE
Implement as_steps in profile layer state

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ v1.3.0 (unreleased)
 * Remove bundled version of pvextractor and include it as a proper
   dependency. [#2252]
 
+* Support toggling plotting profile viewer layer as steps. [#2292]
+
 v1.2.5 (unreleased)
 -------------------
 

--- a/glue/viewers/profile/layer_artist.py
+++ b/glue/viewers/profile/layer_artist.py
@@ -27,7 +27,8 @@ class ProfileLayerArtist(MatplotlibLayerArtist):
         self._viewer_state.add_global_callback(self._update_profile)
         self.state.add_global_callback(self._update_profile)
 
-        self.plot_artist = self.axes.plot([1, 2, 3], [3, 4, 5], 'k-', drawstyle='steps-mid')[0]
+        drawstyle = 'steps-mid' if self.state.as_steps else 'default'
+        self.plot_artist = self.axes.plot([1, 2, 3], [3, 4, 5], 'k-', drawstyle=drawstyle)[0]
 
         self.mpl_artists = [self.plot_artist]
 
@@ -115,6 +116,7 @@ class ProfileLayerArtist(MatplotlibLayerArtist):
             mpl_artist.set_color(self.state.color)
             mpl_artist.set_alpha(self.state.alpha)
             mpl_artist.set_linewidth(self.state.linewidth)
+            mpl_artist.set_drawstyle('steps-mid' if self.state.as_steps else 'default')
 
         self.redraw()
 
@@ -133,7 +135,7 @@ class ProfileLayerArtist(MatplotlibLayerArtist):
             self._calculate_profile(reset=force)
             force = True
 
-        if force or any(prop in changed for prop in ('alpha', 'color', 'zorder', 'linewidth')):
+        if force or any(prop in changed for prop in ('alpha', 'color', 'zorder', 'linewidth', 'as_steps')):
             self._update_visual_attributes()
 
     @defer_draw

--- a/glue/viewers/profile/state.py
+++ b/glue/viewers/profile/state.py
@@ -215,7 +215,7 @@ class ProfileLayerState(MatplotlibLayerState, HubListener):
     percentile = DDSCProperty(docstring='The percentile value used to '
                                         'automatically calculate levels')
 
-    as_steps = DDCProperty(False, docstring='Whether to display the profile as steps')
+    as_steps = DDCProperty(True, docstring='Whether to display the profile as steps')
 
     _viewer_callbacks_set = False
     _layer_subset_updates_subscribed = False
@@ -240,7 +240,6 @@ class ProfileLayerState(MatplotlibLayerState, HubListener):
 
         self.add_callback('layer', self._on_layer_change, priority=1000)
         self.add_callback('visible', self.reset_cache, priority=1000)
-        self.add_callback('as_steps', self._on_as_steps_change, priority=1000)
 
         if layer is not None:
             self._on_layer_change()
@@ -339,21 +338,10 @@ class ProfileLayerState(MatplotlibLayerState, HubListener):
             axis_view[pix_cid.axis] = slice(None)
             axis_values = data[self.viewer_state.x_att, tuple(axis_view)]
 
-            if self.as_steps:
-                a = np.insert(axis_values, 0, 2*axis_values[0] - axis_values[1])
-                b = np.append(axis_values, 2*axis_values[-1] - axis_values[-2])
-                edges = (a + b) / 2
-                axis_values = np.concatenate((edges[:1], np.repeat(edges[1:-1], 2), edges[-1:]))
-                profile_values = np.repeat(profile_values, 2)
-
             self._profile_cache = axis_values, profile_values
 
         if update_limits:
             self.update_limits(update_profile=False)
-
-    def _on_as_steps_change(self, *args):
-        self.reset_cache()
-        self.update_profile()
 
     def update_limits(self, update_profile=True):
         with delay_callback(self, 'v_min', 'v_max'):

--- a/glue/viewers/profile/state.py
+++ b/glue/viewers/profile/state.py
@@ -215,6 +215,8 @@ class ProfileLayerState(MatplotlibLayerState, HubListener):
     percentile = DDSCProperty(docstring='The percentile value used to '
                                         'automatically calculate levels')
 
+    as_steps = DDCProperty(False, docstring='Whether to display the profile as steps')
+
     _viewer_callbacks_set = False
     _layer_subset_updates_subscribed = False
     _profile_cache = None
@@ -238,6 +240,7 @@ class ProfileLayerState(MatplotlibLayerState, HubListener):
 
         self.add_callback('layer', self._on_layer_change, priority=1000)
         self.add_callback('visible', self.reset_cache, priority=1000)
+        self.add_callback('as_steps', self._on_as_steps_change, priority=1000)
 
         if layer is not None:
             self._on_layer_change()
@@ -335,10 +338,22 @@ class ProfileLayerState(MatplotlibLayerState, HubListener):
             axis_view = [0] * data.ndim
             axis_view[pix_cid.axis] = slice(None)
             axis_values = data[self.viewer_state.x_att, tuple(axis_view)]
+
+            if self.as_steps:
+                a = np.insert(axis_values, 0, 2*axis_values[0] - axis_values[1])
+                b = np.append(axis_values, 2*axis_values[-1] - axis_values[-2])
+                edges = (a + b) / 2
+                axis_values = np.concatenate((edges[:1], np.repeat(edges[1:-1], 2), edges[-1:]))
+                profile_values = np.repeat(profile_values, 2)
+
             self._profile_cache = axis_values, profile_values
 
         if update_limits:
             self.update_limits(update_profile=False)
+
+    def _on_as_steps_change(self, *args):
+        self.reset_cache()
+        self.update_profile()
 
     def update_limits(self, update_profile=True):
         with delay_callback(self, 'v_min', 'v_max'):


### PR DESCRIPTION
## Description

This implements a new boolean switch in the profile layer state to toggle displaying the profile as steps vs a line plot.  ~The actual binning logic is adopted from https://github.com/astropy/specutils/blob/main/specutils/spectra/spectral_axis.py#L42.~ (binning logic has now been moved to the bqplot artist in glue-viz/glue-jupyter#309)
