### PR TITLE
Error when passing in an incorrect string for a colormap for VisualAttributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ glue/qt/glue_qt_resources.py
 .pytest_cache
 .tox
 .vscode
+# vscode plugin
+.history

--- a/glue/core/tests/test_visual.py
+++ b/glue/core/tests/test_visual.py
@@ -1,20 +1,29 @@
 from glue.core.visual import VisualAttributes
 from matplotlib.cm import get_cmap
-
+import pytest
 
 def test_VA_preferred_cmap():
-    # Not a real CMAP array
-    va = VisualAttributes(preferred_cmap=1)
-    assert va.preferred_cmap == 1
+    # Not a real CMAP array - errors
+    with pytest.raises(ValueError,match="`preferred_cmap` must be a string or an instance of a matplotlib.colors.Colormap"):
+        VisualAttributes(preferred_cmap=1)
 
-    # Not a valid string for a CMAP
-    va = VisualAttributes(preferred_cmap="not_a_cmap")
-    assert va.preferred_cmap is None
+    # Not a valid string for a CMAP - errors
+    with pytest.raises(ValueError,match="not_a_cmap is not a valid colormap name."):
+        VisualAttributes(preferred_cmap="not_a_cmap")
+
+    viridis_cmap = get_cmap("viridis")
 
     # get_cmap cmap name
     va = VisualAttributes(preferred_cmap="viridis")
-    assert va.preferred_cmap == get_cmap("viridis")
-
+    assert va.preferred_cmap == viridis_cmap
     # formal cmap name
     va = VisualAttributes(preferred_cmap="Viridis")
-    assert va.preferred_cmap == get_cmap("viridis")
+    assert va.preferred_cmap == viridis_cmap
+
+    # Valid Colormap
+    va = VisualAttributes(preferred_cmap=viridis_cmap)
+    assert va.preferred_cmap == viridis_cmap
+
+    # None is allowed - it is the default
+    va = VisualAttributes(preferred_cmap=None)
+    assert va.preferred_cmap == None

--- a/glue/core/tests/test_visual.py
+++ b/glue/core/tests/test_visual.py
@@ -2,13 +2,14 @@ from glue.core.visual import VisualAttributes
 from matplotlib.cm import get_cmap
 import pytest
 
+
 def test_VA_preferred_cmap():
     # Not a real CMAP array - errors
-    with pytest.raises(ValueError,match="`preferred_cmap` must be a string or an instance of a matplotlib.colors.Colormap"):
+    with pytest.raises(TypeError, match="`preferred_cmap` must be a string or an instance of a matplotlib.colors.Colormap"):
         VisualAttributes(preferred_cmap=1)
 
     # Not a valid string for a CMAP - errors
-    with pytest.raises(ValueError,match="not_a_cmap is not a valid colormap name."):
+    with pytest.raises(ValueError, match="not_a_cmap is not a valid colormap name."):
         VisualAttributes(preferred_cmap="not_a_cmap")
 
     viridis_cmap = get_cmap("viridis")
@@ -26,4 +27,4 @@ def test_VA_preferred_cmap():
 
     # None is allowed - it is the default
     va = VisualAttributes(preferred_cmap=None)
-    assert va.preferred_cmap == None
+    assert va.preferred_cmap is None

--- a/glue/core/tests/test_visual.py
+++ b/glue/core/tests/test_visual.py
@@ -4,17 +4,17 @@ from matplotlib.cm import get_cmap
 
 def test_VA_preferred_cmap():
     # Not a real CMAP array
-    abc = VisualAttributes(preferred_cmap=1)
-    assert abc.preferred_cmap == 1
+    va = VisualAttributes(preferred_cmap=1)
+    assert va.preferred_cmap == 1
 
     # Not a valid string for a CMAP
-    abc = VisualAttributes(preferred_cmap="not_a_cmap")
-    assert abc.preferred_cmap is None
+    va = VisualAttributes(preferred_cmap="not_a_cmap")
+    assert va.preferred_cmap is None
 
     # get_cmap cmap name
-    abc = VisualAttributes(preferred_cmap="viridis")
-    assert abc.preferred_cmap == get_cmap("viridis")
+    va = VisualAttributes(preferred_cmap="viridis")
+    assert va.preferred_cmap == get_cmap("viridis")
 
     # formal cmap name
-    abc = VisualAttributes(preferred_cmap="Viridis")
-    assert abc.preferred_cmap == get_cmap("viridis")
+    va = VisualAttributes(preferred_cmap="Viridis")
+    assert va.preferred_cmap == get_cmap("viridis")

--- a/glue/core/tests/test_visual.py
+++ b/glue/core/tests/test_visual.py
@@ -1,0 +1,20 @@
+from glue.core.visual import VisualAttributes
+from matplotlib.cm import get_cmap
+
+
+def test_VA_preferred_cmap():
+    # Not a real CMAP array
+    abc = VisualAttributes(preferred_cmap=1)
+    assert abc.preferred_cmap == 1
+
+    # Not a valid string for a CMAP
+    abc = VisualAttributes(preferred_cmap="not_a_cmap")
+    assert abc.preferred_cmap is None
+
+    # get_cmap cmap name
+    abc = VisualAttributes(preferred_cmap="viridis")
+    assert abc.preferred_cmap == get_cmap("viridis")
+
+    # formal cmap name
+    abc = VisualAttributes(preferred_cmap="Viridis")
+    assert abc.preferred_cmap == get_cmap("viridis")

--- a/glue/core/visual.py
+++ b/glue/core/visual.py
@@ -1,4 +1,4 @@
-from matplotlib.colors import ColorConverter
+from matplotlib.colors import ColorConverter, Colormap
 from matplotlib.cm import get_cmap
 
 from glue.config import settings
@@ -128,9 +128,11 @@ class VisualAttributes(HasCallbackProperties):
                         break
                 else:
                     # If the string name fails to be validated
-                    self._preferred_cmap = None
-        else:
+                    raise ValueError(f"{value} is not a valid colormap name.")
+        elif isinstance(value, Colormap) or value is None:
             self._preferred_cmap = value
+        else:
+            raise ValueError("`preferred_cmap` must be a string or an instance of a matplotlib.colors.Colormap")
 
     @callback_property
     def alpha(self):

--- a/glue/core/visual.py
+++ b/glue/core/visual.py
@@ -19,21 +19,21 @@ class VisualAttributes(HasCallbackProperties):
 
     Parameters
     ----------
-    parent : QObject, optional
+    parent : :class:`~PyQt5.QtCore.QObject`, optional
         The object that this visual attributes object is attached to. Default is `None`.
-    color : str, optional
-        A matplotlib color string. Default is `None`.
-    alpha : float, optional
-        Opacity, between 0-1. Default is `None`.
-    preferred_cmap : str, optional
-        The name of the preferred colormap. Default is `None`.
-    linewidth : float, optional
+    color : `str`, optional
+        A matplotlib color string. Default is is set from `~glue.config.SettingsRegistry`.
+    alpha : `float`, optional
+        Opacity, between 0-1. Default is is set from `~glue.config.SettingsRegistry`.
+    preferred_cmap : `str` or :class:`~matplotlib.colors.Colormap`, optional
+        A colormap to be used as the preferred colormap, by name or instance. Default is `None`.
+    linewidth : `float`, optional
         The linewidth. Default is 1.
-    linestyle : str, optional
+    linestyle : `str`, optional
         The linestyle. Default is `'solid'`.
-    marker : str, optional
+    marker : `str`, optional
         The matplotlib marker shape. Default is `'o'`.
-    markersize : float, optional
+    markersize : `float`, optional
         The size of the marker. Default is 3.
     """
 

--- a/glue/core/visual.py
+++ b/glue/core/visual.py
@@ -19,12 +19,12 @@ class VisualAttributes(HasCallbackProperties):
 
     Parameters
     ----------
-    parent : :class:`~PyQt5.QtCore.QObject`, optional
+    parent : :class:`~PyQt5.api.qtcore.qobject`, optional
         The object that this visual attributes object is attached to. Default is `None`.
     color : `str`, optional
-        A matplotlib color string. Default is is set from `~glue.config.SettingsRegistry`.
+        A matplotlib color string. Default is is set from `~glue.config.SettingRegistry`.
     alpha : `float`, optional
-        Opacity, between 0-1. Default is is set from `~glue.config.SettingsRegistry`.
+        Opacity, between 0-1. Default is is set from `~glue.config.SettingRegistry`.
     preferred_cmap : `str` or :class:`~matplotlib.colors.Colormap`, optional
         A colormap to be used as the preferred colormap, by name or instance. Default is `None`.
     linewidth : `float`, optional

--- a/glue/core/visual.py
+++ b/glue/core/visual.py
@@ -15,21 +15,29 @@ __all__ = ['VisualAttributes']
 class VisualAttributes(HasCallbackProperties):
 
     """
-    This class is used to define visual attributes for any kind of objects
+    This class is used to define visual attributes for any kind of objects.
 
-    The essential attributes of a VisualAttributes instance are:
-
-    :param color: A matplotlib color string
-    :param alpha: Opacity (0-1)
-    :param linewidth: The linewidth (float or int)
-    :param linestyle: The linestyle (``'solid' | 'dashed' | 'dash-dot' | 'dotted' | 'none'``)
-    :param marker: The matplotlib marker shape (``'o' | 's' | '^' | etc``)
-    :param markersize: The size of the marker (int)
-    :param preferred_cmap: The colormap required (str)
-
+    Parameters
+    ----------
+    parent : QObject, optional
+        The object that this visual attributes object is attached to. Default is `None`.
+    color : str, optional
+        A matplotlib color string. Default is `None`.
+    alpha : float, optional
+        Opacity, between 0-1. Default is `None`.
+    preferred_cmap : str, optional
+        The name of the preferred colormap. Default is `None`.
+    linewidth : float, optional
+        The linewidth. Default is 1.
+    linestyle : str, optional
+        The linestyle. Default is `'solid'`.
+    marker : str, optional
+        The matplotlib marker shape. Default is `'o'`.
+    markersize : float, optional
+        The size of the marker. Default is 3.
     """
 
-    def __init__(self, parent=None, color=None, alpha=None, preferred_cmap=None):
+    def __init__(self, parent=None, color=None, alpha=None, preferred_cmap=None, linewidth=1, linestyle='solid', marker='o', markersize=3):
 
         super(VisualAttributes, self).__init__()
 
@@ -44,10 +52,10 @@ class VisualAttributes(HasCallbackProperties):
         self.color = color
         self.alpha = alpha
         self.preferred_cmap = preferred_cmap
-        self.linewidth = 1
-        self.linestyle = 'solid'
-        self.marker = 'o'
-        self.markersize = 3
+        self.linewidth = linewidth
+        self.linestyle = linestyle
+        self.marker = marker
+        self.markersize = markersize
 
     def __eq__(self, other):
         if not isinstance(other, VisualAttributes):

--- a/glue/core/visual.py
+++ b/glue/core/visual.py
@@ -132,7 +132,7 @@ class VisualAttributes(HasCallbackProperties):
         elif isinstance(value, Colormap) or value is None:
             self._preferred_cmap = value
         else:
-            raise ValueError("`preferred_cmap` must be a string or an instance of a matplotlib.colors.Colormap")
+            raise TypeError("`preferred_cmap` must be a string or an instance of a matplotlib.colors.Colormap")
 
     @callback_property
     def alpha(self):

--- a/glue/core/visual.py
+++ b/glue/core/visual.py
@@ -25,10 +25,11 @@ class VisualAttributes(HasCallbackProperties):
     :param linestyle: The linestyle (``'solid' | 'dashed' | 'dash-dot' | 'dotted' | 'none'``)
     :param marker: The matplotlib marker shape (``'o' | 's' | '^' | etc``)
     :param markersize: The size of the marker (int)
+    :param preferred_cmap: The colormap required (str)
 
     """
 
-    def __init__(self, parent=None, washout=False, color=None, alpha=None, preferred_cmap=None):
+    def __init__(self, parent=None, color=None, alpha=None, preferred_cmap=None):
 
         super(VisualAttributes, self).__init__()
 
@@ -109,11 +110,17 @@ class VisualAttributes(HasCallbackProperties):
     def preferred_cmap(self, value):
         if isinstance(value, str):
             try:
-                for i, element in enumerate(colormaps.members):
+                self._preferred_cmap = get_cmap(value)
+            except ValueError:
+                # This checks for the formal name of the colormap.
+                # e.g., 'viridis' is 'Viridis'
+                for element in colormaps.members:
                     if element[0] == value:
                         self._preferred_cmap = element[1]
-            except TypeError:
-                self._preferred_cmap = get_cmap(value)
+                        break
+                else:
+                    # If the string name fails to be validated
+                    self._preferred_cmap = None
         else:
             self._preferred_cmap = value
 

--- a/glue/core/visual.py
+++ b/glue/core/visual.py
@@ -22,9 +22,9 @@ class VisualAttributes(HasCallbackProperties):
     parent : :class:`~PyQt5.api.qtcore.qobject`, optional
         The object that this visual attributes object is attached to. Default is `None`.
     color : `str`, optional
-        A matplotlib color string. Default is is set from `~glue.config.SettingRegistry`.
+        A matplotlib color string. Default is set from :class:`~glue.config.SettingRegistry`.
     alpha : `float`, optional
-        Opacity, between 0-1. Default is is set from `~glue.config.SettingRegistry`.
+        Opacity, between 0-1. Default is set from :class:`~glue.config.SettingRegistry`.
     preferred_cmap : `str` or :class:`~matplotlib.colors.Colormap`, optional
         A colormap to be used as the preferred colormap, by name or instance. Default is `None`.
     linewidth : `float`, optional

--- a/glue/core/visual.py
+++ b/glue/core/visual.py
@@ -19,7 +19,7 @@ class VisualAttributes(HasCallbackProperties):
 
     Parameters
     ----------
-    parent : :class:`~PyQt5.api.qtcore.qobject`, optional
+    parent : `QObject`, optional
         The object that this visual attributes object is attached to. Default is `None`.
     color : `str`, optional
         A matplotlib color string. Default is set from :class:`~glue.config.SettingRegistry`.


### PR DESCRIPTION
## Description

So I was trying to set a colormap as a string and if the string does not hit either block of logic, `_preferred_cmap` is never set and then it will error during the data loading process.

I was unclear if I should raise an error or just set `_preferred_cmap` as `None` but I decided on `None` and carrying on.

I also added to the gitignore a common(?) vscode plugin directory that is created by that plugin. 
