### PR TITLE
Provide interface for doing in-place unit conversions on components

### DIFF
--- a/glue/core/component.py
+++ b/glue/core/component.py
@@ -45,7 +45,6 @@ class Component(object):
 
         # The physical units of the data
         self.units = units
-        self._original_units = self._units
 
         # The actual data
         # subclasses may pass non-arrays here as placeholders.
@@ -66,7 +65,13 @@ class Component(object):
         if value is None:
             self._units = ''
         else:
-            self._units = str(value)
+            new_units = str(value)
+        if getattr(self, '_original_units', '') == '':
+            self._original_units = new_units
+        if not u.Unit(self._original_units).is_equivalent(u.Unit(new_units)):
+            raise u.UnitConversionError(f"New unit '{new_units}' must be convertible "
+                                        f"from original one '{self._original_units}'")
+        self._units = new_units
 
     def _convert_to_units(self, units):
         self.units = units

--- a/glue/core/component.py
+++ b/glue/core/component.py
@@ -63,7 +63,7 @@ class Component(object):
     @units.setter
     def units(self, value):
         if value is None:
-            self._units = ''
+            new_units = ''
         else:
             new_units = str(value)
         if getattr(self, '_original_units', '') == '':

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -1433,6 +1433,11 @@ class Data(BaseCartesianData):
         else:
             raise IncompatibleAttribute(component_id)
 
+    def convert_component_units_to(self, component_id, units):
+        comp = self.get_component(component_id)
+        comp._convert_to_units(units)
+        self._numerical_data_changed()
+
     def to_dataframe(self, index=None):
         """Convert the Data object into a :class:`pandas.DataFrame` object.
 
@@ -1511,12 +1516,15 @@ class Data(BaseCartesianData):
             comp._data = data
 
         # alert hub of the change
-        if self.hub is not None:
-            msg = NumericalDataChangedMessage(self)
-            self.hub.broadcast(msg)
+        self._numerical_data_changed()
 
         for subset in self.subsets:
             clear_cache(subset.subset_state.to_mask)
+
+    def _numerical_data_changed(self):
+        if self.hub is not None:
+            msg = NumericalDataChangedMessage(self)
+            self.hub.broadcast(msg)
 
     def update_values_from_data(self, data):
         """
@@ -1583,9 +1591,7 @@ class Data(BaseCartesianData):
         self.coords = data.coords
 
         # alert hub of the change
-        if self.hub is not None:
-            msg = NumericalDataChangedMessage(self)
-            self.hub.broadcast(msg)
+        self._numerical_data_changed()
 
         for subset in self.subsets:
             clear_cache(subset.subset_state.to_mask)


### PR DESCRIPTION
This is a work in progress to experiment with unit conversions. At the moment this provides an interface to convert the data values of a ``Component`` on-the-fly when accessed. This causes a ``NumericalDataChangedMessage`` message to be broadcast via the hub which then should trigger updates in the viewers (though some viewers I think here and maybe in glue-jupyter don't actually listen for this message - I need to go through and check).

With this, one could do e.g.

```
data.convert_component_units_to('flux', 'mJy')
```

If the original flux of a component was in ``Jy`` and the component will then behave for all intents and purposes as if it was in mJy.

What still needs doing if we decide to go ahead with this:

* [ ] Any kind of error checking to make sure the unit conversion is valid/possible
* [ ] Figuring out how to extend this to derived and coordinate components
* [ ] Dealing with cases where the original units are blank and units are then set (different from conversion)
* [ ] Adding support for equivalencies
* [ ] Thinking about how to deal with the case where an equivalency might need another component, e.g. to convert spectral density one might need the spectral axis depending on the unit conversion
* [ ] Tests and Documentation!

cc @kecnry 