### PR TITLE
Force line collection to always respect colormap

### DIFF
--- a/glue/viewers/scatter/layer_artist.py
+++ b/glue/viewers/scatter/layer_artist.py
@@ -110,6 +110,7 @@ class ColoredLineCollection(LineCollection):
             data_new = np.zeros((len(data) - 1) * 2)
             data_new[::2] = data[:-1]
             data_new[1::2] = data[1:]
+            self.set_color(None)
             set_mpl_artist_cmap(self, data_new, **kwargs)
         else:
             if isinstance(color, np.ndarray):


### PR DESCRIPTION
The scatter viewer currently has a bug (noticed by @victoriaono) where the line collection that connects points will only obey the selected colormap if that colormap was set before a line was first displayed on the viewer. Additionally, if a fixed color is set after the line displays, subsequent colormap usage will not be respected. See the video below for an example.

https://user-images.githubusercontent.com/14281631/169670639-f856a81a-ba8b-4c02-ad55-89c1e6b6b8aa.mp4

This PR creates consistent behavior by calling `set_color(None)` inside the line collection's `set_linearcolor` method. The reason for this has to do with how the behavior is implemented inside `matplotlib`. Whenever the colormap mode is Fixed, we call `set_linearcolor` with `color=self.state.color` [here](https://github.com/glue-viz/glue/blob/main/glue/viewers/scatter/layer_artist.py#L435). This call's the artist's [`set_color`](https://github.com/matplotlib/matplotlib/blob/main/lib/matplotlib/collections.py#L715) method, which ultimately calls [`set_facecolor`](https://github.com/matplotlib/matplotlib/blob/main/lib/matplotlib/collections.py#L742) and sets `_original_facecolor` to that color.

However, when  `cmap_mode` is set to `Linear`, we call `set_mpl_artist_cmap` [here](https://github.com/glue-viz/glue/blob/main/glue/viewers/scatter/layer_artist.py#L357) without a color argument, which doesn't doesn't call `set_color`, and so `_original_facecolor` remains as the solid color. The artist's `_edge_is_mapped` attribute is set to false [if `_original_edgecolor` has a color value](https://github.com/matplotlib/matplotlib/blob/main/lib/matplotlib/collections.py#L857), which means that the edgecolors of the artist are [set to the original edgecolor, rather than the colormapped colors](https://github.com/matplotlib/matplotlib/blob/main/lib/matplotlib/collections.py#L899). This is why things work if we set the colormap before the line first displays - we haven't made a call to the line collection's `set_color` method yet, so `_original_facecolor` is still `None`. By calling `set_color(None)`, we reset `_original_facecolor` to `None`, allowing the line collection edges to be colormapped.