### PR TITLE
Redraw empty histogram layer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 Full changelog
 ==============
 
+v1.4.0 (2022-05-31)
+-------------------
+
+* Fix an issue where the histogram layer artist would not redraw if
+* the histogram sum was zero. [#2300]
+
 v1.3.0 (2022-04-22)
 -------------------
 

--- a/glue/viewers/histogram/layer_artist.py
+++ b/glue/viewers/histogram/layer_artist.py
@@ -128,11 +128,11 @@ class HistogramLayerArtist(MatplotlibLayerArtist):
             self.state._y_min = 0
 
         largest_y_max = max(getattr(layer, '_y_max', 0) for layer in self._viewer_state.layers)
-        if largest_y_max != self._viewer_state.y_max:
+        if np.isfinite(largest_y_max) and largest_y_max != self._viewer_state.y_max:
             self._viewer_state.y_max = largest_y_max
 
         smallest_y_min = min(getattr(layer, '_y_min', np.inf) for layer in self._viewer_state.layers)
-        if smallest_y_min != self._viewer_state.y_min:
+        if np.isfinite(smallest_y_min) and smallest_y_min != self._viewer_state.y_min:
             self._viewer_state.y_min = smallest_y_min
 
         self.redraw()

--- a/glue/viewers/histogram/layer_artist.py
+++ b/glue/viewers/histogram/layer_artist.py
@@ -79,7 +79,7 @@ class HistogramLayerArtist(MatplotlibLayerArtist):
         except Exception:
             return
 
-        if mpl_hist_edges.size == 0 or mpl_hist.sum() == 0:
+        if mpl_hist_edges.size == 0:
             return
 
         if len(self.mpl_artists) > len(mpl_hist):

--- a/glue/viewers/histogram/qt/tests/test_data_viewer.py
+++ b/glue/viewers/histogram/qt/tests/test_data_viewer.py
@@ -11,7 +11,7 @@ from numpy.testing import assert_equal, assert_allclose
 from glue.core.message import SubsetUpdateMessage
 from glue.core import HubListener, Data
 from glue.core.roi import XRangeROI, RectangularROI
-from glue.core.subset import RangeSubsetState, CategoricalROISubsetState, RoiSubsetState
+from glue.core.subset import SubsetState, RangeSubsetState, CategoricalROISubsetState, RoiSubsetState
 from glue import core
 from glue.app.qt import GlueApplication
 from glue.core.component_id import ComponentID
@@ -685,6 +685,15 @@ class TestHistogramViewer(object):
         assert labels[1] == 'test'
 
         assert to_hex(handles[1].get_facecolor()) == viewer_state.layers[1].color
+
+    def test_redraw_empty_subset(self):
+        self.viewer.add_data(self.data)
+        self.data_collection.new_subset_group('redraw_empty', self.data.id['x'] > 1)
+        layer_artist = self.viewer.layers[-1]
+        subset = layer_artist.layer
+        subset.subset_state = SubsetState()
+        for artist in layer_artist.mpl_artists:
+            assert artist.get_height() == 0
 
 
 def test_with_dask_array():

--- a/glue/viewers/histogram/state.py
+++ b/glue/viewers/histogram/state.py
@@ -73,8 +73,12 @@ class HistogramViewerState(MatplotlibDataViewerState):
 
     def reset_limits(self):
         self._reset_x_limits()
-        self.y_min = min(getattr(layer, '_y_min', np.inf) for layer in self.layers)
-        self.y_max = max(getattr(layer, '_y_max', 0) for layer in self.layers)
+        y_min = min(getattr(layer, '_y_min', np.inf) for layer in self.layers)
+        if np.isfinite(y_min):
+            self.y_min = y_min
+        y_max = max(getattr(layer, '_y_max', 0) for layer in self.layers)
+        if np.isfinite(y_max):
+            self.y_max = y_max
 
     def _update_priority(self, name):
         if name == 'layers':


### PR DESCRIPTION
This PR addresses an issue that was discussed at a glue meeting a little while ago (don't remember the exact date). The issue is that if a subset group is modified to make it empty, the corresponding histogram layer artist is not redrawn. See the video below.

https://user-images.githubusercontent.com/14281631/169853796-d7dd56b3-7d5b-4ed8-90a2-5931bc0a6e2e.mp4

The issue seems to be [here](https://github.com/glue-viz/glue/blob/main/glue/viewers/histogram/layer_artist.py#L82), where `_update_artists` return if the sum of the histogram is empty (that is, the layer has no content). To fix this, I've removed the `mpl_hist.sum() == 0` check. Allowing the possibility for empty layer opens the door for the `largest_y_max` and `smallest_y_min` values computed later in the method to be NaN or infinite (in particular, if all of the layers are empty). I couldn't think of a better default behavior than just punting on updating the bounds in this case, so I've added `numpy.isfinite` checks around both assignments to the relevant viewer state properties.
