### PR TITLE
Fix bug when chunking large arrays with a subset defined

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@ v1.4.0 (unreleased)
 
 * Add support for using degrees in full-sphere projections. [#2279]
 
+* Fixed a bug in when using `compute_statistic` on an array large enough to
+  need chunking when a subset is defined. [#2302]
+
 v1.3.0 (2022-04-22)
 -------------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,8 +11,9 @@ v1.4.0 (unreleased)
 
 * Add support for using degrees in full-sphere projections. [#2279]
 
-* Fixed a bug in when using `compute_statistic` on an array large enough to
-  need chunking when a subset is defined. [#2302]
+* Fixed a bug on setting a return view in `compute_statistic` when a subset
+  is defined, resulting in a broadcast error in arrays large enough to need
+  chunking. [#2302]
 
 v1.3.0 (2022-04-22)
 -------------------

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -19,7 +19,7 @@ from glue.core.message import (DataUpdateMessage, DataRemoveComponentMessage,
 from glue.core.decorators import clear_cache
 from glue.core.util import split_component_view
 from glue.core.hub import Hub
-from glue.core.subset import Subset, SubsetState, SliceSubsetState
+from glue.core.subset import Subset, SubsetState, SliceSubsetState, RangeSubsetState
 from glue.core.component_id import ComponentIDList
 from glue.core.component_link import ComponentLink, CoordinateComponentLink
 from glue.core.exceptions import IncompatibleAttribute
@@ -1643,7 +1643,7 @@ class Data(BaseCartesianData):
                 len(axis) > 0 and
                 len(axis) == self.ndim - 1 and
                 self.size > n_chunk_max and
-                not isinstance(subset_state, SliceSubsetState)):
+                not isinstance(subset_state, (SliceSubsetState, RangeSubsetState))):
 
             # We operate in chunks here to avoid memory issues.
 

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -1839,7 +1839,6 @@ class Data(BaseCartesianData):
             else:
                 chunk_shape = subset_state.to_mask(self, chunk_view).shape
                 full_shape = [chunk_shape[idim] for idim in range(self.ndim) if idim not in axis]
-                view_start = [chunk_view[idim].start for idim in range(self.ndim) if idim not in axis][0]
 
             full_result = np.zeros(full_shape) * np.nan
             full_result[result_slices] = result

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -1643,7 +1643,7 @@ class Data(BaseCartesianData):
                 len(axis) > 0 and
                 len(axis) == self.ndim - 1 and
                 self.size > n_chunk_max and
-                not isinstance(subset_state, (SliceSubsetState, RangeSubsetState))):
+                not isinstance(subset_state, SliceSubsetState)):
 
             # We operate in chunks here to avoid memory issues.
 

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -1828,7 +1828,8 @@ class Data(BaseCartesianData):
             # shape of the full results had subarray_slices not been set,
             # then insert the result into it. If axis is None, then we don't
             # need to do anything, and this is covered by the first clause
-            # of the if statement above.
+            # of the if statement above. Likewise if a view was specified,
+            # only the result within the view is returned.
             if not isinstance(axis, tuple):
                 axis = (axis,)
             result_slices = tuple([subarray_slices[idim] for idim in range(self.ndim) if idim not in axis])

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -1829,9 +1829,10 @@ class Data(BaseCartesianData):
             # then insert the result into it. If axis is None, then we don't
             # need to do anything, and this is covered by the first clause
             # of the if statement above.
-            result_slices = tuple([subarray_slices[idim] for idim in range(self.ndim) if idim not in axis])
             if not isinstance(axis, tuple):
                 axis = (axis,)
+            result_slices = tuple([subarray_slices[idim] for idim in range(self.ndim) if idim not in axis])
+
             if chunk_view is None:
                 full_shape = [self.shape[idim] for idim in range(self.ndim) if idim not in axis]
             else:

--- a/glue/core/tests/test_data.py
+++ b/glue/core/tests/test_data.py
@@ -1036,45 +1036,41 @@ def test_compute_statistic_shape():
     assert result.shape == (20,)
 
 
-def test_compute_statistic_shape_view():
+@pytest.mark.parametrize('view', ((slice(0, 5), slice(4, 14), slice(10, 22)),
+                                  (slice(0, 6), slice(4, 12), slice(0, 16)),
+                                  (slice(2, 5), slice(6, 12), slice(10, 20))))
+def test_compute_statistic_shape_view(view):
 
-    # Test the compute_statistic method with the same optimizations, but setting
-    # the `view` parameter for sub-slicing the dataset.
+    # Test the compute_statistic method with the same optimizations and combined
+    # with different settings of the `view` parameter for sub-slicing the dataset.
 
-    array = np.ones(10 * 20 * 30).reshape((10, 20, 30))
+    array = np.ones((10, 20, 30))
     array[3:5, 6:14, 10:21] += 1
 
     data = Data(x=array, y=array)
 
-    subset_state = data.id['y'] > 1.5
+    state = data.id['y'] > 1.5
 
-    view = (slice(0, 5), slice(4, 12), slice(0, 10))
-    subset_state = data.id['y'] > 1.5
-
-    result = data.compute_statistic('sum', data.id['x'], subset_state=subset_state, view=view)
+    result = data.compute_statistic('sum', data.id['x'], subset_state=state, view=view)
     assert np.isscalar(result)
 
-    result = data.compute_statistic('sum', data.id['x'], subset_state=subset_state,
-                                    axis=1, view=view)
-    assert result.shape == (5, 10)
+    result = data.compute_statistic('sum', data.id['x'], subset_state=state, view=view, axis=1)
+    assert result.shape == (view[0].stop - view[0].start, view[1].stop - view[1].start)
 
-    result = data.compute_statistic('sum', data.id['x'], subset_state=subset_state,
-                                    axis=(0, 2), view=view)
-    assert result.shape == (8,)
+    result = data.compute_statistic('sum', data.id['x'], subset_state=state, view=view, axis=(0, 2))
+    assert result.shape == (view[1].stop - view[1].start,)
 
     roi = RangeROI('x', min=1.5, max=2.0)
-    subset_state = roi_to_subset_state(roi, x_att='x')
+    state = roi_to_subset_state(roi, x_att='x')
 
-    result = data.compute_statistic('sum', data.id['x'], subset_state=subset_state, view=view)
+    result = data.compute_statistic('sum', data.id['x'], subset_state=state, view=view)
     assert np.isscalar(result)
 
-    result = data.compute_statistic('sum', data.id['x'], subset_state=subset_state,
-                                    axis=1, view=view)
-    assert result.shape == (5, 10)
+    result = data.compute_statistic('sum', data.id['x'], subset_state=state, view=view, axis=1)
+    assert result.shape == (view[0].stop - view[0].start, view[1].stop - view[1].start)
 
-    result = data.compute_statistic('sum', data.id['x'], subset_state=subset_state,
-                                    axis=(0, 2), view=view)
-    assert result.shape == (8,)
+    result = data.compute_statistic('sum', data.id['x'], subset_state=state, view=view, axis=(0, 2))
+    assert result.shape == (view[1].stop - view[1].start,)
 
 
 def test_compute_histogram_log():

--- a/glue/core/tests/test_data.py
+++ b/glue/core/tests/test_data.py
@@ -1055,7 +1055,7 @@ def test_compute_statistic_shape_view(view):
     assert np.isscalar(result)
 
     result = data.compute_statistic('sum', data.id['x'], subset_state=state, view=view, axis=1)
-    assert result.shape == (view[0].stop - view[0].start, view[1].stop - view[1].start)
+    assert result.shape == (view[0].stop - view[0].start, view[2].stop - view[2].start)
 
     result = data.compute_statistic('sum', data.id['x'], subset_state=state, view=view, axis=(0, 2))
     assert result.shape == (view[1].stop - view[1].start,)
@@ -1067,7 +1067,7 @@ def test_compute_statistic_shape_view(view):
     assert np.isscalar(result)
 
     result = data.compute_statistic('sum', data.id['x'], subset_state=state, view=view, axis=1)
-    assert result.shape == (view[0].stop - view[0].start, view[1].stop - view[1].start)
+    assert result.shape == (view[0].stop - view[0].start, view[2].stop - view[2].start)
 
     result = data.compute_statistic('sum', data.id['x'], subset_state=state, view=view, axis=(0, 2))
     assert result.shape == (view[1].stop - view[1].start,)

--- a/glue/core/tests/test_data.py
+++ b/glue/core/tests/test_data.py
@@ -855,8 +855,53 @@ def test_compute_statistic_chunks(shape):
     data = Data(x=np.random.random(shape))
 
     axis = tuple(range(data.ndim - 1))
+
     assert_allclose(data.compute_statistic('mean', data.id['x'], axis=axis),
                     data.compute_statistic('mean', data.id['x'], axis=axis, n_chunk_max=10))
+
+    subset_state = SliceSubsetState(data, [slice(5)])
+    stats = data.compute_statistic('mean', data.id['x'], axis=axis, subset_state=subset_state)
+    chunked = data.compute_statistic('mean', data.id['x'], axis=axis, subset_state=subset_state,
+                                     n_chunk_max=10)
+    assert_allclose(stats, chunked)
+
+    subset_state = data.id['x'] > 0.25
+    stats = data.compute_statistic('mean', data.id['x'], axis=axis, subset_state=subset_state)
+    chunked = data.compute_statistic('mean', data.id['x'], axis=axis, subset_state=subset_state,
+                                     n_chunk_max=10)
+    assert_allclose(stats, chunked)
+
+    roi = RangeROI('x', min=0.1, max=0.95)
+    subset_state = roi_to_subset_state(roi, x_att='x')
+    stats = data.compute_statistic('mean', data.id['x'], axis=axis, subset_state=subset_state)
+    chunked = data.compute_statistic('mean', data.id['x'], axis=axis, subset_state=subset_state,
+                                     n_chunk_max=10)
+    assert_allclose(stats, chunked)
+
+    if data.ndim < 3:
+        return
+
+    assert_allclose(data.compute_statistic('mean', data.id['x'], axis=2),
+                    data.compute_statistic('mean', data.id['x'], axis=2, n_chunk_max=10))
+
+    subset_state = SliceSubsetState(data, [slice(5)])
+    stats = data.compute_statistic('mean', data.id['x'], axis=2, subset_state=subset_state)
+    chunked = data.compute_statistic('mean', data.id['x'], axis=2, subset_state=subset_state,
+                                     n_chunk_max=10)
+    assert_allclose(stats, chunked)
+
+    subset_state = data.id['x'] > 0.25
+    stats = data.compute_statistic('mean', data.id['x'], axis=2, subset_state=subset_state)
+    chunked = data.compute_statistic('mean', data.id['x'], axis=2, subset_state=subset_state,
+                                     n_chunk_max=10)
+    assert_allclose(stats, chunked)
+
+    roi = RangeROI('x', min=0.1, max=0.95)
+    subset_state = roi_to_subset_state(roi, x_att='x')
+    stats = data.compute_statistic('mean', data.id['x'], axis=2, subset_state=subset_state)
+    chunked = data.compute_statistic('mean', data.id['x'], axis=2, subset_state=subset_state,
+                                     n_chunk_max=10)
+    assert_allclose(stats, chunked)
 
 
 def test_compute_statistic_random_subset():
@@ -989,6 +1034,47 @@ def test_compute_statistic_shape():
     result = data.compute_statistic('sum', data.id['x'], subset_state=subset_state,
                                     axis=(0, 2))
     assert result.shape == (20,)
+
+
+def test_compute_statistic_shape_view():
+
+    # Test the compute_statistic method with the same optimizations, but setting
+    # the `view` parameter for sub-slicing the dataset.
+
+    array = np.ones(10 * 20 * 30).reshape((10, 20, 30))
+    array[3:5, 6:14, 10:21] += 1
+
+    data = Data(x=array, y=array)
+
+    subset_state = data.id['y'] > 1.5
+
+    view = (slice(0, 5), slice(4, 12), slice(0, 10))
+    subset_state = data.id['y'] > 1.5
+
+    result = data.compute_statistic('sum', data.id['x'], subset_state=subset_state, view=view)
+    assert np.isscalar(result)
+
+    result = data.compute_statistic('sum', data.id['x'], subset_state=subset_state,
+                                    axis=1, view=view)
+    assert result.shape == (5, 10)
+
+    result = data.compute_statistic('sum', data.id['x'], subset_state=subset_state,
+                                    axis=(0, 2), view=view)
+    assert result.shape == (8,)
+
+    roi = RangeROI('x', min=1.5, max=2.0)
+    subset_state = roi_to_subset_state(roi, x_att='x')
+
+    result = data.compute_statistic('sum', data.id['x'], subset_state=subset_state, view=view)
+    assert np.isscalar(result)
+
+    result = data.compute_statistic('sum', data.id['x'], subset_state=subset_state,
+                                    axis=1, view=view)
+    assert result.shape == (5, 10)
+
+    result = data.compute_statistic('sum', data.id['x'], subset_state=subset_state,
+                                    axis=(0, 2), view=view)
+    assert result.shape == (8,)
 
 
 def test_compute_histogram_log():


### PR DESCRIPTION
## Description

We were running into a bug for large cubes in Jdaviz, where we couldn't retrieve the collapsed spectrum if the cube was above a certain size (above `n_chunk_max` in `compute_statistic` as it turned out). I'm not sure if this is the best fix, but it works to avoid the broadcast error we were encountering on [line 1689](https://github.com/glue-viz/glue/blob/bc9382839d4a28d82c5a24aaedd50708bb198a00/glue/core/data.py#L1689) where there was an array size mismatch with a `RangeSubsetState` defined and number of array elements > `n_chunk_max`.