### PR TITLE
Fix return shape of compute_statistic with view set or computed in chunks

### DIFF
--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -1633,6 +1633,11 @@ class Data(BaseCartesianData):
 
         # TODO: generalize chunking to more types of axis
 
+        if view is None:
+            use_view = False
+        else:
+            use_view = True
+
         # In recent version of Numpy, using lists is not the same as using
         # tuples, so we make sure we always use tuples to avoid confusion.
         if isinstance(view, list):
@@ -1818,18 +1823,19 @@ class Data(BaseCartesianData):
         result = compute_statistic(statistic, data, mask=mask, axis=axis, finite=finite,
                                    positive=positive, percentile=percentile)
 
-        if subarray_slices is None or axis is None:
+        if subarray_slices is None or axis is None or use_view:
             return result
         else:
             # Since subarray_slices was set above, we need to determine the
             # shape of the full results had subarray_slices not been set,
             # then insert the result into it. If axis is None, then we don't
             # need to do anything, and this is covered by the first clause
-            # of the if statement above.
+            # of the if statement above. Likewise if a view was specified,
+            # only the result within the view is returned.
             if not isinstance(axis, tuple):
                 axis = (axis,)
             full_shape = [self.shape[idim] for idim in range(self.ndim) if idim not in axis]
-            full_result = np.zeros(full_shape) * np.nan
+            full_result = np.full(full_shape, np.nan)
             result_slices = tuple([subarray_slices[idim] for idim in range(self.ndim) if idim not in axis])
             full_result[result_slices] = result
             return full_result


### PR DESCRIPTION
## Description
This is a follow-up/replacement for #2302, which identified a broadcast error when calling `compute_statistic` with a `RangeSubsetState` defined on `data.size > n_chunk_max`.
The underlying issue appears to be that a call with `subset_state` and `view` set like
`data.compute_statistic('mean', data.id['x'], axis=(1, 2), subset_state=subset_state, view=(slice(0, 6), slice(None), slice(None)))`
returns an array of the original axis-0 length with values past [:6] filled with NaN, while the same without a `subset_state` returns a length-6 array. This was probably introduced with the shape adjustments added as part of #2147.
Attempts to set the return shape in https://github.com/glue-viz/glue/blob/bc9382839d4a28d82c5a24aaedd50708bb198a00/glue/core/data.py#L1831
from `data.shape` or `mask.shape` instead did fix this issue, but broke the test cases in `test_compute_statistic_shape` again, so instead I am tracking here if a `view` was initially specified to directly return `result`.
I honestly do not completely understand how this works now for the combination of the efficient subset calculation _and_ `view` set, but the added tests are passing...

@rosteen could you test if this also fixes your case?