### PR TITLE
Apply foreground color to minor ticks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ Full changelog
 v1.6.0 (unreleased)
 -------------------
 
+* Fixed a bug where minor tick marks were not respecting the settings colors. [#2305]
+
 * Fix an issue where the histogram layer artist would not redraw if
   the histogram sum was zero. [#2300]
 
@@ -17,7 +19,6 @@ v1.5.0 (2022-06-28)
 * Added rotation angle ``theta`` as a property to regions of interest,
   to be set on instantiation or modified using the ``rotate_to`` and
   ``rotate_by`` methods. [#2235]
-
 
 v1.4.0 (2022-05-31)
 -------------------

--- a/glue/app/qt/tests/test_preferences.py
+++ b/glue/app/qt/tests/test_preferences.py
@@ -292,7 +292,7 @@ def assert_axes_foreground(axes, color):
             assert spine.get_edgecolor() == color
         for tick in axes.xaxis.get_ticklines() + axes.yaxis.get_ticklines():
             assert tick.get_color() == color
-        for label in axes.xaxis.get_ticklabels() + axes.yaxis.get_ticklabels():
+        for label in axes.xaxis.get_ticklabels(which="both") + axes.yaxis.get_ticklabels(which="both"):
             assert label.get_color() == color
         assert axes.xaxis.label.get_color() == color
         assert axes.yaxis.label.get_color() == color

--- a/glue/viewers/matplotlib/mpl_axes.py
+++ b/glue/viewers/matplotlib/mpl_axes.py
@@ -22,7 +22,8 @@ def set_foreground_color(axes, color):
     else:
         for spine in axes.spines.values():
             spine.set_color(color)
-        axes.tick_params(color=color,
+        axes.tick_params(which="both",
+                         color=color,
                          labelcolor=color)
         axes.xaxis.label.set_color(color)
         axes.yaxis.label.set_color(color)


### PR DESCRIPTION
There is currently a bug where any minor ticks displayed will not match the user's global settings. (Note that this isn't an issue with the default settings, since the labels are black either way.) One prominent example is the scientific notation tick marks that are sometimes used when displaying an axis in log mode. See below for an example:

![log-label-colors](https://user-images.githubusercontent.com/14281631/171296270-548958ce-0e7b-4b72-8627-283437637cef.png)

This occurs because we only set major tick labels to match the given color in `set_foreground_color` (see the matplotlib documentation [here](https://matplotlib.org/3.1.1/api/_as_gen/matplotlib.axes.Axes.tick_params.html#matplotlib.axes.Axes.tick_params); the default value for `which` is `"major"`). This PR fixes the issue by setting `which="both"`).