### PR TITLE
Avoid float -> int conversion error in Python 3.10

### DIFF
--- a/glue/viewers/matplotlib/qt/widget.py
+++ b/glue/viewers/matplotlib/qt/widget.py
@@ -5,7 +5,7 @@ import matplotlib
 from matplotlib.figure import Figure
 
 from qtpy import QtCore, QtGui, QtWidgets
-from qtpy.QtCore import Qt
+from qtpy.QtCore import Qt, QRectF
 from glue.config import settings
 from glue.utils.matplotlib import DEFER_DRAW_BACKENDS
 
@@ -105,7 +105,7 @@ class MplCanvas(FigureCanvasQTAgg):
                     dpi_ratio = self.devicePixelRatio() or 1
                 except AttributeError:  # Matplotlib <2
                     dpi_ratio = 1
-                painter.drawRect(*(pt / dpi_ratio for pt in rect))
+                painter.drawRect(QRectF(*(pt / dpi_ratio for pt in rect)))
 
         # This function will be called at the end of the paintEvent
         self._draw_zoom_rect = _draw_zoom_rect


### PR DESCRIPTION
This PR addresses #2306. The cause of the problem is the call to `QPainter::drawRect` that is made [here](https://github.com/Carifio24/glue/blob/master/glue/viewers/matplotlib/qt/widget.py#L108). The unpacked arguments `*(pt / dpi_ratio for pt in rect)` is a list of floats, but the four-argument overload of `drawRect` has signature `drawRect(self, int, int, int, int)`. In Python <= 3.9, the interpreter (or at least CPython) would automatically make this conversion for us, but is no longer the case in 3.10 - see [here](https://bugs.python.org/issue37999). To fix this issue, this PR creates a `QRectF` to use as the argument for `drawRect`.
