### PR TITLE
Add `tests` requirement to publish workflow in CI

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -57,7 +57,6 @@ jobs:
         - macos: py38-test-pyqt514
         - macos: py310-test-pyqt515-all
           PLAT: arm64
-        - macos: py38-test-pyside514
 
         # Try out documentation build on macOS
         - macos: py37-docs-pyqt513
@@ -65,15 +64,38 @@ jobs:
 
         # Test some configurations on Windows
         - windows: py37-test-pyqt510
-        - windows: py38-test-pyqt514-all
         - windows: py310-test-pyqt515
-        - windows: py39-test-pyside515-all
 
         # Try out documentation build on Windows
         - windows: py38-docs-pyqt513
           coverage: false
 
+  allowed_failures:
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    with:
+      coverage: codecov
+      display: true
+      # The Linux PyQt 5.15 installation requires apt-getting its xcb deps and headless X11 display
+      libraries: |
+        apt:
+          - libxkbcommon-x11-dev
+          - libxcb-icccm4-dev
+          - libxcb-image0-dev
+          - libxcb-keysyms1-dev
+          - libxcb-randr0-dev
+          - libxcb-render-util0-dev
+          - libxcb-xinerama0-dev
+        brew:
+          - enchant
+      envs: |
+        # Some (PySide2 in particular) envs are failing with runtime errors
+        - linux: py38-test-pyside514
+        - macos: py38-test-pyside514
+        - windows: py38-test-pyqt514-all
+        - windows: py39-test-pyside515-all
+
   publish:
+    needs: tests
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@v1
     with:
       # Setup PyQt5 deps and headless X server as per pyvista/setup-headless-display-action@v1

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -27,13 +27,8 @@ jobs:
       # The Linux PyQt 5.15 installation requires apt-getting its xcb deps and headless X11 display
       libraries: |
         apt:
+          - '^libxcb.*-dev'
           - libxkbcommon-x11-dev
-          - libxcb-icccm4-dev
-          - libxcb-image0-dev
-          - libxcb-keysyms1-dev
-          - libxcb-randr0-dev
-          - libxcb-render-util0-dev
-          - libxcb-xinerama0-dev
         brew:
           - enchant
 
@@ -84,13 +79,8 @@ jobs:
       # The Linux PyQt 5.15 installation requires apt-getting its xcb deps and headless X11 display
       libraries: |
         apt:
+          - '^libxcb.*-dev'
           - libxkbcommon-x11-dev
-          - libxcb-icccm4-dev
-          - libxcb-image0-dev
-          - libxcb-keysyms1-dev
-          - libxcb-randr0-dev
-          - libxcb-render-util0-dev
-          - libxcb-xinerama0-dev
         brew:
           - enchant
       envs: |
@@ -105,7 +95,7 @@ jobs:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@v1
     with:
       # Setup PyQt5 deps and headless X server as per pyvista/setup-headless-display-action@v1
-      libraries: 'libxkbcommon-x11-dev libxcb-icccm4-dev libxcb-image0-dev libxcb-keysyms1-dev libxcb-randr0-dev libxcb-render-util0-dev libxcb-xinerama0-dev libgl1-mesa-glx xvfb'
+      libraries: '^libxcb.*-dev libxkbcommon-x11-dev libgl1-mesa-glx xvfb'
       test_extras: 'test,qt'
       test_command: Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 & sleep 3; DISPLAY=:99.0 pytest --pyargs glue
     secrets:

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -9,7 +9,17 @@ on:
   pull_request:
 
 jobs:
+  initial_checks:
+    # Mandatory checks before CI tests
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    with:
+      coverage: false
+      envs: |
+        # Code style
+        - linux: codestyle
+
   tests:
+    needs: initial_checks
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:
       coverage: codecov
@@ -28,11 +38,6 @@ jobs:
           - enchant
 
       envs: |
-        # Code style
-        - linux: codestyle
-          libraries:
-          coverage: false
-
         # Standard tests
         # Linux builds - test on all supported PyQt5 and PySide2 versions,
         # and include all dependencies in some builds
@@ -71,6 +76,7 @@ jobs:
           coverage: false
 
   allowed_failures:
+    needs: initial_checks
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:
       coverage: codecov

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+comment: off
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        # adjust accordingly based on how flaky your tests are
+        # this allows a 0.001% drop from the previous base commit coverage
+        # basically just to prevent counting zero changes as negative
+        threshold: 0.001%

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -969,7 +969,7 @@ class Data(BaseCartesianData):
                 raise TypeError("Cannot add a derived component as a first component")
             component.set_parent(self)
 
-        if not(self._check_can_add(component)):
+        if not self._check_can_add(component):
             raise ValueError("The dimensions of component %s are "
                              "incompatible with the dimensions of this data: "
                              "%r vs %r" % (label, component.shape, self.shape))

--- a/glue/utils/matplotlib.py
+++ b/glue/utils/matplotlib.py
@@ -112,7 +112,7 @@ def view_cascade(data, view):
     step = max(step, 1)
 
     for i, v in enumerate(v2):
-        if not(isinstance(v, slice)):
+        if not isinstance(v, slice):
             continue
         v2[i] = slice(0, shp[i - 1], step)
 

--- a/glue/viewers/custom/qt/elements.py
+++ b/glue/viewers/custom/qt/elements.py
@@ -50,7 +50,7 @@ class QLabeledSlider(QWidget):
         if self.integer:
             return int(value)
         else:
-            return(value)
+            return value
 
     _in_set_value = False
 


### PR DESCRIPTION
## Description
To let the `publish` job only run after all envs in `tests` have completed successfully; to allow this to actually happen added `allowed_failures` to the (mostly PySide2) envs that are failing or segfaulting more or less erratically.
Also adding a `codecov.yml` to keep it from failing at essentially zero changes (which is probably due rounding errors).