### PR TITLE
Experimental image rotation

### DIFF
--- a/glue/core/fixed_resolution_buffer.py
+++ b/glue/core/fixed_resolution_buffer.py
@@ -174,8 +174,18 @@ def compute_fixed_resolution_buffer(data, bounds, target_data=None, target_cid=N
 
     # Transform these coordinates by the affine transform if specified
     if affine_transform is not None:
-        pixel_coords = affine_transform(pixel_coords[1], pixel_coords[0])
-        pixel_coords = pixel_coords[1], pixel_coords[0]
+        ix, iy = None, None
+        for ibound, bound in enumerate(bounds):
+            if isinstance(bound, tuple):
+                if ix is None:
+                    ix = ibound
+                elif iy is None:
+                    iy = ibound
+                else:
+                    raise ValueError('Cannot set affine_transform for buffers that are not two-dimensional')
+        result = affine_transform(pixel_coords[iy], pixel_coords[ix])
+        pixel_coords[ix] = result[1]
+        pixel_coords[iy] = result[0]
 
     # Now loop through the dimensions of 'data' to find the corresponding
     # coordinates in the frame of view of this dataset.

--- a/glue/core/fixed_resolution_buffer.py
+++ b/glue/core/fixed_resolution_buffer.py
@@ -91,7 +91,7 @@ def bounds_for_cache(bounds, dimensions):
 
 def compute_fixed_resolution_buffer(data, bounds, target_data=None, target_cid=None,
                                     subset_state=None, broadcast=True, cache_id=None,
-                                    affine_transform=None):
+                                    transform=None):
     """
     Get a fixed-resolution buffer for a dataset.
 
@@ -117,6 +117,9 @@ def compute_fixed_resolution_buffer(data, bounds, target_data=None, target_cid=N
         is not a scalar does not affect any of the dimensions in ``data``,
         then the final array will be effectively broadcast along this
         dimension, otherwise an error will be raised.
+    transform : `~glue.core.roi_pretransform.Transform`
+        A transform to apply to the pixel locations of the fixed resolution
+        buffer before transforming them to other datasets.
     """
 
     if target_data is None:
@@ -138,12 +141,12 @@ def compute_fixed_resolution_buffer(data, bounds, target_data=None, target_cid=N
 
     if cache_id is not None:
 
-        if affine_transform is None:
+        if transform is None:
             affine_hash = b''
         else:
             # TODO: find a better way to do the following that doesn't rely
             # on a private attribute.
-            affine_hash = affine_transform._transform.get_matrix().tobytes()
+            affine_hash = transform.hash()
 
         if subset_state is None:
             # Use uuid for component ID since otherwise component IDs don't return
@@ -173,7 +176,7 @@ def compute_fixed_resolution_buffer(data, bounds, target_data=None, target_cid=N
     original_shape = pixel_coords[0].shape
 
     # Transform these coordinates by the affine transform if specified
-    if affine_transform is not None:
+    if transform is not None:
         ix, iy = None, None
         for ibound, bound in enumerate(bounds):
             if isinstance(bound, tuple):
@@ -183,7 +186,7 @@ def compute_fixed_resolution_buffer(data, bounds, target_data=None, target_cid=N
                     iy = ibound
                 else:
                     raise ValueError('Cannot set affine_transform for buffers that are not two-dimensional')
-        result = affine_transform(pixel_coords[iy], pixel_coords[ix])
+        result = transform(pixel_coords[iy], pixel_coords[ix])
         pixel_coords[ix] = result[1]
         pixel_coords[iy] = result[0]
 

--- a/glue/core/roi_pretransforms.py
+++ b/glue/core/roi_pretransforms.py
@@ -5,7 +5,11 @@ from matplotlib.transforms import Affine2D
 import numpy as np
 
 
-class ProjectionMplTransform(object):
+class Transform:
+    pass
+
+
+class ProjectionMplTransform(Transform):
     def __init__(self, projection, x_lim, y_lim, x_scale, y_scale):
         self._state = {'projection': projection, 'x_lim': x_lim, 'y_lim': y_lim,
                        'x_scale': x_scale, 'y_scale': y_scale}
@@ -33,7 +37,7 @@ class ProjectionMplTransform(object):
                    state['x_scale'], state['y_scale'])
 
 
-class RadianTransform(object):
+class RadianTransform(Transform):
     # We define 'next_transform' so that this pre-transform can
     # be chained together with another transformation, if desired
     def __init__(self, coords=[], next_transform=None):
@@ -60,7 +64,7 @@ class RadianTransform(object):
         return cls(state['coords'], state['next_transform'])
 
 
-class Affine2DTransform(object):
+class Affine2DTransform(Transform):
     # We define 'next_transform' so that this pre-transform can
     # be chained together with another transformation, if desired
     def __init__(self, affine_matrix=None, theta=0, xy=None, next_transform=None):
@@ -76,6 +80,9 @@ class Affine2DTransform(object):
             self._transform.rotate(theta)
         else:
             self._transform.rotate_around(*xy, theta)
+
+    def hash(self):
+        return self._transform.get_matrix().tobytes()
 
     def __call__(self, x, y):
         if np.isscalar(x):

--- a/glue/core/roi_pretransforms.py
+++ b/glue/core/roi_pretransforms.py
@@ -78,10 +78,13 @@ class Affine2DTransform(object):
             self._transform.rotate_around(*xy, theta)
 
     def __call__(self, x, y):
-        shape = x.shape
-        x, y = self._transform.transform(np.vstack([x.ravel(), y.ravel()]).T).T
-        x = x.reshape(shape)
-        y = y.reshape(shape)
+        if np.isscalar(x):
+            x, y = self._transform.transform(np.array([[x, y]]))[0]
+        else:
+            shape = x.shape
+            x, y = self._transform.transform(np.vstack([x.ravel(), y.ravel()]).T).T
+            x = x.reshape(shape)
+            y = y.reshape(shape)
         if self._next_transform is not None:
             return self._next_transform(x, y)
         else:

--- a/glue/viewers/image/layer_artist.py
+++ b/glue/viewers/image/layer_artist.py
@@ -186,7 +186,7 @@ class ImageLayerArtist(BaseImageLayerArtist):
 
         if force or any(prop in changed for prop in ('layer', 'attribute',
                                                      'slices', 'x_att', 'y_att',
-                                                     'affine_matrix')):
+                                                     'rotation')):
             self._update_image_data()
             force = True  # make sure scaling and visual attributes are updated
 

--- a/glue/viewers/image/layer_artist.py
+++ b/glue/viewers/image/layer_artist.py
@@ -347,7 +347,8 @@ class ImageSubsetLayerArtist(BaseImageLayerArtist):
         changed = self.pop_changed_properties()
 
         if force or any(prop in changed for prop in ('layer', 'attribute', 'color',
-                                                     'x_att', 'y_att', 'slices')):
+                                                     'x_att', 'y_att', 'slices',
+                                                     'rotation')):
             self._update_data()
             force = True  # make sure scaling and visual attributes are updated
 

--- a/glue/viewers/image/layer_artist.py
+++ b/glue/viewers/image/layer_artist.py
@@ -185,7 +185,8 @@ class ImageLayerArtist(BaseImageLayerArtist):
         changed = self.pop_changed_properties()
 
         if force or any(prop in changed for prop in ('layer', 'attribute',
-                                                     'slices', 'x_att', 'y_att')):
+                                                     'slices', 'x_att', 'y_att',
+                                                     'affine_matrix')):
             self._update_image_data()
             force = True  # make sure scaling and visual attributes are updated
 

--- a/glue/viewers/image/python_export.py
+++ b/glue/viewers/image/python_export.py
@@ -25,6 +25,9 @@ def python_export_image_layer(layer, *args):
     if transpose:
         options['transpose'] = True
 
+    if layer._viewer_state.rotation != 0:
+        options['rotation'] = layer._viewer_state.rotation
+
     script += "array_maker = get_sliced_data_maker({0})\n\n".format(serialize_options(options))
 
     script += "composite.allocate('{0}')\n".format(layer.uuid)
@@ -87,6 +90,9 @@ def python_export_image_subset_layer(layer, *args):
 
     if transpose:
         options['transpose'] = True
+
+    if layer._viewer_state.rotation != 0:
+        options['rotation'] = layer._viewer_state.rotation
 
     script += "array_maker = get_sliced_data_maker({0})\n\n".format(serialize_options(options))
 

--- a/glue/viewers/image/qt/options_widget.ui
+++ b/glue/viewers/image/qt/options_widget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>288</width>
-    <height>238</height>
+    <height>277</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -29,7 +29,7 @@
    <property name="verticalSpacing">
     <number>5</number>
    </property>
-   <item row="14" column="0">
+   <item row="10" column="0">
     <widget class="QTabWidget" name="tab_widget">
      <property name="currentIndex">
       <number>0</number>
@@ -57,6 +57,39 @@
        <property name="verticalSpacing">
         <number>5</number>
        </property>
+       <item row="5" column="0">
+        <widget class="QLabel" name="x_lab">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>y axis</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QComboBox" name="combosel_color_mode">
+         <property name="sizeAdjustPolicy">
+          <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QComboBox" name="combosel_aspect">
+         <property name="sizeAdjustPolicy">
+          <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="0" colspan="2">
+        <layout class="QVBoxLayout" name="layout_slices"/>
+       </item>
        <item row="0" column="0">
         <widget class="QLabel" name="label_3">
          <property name="font">
@@ -73,28 +106,7 @@
          </property>
         </widget>
        </item>
-       <item row="1" column="1">
-        <widget class="QComboBox" name="combosel_aspect">
-         <property name="sizeAdjustPolicy">
-          <enum>QComboBox::AdjustToMinimumContentsLength</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="1">
-        <widget class="QComboBox" name="combosel_reference_data">
-         <property name="sizeAdjustPolicy">
-          <enum>QComboBox::AdjustToMinimumContentsLength</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="0" colspan="2">
-        <widget class="Line" name="line">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="8" column="1">
+       <item row="14" column="1">
         <spacer name="horizontalSpacer_2">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
@@ -123,13 +135,6 @@
          </property>
         </widget>
        </item>
-       <item row="0" column="1">
-        <widget class="QComboBox" name="combosel_color_mode">
-         <property name="sizeAdjustPolicy">
-          <enum>QComboBox::AdjustToMinimumContentsLength</enum>
-         </property>
-        </widget>
-       </item>
        <item row="1" column="0">
         <widget class="QLabel" name="label">
          <property name="font">
@@ -143,6 +148,27 @@
          </property>
          <property name="alignment">
           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="QComboBox" name="combosel_x_att_world">
+         <property name="sizeAdjustPolicy">
+          <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QComboBox" name="combosel_reference_data">
+         <property name="sizeAdjustPolicy">
+          <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0" colspan="2">
+        <widget class="Line" name="line">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
          </property>
         </widget>
        </item>
@@ -162,22 +188,6 @@
          </property>
         </widget>
        </item>
-       <item row="5" column="0">
-        <widget class="QLabel" name="x_lab">
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>y axis</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
        <item row="5" column="1">
         <widget class="QComboBox" name="combosel_y_att_world">
          <property name="sizeAdjustPolicy">
@@ -185,17 +195,7 @@
          </property>
         </widget>
        </item>
-       <item row="4" column="1">
-        <widget class="QComboBox" name="combosel_x_att_world">
-         <property name="sizeAdjustPolicy">
-          <enum>QComboBox::AdjustToMinimumContentsLength</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="0" colspan="2">
-        <layout class="QVBoxLayout" name="layout_slices"/>
-       </item>
-       <item row="9" column="1">
+       <item row="15" column="1">
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -207,6 +207,42 @@
           </size>
          </property>
         </spacer>
+       </item>
+       <item row="12" column="1">
+        <widget class="QDoubleSpinBox" name="value_rotation">
+         <property name="minimum">
+          <double>-6.290000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>6.290000000000000</double>
+         </property>
+         <property name="singleStep">
+          <double>0.020000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="0" colspan="2">
+        <widget class="Line" name="line_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="12" column="0">
+        <widget class="QLabel" name="rot_lab">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>rotation</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>

--- a/glue/viewers/image/qt/tests/test_data_viewer.py
+++ b/glue/viewers/image/qt/tests/test_data_viewer.py
@@ -768,6 +768,12 @@ class TestImageViewer(object):
         assert self.viewer.state.y_min == -0.5
         assert self.viewer.state.y_max == 1.5
 
+    def test_rotation(self):
+        self.viewer.add_data(self.image1)
+        self.viewer.state.rotation = np.pi / 6
+        self.viewer.add_data(self.hypercube)
+        self.viewer.state.reference_data = self.hypercube
+
 
 class TestSessions(object):
 

--- a/glue/viewers/image/qt/tests/test_python_export.py
+++ b/glue/viewers/image/qt/tests/test_python_export.py
@@ -2,6 +2,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 from astropy.utils import NumpyRNGContext
 
+from glue.core.roi import RectangularROI
 from glue.core import Data, DataCollection
 from glue.app.qt.application import GlueApplication
 from glue.viewers.image.qt import ImageViewer
@@ -84,4 +85,16 @@ class TestExportPython(BaseTestExportPython):
         self.viewer.state.x_att = self.data.pixel_component_ids[0]
         self.viewer.state.y_att = self.data.pixel_component_ids[1]
         self.data_collection.new_subset_group('mysubset', self.data.id['cube'] > 0.5)
+        self.assert_same(tmpdir)
+
+    def test_rotation(self, tmpdir):
+        self.viewer.state.rotation = 0.2
+        self.viewer.apply_roi(RectangularROI(xmin=10, xmax=20, ymin=5, ymax=15))
+        self.assert_same(tmpdir)
+
+    def test_rotation_different_axis_order(self, tmpdir):
+        self.viewer.state.rotation = 0.2
+        self.viewer.state.x_att = self.data.pixel_component_ids[1]
+        self.viewer.state.y_att = self.data.pixel_component_ids[0]
+        self.viewer.apply_roi(RectangularROI(xmin=10, xmax=20, ymin=5, ymax=15))
         self.assert_same(tmpdir)

--- a/glue/viewers/image/state.py
+++ b/glue/viewers/image/state.py
@@ -43,11 +43,11 @@ def get_sliced_data_maker(x_axis=None, y_axis=None, slices=None, data=None,
         if isinstance(data, BaseData):
             array = data.compute_fixed_resolution_buffer(full_bounds, target_data=reference_data,
                                                          target_cid=target_cid, broadcast=False,
-                                                         affine_transform=affine_transform)
+                                                         transform=affine_transform)
         else:
             array = data.data.compute_fixed_resolution_buffer(full_bounds, target_data=reference_data,
                                                               subset_state=data.subset_state, broadcast=False,
-                                                              affine_transform=affine_transform)
+                                                              transform=affine_transform)
 
         if transpose:
             array = array.transpose()
@@ -423,7 +423,6 @@ class ImageViewerState(MatplotlibDataViewerState):
                                xy=(self.reference_data.shape[1] / 2,
                                    self.reference_data.shape[0] / 2))
 
-
         # Find new center
         x_cen_new, y_cen_new = tr(x_cen, y_cen)
 
@@ -514,11 +513,11 @@ class BaseImageLayerState(MatplotlibLayerState):
                 affine_pretransform = affine_pretransform.inverse
             image = self.layer.compute_fixed_resolution_buffer(full_view, target_data=self.viewer_state.reference_data,
                                                                target_cid=self.attribute, broadcast=False, cache_id=self.uuid,
-                                                               affine_transform=affine_pretransform)
+                                                               transform=affine_pretransform)
         else:
             image = self.layer.data.compute_fixed_resolution_buffer(full_view, target_data=self.viewer_state.reference_data,
                                                                     subset_state=self.layer.subset_state, broadcast=False, cache_id=self.uuid,
-                                                                    affine_transform=affine_pretransform)
+                                                                    transform=affine_pretransform)
 
         # We apply aggregation functions if needed
 

--- a/glue/viewers/image/state.py
+++ b/glue/viewers/image/state.py
@@ -34,7 +34,7 @@ def get_sliced_data_maker(x_axis=None, y_axis=None, slices=None, data=None,
         full_bounds[x_axis] = bounds[1]
 
         if rotation is not None and rotation != 0:
-            affine_transform = Affine2DTransform(theta=rotation,
+            affine_transform = Affine2DTransform(theta=-rotation,
                                                  xy=(reference_data.shape[1] / 2,
                                                      reference_data.shape[0] / 2))
         else:

--- a/glue/viewers/image/state.py
+++ b/glue/viewers/image/state.py
@@ -514,11 +514,11 @@ class BaseImageLayerState(MatplotlibLayerState):
                 affine_pretransform = affine_pretransform.inverse
             image = self.layer.compute_fixed_resolution_buffer(full_view, target_data=self.viewer_state.reference_data,
                                                                target_cid=self.attribute, broadcast=False, cache_id=self.uuid,
-                                                               affine_transform=self.viewer_state._affine_pretransform.inverse)
+                                                               affine_transform=affine_pretransform)
         else:
             image = self.layer.data.compute_fixed_resolution_buffer(full_view, target_data=self.viewer_state.reference_data,
                                                                     subset_state=self.layer.subset_state, broadcast=False, cache_id=self.uuid,
-                                                                    affine_transform=self.viewer_state._affine_pretransform.inverse)
+                                                                    affine_transform=affine_pretransform)
 
         # We apply aggregation functions if needed
 

--- a/glue/viewers/image/state.py
+++ b/glue/viewers/image/state.py
@@ -508,11 +508,11 @@ class BaseImageLayerState(MatplotlibLayerState):
         if isinstance(self.layer, BaseData):
             image = self.layer.compute_fixed_resolution_buffer(full_view, target_data=self.viewer_state.reference_data,
                                                                target_cid=self.attribute, broadcast=False, cache_id=self.uuid,
-                                                               affine_transform=self.viewer_state._affine_pretransform)
+                                                               affine_transform=self.viewer_state._affine_pretransform.inverse)
         else:
             image = self.layer.data.compute_fixed_resolution_buffer(full_view, target_data=self.viewer_state.reference_data,
                                                                     subset_state=self.layer.subset_state, broadcast=False, cache_id=self.uuid,
-                                                                    affine_transform=self.viewer_state._affine_pretransform)
+                                                                    affine_transform=self.viewer_state._affine_pretransform.inverse)
 
         # We apply aggregation functions if needed
 

--- a/glue/viewers/image/state.py
+++ b/glue/viewers/image/state.py
@@ -419,7 +419,7 @@ class ImageViewerState(MatplotlibDataViewerState):
         dr = rotation_new - rotation_old
 
         # Set up transformation
-        tr = Affine2DTransform(theta=-dr,
+        tr = Affine2DTransform(theta=dr,
                                xy=(self.reference_data.shape[1] / 2,
                                    self.reference_data.shape[0] / 2))
 

--- a/glue/viewers/image/state.py
+++ b/glue/viewers/image/state.py
@@ -433,6 +433,9 @@ class ImageViewerState(MatplotlibDataViewerState):
             self.x_max = x_cen_new + 0.5 * dx
             self.y_min = y_cen_new - 0.5 * dy
             self.y_max = y_cen_new + 0.5 * dy
+            # We need to adjust the limits in here to avoid triggering all
+            # the update events then changing the limits again.
+            self._adjust_limits_aspect()
 
 
 class BaseImageLayerState(MatplotlibLayerState):

--- a/glue/viewers/image/state.py
+++ b/glue/viewers/image/state.py
@@ -507,10 +507,11 @@ class BaseImageLayerState(MatplotlibLayerState):
 
         # We now get the fixed resolution buffer
 
+        affine_pretransform = self.viewer_state._affine_pretransform
+        if affine_pretransform is not None:
+            affine_pretransform = affine_pretransform.inverse
+
         if isinstance(self.layer, BaseData):
-            affine_pretransform = self.viewer_state._affine_pretransform
-            if affine_pretransform is not None:
-                affine_pretransform = affine_pretransform.inverse
             image = self.layer.compute_fixed_resolution_buffer(full_view, target_data=self.viewer_state.reference_data,
                                                                target_cid=self.attribute, broadcast=False, cache_id=self.uuid,
                                                                transform=affine_pretransform)

--- a/glue/viewers/image/state.py
+++ b/glue/viewers/image/state.py
@@ -18,7 +18,8 @@ __all__ = ['ImageViewerState', 'ImageLayerState', 'ImageSubsetLayerState', 'Aggr
 
 
 def get_sliced_data_maker(x_axis=None, y_axis=None, slices=None, data=None,
-                          target_cid=None, reference_data=None, transpose=False):
+                          target_cid=None, reference_data=None, transpose=False,
+                          rotation=None):
     """
     Convenience function for use in exported Python scripts.
     """
@@ -32,12 +33,21 @@ def get_sliced_data_maker(x_axis=None, y_axis=None, slices=None, data=None,
         full_bounds[y_axis] = bounds[0]
         full_bounds[x_axis] = bounds[1]
 
+        if rotation is not None and rotation != 0:
+            affine_transform = Affine2DTransform(theta=rotation,
+                                                 xy=(reference_data.shape[1] / 2,
+                                                     reference_data.shape[0] / 2))
+        else:
+            affine_transform = None
+
         if isinstance(data, BaseData):
             array = data.compute_fixed_resolution_buffer(full_bounds, target_data=reference_data,
-                                                         target_cid=target_cid, broadcast=False)
+                                                         target_cid=target_cid, broadcast=False,
+                                                         affine_transform=affine_transform)
         else:
             array = data.data.compute_fixed_resolution_buffer(full_bounds, target_data=reference_data,
-                                                              subset_state=data.subset_state, broadcast=False)
+                                                              subset_state=data.subset_state, broadcast=False,
+                                                              affine_transform=affine_transform)
 
         if transpose:
             array = array.transpose()
@@ -389,8 +399,8 @@ class ImageViewerState(MatplotlibDataViewerState):
             return None
         else:
             return Affine2DTransform(theta=self.rotation,
-                                    xy=(self.reference_data.shape[1] / 2,
-                                        self.reference_data.shape[0] / 2))
+                                     xy=(self.reference_data.shape[1] / 2,
+                                         self.reference_data.shape[0] / 2))
 
 
 class BaseImageLayerState(MatplotlibLayerState):

--- a/glue/viewers/image/state.py
+++ b/glue/viewers/image/state.py
@@ -509,6 +509,9 @@ class BaseImageLayerState(MatplotlibLayerState):
         # We now get the fixed resolution buffer
 
         if isinstance(self.layer, BaseData):
+            affine_pretransform = self.viewer_state._affine_pretransform
+            if affine_pretransform is not None:
+                affine_pretransform = affine_pretransform.inverse
             image = self.layer.compute_fixed_resolution_buffer(full_view, target_data=self.viewer_state.reference_data,
                                                                target_cid=self.attribute, broadcast=False, cache_id=self.uuid,
                                                                affine_transform=self.viewer_state._affine_pretransform.inverse)

--- a/glue/viewers/image/state.py
+++ b/glue/viewers/image/state.py
@@ -71,6 +71,8 @@ class ImageViewerState(MatplotlibDataViewerState):
     A state class that includes all the attributes for an image viewer.
     """
 
+    affine_matrix = DDCProperty(None, docstring='The affine matrix to apply to the viewport')
+
     x_att = DDCProperty(docstring='The component ID giving the pixel component '
                                   'shown on the x axis')
     y_att = DDCProperty(docstring='The component ID giving the pixel component '
@@ -450,10 +452,12 @@ class BaseImageLayerState(MatplotlibLayerState):
 
         if isinstance(self.layer, BaseData):
             image = self.layer.compute_fixed_resolution_buffer(full_view, target_data=self.viewer_state.reference_data,
-                                                               target_cid=self.attribute, broadcast=False, cache_id=self.uuid)
+                                                               target_cid=self.attribute, broadcast=False, cache_id=self.uuid,
+                                                               affine_matrix=self.viewer_state.affine_matrix)
         else:
             image = self.layer.data.compute_fixed_resolution_buffer(full_view, target_data=self.viewer_state.reference_data,
-                                                                    subset_state=self.layer.subset_state, broadcast=False, cache_id=self.uuid)
+                                                                    subset_state=self.layer.subset_state, broadcast=False, cache_id=self.uuid,
+                                                                    affine_matrix=self.viewer_state.affine_matrix)
 
         # We apply aggregation functions if needed
 

--- a/glue/viewers/image/viewer.py
+++ b/glue/viewers/image/viewer.py
@@ -164,7 +164,7 @@ class MatplotlibImageMixin(object):
                                            use_pretransform=self.state._affine_pretransform is not None)
 
         if self.state._affine_pretransform is not None:
-            subset_state.pretransform = self.state._affine_pretransform.inverse
+            subset_state.pretransform = self.state._affine_pretransform
 
         self.apply_subset_state(subset_state, override_mode=override_mode)
 

--- a/glue/viewers/image/viewer.py
+++ b/glue/viewers/image/viewer.py
@@ -6,6 +6,7 @@ from astropy.wcs import WCS
 from glue.core.subset import roi_to_subset_state
 from glue.core.coordinates import Coordinates, LegacyCoordinates
 from glue.core.coordinate_helpers import dependent_axes
+from glue.core.roi_pretransforms import Affine2DTransform
 
 from glue.viewers.scatter.layer_artist import ScatterLayerArtist
 from glue.viewers.image.layer_artist import ImageLayerArtist, ImageSubsetLayerArtist
@@ -164,15 +165,9 @@ class MatplotlibImageMixin(object):
                                            use_pretransform=self.state.affine_matrix is not None)
 
         if self.state.affine_matrix is not None:
+            transform = Affine2DTransform(self.state.affine_matrix)
 
-            def wrapper(x, y):
-                import numpy as np
-                shape = x.shape
-                xn, yn = self.state.affine_matrix.transform(np.vstack([x.ravel(), y.ravel()]).T).T
-                xn, yn = xn.reshape(shape), yn.reshape(shape)
-                return xn, yn
-
-            subset_state.pretransform = wrapper
+            subset_state.pretransform = transform
 
         self.apply_subset_state(subset_state, override_mode=override_mode)
 

--- a/glue/viewers/image/viewer.py
+++ b/glue/viewers/image/viewer.py
@@ -1,4 +1,5 @@
 import os
+from tkinter.messagebox import YESNO
 
 from astropy.wcs import WCS
 
@@ -159,7 +160,19 @@ class MatplotlibImageMixin(object):
 
         subset_state = roi_to_subset_state(roi,
                                            x_att=self.state.x_att,
-                                           y_att=self.state.y_att)
+                                           y_att=self.state.y_att,
+                                           use_pretransform=self.state.affine_matrix is not None)
+
+        if self.state.affine_matrix is not None:
+
+            def wrapper(x, y):
+                import numpy as np
+                shape = x.shape
+                xn, yn = self.state.affine_matrix.transform(np.vstack([x.ravel(), y.ravel()]).T).T
+                xn, yn = xn.reshape(shape), yn.reshape(shape)
+                return xn, yn
+
+            subset_state.pretransform = wrapper
 
         self.apply_subset_state(subset_state, override_mode=override_mode)
 

--- a/glue/viewers/image/viewer.py
+++ b/glue/viewers/image/viewer.py
@@ -1,5 +1,4 @@
 import os
-from tkinter.messagebox import YESNO
 
 from astropy.wcs import WCS
 
@@ -162,12 +161,10 @@ class MatplotlibImageMixin(object):
         subset_state = roi_to_subset_state(roi,
                                            x_att=self.state.x_att,
                                            y_att=self.state.y_att,
-                                           use_pretransform=self.state.affine_matrix is not None)
+                                           use_pretransform=self.state._affine_pretransform is not None)
 
-        if self.state.affine_matrix is not None:
-            transform = Affine2DTransform(self.state.affine_matrix)
-
-            subset_state.pretransform = transform
+        if self.state._affine_pretransform is not None:
+            subset_state.pretransform = self.state._affine_pretransform.inverse
 
         self.apply_subset_state(subset_state, override_mode=override_mode)
 

--- a/glue/viewers/image/viewer.py
+++ b/glue/viewers/image/viewer.py
@@ -5,7 +5,6 @@ from astropy.wcs import WCS
 from glue.core.subset import roi_to_subset_state
 from glue.core.coordinates import Coordinates, LegacyCoordinates
 from glue.core.coordinate_helpers import dependent_axes
-from glue.core.roi_pretransforms import Affine2DTransform
 
 from glue.viewers.scatter.layer_artist import ScatterLayerArtist
 from glue.viewers.image.layer_artist import ImageLayerArtist, ImageSubsetLayerArtist


### PR DESCRIPTION
For now this makes it possible to apply an arbitrary affine transform to the image viewport.

* [x] Also apply transformations to selections (check how this is done for polar selections as we can likely re-use this)
* [x] Clean up API in compute_fixed_resolution_buffer

To do once things work on the jdaviz side:

* [ ] Fix rotation of markers in Matplotlib viewers
* [ ] Update WCS labels in Matplotlib viewer - we should do this by developing an APE-14-compliant rotated WCS class and adding it to the WCS at the last minute.
