### PR TITLE
Test PyQt6 and PySide6 envs in CI

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -76,19 +76,30 @@ jobs:
     with:
       coverage: codecov
       display: true
-      # The Linux PyQt 5.15 installation requires apt-getting its xcb deps and headless X11 display
+      # Linux PyQt 5.15 and 6.3 installations require apt-getting xcb and EGL deps
       libraries: |
         apt:
           - '^libxcb.*-dev'
           - libxkbcommon-x11-dev
+          - libegl1-mesa
         brew:
           - enchant
       envs: |
-        # Some (PySide2 in particular) envs are failing with runtime errors
+        # Some (PySide2 in particular) envs are failing with runtime errors;
+        # PyQt6 and PySide6 support in progress
         - linux: py38-test-pyside514
+        - linux: py310-test-pyqt63-all
+        - linux: py310-test-pyside63
+
         - macos: py38-test-pyside514
+        - macos: py310-test-pyqt63
+        - macos: py310-test-pyside63
+
         - windows: py38-test-pyqt514-all
         - windows: py39-test-pyside515-all
+        - windows: py310-test-pyqt63
+        - windows: py310-test-pyside63
+
 
   publish:
     needs: tests

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{37,38,39,310}-{codestyle,test,docs}-{pyqt57,pyqt58,pyqt59,pyqt510,pyqt511,pyqt512,pyqt513,pyside511,pyside512,pyside513,pyside514,pyside515}-all-{dev,legacy}
+    py{37,38,39,310}-{codestyle,test,docs}-{pyqt59,pyqt510,pyqt511,pyqt512,pyqt513,pyside511,pyside512,pyside513,pyside514,pyside515,pyqt63,pyside63}-all-{dev,legacy}
 requires = pip >= 18.0
            setuptools >= 30.3.0
 
@@ -28,11 +28,13 @@ deps =
     pyqt513: PyQt5==5.13.*
     pyqt514: PyQt5==5.14.*
     pyqt515: PyQt5==5.15.*
+    pyqt63: PyQt6==6.3.*
     pyside511: PySide2==5.11.*
     pyside512: PySide2==5.12.*
     pyside513: PySide2==5.13.*
     pyside514: PySide2==5.14.*
     pyside515: PySide2==5.15.*
+    pyside63: PySide6==6.3.*
     dev: git+https://github.com/numpy/numpy
     dev: git+https://github.com/astropy/astropy
     legacy: numpy==1.17.*


### PR DESCRIPTION
## Description
Adding configurations for PyQt6 6.3 and PySide6 6.3 envs each on linux, macos and windows; work on supporting them is underway in #2318.