### PR TITLE
Don't change labels when using log scale axes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ Full changelog
 v1.6.0 (unreleased)
 -------------------
 
+* Modify scatter viewer to not prepend axis labels with 'Log' when using log scale axes. [#2323]
+
 * Fixed a bug where minor tick marks were not respecting the settings colors. [#2305]
 
 * Fix an issue where the histogram layer artist would not redraw if

--- a/glue/viewers/scatter/qt/tests/test_data_viewer.py
+++ b/glue/viewers/scatter/qt/tests/test_data_viewer.py
@@ -208,7 +208,7 @@ class TestScatterViewer(object):
 
         viewer_state.x_log = True
 
-        assert self.viewer.axes.get_xlabel() == 'Log x'
+        assert self.viewer.axes.get_xlabel() == 'x'
         assert self.viewer.axes.get_ylabel() == 'y'
 
         viewer_state.x_att = self.data.id['y']
@@ -219,7 +219,7 @@ class TestScatterViewer(object):
         viewer_state.y_log = True
 
         assert self.viewer.axes.get_xlabel() == 'y'
-        assert self.viewer.axes.get_ylabel() == 'Log y'
+        assert self.viewer.axes.get_ylabel() == 'y'
 
     def test_component_replaced(self):
 

--- a/glue/viewers/scatter/viewer.py
+++ b/glue/viewers/scatter/viewer.py
@@ -46,18 +46,10 @@ class MatplotlibScatterMixin(object):
         self._update_ticks(args)
 
         if self.state.x_att is not None:
-
-            if self.state.x_log:
-                self.state.x_axislabel = 'Log ' + self.state.x_att.label
-            else:
-                self.state.x_axislabel = self.state.x_att.label
+            self.state.x_axislabel = self.state.x_att.label
 
         if self.state.y_att is not None:
-
-            if self.state.y_log:
-                self.state.y_axislabel = 'Log ' + self.state.y_att.label
-            else:
-                self.state.y_axislabel = self.state.y_att.label
+            self.state.y_axislabel = self.state.y_att.label
 
         self.axes.figure.canvas.draw_idle()
 


### PR DESCRIPTION
This PR addresses #2193. As pointed out there, "Log" shouldn't be prepended to the axis label when using log scale axes, since we aren't actually plotting the log of the component values. This also modifies the `test_axes_labels` test to account for this change.