### PR TITLE
Fix issue where matplotlib viewers using ``y`` log axes were not initialized correctly.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,8 +4,6 @@ Full changelog
 v1.6.0 (unreleased)
 -------------------
 
-* Fix issue where matplotlib viewers using y log axes were not initialized correctly. [#2324]
-
 * Added one-to-one ``join_on_key``-type links to the link-manager allowing 
   them to be created and deleted through the UI. This option is available 
   under 'Create advanced link>Join>Join on ID.' [#2215]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ Full changelog
 v1.6.0 (unreleased)
 -------------------
 
+* Fix issue where matplotlib viewers using y log axes were not initialized correctly. [#2324]
+
 * Added one-to-one ``join_on_key``-type links to the link-manager allowing 
   them to be created and deleted through the UI. This option is available 
   under 'Create advanced link>Join>Join on ID.' [#2215]

--- a/glue/viewers/matplotlib/viewer.py
+++ b/glue/viewers/matplotlib/viewer.py
@@ -100,6 +100,7 @@ class MatplotlibViewerMixin(object):
         self.state.add_callback('y_log', self.update_y_log, priority=1000)
 
         self.update_x_log()
+        self.update_y_log()
 
         self.axes.callbacks.connect('xlim_changed', self.limits_from_mpl)
         self.axes.callbacks.connect('ylim_changed', self.limits_from_mpl)


### PR DESCRIPTION
This PR aims to fix #2194, which actually affects any of the matplotlib viewers that use log axes. The reason for the incorrect aspect described in the issue is that we currently only update the x log axes when setting up callbacks. This PR adds a call to `update_y_log` as well.
