### PR TITLE
Don't change labels when using log x axis in histogram viewer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ Full changelog
 v1.6.0 (unreleased)
 -------------------
 
+* Modify histogram viewer to not prepend x-axis label with 'Log' when using a log scale x-axis. [#2325]
+
 * Modify scatter viewer to not prepend axis labels with 'Log' when using log scale axes. [#2323]
 
 * Fixed a bug where minor tick marks were not respecting the settings colors. [#2305]

--- a/glue/viewers/histogram/qt/tests/test_data_viewer.py
+++ b/glue/viewers/histogram/qt/tests/test_data_viewer.py
@@ -347,7 +347,7 @@ class TestHistogramViewer(object):
 
         viewer_state.x_log = True
 
-        assert self.viewer.axes.get_xlabel() == 'Log x'
+        assert self.viewer.axes.get_xlabel() == 'x'
         assert self.viewer.axes.get_ylabel() == 'Number'
 
         viewer_state.x_att = self.data.id['y']

--- a/glue/viewers/histogram/viewer.py
+++ b/glue/viewers/histogram/viewer.py
@@ -23,10 +23,7 @@ class MatplotlibHistogramMixin(object):
             # Update ticks, which sets the labels to categories if components are categorical
             update_ticks(self.axes, 'x', self.state.x_kinds, self.state.x_log, self.state.x_categories)
 
-            if self.state.x_log:
-                self.state.x_axislabel = 'Log ' + self.state.x_att.label
-            else:
-                self.state.x_axislabel = self.state.x_att.label
+            self.state.x_axislabel = self.state.x_att.label
 
         if self.state.normalize:
             self.state.y_axislabel = 'Normalized number'


### PR DESCRIPTION
This PR, like #2323, addresses #2193. The original issue only mentioned the scatter viewer, which was taken care of in #2323, but the same logic applies to the x-axis label in the histogram viewer. This PR makes that change, as well as updates the histogram viewer's `test_axes_labels` test accordingly.