### PR TITLE
Fix bugs in BaseCartesianData.get_data for pixel and world component IDs

### DIFF
--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -442,13 +442,16 @@ class BaseCartesianData(BaseData, metaclass=abc.ABCMeta):
         if cid in self.pixel_component_ids:
             shape = tuple(-1 if i == cid.axis else 1 for i in range(self.ndim))
             pix = np.arange(self.shape[cid.axis], dtype=float).reshape(shape)
-            return broadcast_to(pix, self.shape)[view]
-        elif cid in self.world_component_ids:
-            comp = self.world_components[cid]
-            if view is not None:
-                result = comp[view]
+            if view is None:
+                return broadcast_to(pix, self.shape)
             else:
-                result = comp.data
+                return broadcast_to(pix, self.shape)[view]
+        elif cid in self.world_component_ids:
+            comp = self._world_components[cid]
+            if view is None:
+                return comp.data
+            else:
+                return comp[view]
         else:
             raise IncompatibleAttribute(cid)
 

--- a/glue/core/tests/test_data.py
+++ b/glue/core/tests/test_data.py
@@ -1163,3 +1163,11 @@ def test_base_cartesian_data_coords():
     data2 = CustomData(coords=IdentityCoordinates(n_dim=3))
     assert len(data2.pixel_component_ids) == 3
     assert len(data2.world_component_ids) == 3
+
+    for idx in range(3):
+
+        assert_allclose(data2[data2.world_component_ids[idx]],
+                        data2[data2.pixel_component_ids[idx]])
+
+        assert_allclose(data2[data2.world_component_ids[idx], (0, slice(2), 2)],
+                        data2[data2.pixel_component_ids[idx], (0, slice(2), 2)])


### PR DESCRIPTION
Found while trying to work on linking for BaseCartesianData