### PR TITLE
Setup automated changelog generation for release process

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,21 @@
+changelog:
+  exclude:
+    authors:
+      - pre-commit-ci
+    labels:
+      - no-changelog-entry-needed
+      - skip-changelog
+
+  categories:
+    - title: Bug Fixes
+      labels:
+        - bug
+    - title: New Features
+      labels:
+        - enhancement
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -1,0 +1,33 @@
+# This workflow takes the GitHub release notes and updates the changelog on the
+# main branch with the body of the release notes, thereby keeping a log in
+# the git repo of the changes.
+
+name: "Update Changelog"
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: main
+
+      - name: Update Changelog
+        uses: stefanzweifel/changelog-updater-action@v1
+        with:
+          release-notes: ${{ github.event.release.body }}
+          latest-version: ${{ github.event.release.name }}
+          path-to-changelog: CHANGES.md
+
+      - name: Commit updated Changelog
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          branch: main
+          commit_message: Update CHANGELOG
+          file_pattern: CHANGES.md

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,447 +1,484 @@
-Full changelog
-==============
+# Full changelog
 
-v1.6.0 (unreleased)
--------------------
+## [v1.5.0](https://github.com/glue-viz/glue/compare/v1.4.0...v1.5.0) - 2022-06-28
 
-* Added one-to-one ``join_on_key``-type links to the link-manager allowing 
-  them to be created and deleted through the UI. This option is available 
-  under 'Create advanced link>Join>Join on ID.' [#2215]
+### What's Changed
 
-* Modify histogram viewer to not prepend x-axis label with 'Log' when using a log scale x-axis. [#2325]
+#### New Features
 
-* Modify scatter viewer to not prepend axis labels with 'Log' when using log scale axes. [#2323]
-
-* Fixed a bug where minor tick marks were not respecting the settings colors. [#2305]
-
-* Fix an issue where the histogram layer artist would not redraw if
-  the histogram sum was zero. [#2300]
-
-v1.5.0 (2022-06-28)
--------------------
-
-* Fixed a bug on setting a return view in `compute_statistic` when a subset
-  is defined, resulting in a broadcast error in arrays large enough to need
-  chunking. [#2302]
-
-* Added rotation angle ``theta`` as a property to regions of interest,
+- Added rotation angle ``theta`` as a property to regions of interest,
   to be set on instantiation or modified using the ``rotate_to`` and
   ``rotate_by`` methods. [#2235]
 
-v1.4.0 (2022-05-31)
--------------------
+#### Bug Fixes
 
-* Add support for specifying visual attributes when creating a subset group. [#2297]
+- Fixed a bug on setting a return view in ``compute_statistic`` when a subset
+  is defined, resulting in a broadcast error in arrays large enough to need
+  chunking. [#2302]
 
-* Modify profile viewer so that when in 'Sum' mode, parts of profiles
+## [v1.4.0](https://github.com/glue-viz/glue/compare/v1.3.0...v1.4.0) - 2022-05-31
+
+### What's Changed
+
+#### New Features
+
+- Add support for specifying visual attributes when creating a subset group. [#2297]
+
+- Add support for using degrees in full-sphere projections. [#2279]
+
+#### Bug Fixes
+
+- Modify profile viewer so that when in 'Sum' mode, parts of profiles
   with no valid values are NaN rather than zero. [#2298]
 
-* Add support for using degrees in full-sphere projections. [#2279]
+## [v1.3.0](https://github.com/glue-viz/glue/compare/v1.2.4...v1.3.0) - 2022-04-22
 
-v1.3.0 (2022-04-22)
--------------------
+### What's Changed
 
-* Modify scatter viewer so that axis labels are shown in tick marks
+#### New Features
+
+- Modify scatter viewer so that axis labels are shown in tick marks
   when in polar mode. [#2267]
 
-* Remove bundled version of pvextractor and include it as a proper
-  dependency. [#2252]
+- Support toggling plotting profile viewer layer as steps. [#2292]
 
-* Support toggling plotting profile viewer layer as steps. [#2292]
+#### Bug Fixes
 
-* Reset limits in profile viewer when changing collapse function. [#2277]
+- Reset limits in profile viewer when changing collapse function. [#2277]
 
-* Fixed a bug that caused an error when the table viewer tried to show
+- Fixed a bug that caused an error when the table viewer tried to show
   disabled layers. [#2286]
 
-* Fixed an issue where glue modified global logging settings. [#2281]
+- Fixed an issue where glue modified global logging settings. [#2281]
 
-v1.2.4 (2022-01-27)
--------------------
+#### Other Changes
 
-* Fixed a bug that caused selections to no longer work
+- Remove bundled version of pvextractor and include it as a proper
+  dependency. [#2252]
+
+## [v1.2.4](https://github.com/glue-viz/glue/compare/v1.2.3...v1.2.4) - 2022-01-27
+
+### What's Changed
+
+#### Bug Fixes
+
+- Fixed a bug that caused selections to no longer work
   in a scatter viewer once its projection had been changed. [#2262]
 
-* Fixed a bug which prevented serialization for polar plots in degree
+- Fixed a bug which prevented serialization for polar plots in degree
   mode. [#2259]
 
-* Fixed a bug that caused histograms and density maps to not work
+- Fixed a bug that caused histograms and density maps to not work
   correctly with attributes linked using ``join_on_key``. [#2242]
 
-* Fixed issues in viewers when dask arrays were used. [#2249]
+- Fixed issues in viewers when dask arrays were used. [#2249]
 
-v1.2.3 (2021-11-14)
--------------------
+## [v1.2.3](https://github.com/glue-viz/glue/compare/v1.2.2...v1.2.3) - 2021-11-14
 
-* Fixed compatibility with Matplotlib 3.5.0. [#2250]
+### What's Changed
 
-* Remove bottleneck dependency as it is no longer maintained. Certain
+#### Bug Fixes
+
+- Fixed compatibility with Matplotlib 3.5.0. [#2250]
+
+- Fixed compatibility with Python 3.10 and recent versions of PyQt. [#2258]
+
+#### Other Changes
+
+- Remove bottleneck dependency as it is no longer maintained. Certain
   array operations may be slower as a result. [#2258]
 
-* Fixed compatibility with Python 3.10 and recent versions of PyQt. [#2258]
+## [v1.2.2](https://github.com/glue-viz/glue/compare/v1.2.1...v1.2.2) - 2021-09-16
 
-v1.2.2 (2021-09-16)
--------------------
+### What's Changed
 
-* Prevent resetting of image viewer limits when adding a dataset to the
+#### Bug Fixes
+
+- Prevent resetting of image viewer limits when adding a dataset to the
   viewer. [#2232]
 
-* Fixed home button for resetting limits in profile viewer. [#2233]
+- Fixed home button for resetting limits in profile viewer. [#2233]
 
-* Fixed a bug that caused the visibility checkbox of layers in the profile
+- Fixed a bug that caused the visibility checkbox of layers in the profile
   viewer to not always correctly. [#2233]
 
-* Fixed a bug that caused the profile viewer limits to be unecessarily
+- Fixed a bug that caused the profile viewer limits to be unecessarily
   changed every time a subset was updated or a dataset was added. [#2233]
 
-v1.2.1 (2021-08-24)
--------------------
+## [v1.2.1](https://github.com/glue-viz/glue/compare/v1.2.0...v1.2.1) - 2021-08-24
 
-* Fixed a bug that caused issues with packages depending on glue which
+### What's Changed
+
+#### Bug Fixes
+
+- Fixed a bug that caused issues with packages depending on glue which
   defined layer artists with no zorder on the artist class. [#2226, #2227]
 
-v1.2.0 (2021-08-14)
--------------------
+## [v1.2.0](https://github.com/glue-viz/glue/compare/v1.1.0...v1.2.0) - 2021-08-14
 
-* Added a new ``WCSLink.as_affine_link`` method which can be used to find
+### What's Changed
+
+#### New Features
+
+- Added a new ``WCSLink.as_affine_link`` method which can be used to find
   an affine approximation to a WCSLink. [#2219]
 
-* Avoid duplicate update of layer artist when creating a new layer. [#2220]
-
-* Expose ``DataCollection.delay_link_manager_update`` which can be used
+- Expose ``DataCollection.delay_link_manager_update`` which can be used
   to delay any updating to the link tree when adding datasets. [#2225]
 
-* Allow CategoricalComponents to be n-dimensional. [#2214]
+- Allow CategoricalComponents to be n-dimensional. [#2214]
 
-* Improve usability of 2D scatter plot in non-cartesian projection. [#2200]
+- Improve usability of 2D scatter plot in non-cartesian projection. [#2200]
 
-v1.1.0 (2021-07-21)
--------------------
+#### Bug Fixes
 
-* Fix compatibility with xlrd 2.0 and require openpyxl for .xlsx input. [#2196]
+- Avoid duplicate update of layer artist when creating a new layer. [#2220]
 
-* Dropped support for Python 3.6. [#2196]
+## [v1.1.0](https://github.com/glue-viz/glue/compare/v1.0.1...v1.1.0) - 2021-07-21
 
-* Fixed compatibility with recent releases of Matplotlib. [#2196]
+### What's Changed
 
-* Avoid warnings with recent releases of astropy. [#2212]
+#### Bug Fixes
 
-* Fixed compatibility of auto-linking with all APE 14 WCSes. [#2209]
+- Fix compatibility with xlrd 2.0 and require openpyxl for .xlsx input. [#2196]
 
-v1.0.1 (2020-11-10)
--------------------
+- Fixed compatibility with recent releases of Matplotlib. [#2196]
 
-* Updated supported versions of jupyter_client. [#2175]
+- Avoid warnings with recent releases of astropy. [#2212]
 
-v1.0.0 (2020-09-17)
--------------------
+- Fixed compatibility of auto-linking with all APE 14 WCSes. [#2209]
 
-* Remove bundled echo package and list as a dependency. [#2125]
+#### Other Changes
 
-* Add the ability to export Python scripts for the profile viewer. [#2082]
+- Dropped support for Python 3.6. [#2196]
 
-* Add support for polar and other non-rectilinear projections in
+## [v1.0.1](https://github.com/glue-viz/glue/compare/v1.0.0...v1.0.1) - 2020-11-10
+
+### What's Changed
+
+- Updated supported versions of ``jupyter_client``. [#2175]
+
+## [v1.0.0](https://github.com/glue-viz/glue/compare/v0.15.7...v1.0.0) - 2020-09-17
+
+### What's Changed
+
+- Remove bundled echo package and list as a dependency. [#2125]
+
+- Add the ability to export Python scripts for the profile viewer. [#2082]
+
+- Add support for polar and other non-rectilinear projections in
   2-d scatter viewer [#2170]
 
-* Add legend for matplotlib viewers (in qt and in export scripts) [#2097, #2144, #2146]
+- Add legend for matplotlib viewers (in qt and in export scripts) [#2097, #2144, #2146]
 
-* Add new registry to apply in-place patches to the session file [#2127]
+- Add new registry to apply in-place patches to the session file [#2127]
 
-* Initial support for dask arrays. [#2137, #2149]
+- Initial support for dask arrays. [#2137, #2149]
 
-* Don't sync color and transparency of image layers by default. [#2116]
+- Don't sync color and transparency of image layers by default. [#2116]
 
-* Python 2.7 and 3.5 are no longer supported. [#2075]
+- Python 2.7 and 3.5 are no longer supported. [#2075]
 
-* Always use replace mode when creating a new subset. [#2090]
+- Always use replace mode when creating a new subset. [#2090]
 
-* Fixed bugs in the profile viewer that occurred when using the profile viewer and
-  setting reference_data to a different value than the default one. [#2078]
+- Fixed bugs in the profile viewer that occurred when using the profile viewer and
+  setting ``reference_data`` to a different value than the default one. [#2078]
 
-* Updated the data loader to be able to select directories. [#2077,#2080]
+- Updated the data loader to be able to select directories. [#2077,#2080]
 
-* Move spectral-cube data loader to glue-astronomy plugin package. [#2077]
+- Move spectral-cube data loader to glue-astronomy plugin package. [#2077]
 
-* Show session filename path in window title. [#2096]
+- Show session filename path in window title. [#2096]
 
-* Change ``Data.coords`` API to now rely on the API described in
+- Change ``Data.coords`` API to now rely on the API described in
   https://github.com/astropy/astropy-APEs/blob/master/APE14.rst [#2079]
 
-* Update minimum required version of Astropy to 4.0. [#2079]
+- Update minimum required version of Astropy to 4.0. [#2079]
 
-* Added a ``DataCollection.clear()`` method to remove all datasets. [#2079]
+- Added a ``DataCollection.clear()`` method to remove all datasets. [#2079]
 
-* Fixed a bug that caused profiles of subsets to not be hidden if an
+- Fixed a bug that caused profiles of subsets to not be hidden if an
   existing subset was emptied. [#2095]
 
-* Improved ``IndexedData`` so that world coordinates can now be shown. [#2081]
+- Improved ``IndexedData`` so that world coordinates can now be shown. [#2081]
 
-* Make loading Qt plugins optional when calling ``load_plugins``. [#2112]
+- Make loading Qt plugins optional when calling ``load_plugins``. [#2112]
 
-* Preserve ``RectangularROI`` rather than converting them to ``PolygonalROI``. [#2112]
+- Preserve ``RectangularROI`` rather than converting them to ``PolygonalROI``. [#2112]
 
-* Significantly improve performance of ``compute_fixed_resolution_buffer`` when
+- Significantly improve performance of ``compute_fixed_resolution_buffer`` when
   using linked datasets with some axes uncorrelated. [#2115]
 
-* Improve performance of profile viewer when not all layers are visible. [#2115]
+- Improve performance of profile viewer when not all layers are visible. [#2115]
 
-* Fixed missing .units on ``CoordinateComponent``. [#2117]
+- Fixed missing .units on ``CoordinateComponent``. [#2117]
 
-* Improve auto-linking of astronomical datasets with WCS information. [#2161]
+- Improve auto-linking of astronomical datasets with WCS information. [#2161]
 
-* Fix bug that occurred when using the GUI link editor when links had
+- Fix bug that occurred when using the GUI link editor when links had
   been defined programmatically. [#2166]
 
-* Add the ability to programmatically set the preferred colormap for a
+- Add the ability to programmatically set the preferred colormap for a
   dataset using ``Data.visual.preferred_cmap`` [#2131, #2168]
 
-* Fix bug that caused incorrect unit to be shown on slider for images. [#2159]
+- Fix bug that caused incorrect unit to be shown on slider for images. [#2159]
 
-* Improve performance of ``Data.compute_statistic`` for subsets. [#2147]
+- Improve performance of ``Data.compute_statistic`` for subsets. [#2147]
 
-* Fix a bug where x_att and y_att could end up being out of sync in image viewer. [#2141]
+- Fix a bug where ``x_att`` and ``y_att`` could end up being out of sync in image viewer. [#2141]
 
-v0.15.7 (2020-03-12)
---------------------
+## [v0.15.7](https://github.com/glue-viz/glue/compare/v0.15.6...v0.15.7) - 2020-03-12
 
-* Fix bug that caused an infinite loop in the table viewer and caused glue to
+### What's Changed
+
+- Fix bug that caused an infinite loop in the table viewer and caused glue to
   hang if too many incompatible subsets were in a table viewer. [#2105]
 
-* Fixed a bug that caused an error when an invalid data was added to the table
+- Fixed a bug that caused an error when an invalid data was added to the table
   viewer and the table viewer was then automatically closed. [#2103]
 
-* Fixed the dropdowns for vector and error markers to not include datetime
+- Fixed the dropdowns for vector and error markers to not include datetime
   components (since they represent absolute times, not deltas). [#2102]
 
-* Fixed a bug that caused session files that were saved with LinkCollection to
+- Fixed a bug that caused session files that were saved with LinkCollection to
   not work correctly when re-loaded. [#2100]
 
-* Fixed a bug that caused issues when saving and re-loading sessions that were
+- Fixed a bug that caused issues when saving and re-loading sessions that were
   originally created using Excel data with string columns. [#2101]
 
-* Avoid converting circular selections in Matplotlib plots to polygons if
+- Avoid converting circular selections in Matplotlib plots to polygons if
   it can be avoided. [#2094]
 
-v0.15.6 (2019-08-22)
---------------------
+## [v0.15.6](https://github.com/glue-viz/glue/compare/v0.15.5...v0.15.6) - 2019-08-22
 
-* Fixed bugs related to auto-linking of astronomical data with WCS information. In
+### What's Changed
+
+- Fixed bugs related to auto-linking of astronomical data with WCS information. In
   particular, links between datasets with celestial coordinates in a different order
   or links between some higher dimensional datasets with celestial axes did not
   always work correctly. [#2052]
 
-* Fixed a bug that caused the auto-linking framework to not run when opening glue from
+- Fixed a bug that caused the auto-linking framework to not run when opening glue from
   the ``qglue()`` function. [#2052]
 
-* Fixed a limitation that caused pixel selections to not propagate to other datasets.
+- Fixed a limitation that caused pixel selections to not propagate to other datasets.
   [#2052]
 
-* Fixed a deprecation warning related to ``add_datasets``. [#2052]
+- Fixed a deprecation warning related to ``add_datasets``. [#2052]
 
-* Fixed compatibility with Python 3.7.4. [#2060]
+- Fixed compatibility with Python 3.7.4. [#2060]
 
-* Fixed performance issue with arrays that were not in native C order. [#2056]
+- Fixed performance issue with arrays that were not in native C order. [#2056]
 
-v0.15.5 (2019-07-09)
---------------------
+## [v0.15.5](https://github.com/glue-viz/glue/compare/v0.15.4...v0.15.5) - 2019-07-09
 
-* Fixed bug with density map visibility when using color-coding. [#2041]
+### What's Changed
 
-* Fixed bug with incompatible subsets and density maps. [#2041]
+- Fixed bug with density map visibility when using color-coding. [#2041]
 
-* Make sure that lines/errors/vectors are disabled when in density map mode. [#2041]
+- Fixed bug with incompatible subsets and density maps. [#2041]
 
-v0.15.4 (2019-07-08)
---------------------
+- Make sure that lines/errors/vectors are disabled when in density map mode. [#2041]
 
-* Fixed bug that occurred when trying to add a subset to a new table
+## [v0.15.4](https://github.com/glue-viz/glue/compare/v0.15.3...v0.15.4) - 2019-07-08
+
+### What's Changed
+
+- Fixed bug that occurred when trying to add a subset to a new table
   viewer (without the parent data). [#2038]
 
-v0.15.3 (2019-06-27)
---------------------
+## [v0.15.3](https://github.com/glue-viz/glue/compare/v0.15.2...v0.15.3) - 2019-06-27
 
-* Fixed bugs related to the preferences dialog - first, the dialog would
+### What's Changed
+
+- Fixed bugs related to the preferences dialog - first, the dialog would
   not open if no auto-linkers were present, and second, the preferences
   dialog would sometimes get sent behind the main application when editing
   the color. [#2034]
 
-v0.15.2 (2019-06-24)
---------------------
+## [v0.15.2](https://github.com/glue-viz/glue/compare/v0.15.1...v0.15.2) - 2019-06-24
 
-* Fixed a bug in ``autoconnect_callbacks_to_qt`` which caused some widgets
+### What's Changed
+
+- Fixed a bug in ``autoconnect_callbacks_to_qt`` which caused some widgets
   to not stay connect to state callback properties if a callback property
   was linked to multiple widgets. [#2032]
 
-v0.15.1 (2019-06-24)
---------------------
+## [v0.15.1](https://github.com/glue-viz/glue/compare/v0.15.0...v0.15.1) - 2019-06-24
 
-* Fixed __version__ variable. [#2031]
+### What's Changed
 
-* Fixed tox configuration. [#2031]
+- Fixed ``__version__`` variable. [#2031]
 
-* Improve error message if loading a session file that uses WCS auto-linking
+- Fixed tox configuration. [#2031]
+
+- Improve error message if loading a session file that uses WCS auto-linking
   but the installed version of astropy is too old. [#2031]
 
-v0.15.0 (2019-06-23)
---------------------
+## [v0.15.0](https://github.com/glue-viz/glue/compare/v0.14.2...v0.15.0) - 2019-06-23
 
-* Added a new ``glue.core.coordinates.AffineCoordinates`` class for common
+### What's Changed
+
+- Added a new ``glue.core.coordinates.AffineCoordinates`` class for common
   affine transformations, and also added documentation on defining custom
   coordinates. [#1994]
 
-* Rewrote ``SubsetFacet`` (now ``SubsetFacetDialog``), and updated the
+- Rewrote ``SubsetFacet`` (now ``SubsetFacetDialog``), and updated the
   available colormaps. [#1998]
 
-* Removed the ``ComponentSelector`` class. [#1998]
+- Removed the ``ComponentSelector`` class. [#1998]
 
-* Make it possible to view only a subset of data in the table
+- Make it possible to view only a subset of data in the table
   viewer. [#1988]
 
-* Show dataset name in table viewer title. [#1973]
+- Show dataset name in table viewer title. [#1973]
 
-* Expose an option (``inherit_tools``) on data viewer classes
+- Expose an option (``inherit_tools``) on data viewer classes
   related to whether tools should be inherited or not from
   parent classes. [#1972]
 
-* Added a new method ``compute_fixed_resolution_buffer`` to data
+- Added a new method ``compute_fixed_resolution_buffer`` to data
   objects (including the base data class) and use this for the
   image viewer. This improves the case where images are reprojected
   as they are now all reprojected to the screen resolution rather
   than the resolution of the reference data, and this also opens
   up the possibility of doing n-dimensional reprojection. [#1895]
 
-* Added initial infrastructure for developing auto-linking helpers
+- Added initial infrastructure for developing auto-linking helpers
   and implement an initial astronomy WCS auto-linker. [#1933]
 
-* Improve the user interface for the link editor. [#1934, #1998]
+- Improve the user interface for the link editor. [#1934, #1998]
 
-* Added a new ``IndexedData`` class to represent a derived dataset produced
+- Added a new ``IndexedData`` class to represent a derived dataset produced
   by indexing a higher-dimensional dataset. [#1953]
 
-* Removed plot.ly export plugin - this is now part of the glue-plotly
+- Removed plot.ly export plugin - this is now part of the glue-plotly
   package. [#1999]
 
-* Fix path to data bundle when exporting Python scripts to another directory
+- Fix path to data bundle when exporting Python scripts to another directory
   than the one glue was run from. [#2023]
 
-* Added a ``--faulthandler`` command-line flag to help debug segmentation
+- Added a ``--faulthandler`` command-line flag to help debug segmentation
   faults. [#1974]
 
-* Removed ``glue.core.qt.roi`` submodule. This provided faster versions of
+- Removed ``glue.core.qt.roi`` submodule. This provided faster versions of
   the Matplotlib ROI classes in ``glue.core.roi`` but the latter are now
   efficient enough that the Qt-specific versions are no longer needed. [#1983]
 
-* Moved ``glue.viewers.common.qt.tool`` to ``glue.viewers.common.tool``;
+- Moved ``glue.viewers.common.qt.tool`` to ``glue.viewers.common.tool``;
   ``glue.viewers.common.qt.mouse_mode`` to ``glue.viewers.matplotlib.mouse_mode``;
   and ``glue.viewers.common.qt.toolbar_mode`` to ``glue.viewers.matplotlib.toolbar_mode``
   and ``glue.viewers.matplotlib.qt.toolbar_mode``. [#1984]
 
-* Implement a human-readable str/repr for State objects. [#2021]
+- Implement a human-readable str/repr for State objects. [#2021]
 
-* Avoiding importing Qt when using the base histogram and profile layer artists.
+- Avoiding importing Qt when using the base histogram and profile layer artists.
   [#2012]
 
-* Fixed a bug that caused error bars to be colored incorrectly if NaN values
+- Fixed a bug that caused error bars to be colored incorrectly if NaN values
   were present. [#2020]
 
-* Fixed compatibility with the latest versions of Matplotlib and Astropy. [#2020]
+- Fixed compatibility with the latest versions of Matplotlib and Astropy. [#2020]
 
-* No longer suggest merging data by default whenever datasets are added to
+- No longer suggest merging data by default whenever datasets are added to
   the session. Merging different datasets should now be done manually through
   the GUI. [#2020]
 
-* Fixed compatibility with Numpy 1.16.x. [#1989]
+- Fixed compatibility with Numpy 1.16.x. [#1989]
 
-* Improve tab-completion of attribute names in Data to not include
+- Improve tab-completion of attribute names in Data to not include
   non-relevant items. [#1971]
 
-* Fix an error that occurred if creating a new viewer was
+- Fix an error that occurred if creating a new viewer was
   cancelled. [#1952]
 
-* Fix error in image viewer when using update_values_from_data. [#1975]
+- Fix error in image viewer when using ``update_values_from_data``. [#1975]
 
-* Exclude problematic versions of ipykernel from dependencies. [#1952]
+- Exclude problematic versions of ipykernel from dependencies. [#1952]
 
-* Make sure that scrolling above a viewer does not result in the
+- Make sure that scrolling above a viewer does not result in the
   whole canvas also scrolling. [#1919]
 
-* Fix bug that caused date/time columns in Excel files to not be
+- Fix bug that caused date/time columns in Excel files to not be
   read in correctly.
 
-* Improve performance when reading in large non-FITS files. [#1920]
+- Improve performance when reading in large non-FITS files. [#1920]
 
-* Fix bug that caused log parameter to be ignore for density plots. [#1963]
+- Fix bug that caused log parameter to be ignore for density plots. [#1963]
 
-* Fix bug that caused an error when using the profile collapse tool and
+- Fix bug that caused an error when using the profile collapse tool and
   dragging from right to left. [#2002]
 
-* Fix bug that caused labels on the x-axis of the histogram viewer to
+- Fix bug that caused labels on the x-axis of the histogram viewer to
   be incorrectly set to numbers instead of strings when showing a
   histogram of a string variable and saving/reloading session. [#2009]
 
-v0.14.2 (2019-02-04)
---------------------
+## [v0.14.2](https://github.com/glue-viz/glue/compare/v0.14.2...v0.14.1) - 2019-02-04
 
-* Fix bug that caused demo VO Table to not be read in correctly with
+### What's Changed
+
+- Fix bug that caused demo VO Table to not be read in correctly with
   recent versions of Numpy and Astropy. [#1911]
 
-v0.14.1 (2018-11-23)
---------------------
+## [v0.14.1](https://github.com/glue-viz/glue/compare/v0.14.0...v0.14.1) - 2018-11-23
 
-* Fix bug that caused the links based on ``join_on_key`` to not
+### What's Changed
+
+- Fix bug that caused the links based on ``join_on_key`` to not
   always work. [#1902]
 
-v0.14.0 (2018-11-14)
---------------------
+## [v0.14.0](https://github.com/glue-viz/glue/compare/v0.13.4...v0.14.0) - 2018-11-14
 
-* Improved how we handle equal aspect ratio to not depend on
+### What's Changed
+
+- Improved how we handle equal aspect ratio to not depend on
   Matplotlib. [#1894]
 
-* Avoid showing a warning when closing an empty tab. [#1890]
+- Avoid showing a warning when closing an empty tab. [#1890]
 
-* Fix bug that caused component arithmetic to not work if
+- Fix bug that caused component arithmetic to not work if
   Numpy was imported in user's config.py file. [#1887]
 
-* Added the ability to define custom layer artist makers to
+- Added the ability to define custom layer artist makers to
   override default layer artists in viewers. [#1850]
 
-* Fix Plot.ly exporter for categorical components and histogram
+- Fix Plot.ly exporter for categorical components and histogram
   viewer. [#1886]
 
-* Fix issues with reading very large FITS files on some systems. [#1884]
+- Fix issues with reading very large FITS files on some systems. [#1884]
 
-* Added documentation about plugins. [#1837]
+- Added documentation about plugins. [#1837]
 
-* Better isolate code related to pixel selection tool in image
+- Better isolate code related to pixel selection tool in image
   viewer that depended on Qt. [#1763]
 
-* Improve handling of units in FITS files. [#1723]
+- Improve handling of units in FITS files. [#1723]
 
-* Added documentation about creating viewers for glue using the
+- Added documentation about creating viewers for glue using the
   new state-based infrastructure. [#1740]
 
-* Make it possible to pass the initial state of a viewer to an
+- Make it possible to pass the initial state of a viewer to an
   application's ``new_data_viewer`` method. [#1877]
 
-* Ensure that glue can be imported if QtPy is installed but PyQt
+- Ensure that glue can be imported if QtPy is installed but PyQt
   and PySide aren't. [#1865, #1836]
 
-* Fix unit display for coordinates from WCS headers that don't have
+- Fix unit display for coordinates from WCS headers that don't have
   CTYPE but have CUNIT. [#1856]
 
-* Enable tab completion on Data objects. [#1874]
+- Enable tab completion on Data objects. [#1874]
 
-* Automatically select datasets in link editor if there are only two. [#1837]
+- Automatically select datasets in link editor if there are only two. [#1837]
 
-* Change 'Export Session' dialog to offer to save with relative paths to data
+- Change 'Export Session' dialog to offer to save with relative paths to data
   by default instead of absolute paths. [#1803]
 
-* Added a new method ``screenshot`` on ``GlueApplication`` to save a
+- Added a new method ``screenshot`` on ``GlueApplication`` to save a
   screenshot of the current view. [#1808]
 
-* Show the active subset in the toolbar. [#1797]
+- Show the active subset in the toolbar. [#1797]
 
-* Refactored the viewer class base classes [#1746]:
+- Refactored the viewer class base classes [#1746]:
 
   - ``glue.core.application_base.ViewerBase`` has been removed in favor of
     ``glue.viewers.common.viewer.BaseViewer`` and
@@ -453,976 +490,1003 @@ v0.14.0 (2018-11-14)
 
   - ``glue.viewers.common.qt.DataViewerWithState`` is now deprecated.
 
-* Make it so that the modest image only resamples the data when the
+- Make it so that the modest image only resamples the data when the
   mouse is no longer pressed - this avoids too many refreshes when
   panning/zooming. [#1866]
 
-* Make it possible to unglue multiple links in one go. [#1809]
+- Make it possible to unglue multiple links in one go. [#1809]
 
-* Make it so that adding a subset to a viewer no longer adds the
+- Make it so that adding a subset to a viewer no longer adds the
   associated data, since in some cases the viewer can handle the
   subset size, but not the full data. [#1807]
 
-* Defined a new abstract base class for all datasets, ``BaseData``,
+- Defined a new abstract base class for all datasets, ``BaseData``,
   and a base class ``BaseCartesianData``,
   which can be used to implement interfaces to datasets that may be
   remote or may not be stored as regular cartesian data. [#1768]
 
-* Add a new method ``Data.compute_statistic`` which can be used
+- Add a new method ``Data.compute_statistic`` which can be used
   to find scalar and array statistics on the data, and use for
   the profile viewer and the state limits helpers. [#1737]
 
-* Add a new method ``Data.compute_histogram`` which can be used
+- Add a new method ``Data.compute_histogram`` which can be used
   to find histograms of specific components, with or without
   subsets applied. [#1739]
 
-* Removed ``Data.get_pixel_component_ids`` and ``Data.get_world_component_ids``
+- Removed ``Data.get_pixel_component_ids`` and ``Data.get_world_component_ids``
   in favor of ``Data.pixel_component_ids`` and ``Data.world_component_ids``.
   [#1784]
 
-* Deprecated ``Data.visible_components`` and ``Data.primary_components``. [#1788]
+- Deprecated ``Data.visible_components`` and ``Data.primary_components``. [#1788]
 
-* Speed up histogram calculations by using the fast-histogram package instead of
+- Speed up histogram calculations by using the fast-histogram package instead of
   np.histogram. [#1806]
 
-* In the case of categorical attributes, ``Data[name]`` now returns a
+- In the case of categorical attributes, ``Data[name]`` now returns a
   ``categorical_ndarray`` object rather than the indices of the categories. You
   can access the indices with ``Data[name].codes`` and the unique categories
   with ``Data[name].categories``.  [#1784]
 
-* Compute profiles and histograms asynchronously when dataset is large
+- Compute profiles and histograms asynchronously when dataset is large
   to avoid holding up the UI, and compute profiles in chunks to avoid
   excessive memory usage. [#1736, #1764]
 
-* Improved naming of components when merging datasets. [#1249]
+- Improved naming of components when merging datasets. [#1249]
 
-* Fixed an issue that caused residual references to viewers
+- Fixed an issue that caused residual references to viewers
   after they were closed if they were accessed through the
   IPython console. [#1770]
 
-* Don't show layer edit options if layer is not visible. [#1805]
+- Don't show layer edit options if layer is not visible. [#1805]
 
-* Make the Matplotlib viewer code that doesn't depend on Qt accessible
+- Make the Matplotlib viewer code that doesn't depend on Qt accessible
   to non-Qt frontends. [#1841]
 
-* Avoid repeated coordinate components in merged datasets. [#1792]
+- Avoid repeated coordinate components in merged datasets. [#1792]
 
-* Fix bug that caused new subset to be created when dragging an existing
+- Fix bug that caused new subset to be created when dragging an existing
   subset in an image viewer. [#1793]
 
-* Better preserve data types when exporting data/subsets to FITS
+- Better preserve data types when exporting data/subsets to FITS
   and HDF5 formats. [#1800]
 
-v0.13.4 (2018-10-19)
---------------------
+## [v0.13.4](https://github.com/glue-viz/glue/compare/v0.13.3...v0.13.4) - 2018-10-19
 
-* Fix bug that caused .svg icons to not be correctly installed. [#1882]
+### What's Changed
 
-* Fix bug that occurred in certain cases when using the state attribute limit
+- Fix bug that caused .svg icons to not be correctly installed. [#1882]
+
+- Fix bug that occurred in certain cases when using the state attribute limit
   helper with a state class that did not have a log attribute. [#1842]
 
-* Fix HDF5 reader for string columns. [#1840]
+- Fix HDF5 reader for string columns. [#1840]
 
-* Fix visual bug in link editor in advanced mode when resizing window.
+- Fix visual bug in link editor in advanced mode when resizing window.
 
-* Fixed a bug that caused custom data importers to no longer work. [#1813]
+- Fixed a bug that caused custom data importers to no longer work. [#1813]
 
-* Fixed a bug that caused ROIs to not be erased after selection if the
+- Fixed a bug that caused ROIs to not be erased after selection if the
   active subset was not in the list of layers for the viewer. [#1801]
 
-* Always returned to last used folder when opening/saving files. [#1794]
+- Always returned to last used folder when opening/saving files. [#1794]
 
-* Show correct dataset when using control-click to select to add
+- Show correct dataset when using control-click to select to add
   arithmetic attributes or rename/reorder components. [#1802]
 
-* Improve performance when updating links and changing attributes
+- Improve performance when updating links and changing attributes
   on subsets. [#1716]
 
-* Fix errors that happened when clicking on the 'Export Data' and
+- Fix errors that happened when clicking on the 'Export Data' and
   'Define arithmetic attributes' buttons when no data was present,
   and fixed Qt errors that happened if the data collection changed
   after the 'Export Data' dialog was opened. [#1795]
 
-* Fixed parsing of AVM meta-data from images. [#1732]
+- Fixed parsing of AVM meta-data from images. [#1732]
 
-* Fixed compatibility with Matplotlib 3.0. [#1875]
+- Fixed compatibility with Matplotlib 3.0. [#1875]
 
-v0.13.3 (2018-05-08)
---------------------
+## [v0.13.3](https://github.com/glue-viz/glue/compare/v0.13.2...v0.13.3) - 2018-05-08
 
-* Fixed a bug that caused the expression for derived attributes to
+### What's Changed
+
+- Fixed a bug that caused the expression for derived attributes to
   not immediately be updated in the list of derived attributes. [#1708]
 
-* Fixed a bug that caused combo boxes with Data objects to not update
+- Fixed a bug that caused combo boxes with Data objects to not update
   when a data label was changed. [#1704]
 
-* Fixed a bug related to callback functions when restoring sessions.
+- Fixed a bug related to callback functions when restoring sessions.
   [#1695]
 
-* Fixed a bug that meant that setting Data.coords after adding
+- Fixed a bug that meant that setting Data.coords after adding
   components didn't work as expected. [#1196]
 
-* Fixed bugs related to components with only NaN or Inf values.
+- Fixed bugs related to components with only NaN or Inf values.
   [#1712]
 
-* Fixed a bug that caused an error when the zoom or pan tools were
+- Fixed a bug that caused an error when the zoom or pan tools were
   active and the viewer was closed. [#1712]
 
-* Fixed a Qt-related segmentation fault that occurred during the
+- Fixed a Qt-related segmentation fault that occurred during the
   testing process and may also affect users. [#1703]
 
-* Show image layer attribute in list of layers. [#1706]
+- Show image layer attribute in list of layers. [#1706]
 
-* Fixed a bug that caused scatter plots to not revert to fixed color
+- Fixed a bug that caused scatter plots to not revert to fixed color
   mode after being in linear color mode. [#1705]
 
-v0.13.2 (2018-05-01)
---------------------
+## [v0.13.2](https://github.com/glue-viz/glue/compare/v0.13.1...v0.13.2) - 2018-05-01
 
-* Fixed a bug that caused the EditSubsetMode toolbar to not change
+### What's Changed
+
+- Fixed a bug that caused the EditSubsetMode toolbar to not change
   when EditSubsetMode.mode was changed programatically. [#1684]
 
-* Fixed unintuitive behavior of single-pixel selection tool - now
+- Fixed unintuitive behavior of single-pixel selection tool - now
   moving the crosshairs requires clicking and dragging. [#1684]
 
-* Fixed bug that caused crosshairs to not be hidden when a layer was
+- Fixed bug that caused crosshairs to not be hidden when a layer was
   set to not be visible [#1684]
 
-* Fixed a bug that caused viewers to be closed without warning when
+- Fixed a bug that caused viewers to be closed without warning when
   pressing delete. [#1684]
 
-v0.13.1 (2018-04-29)
---------------------
+## [v0.13.1](https://github.com/glue-viz/glue/compare/v0.13.0...v0.13.1) - 2018-04-29
 
-* Fixed resetting and opening of sessions which caused Glue to quit. [#1681]
+### What's Changed
 
-* Fixed serialization of Data.meta when non-serializable keys or values
+- Fixed resetting and opening of sessions which caused Glue to quit. [#1681]
+
+- Fixed serialization of Data.meta when non-serializable keys or values
   are present. [#1681]
 
-v0.13.0 (2018-04-27)
---------------------
+## [v0.13.0](https://github.com/glue-viz/glue/compare/v0.12.5...v0.13.0) - 2018-04-27
 
-* Added new perceptually uniform Matplotlib colormaps. [#1679]
+### What's Changed
 
-* Fixed a bug that caused vectors to not correctly be flipped when
+- Added new perceptually uniform Matplotlib colormaps. [#1679]
+
+- Fixed a bug that caused vectors to not correctly be flipped when
   flipping the x/y limits of the plot. [#1677]
 
-* Added a CSV and HDF5 data/subset exporter. [#1676]
+- Added a CSV and HDF5 data/subset exporter. [#1676]
 
-* Started adding helpful information dialogs that can be
+- Started adding helpful information dialogs that can be
   hidden. [#1669]
 
-* Make it possible to have a 'None' entry in the ComponentIDComboHelper. [#1661]
+- Make it possible to have a 'None' entry in the ComponentIDComboHelper. [#1661]
 
-* Added a new metadata/header viewer for datasets/subsets. [#1659]
+- Added a new metadata/header viewer for datasets/subsets. [#1659]
 
-* Re-write spectrum viewer into a generic profile viewer that uses
+- Re-write spectrum viewer into a generic profile viewer that uses
   subsets to define the areas in which to compute profiles rather
   than custom ROIs. [#1635]
 
-* Added support for PySide2 and remove support for PyQt4 and
+- Added support for PySide2 and remove support for PyQt4 and
   PySide. [#1662]
 
-* Remove support for Matplotlib 1.5. [#1662]
+- Remove support for Matplotlib 1.5. [#1662]
 
-* Renamed ``qt4_to_mpl_color`` to ``qt_to_mpl_color`` and
+- Renamed ``qt4_to_mpl_color`` to ``qt_to_mpl_color`` and
   ``mpl_to_qt4_color`` to ``mpl_to_qt_color``. [#1662]
 
-* Improve performance when changing visual attributes of subsets.
+- Improve performance when changing visual attributes of subsets.
   [#1617]
 
-* Removed ``glue.core.qt.data_combo_helper`` (we now recommend using
+- Removed ``glue.core.qt.data_combo_helper`` (we now recommend using
   the GUI framework-independent equivalent in
   ``glue.core.data_combo_helper``). [#1625]
 
-* Removed ``glue.viewers.common.qt.attribute_limits_helper`` in favor
+- Removed ``glue.viewers.common.qt.attribute_limits_helper`` in favor
   of ``glue.core.state_objects``. [#1625]
 
-* Removed unused function ``glue.utils.misc.defer``. [#1625]
+- Removed unused function ``glue.utils.misc.defer``. [#1625]
 
-* Added a new ``FloodFillSubsetState`` class to represent and
+- Added a new ``FloodFillSubsetState`` class to represent and
   calculate subsets made by a flood-fill algorithm. [#1616]
 
-* Added the ability to easily create viewer tools with dropdown
+- Added the ability to easily create viewer tools with dropdown
   menus. [#1634]
 
-* Remove the ``MatplotlibViewerToolbar`` class as it is now no
+- Remove the ``MatplotlibViewerToolbar`` class as it is now no
   longer needed - instead you can just list the matplotlib tools
   directly in the ``tools`` attribute of the viewer. [#1634]
 
-* Improve hiding/showing of side-panels. No longer hide side-panels
+- Improve hiding/showing of side-panels. No longer hide side-panels
   when glue application goes out of focus. [#1535]
 
-* Use memory-mapping with contiguous arrays in HDF5 files, resulting
+- Use memory-mapping with contiguous arrays in HDF5 files, resulting
   in improved performance for large files. [#1628]
 
-* Deselect tools when the viewer focus changes. [#1584, #1608]
+- Deselect tools when the viewer focus changes. [#1584, #1608]
 
-* Added support for whether symbols are shown filled or not. [#1559]
+- Added support for whether symbols are shown filled or not. [#1559]
 
-* Improved link editor to include a graph of links. [#1534]
+- Improved link editor to include a graph of links. [#1534]
 
-* Improve mouse interaction with ROIs in image viewers, including
+- Improve mouse interaction with ROIs in image viewers, including
   click-and-drag relocation. Allow for more customization of mouse/toolbar
   modes. [#1515]
 
-* Add a toolbar item to save data. [#1516, #1519, #1575]
+- Add a toolbar item to save data. [#1516, #1519, #1575]
 
-* Give instructions for how to move selections in status tip. [#1504]
+- Give instructions for how to move selections in status tip. [#1504]
 
-* Improve the display of data cube slice labels to include only the
+- Improve the display of data cube slice labels to include only the
   precision required given the separation of world coordinate values.
   [#1500, #1660]
 
-* Removed the ability to edit the marker symbol in the style dialog
+- Removed the ability to edit the marker symbol in the style dialog
   since this isn't recognized by any viewer anymore. [#1560]
 
-* Remove back/forward tools in Matplotlib viewer toolbars to
+- Remove back/forward tools in Matplotlib viewer toolbars to
   declutter. [#1505]
 
-* Added a new component manager that makes it possible to rename,
+- Added a new component manager that makes it possible to rename,
   reorder, and remove components, as well as better manage derived
   components, including editing previous equations. [#1479]
 
-* Added new messages ``DataReorderComponentMessage`` and
+- Added new messages ``DataReorderComponentMessage`` and
   ``DataRenameComponentMessage`` which can be subscribed to. [#1479]
 
-* Add support for the datetime64 dtype in Data objects, and adjust
+- Add support for the datetime64 dtype in Data objects, and adjust
   Matplotlib viewers to correctly show this data. [#1510]
 
-* Make it possible to reorder components in ``Data`` using the new
+- Make it possible to reorder components in ``Data`` using the new
   ``Data.reorder_components`` method. [#1479]
 
-* The default order of components has changed - coordinate components
+- The default order of components has changed - coordinate components
   will now always come first (rather than second). [#1479]
 
-* Added support for scatter density maps, which is useful when making
+- Added support for scatter density maps, which is useful when making
   scatter plots of many points. [#1461]
 
-* Improve how ComponentIDComboHelper deals with non-primary components.
+- Improve how ComponentIDComboHelper deals with non-primary components.
   The .visible property has been removed, and a new .derived property
   has been added (to show/hide derived components). Components are now
   split up into sections in the combo boxes. [#1476]
 
-* Fixed a bug that caused ghost components to be added when creating a
+- Fixed a bug that caused ghost components to be added when creating a
   derived component with data[...] = ... [#1476]
 
-* Fixed a bug that caused errors when removing items from a selection
+- Fixed a bug that caused errors when removing items from a selection
   property linked to a QComboBox. [#1476]
 
-* Added initial support for customizing keyboard shortcuts. [#1475, #1514, #1524]
+- Added initial support for customizing keyboard shortcuts. [#1475, #1514, #1524]
 
-* Added support for using relative paths in session files. [#1537]
+- Added support for using relative paths in session files. [#1537]
 
-* Remember last session filename and filter used. [#1537]
+- Remember last session filename and filter used. [#1537]
 
-* EditSubsetMode is now no longer a singleton class and is
+- EditSubsetMode is now no longer a singleton class and is
   instead instantiated at the Application/Session level. [#1530]
 
-* Improve performance of image viewer. [#1558]
+- Improve performance of image viewer. [#1558]
 
-* Added new ``Projected3dROI`` and ``RoiSubsetState3d`` classes
+- Added new ``Projected3dROI`` and ``RoiSubsetState3d`` classes
   to represent 3D selections made in the projection plane. [#1522]
 
-* Fixed saving of sessions with ``BinaryComponentLink``. [#1533]
+- Fixed saving of sessions with ``BinaryComponentLink``. [#1533]
 
-* Refactored/simplified handling of links between datasets and
+- Refactored/simplified handling of links between datasets and
   fixed performance issues when adding/removing links or loading
   data collections with many links. [#1531, #1533]
 
-* Significantly improve performance of link computations when the
+- Significantly improve performance of link computations when the
   links depend only on pixel or world coordinate components. [#1585]
 
-* Added the ability to customize the appearance of tick and axis
+- Added the ability to customize the appearance of tick and axis
   labels in Matplotlib plots. [#1511]
 
-* Added the ability to export Python scripts from the main
+- Added the ability to export Python scripts from the main
   Matplotlib-based viewers. [#1511]
 
-* Added a new selection mode that always forces the creation of a new subset.
+- Added a new selection mode that always forces the creation of a new subset.
   [#1525]
 
-* Added a mouse over pixel selection tool, which creates a one pixel subset
+- Added a mouse over pixel selection tool, which creates a one pixel subset
   under the mouse cursor. [#1619]
 
-* Fixed an issue that caused sliders to not be correctly updated when
+- Fixed an issue that caused sliders to not be correctly updated when
   switching reference data in the image viewer. [#1665]
 
-* Fixed a bug that caused Data.meta to not be saved/restored from session
+- Fixed a bug that caused Data.meta to not be saved/restored from session
   files. [#1668]
 
-* Fixed an issue that caused an IndexError when quitting glue in some
+- Fixed an issue that caused an IndexError when quitting glue in some
   cases. [#1657]
 
-* Fixed a bug that caused matplotlibrc files to not be ignored. [#1649]
+- Fixed a bug that caused matplotlibrc files to not be ignored. [#1649]
 
-* Fixed a non-deterministic error that happened when closing the
+- Fixed a non-deterministic error that happened when closing the
   TableViewer. [#7310]
 
-* Fixed size of markers when value for size is out of vmin/vmax range. [#1609]
+- Fixed size of markers when value for size is out of vmin/vmax range. [#1609]
 
-* Fix a bug that caused viewer limits to be calculated incorrectly if
+- Fix a bug that caused viewer limits to be calculated incorrectly if
   inf/-inf values were present in the data. [#1614]
 
-* Fixed a bug which caused the y-axis in the PV slice viewer to be
+- Fixed a bug which caused the y-axis in the PV slice viewer to be
   incorrect if the WCS could not be computed. [#1615]
 
-* Fixed a bug that caused the WCS of a PV slice to be incorrect if the
+- Fixed a bug that caused the WCS of a PV slice to be incorrect if the
   user has selected a custom order of the axes of a cube in the image
   viewer. [#1615]
 
-* Fixed ticks on log x-axis in histogram viewer. [#7310]
+- Fixed ticks on log x-axis in histogram viewer. [#7310]
 
-* Fixed a bug that led to poor performance when slicing through data cubes.
+- Fixed a bug that led to poor performance when slicing through data cubes.
   [#1554]
 
-v0.12.5 (2018-03-10)
---------------------
+## [v0.12.5](https://github.com/glue-viz/glue/compare/v0.12.4...v0.12.5) - 2018-03-10
 
-* Fixed a bug which caused the current slices to be lost when adding a second
+### What's Changed
+
+- Fixed a bug which caused the current slices to be lost when adding a second
   dataset to the image viewer. [#1581]
 
-* Fixed a bug when two datasets with a different number of dimensions
+- Fixed a bug when two datasets with a different number of dimensions
   were in an image viewer and a subset was created. [#1577]
 
-* Fixed issues when attempting to close a viewer with the delete key. [#1574]
+- Fixed issues when attempting to close a viewer with the delete key. [#1574]
 
-* Disabled default Matplotlib key bindings. [#1574]
+- Disabled default Matplotlib key bindings. [#1574]
 
-* Fix compatibility with Matplotlib 2.2. [#1566]
+- Fix compatibility with Matplotlib 2.2. [#1566]
 
-* Fix compatibility with some versions of pytest. [#1520]
+- Fix compatibility with some versions of pytest. [#1520]
 
-* Fix calculation of dependent_axes to account for cases where there
+- Fix calculation of ``dependent_axes`` to account for cases where there
   are some non-zero non-diagonal PC values. Previously any such values
   resulted in all axes being returned as dependent axes even though this
   isn't necessary. [#1552]
 
-* Avoid prompting users multiple times to merge data when dragging
+- Avoid prompting users multiple times to merge data when dragging
   and dropping multiple data files onto glue. [#1564]
 
-* Improve error message in PV slicer when _slice_index fails. [#1536]
+- Improve error message in PV slicer when ``_slice_index`` fails. [#1536]
 
-* Fixed a bug that caused an error when trying to save a session that
+- Fixed a bug that caused an error when trying to save a session that
   included an image viewer with an aggregated slice. [#1561]
 
-* Fixed a bug that caused an error in the terminal if creating a data
+- Fixed a bug that caused an error in the terminal if creating a data
   viewer failed properly (with a GUI error message). [#1501]
 
-* Fixed a bug that caused performance issues when hiding all image
+- Fixed a bug that caused performance issues when hiding all image
   layers from an image viewer. [#1557, #1562]
 
-* Fixed a bug that caused layers to not always be properly removed
+- Fixed a bug that caused layers to not always be properly removed
   when deleting a row from the layer list. [#1502]
 
-* Make JSON circular reference errors more explicit. [#1529]
+- Make JSON circular reference errors more explicit. [#1529]
 
-v0.12.4 (2018-01-09)
---------------------
+## [v0.12.4](https://github.com/glue-viz/glue/compare/v0.12.3...v0.12.4) - 2018-01-09
 
-* Improve plugin loading to be less sensitive to exact versions of
+### What's Changed
+
+- Improve plugin loading to be less sensitive to exact versions of
   installed dependencies for plugins. [#1487]
 
-v0.12.3 (2017-11-14)
---------------------
+## [v0.12.3](https://github.com/glue-viz/glue/compare/v0.12.3...v0.12.2) - 2017-11-14
 
-* Fixed issues with PV slicer and spectrum viewer when changing axes
+### What's Changed
+
+- Fixed issues with PV slicer and spectrum viewer when changing axes
   in the parent image viewer.
 
-v0.12.2 (2017-11-09)
---------------------
+## [v0.12.2](https://github.com/glue-viz/glue/compare/v0.12.1...v0.12.3) - 2017-11-09
 
-* Fix a bug when renaming tabs through the UI. [#1470]
+### What's Changed
 
-* Fix a bug that caused the 1D and 2D viewers to not update correctly
+- Fix a bug when renaming tabs through the UI. [#1470]
+
+- Fix a bug that caused the 1D and 2D viewers to not update correctly
   when the numerical values in data were changed. [#1471]
 
-* Fix a bug that caused exporting of subsets to not work with integer
+- Fix a bug that caused exporting of subsets to not work with integer
   data. [#1472]
 
-v0.12.1 (2017-10-30)
---------------------
+## [v0.12.1](https://github.com/glue-viz/glue/compare/v0.12.0...v0.12.1) - 2017-10-30
 
-* Fix a bug that caused glue to crash when adding components to a dataset
+### What's Changed
+
+- Fix a bug that caused glue to crash when adding components to a dataset
   after closing a viewer that had that data. [#1460, #1464]
 
-v0.12.0 (2017-10-25)
---------------------
+## [v0.12.0](https://github.com/glue-viz/glue/compare/v0.11.1...v0.12.0) - 2017-10-25
 
-* Show a GUI error message when restoring a session via drag-and-drop
+### What's Changed
+
+- Show a GUI error message when restoring a session via drag-and-drop
   if session loading fails. [#1454]
 
-* Don't disable layer completely if it is not enabled, just disable checkbox.
+- Don't disable layer completely if it is not enabled, just disable checkbox.
   Also show warnings instead of layer style editor. [#1451]
 
-* Generalize registry for data/subset actions to replace the former
-  single_subset_action registry (which applied only to single subset selections).
+- Generalize registry for data/subset actions to replace the former
+  ``single_subset_action`` registry (which applied only to single subset selections).
   Layer actions can now be registered with the ``@layer_action`` decorator. [#1396]
 
-* Added support for plotting vectors in the scatter plot viewer. [#1410]
+- Added support for plotting vectors in the scatter plot viewer. [#1410]
 
-* Added glue plugins to the Version Information dialog. [#1427]
+- Added glue plugins to the Version Information dialog. [#1427]
 
-* Added the ability to create fixed layout tabs. [#1403]
+- Added the ability to create fixed layout tabs. [#1403]
 
-* Fix selection in custom viewers. [#1453]
+- Fix selection in custom viewers. [#1453]
 
-* Fix a bug that caused the home/reset limits button to not work correctly. [#1452]
+- Fix a bug that caused the home/reset limits button to not work correctly. [#1452]
 
-* Fix a bug that caused the wrong layers to be enabled when mixing image and
+- Fix a bug that caused the wrong layers to be enabled when mixing image and
   scatter layers and setting up links. [#1451]
 
-* Remove 'sep' from menu on Linux. [#1394]
+- Remove 'sep' from menu on Linux. [#1394]
 
-* Fixed bug in spectrum tool that caused the upper range in aggregations
+- Fixed bug in spectrum tool that caused the upper range in aggregations
   to be incorrectly calculated. [#1402]
 
-* Fixed icon for scatter plot layer when a colormap is used, and fix issues with
+- Fixed icon for scatter plot layer when a colormap is used, and fix issues with
   viewer layer icons not updating immediately. [#1425]
 
-* Fixed dragging and dropping session files onto glue (this now loads the session
+- Fixed dragging and dropping session files onto glue (this now loads the session
   rather than trying to load it as a dataset). Also now show a warning when
   the application is about to be reset to open a new session. [#1425, #1448]
 
-* Make sure no errors happen if making a selection in an empty viewer. [#1425]
+- Make sure no errors happen if making a selection in an empty viewer. [#1425]
 
-* Fix creating faceted subsets on Python 3.x when no dataset is selected. [#1425]
+- Fix creating faceted subsets on Python 3.x when no dataset is selected. [#1425]
 
-* Fix issues with overlaying a scatter layer on an image. [#1425]
+- Fix issues with overlaying a scatter layer on an image. [#1425]
 
-* Fix issues with labels for categorical axes in the scatter and histogram
+- Fix issues with labels for categorical axes in the scatter and histogram
   viewers, in particular when loading viewers with categorical axes from
   session files. [#1425]
 
-* Make sure a GUI error message is shown when adding non-1-dimensional data
+- Make sure a GUI error message is shown when adding non-1-dimensional data
   to a table viewer. [#1425]
 
-* Fix issues when trying to launch glue multiple times from a Jupyter session.
+- Fix issues when trying to launch glue multiple times from a Jupyter session.
   [#1425]
 
-* Remove the ability to define the color of a subset differ from that of a
+- Remove the ability to define the color of a subset differ from that of a
   subset group it belongs to - this was virtually never needed but could
   cause issues. [#1426]
 
-* Fixed a bug that caused a previously disabled image subset layer to not
+- Fixed a bug that caused a previously disabled image subset layer to not
   become visible when shown again. [#1450]
 
-* Added the ability to rename tabs programmatically. [#1405]
+- Added the ability to rename tabs programmatically. [#1405]
 
-v0.11.1 (2017-08-25)
---------------------
+## [v0.11.1](https://github.com/glue-viz/glue/compare/v0.11.0...v0.11.1) - 2017-08-25
 
-* Fixed bug that caused ModestImage references to not be properly deleted, in
+### What's Changed
+
+- Fixed bug that caused ModestImage references to not be properly deleted, in
   turn leading to issues/crashes when removing subsets from image viewers. [#1390]
 
-* Fixed bug with reading in old session files with a table viewer. [#1389]
+- Fixed bug with reading in old session files with a table viewer. [#1389]
 
-v0.11.0 (2017-08-22)
---------------------
+## [v0.11.0](https://github.com/glue-viz/glue/compare/v0.10.4...v0.11.0) - 2017-08-22
 
-* Added splash screen. [#694]
+### What's Changed
 
-* Make file extension check case-insensitive. [#1275]
+- Added splash screen. [#694]
 
-* Fixed bug that caused table viewer to not update when adding components. [#1386]
+- Make file extension check case-insensitive. [#1275]
 
-* Fixed loading of plain (non-structured) arrays from Numpy files. [#1314, #1385]
+- Fixed bug that caused table viewer to not update when adding components. [#1386]
 
-* Disabled layer artists can no longer be selected to avoid any confusion. [#1367]
+- Fixed loading of plain (non-structured) arrays from Numpy files. [#1314, #1385]
 
-* Layer artist icons can now show colormaps when appropriate. [#1367]
+- Disabled layer artists can no longer be selected to avoid any confusion. [#1367]
 
-* Fix behavior of data wizard so that it doesn't overwrite labels set by data
+- Layer artist icons can now show colormaps when appropriate. [#1367]
+
+- Fix behavior of data wizard so that it doesn't overwrite labels set by data
   factories. [#1367]
 
-* Add a status tip for all ROI selection tools. [#1367]
+- Add a status tip for all ROI selection tools. [#1367]
 
-* Fixed a bug that caused the terminal to not be available after
+- Fixed a bug that caused the terminal to not be available after
   resetting or opening a session. [#1366]
 
-* If a subset's visual properties are changed, change the visual
+- If a subset's visual properties are changed, change the visual
   properties of the parent SubsetGroup. [#1365]
 
-* Give an error if the user selects a session file when going through
+- Give an error if the user selects a session file when going through
   the 'Open Data Set' menu. [#1364]
 
-* Improved scatter plot viewer to be able to show points with color or
+- Improved scatter plot viewer to be able to show points with color or
   size based on other attributes. Also added a 'line' style to make line
   plots, and added the ability to show error bars. [#1358]
 
-* Changed order of arguments for data exporters from (data, filename)
+- Changed order of arguments for data exporters from (data, filename)
   to (filename, data). [#1251]
 
-* Added registry decorators to define subset mask importers and
+- Added registry decorators to define subset mask importers and
   exporters. [#1251]
 
-* Get rid of QTimers for updating the data collection and layer artist
+- Get rid of QTimers for updating the data collection and layer artist
   lists, and instead refresh whenever a message is sent from the hub
   (which results in immediate changes rather than waiting up to a
    second for things to change). [#1343]
 
-* Made it possible to delay callbacks from the Hub using the
+- Made it possible to delay callbacks from the Hub using the
   ``Hub.delay_callbacks`` context manager. Also fixed the Hub so that
   it uses weak references to classes and methods wherever possible. [#1339]
 
-* Added a new method DataCollection.remove_link to match existing
-  DataCollection.add_link. [#1339]
+- Added a new method ``DataCollection.remove_link`` to match existing
+  ``DataCollection.add_link``. [#1339]
 
-* Fix a bug that caused no messages to be emitted when components were
+- Fix a bug that caused no messages to be emitted when components were
   removed from Data objects, and add a new DataRemoveComponentMesssage.
   [#1339]
 
-* Fix a long-standing bug which caused performance issues after linking
+- Fix a long-standing bug which caused performance issues after linking
   coordinate or derived components between datasets. [#1339]
 
-* Added a function is_equivalent_cid that can be used to determine whether
+- Added a function ``is_equivalent_cid`` that can be used to determine whether
   two component IDs in a dataset are equivalent. [#1339]
 
-* The image contrast and bias can now be set with the left click as well
+- The image contrast and bias can now be set with the left click as well
   as right click. [#1323]
 
-* Updated ComponentIDComboHelper so that it can work with single datasets
+- Updated ComponentIDComboHelper so that it can work with single datasets
   that aren't necessarily attached to a DataCollection. [#1296]
 
-* Updated bundled version of echo to include fixes to avoid circular
+- Updated bundled version of echo to include fixes to avoid circular
   references, which in turn caused some callback functions to not be
   cleaned up. [#1281]
 
-* Rewrote the histogram, scatter, and image viewers to use the new state
+- Rewrote the histogram, scatter, and image viewers to use the new state
   infrastructure. This significantly simplifies the actual histogram viewer code
   both in terms of number of lines and in terms of the number of
   connections/callbacks that need to be set up manually. [#1278, #1289, #1388]
 
-* Updated EditSubsetMode so that Data objects no longer have an edit_subset
+- Updated EditSubsetMode so that Data objects no longer have an ``edit_subset``
   attribute - instead, the current list of subsets being edited is kept in
   EditSubsetMode itself. We also update the subset state only once on each
   subset group, rather than once per dataset, which avoids doing the same
   update to each dataset multiple times. [#1338]
 
-* Remove the ability to create a new viewer by right-clicking on the canvas,
+- Remove the ability to create a new viewer by right-clicking on the canvas,
   since this causes confusion when trying to control-click to paste in the
   IPython terminal. [#1342]
 
-* Make process_dialog more robust. [#1333]
+- Make ``process_dialog`` more robust. [#1333]
 
-* Fix example of setting up a custom preferences pane. [#1326]
+- Fix example of setting up a custom preferences pane. [#1326]
 
-* Fix a bug that caused links to not get removed if associated datasets
+- Fix a bug that caused links to not get removed if associated datasets
   were removed. [#1329]
 
-* Fixed a bug that meant that the table viewer did not update when
+- Fixed a bug that meant that the table viewer did not update when
   a ``NumericalDataChangedMessage`` message was emitted. [#1378]
 
-* Added new combo helpers in ``glue.core.data_combo_helper`` which
+- Added new combo helpers in ``glue.core.data_combo_helper`` which
   are similar to those in ``glue.core.qt.data_combo_helper`` but
   operate on ``SelectionCallbackProperty`` and are Qt-independent.
   [#1346]
 
-* Rewrote installation instructions. [#1330]
+- Rewrote installation instructions. [#1330]
 
-v0.10.4 (2017-05-23)
---------------------
+## [v0.10.4](https://github.com/glue-viz/glue/compare/v0.10.3...v0.10.4) - 2017-05-23
 
-* Fixed a bug that caused merged datasets to crash viewers (because
-  the visible_components attribute returned an empty list). [#1288]
+### What's Changed
 
-v0.10.3 (2017-04-20)
--------------------
+- Fixed a bug that caused merged datasets to crash viewers (because
+  the ``visible_components`` attribute returned an empty list). [#1288]
 
-* Fixed bugs with saving and restoring of various types of subset states. [#1285]
+## [v0.10.3](https://github.com/glue-viz/glue/compare/v0.10.2...v0.10.3) - 2017-04-20
 
-* Fixed a bug that caused glue to not open when IPython 4.0 was installed. [#1287]
+### What's Changed
 
-v0.10.2 (2017-03-22)
---------------------
+- Fixed bugs with saving and restoring of various types of subset states. [#1285]
 
-* Fixed a bug that caused components that were linked to then disappear from
+- Fixed a bug that caused glue to not open when IPython 4.0 was installed. [#1287]
+
+## [v0.10.2](https://github.com/glue-viz/glue/compare/v0.10.1...v0.10.2) - 2017-03-22
+
+### What's Changed
+
+- Fixed a bug that caused components that were linked to then disappear from
   drop-down lists of available components in new viewers. [#1270]
 
-* Fixed a bug that caused Data.find_component_id to return incorrect results
+- Fixed a bug that caused ``Data.find_component_id`` to return incorrect results
   when string components were present in the data. [#1269]
 
-* Fixed a bug that caused errors to appear in the console log after a
+- Fixed a bug that caused errors to appear in the console log after a
   table viewer was closed. [#1267]
 
-* Fixed a bug that caused error message dialogs to not work correctly with
+- Fixed a bug that caused error message dialogs to not work correctly with
   Qt4. [#1262]
 
-* Fixed a deprecation warning for pandas >= 0.19. [#1263]
+- Fixed a deprecation warning for pandas >= 0.19. [#1263]
 
-* Hide common Matplotlib warnings when min/max along an axis are equal. [#1268]
+- Hide common Matplotlib warnings when min/max along an axis are equal. [#1268]
 
-* Fixed a bug that caused sessions with table viewers that had no subsets
+- Fixed a bug that caused sessions with table viewers that had no subsets
   to not be restored correctly. [#1271]
 
-v0.10.1 (2017-03-16)
---------------------
+## [v0.10.1](https://github.com/glue-viz/glue/compare/v0.10.0...v0.10.1) - 2017-03-16
 
-* Fixed compatibility with session files from before v0.8. [#1243]
+### What's Changed
 
-* Renamed package to glue-core, since glueviz is now a meta-package (no need
+- Fixed compatibility with session files from before v0.8. [#1243]
+
+- Renamed package to glue-core, since glueviz is now a meta-package (no need
   for a new major version since this change should be seamless to users).
 
-v0.10.0 (2017-02-14)
---------------------
+## [v0.10.0](https://github.com/glue-viz/glue/compare/v0.9.1...v0.10.0) - 2017-02-14
 
-* The GlueApplication.add_data and load_data methods now return the
+### What's Changed
+
+- The ``GlueApplication.add_data`` and ``load_data`` methods now return the
   loaded data objects. [#1239]
 
-* Change default name of subsets to include the word 'Subset'. [#1234]
+- Change default name of subsets to include the word 'Subset'. [#1234]
 
-* Removed ginga plugin from core package and moved it to a separate repository
+- Removed ginga plugin from core package and moved it to a separate repository
   at https://github.com/ejeschke/glue-ginga.
 
-* Switch from using bundled WCSAxes to using the version in Astropy, and fixed
+- Switch from using bundled WCSAxes to using the version in Astropy, and fixed
   an issue that caused the frame of the axes to be too thick. [#1231]
 
-* Make it possible to define a default index for DataComboHelper - this makes
+- Make it possible to define a default index for DataComboHelper - this makes
   it possible for viewers to have three DataComboHelper and ensure that they
   default to different attributes. [#1163]
 
-* Deal properly with adding Subset objects to DataComboHelper. [#1163]
+- Deal properly with adding Subset objects to DataComboHelper. [#1163]
 
-* Added the ability to export data and subset from the data collection view via
+- Added the ability to export data and subset from the data collection view via
   contextual menus. It was previously possible to export only the mask itself,
   and only to FITS files, but the framework for exporting data/subsets has now
   been generalized.
 
-* When hiding layers in the RGB image viewer, make sure the current layer changes
+- When hiding layers in the RGB image viewer, make sure the current layer changes
   to be a visible one if possible.
 
-* Avoid merging IDs when creating identity links. The previous behavior of
+- Avoid merging IDs when creating identity links. The previous behavior of
   merging was good for performance but made it impossible to undo the linking by
   un-glueing. Derived components created by links are now hidden by default.
   Finally, ``ComponentID`` objects now hold a reference to the first parent data
   they are used in. [#1189]
 
-* Added a decorator that can be used to avoid circular calling of methods (can
+- Added a decorator that can be used to avoid circular calling of methods (can
   occur when dealing with callbacks). [#1207]
 
-* Drop support for IPython 3.x and below, and make IPython and qtconsole into
+- Drop support for IPython 3.x and below, and make IPython and qtconsole into
   required dependencies. [#1145]
 
-* Added new classes that can be used to hold the state of e.g. viewers and other
+- Added new classes that can be used to hold the state of e.g. viewers and other
   objects. These classes allow callbacks to be attached to various properties,
   and can be used to define logical relations between different attributes
   in a GUI-independent way.
 
-* Fix selections when using Matplotlib 2.x, PyQt5 and a retina display. [#1236]
+- Fix selections when using Matplotlib 2.x, PyQt5 and a retina display. [#1236]
 
-* Updated ComponentIDComboHelper to no longer store ``(cid, data)`` as the
+- Updated ComponentIDComboHelper to no longer store ``(cid, data)`` as the
   ``userData`` but instead just the ``cid`` (the data is now accessible via
   ``cid.parent``). [#1212]
 
-* Avoid duplicate toolbar in dendrogram viewer. [#1213, #1237]
+- Avoid duplicate toolbar in dendrogram viewer. [#1213, #1237]
 
-* Fixed bug that caused the contrast to change for the incorrect layer in the
+- Fixed bug that caused the contrast to change for the incorrect layer in the
   RGB image viewer.
 
-* Fixed bug that caused coordinate information to be lost when merging datasets.
+- Fixed bug that caused coordinate information to be lost when merging datasets.
   The original behavior of keeping the coordinate information from the first
   dataset has been restored. [#1186]
 
-* Fix Data.update_values_from_data to make sure that original component order
+- Fix ``Data.update_values_from_data`` to make sure that original component order
   is preserved. [#1238]
 
-* Fix Data.components to return original component order, not alphabetical order.
+- Fix Data.components to return original component order, not alphabetical order.
   [#1238]
 
-* Fix significant performance bottlenecks with WCS coordinate conversions. [#1185]
+- Fix significant performance bottlenecks with WCS coordinate conversions. [#1185]
 
-* Fix error when changing the contrast radio button the RGB image viewer mode,
+- Fix error when changing the contrast radio button the RGB image viewer mode,
   and also fix bugs with setting the range of values manually. [#1187]
 
-* Fix a bug that caused coordinate axis labels to be lost during merging. [#1195]
+- Fix a bug that caused coordinate axis labels to be lost during merging. [#1195]
 
-* Fix a bug that caused tab names to not be saved and restored to/from session
+- Fix a bug that caused tab names to not be saved and restored to/from session
   files. [#1241, #1242]
 
-v0.9.1 (2016-11-01)
--------------------
+## [v0.9.1](https://github.com/glue-viz/glue/compare/v0.9.0...v0.9.1) - 2016-11-01
 
-* Fixed loading of session files made with earlier versions of glue that
+### What's Changed
+
+- Fixed loading of session files made with earlier versions of glue that
   contained selections made in 3D viewers. [#1160]
 
-* Fixed plotting of fit on spectrum to make sure that the two are properly
+- Fixed plotting of fit on spectrum to make sure that the two are properly
   aligned. [#1158]
 
-* Made it possible to now create InequalitySubsetStates for
+- Made it possible to now create InequalitySubsetStates for
   categorical components using e.g. d.id['a'] == 'string'. [#1153]
 
-* Fixed a bug that caused selections to not propagate properly between
+- Fixed a bug that caused selections to not propagate properly between
   linked images and cubes. [#1144]
 
-* Make last interval of faceted subsets inclusive so as to make sure all values
+- Make last interval of faceted subsets inclusive so as to make sure all values
   in the faceted subset range end up in a subset. [#1154]
 
-v0.9.0 (2016-10-10)
--------------------
+## [v0.9.0](https://github.com/glue-viz/glue/compare/v0.8.2...v0.9.0) - 2016-10-10
 
-* Fix serialization of celestial coordinate link functions. Classes
-  inheriting from MultiLink should now call MultiLink.__init__ with
-  individual components (not grouped into left/right) then the create_links
+### What's Changed
+
+- Fix serialization of celestial coordinate link functions. Classes
+  inheriting from MultiLink should now call ``MultiLink.__init__`` with
+  individual components (not grouped into left/right) then the ``create_links``
   method with the components separated into left/right and the methods for
   forward/backward transformation. The original behavior can be retained
   by using the ``multi_link`` function instead of the ``MultiLink`` class.
   [#1139]
 
-* Improve support for spectral cubes. [#1075]
+- Improve support for spectral cubes. [#1075]
 
-* Allow link functions/helpers to define a category using the ``category=``
+- Allow link functions/helpers to define a category using the ``category=``
   argument (which defaults to ``General``), and make it possible to filter
   by category in the link editor. [#1141]
 
-* Only show the 'waiting' cursor when glue is doing something. [#1097]
+- Only show the 'waiting' cursor when glue is doing something. [#1097]
 
-* Make sure that the scatter layer artist style editor is shown when overplotting
+- Make sure that the scatter layer artist style editor is shown when overplotting
   a scatter plot on top of an image. [#1134]
 
-* Data viewers can now make layer_style_widget_cls a dictionary in cases
+- Data viewers can now make ``layer_style_widget_cls`` a dictionary in cases
   where multiple layer artist types are supported. [#1134]
 
-* Fix compatibility of test suite with pytest 3.x. [#1116]
+- Fix compatibility of test suite with pytest 3.x. [#1116]
 
-* Updated bundled version of WCSAxes to v0.9. [#1089]
+- Updated bundled version of WCSAxes to v0.9. [#1089]
 
-* Fix compatibility with pre-releases of Matplotlib 2.0. [#1115]
+- Fix compatibility with pre-releases of Matplotlib 2.0. [#1115]
 
-* Implement new widget with better control over exporting to Plotly. The
+- Implement new widget with better control over exporting to Plotly. The
   preference pane for Plotly export has now been removed in favor of this new
   way to set the options. [#1057]
 
-* Renamed the ``ComponentIDComboHelper`` and ``ManualDataComboHelper``
+- Renamed the ``ComponentIDComboHelper`` and ``ManualDataComboHelper``
   ``append`` methods to ``append_data`` and the ``remove`` methods to
   ``remove_data``, and added a new ``ComponentIDComboHelper.set_multiple_data``
   method. [#1060]
 
-* Fixed reading of units from FITS and VO tables, and display units in
+- Fixed reading of units from FITS and VO tables, and display units in
   table viewer. [#1135, #1137]
 
-* Make use of the QtPy package to deal with differences between PyQt4, PyQt5,
+- Make use of the QtPy package to deal with differences between PyQt4, PyQt5,
   and PySide, instead of the custom qt-helpers package. The
   ``glue.external.qt`` package is now deprecated. The ``get_qapp`` and
   ``load_ui`` functions are now available in ``glue.utils.qt``.
   [#1018, #1074, #1077, #1078, #1081]
 
-* Avoid raising a (harmless) error when selecting a region in between two
+- Avoid raising a (harmless) error when selecting a region in between two
   categorical components.
 
-* Added a new Data method, ``update_values_from_data``, that can be used to replicate
+- Added a new Data method, ``update_values_from_data``, that can be used to replicate
   components from one dataset into another. [#1112]
 
-* Refactored code related to toolbars in order to make it easier to define
+- Refactored code related to toolbars in order to make it easier to define
   toolbars and toolbar modes that aren't Matplotlib-specific. [#1085, #1120]
 
-* Added a new table viewer. [#1084, #1123]
+- Added a new table viewer. [#1084, #1123]
 
-* Fix saving/loading of categorical components. [#1084]
+- Fix saving/loading of categorical components. [#1084]
 
-* Make it possible for tools to define a status bar message. [#1084]
+- Make it possible for tools to define a status bar message. [#1084]
 
-* Added a command-line option, ``--no-maximized``, that prevents glue
+- Added a command-line option, ``--no-maximized``, that prevents glue
   from opening up with the application window maximized. [#1093, #1126]
 
-* When opening multiple files in one go, if one of the files fails to
+- When opening multiple files in one go, if one of the files fails to
   read, the error will now indicate which file failed. [#1104]
 
-* Fixed a bug that caused new subset colors to incorrectly start from the start
+- Fixed a bug that caused new subset colors to incorrectly start from the start
   of the color cycle after loading a session. [#1055]
 
-* Fixed a bug that caused the functionality to execute scripts (glue -x) to not
+- Fixed a bug that caused the functionality to execute scripts (glue -x) to not
   work in Python 3. [#1101, #1114]
 
-* The minimum supported version of Astropy is now 1.0, and the minimum
+- The minimum supported version of Astropy is now 1.0, and the minimum
   supported version of IPython is now 1.0. [#1076]
 
-* Show world coordinates and units in the cube slicer. [#1059, #1068]
+- Show world coordinates and units in the cube slicer. [#1059, #1068]
 
-* Fix errors that occurred when selecting categorical data. [#1069]
+- Fix errors that occurred when selecting categorical data. [#1069]
 
-* Added experimental support for joining on multiple keys in ``join_on_key``. [#974]
+- Added experimental support for joining on multiple keys in ``join_on_key``. [#974]
 
-* Fix compatibility with the latest version of ginga. [#1063]
+- Fix compatibility with the latest version of ginga. [#1063]
 
-v0.8.2 (2016-07-06)
--------------------
+## [v0.8.2](https://github.com/glue-viz/glue/compare/v0.8.1...v0.8.2) - 2016-07-06
 
-* Implement missing MaskSubsetState.copy. [#1033]
+### What's Changed
 
-* Ensure that failing data factory identifier functions are skipped. [#1029]
+- Implement missing MaskSubsetState.copy. [#1033]
 
-* The naming of pixel axes is now more consistent between data with 3 or
+- Ensure that failing data factory identifier functions are skipped. [#1029]
+
+- The naming of pixel axes is now more consistent between data with 3 or
   fewer dimensions, and data with more than 3 dimensions. The naming is now
   always ``Pixel Axis ?`` where ``?`` is the index of the array, and for
   datasets with 1 to 3 dimensions, we add a suffix e.g. ``[x]`` to indicate
   the traditional axes. [#1029]
 
-* Implemented a number of performance improvements, including for: the check
+- Implemented a number of performance improvements, including for: the check
   of whether points are in polygon (``points_inside_poly``), the selection of
   polygonal regions in multi-dimentional cubes when the selections are along
   pixel axes, the selection of points in scatter plots with one or two
   categorical components for rectangular, circular, and polygonal regions.
   [#1029]
 
-* Fix a bug that caused multiple custom viewer classes to not work properly
+- Fix a bug that caused multiple custom viewer classes to not work properly
   if the user did not override ``_custom_functions`` (which was private).
   [#810]
 
-* Make sure histograms are updated if only the attribute changes and the
+- Make sure histograms are updated if only the attribute changes and the
   limits and number of bins stay the same. [#1012]
 
-* Fix a bug on Windows that caused drag and dropping files onto the glue
+- Fix a bug on Windows that caused drag and dropping files onto the glue
   application to not work. [#1007]
 
-* Fix compatibility with PyQt5. [#1015]
+- Fix compatibility with PyQt5. [#1015]
 
-* Fix a bug that caused ComponentIDComboHelper to not take into account the
-  numeric and categorical options in __init__. [#1014]
+- Fix a bug that caused ComponentIDComboHelper to not take into account the
+  numeric and categorical options in ``__init__``. [#1014]
 
-* Fix a bug that caused saving of scatter plots to SVG files to crash. [#984]
+- Fix a bug that caused saving of scatter plots to SVG files to crash. [#984]
 
-v0.8.1 (2016-05-25)
--------------------
+## [v0.8.1](https://github.com/glue-viz/glue/compare/v0.8...v0.8.1) - 2016-05-25
 
-* Fixed a bug in the memoize function that caused selections using
+### What's Changed
+
+- Fixed a bug in the memoize function that caused selections using
   ElementSubsetState to fail when using views on the data. [#1004]
 
-* Explicitly set the icon size for the slicing playback controls to avoid
+- Explicitly set the icon size for the slicing playback controls to avoid
   issues when using a mix of retina and non-retina displays. [#1005]
 
-* Fixed a bug that caused add_datasets to crash if ``datasets`` was a list of
+- Fixed a bug that caused ``add_datasets`` to crash if ``datasets`` was a list of
   lists of data, which is possible if a data factory returns more than one data
   object. [#1006]
 
-v0.8 (2016-05-23)
------------------
+## [v0.8](https://github.com/glue-viz/glue/compare/v0.7.3...v0.8) - 2016-05-23
 
-* Add support for circular and polygonal spectrum extraction. [#994, #1003]
+### What's Changed
 
-* Fix compatibility with latest developer version of Numpy which does not allow
+- Add support for circular and polygonal spectrum extraction. [#994, #1003]
+
+- Fix compatibility with latest developer version of Numpy which does not allow
   non-integer indices for arrays. [#1002]
 
-* Add a new method ``add_data`` to application instances. This allows for
+- Add a new method ``add_data`` to application instances. This allows for
   example additional data to be passed to glue after being launched by
   ``qglue``. [#993]
 
-* Add playback controls to slice widget. [#971]
+- Add playback controls to slice widget. [#971]
 
-* Add tooltip for data labels so that long labels can be more easily
+- Add tooltip for data labels so that long labels can be more easily
   inspected. [#912]
 
-* Added a new helper class ``AttributeLimitsHelper`` to link widgets related to
+- Added a new helper class ``AttributeLimitsHelper`` to link widgets related to
   setting limits and handle the caching of the limits as a function of
   attribute. [#872]
 
-* Add Quit menu item for Linux and Windows. [#926]
+- Add Quit menu item for Linux and Windows. [#926]
 
-* Refactored the window for sending feedback to include more version
+- Refactored the window for sending feedback to include more version
   information, and also to have a separate form for feedback and crash
   reports. [#955]
 
-* Add log= option to ValueProperty and remove mapping= option. [#965]
+- Add log= option to ValueProperty and remove mapping= option. [#965]
 
-* Added helper classes for ComponentID and Data combo boxes. [#891]
+- Added helper classes for ComponentID and Data combo boxes. [#891]
 
-* Improved new component window: expressions can now include math or numpy
+- Improved new component window: expressions can now include math or numpy
   functions by default, and expressions are tested on-the-fly to check that
   there are no issues with syntax or undefined variables. [#956]
 
-* Fixed D3PO export when using Python 3. [#989]
+- Fixed D3PO export when using Python 3. [#989]
 
-* Fixed display of certain error messages when using Python 3. [#989]
+- Fixed display of certain error messages when using Python 3. [#989]
 
-* Add an extensible preferences window. [#988]
+- Add an extensible preferences window. [#988]
 
-* Add the ability to change the foreground and background color for viewers.
+- Add the ability to change the foreground and background color for viewers.
   [#988]
 
-* Fixed a bug that caused images to appear over-pixellated on the edges when
+- Fixed a bug that caused images to appear over-pixellated on the edges when
   zooming in. [#1000]
 
-* Added an option to control whether warnings are shown when passing large data objects to viewers. [#999]
+- Added an option to control whether warnings are shown when passing large data objects to viewers. [#999]
 
-v0.7.3 (2016-05-04)
--------------------
+## [v0.7.3](https://github.com/glue-viz/glue/compare/v0.7.2...v0.7.3) - 2016-05-04
 
-* Remove icons for actions that appear in contextual menus, since these
+### What's Changed
+
+- Remove icons for actions that appear in contextual menus, since these
   appear too large due to a Qt bug. [#911]
 
-* Add missing find_spec for import hook, to avoid issues when trying to set
+- Add missing ``find_spec`` for import hook, to avoid issues when trying to set
   colormap. [#930]
 
-* Ignore extra dimensions in WCS (for instance, if the data is 3D and the
+- Ignore extra dimensions in WCS (for instance, if the data is 3D and the
   header is 4D, ignore the 4th dimension in the WCS). [#935]
 
-* Fix a bug that caused the merge window to appear multiple times, make sure
+- Fix a bug that caused the merge window to appear multiple times, make sure
   that all components named PRIMARY get renamed after merging, and make sure
   that the merge mechanism is also triggered when opening datasets from the
   command-line. [#936]
 
-* Remove the scrollbars added in v0.7.1 since they cause issues on certain
+- Remove the scrollbars added in v0.7.1 since they cause issues on certain
   systems. [#953]
 
-* Fix saving of ElementSubsetState to session files. [#966]
+- Fix saving of ElementSubsetState to session files. [#966]
 
-* Fix saving of Matplotlib colormaps to session files. [#967]
+- Fix saving of Matplotlib colormaps to session files. [#967]
 
-* Fix the selection of the default viewer based on the data shape. [#968]
+- Fix the selection of the default viewer based on the data shape. [#968]
 
-* Make sure that no combo boxes get resized based on the content (unless
+- Make sure that no combo boxes get resized based on the content (unless
   strictly needed). [#978]
 
-v0.7.2 (2016-04-05)
--------------------
+## [v0.7.2](https://github.com/glue-viz/glue/compare/v0.7.1...v0.7.2) - 2016-04-05
 
-* Fix a bug that caused string columns in FITS files to not be read
-  correctly, and updated coerce_numeric to give a ValueError for string
+### What's Changed
+
+- Fix a bug that caused string columns in FITS files to not be read
+  correctly, and updated ``coerce_numeric`` to give a ``ValueError`` for string
   columns that can't be convered. [#919]
 
-* Make sure main window title is set. [#914]
+- Make sure main window title is set. [#914]
 
-* Fix issue with FITS files that are missing an END card. [#915]
+- Fix issue with FITS files that are missing an END card. [#915]
 
-* Fix a bug that caused values in exponential notation in text fields to lose
+- Fix a bug that caused values in exponential notation in text fields to lose
   a trailing zero (e.g. 1.000e+10 would become 1.000e+1). [#925]
 
-v0.7.1 (2016-03-30)
--------------------
+## [v0.7.1](https://github.com/glue-viz/glue/compare/v0.7...v0.7.1) - 2016-03-30
 
-* Fix issue with small screens and layer and viewer options by adding
+### What's Changed
+
+- Fix issue with small screens and layer and viewer options by adding
   scrollbars. [#902]
 
-* Fixed a failure due to a missing Qt import in glue.core.roi. [#901]
+- Fixed a failure due to a missing Qt import in glue.core.roi. [#901]
 
-* Fixed a bug that caused an abort trap if the filename specified on the
+- Fixed a bug that caused an abort trap if the filename specified on the
   command line did not exist. [#903]
 
-* Gracefully skip vector columnns when reading in FITS files. [#896]
+- Gracefully skip vector columnns when reading in FITS files. [#896]
 
-* Change default gray color to work on black and white backgrounds. [#906]
+- Change default gray color to work on black and white backgrounds. [#906]
 
-* Fixed a bug that caused the color in the scatter and histogram style
+- Fixed a bug that caused the color in the scatter and histogram style
   editors to not show the correct initial color. [#907]
 
-v0.7 (2016-03-10)
------------------
+## [v0.7](https://github.com/glue-viz/glue/compare/v0.6...v0.7) - 2016-03-10
 
-* Python 2.6 is no longer supported. [#804]
+### What's Changed
 
-* Added a generic QColorBox widget to pick colors, and an associated
-  connect_color helper for callback properties. [#864]
+- Python 2.6 is no longer supported. [#804]
 
-* Added a generic QColormapCombo widget to pick colormaps.
+- Added a generic QColorBox widget to pick colors, and an associated
+  ``connect_color`` helper for callback properties. [#864]
 
-* The ``artist_container`` argument to client classes has been renamed to
+- Added a generic QColormapCombo widget to pick colormaps.
+
+- The ``artist_container`` argument to client classes has been renamed to
   ``layer_artist_container``. [#814]
 
-* Added documentation about how to use layer artists in custom Qt data viewers.
+- Added documentation about how to use layer artists in custom Qt data viewers.
   [#814]
 
-* Fixed missing newline in Data.__str__. [#877]
+- Fixed missing newline in ``Data.__str__``. [#877]
 
-* A large fraction of the code has been re-organized, which may lead to some
+- A large fraction of the code has been re-organized, which may lead to some
   imports in ``config.py`` files no longer working. However, no functionality
   has been removed, so this can be fixed by updating the imports to reflect the
   new locations.
@@ -1515,187 +1579,193 @@ v0.7 (2016-03-10)
 
   [#845]
 
-* Improved under-the-hood creation of ROIs for Scatter and Histogram Clients. [#676]
+- Improved under-the-hood creation of ROIs for Scatter and Histogram Clients. [#676]
 
-* Data viewers can now define a layer artist style editor class that appears
+- Data viewers can now define a layer artist style editor class that appears
   under the list of layer artists. [#852]
 
-* Properties of the VisualAttributes class are now callback properties. [#852]
+- Properties of the VisualAttributes class are now callback properties. [#852]
 
-* Add ``glue.utils.qt.widget_properties.connect_value`` function which can take
-  an optional value_range and log option to scale the Qt values to a custom
+- Add ``glue.utils.qt.widget_properties.connect_value`` function which can take
+  an optional ``value_range`` and log option to scale the Qt values to a custom
   range of values (optionally in log space). [#852]
 
-* Make list of data viewers sorted alphabetically. [#866]
+- Make list of data viewers sorted alphabetically. [#866]
 
-v0.6 (2015-11-20)
------------------
+## [v0.6](https://github.com/glue-viz/glue/compare/v0.5.2...v0.6) - 2015-11-20
 
-* Added experimental support for PyQt5. [#663]
+### What's Changed
 
-* Fix ``glue -t`` option. [#791]
+- Added experimental support for PyQt5. [#663]
 
-* Updated ``glue-deps`` to show PyQt/PySide versions. [#796]
+- Fix ``glue -t`` option. [#791]
 
-* Fix bug that caused viewers to be restored with the wrong size. [#781, #783]
+- Updated ``glue-deps`` to show PyQt/PySide versions. [#796]
 
-* Fixed compatibility with the latest stable version of ginga. [#797]
+- Fix bug that caused viewers to be restored with the wrong size. [#781, #783]
 
-* Prevent axes from moving around when data viewers are being resized, and
+- Fixed compatibility with the latest stable version of ginga. [#797]
+
+- Prevent axes from moving around when data viewers are being resized, and
   instead make the absolute margins between axes and figure edge fixed. [#745]
 
-* Fixed a bug that caused image plots to not be updated immediately when
+- Fixed a bug that caused image plots to not be updated immediately when
   changing component, and fixed a bug that caused data and attribute combo
   boxes to not update correctly when showing multiple datasets in an
   ImageWidget. [#755]
 
-* Added tests to ensure that we remain backward-compatible with old session
+- Added tests to ensure that we remain backward-compatible with old session
   files for the FITS and HDF5 factories. [#736, #748]
 
-* When a box has been drawn to extract a spectrum from a cube, the box can
+- When a box has been drawn to extract a spectrum from a cube, the box can
   then be moved by pressing the control key and dragging it. [#707]
 
-* Refactored ASCII I/O to include more Astropy table formats. [#762]
+- Refactored ASCII I/O to include more Astropy table formats. [#762]
 
-* When saving a session, if no extension is specified, the .glu extension is
+- When saving a session, if no extension is specified, the .glu extension is
   added. [#729]
 
-* Added a GUI plugin manager in the 'Plugins' menu. [#682]
+- Added a GUI plugin manager in the 'Plugins' menu. [#682]
 
-* Added an option to specify whether to use an automatic aspect ratio for image
+- Added an option to specify whether to use an automatic aspect ratio for image
   data or whether to enforce square pixels. [#717]
 
-* Data factories can now be given priorities to determine which ones should
+- Data factories can now be given priorities to determine which ones should
   take precedence in ambiguous cases. The ``set_default_factory`` and
   ``get_default_factory`` functions are now deprecated since it is possible to
   achieve this solely with priorities. [#719]
 
-* Improved cube slider to include editable slice value as well as
+- Improved cube slider to include editable slice value as well as
   first/previous/next/last buttons, and improved spacing of sliders for 4+
   dimensional cubes. [#690, #734]
 
-* Registering data factories should now always be done with the
+- Registering data factories should now always be done with the
   ``@data_factory`` decorator, and not by adding functions to
   ``__factories__``, as was possible in early versions of Glue. [#724]
 
-* Made the Excel spreadsheet reader more robust: column headers no longer have
+- Made the Excel spreadsheet reader more robust: column headers no longer have
   to be strings, and the reader no longer expects the first sheet to be called
   'Sheet1'. All sheets are now read by default. Datasets are now named as
   filename:sheetname. [#726]
 
-* Fix compatibility with IPython 4. [#733]
+- Fix compatibility with IPython 4. [#733]
 
-* Improved reading of FITS files - all HDUs are now read by default. [#704, #732]
+- Improved reading of FITS files - all HDUs are now read by default. [#704, #732]
 
-* Added new widget property classes, for combo boxes (based on label instead of
+- Added new widget property classes, for combo boxes (based on label instead of
   data) and for tab widgets. [#752]
 
-* Improved reading of HDF5 files - all datasets in an HDF5 file are now read by
+- Improved reading of HDF5 files - all datasets in an HDF5 file are now read by
   default. [#747]
 
-* Fix a bug that caused images to not be shown at full resolution after resizing. [#768]
+- Fix a bug that caused images to not be shown at full resolution after resizing. [#768]
 
-* Fix a bug that caused the color of an extracted spectrum to vary if extracted
+- Fix a bug that caused the color of an extracted spectrum to vary if extracted
   multiple times. [#743]
 
-* Fixed a bug that caused compressed image HDUs to not be read correctly.
+- Fixed a bug that caused compressed image HDUs to not be read correctly.
   [#767]
 
-* Added two new settings ``settings.SUBSET_COLORS`` and ``settings.DATA_COLOR``
+- Added two new settings ``settings.SUBSET_COLORS`` and ``settings.DATA_COLOR``
   that can be used to customize the default subset and data colors. [#742]
 
-v0.5.3 (unreleased)
--------------------
+## v0.5.3 (unreleased)
 
-* Fix selection in scatter plots when categorical data are present. [#727]
+### What's Changed
 
-v0.5.2 (2015-08-13)
--------------------
+- Fix selection in scatter plots when categorical data are present. [#727]
 
-* Fix loading of plugins with setuptools < 11.3 [#699]
+## [v0.5.2](https://github.com/glue-viz/glue/compare/v0.5.1...v0.5.2) - 2015-08-13
 
-* Fix loading of plugins when using glue programmatically rather than through the GUI [#698]
+### What's Changed
 
-* Backward-compatibility fixes after refactoring data_factories [#696, #703]
+- Fix loading of plugins with setuptools < 11.3 [#699]
 
-v0.5.1 (2015-07-06)
--------------------
+- Fix loading of plugins when using glue programmatically rather than through the GUI [#698]
 
-* Fixed treatment of newlines when copying detailed error. [#687]
+- Backward-compatibility fixes after refactoring ``data_factories`` [#696, #703]
 
-* Fix a bug that prevented sessions from being saved with embedded files if
+## [v0.5.1](https://github.com/glue-viz/glue/compare/v0.5...v0.5.1) - 2015-07-06
+
+### What's Changed
+
+- Fixed treatment of newlines when copying detailed error. [#687]
+
+- Fix a bug that prevented sessions from being saved with embedded files if
   component units were Astropy units. [#686]
 
-* Users should now press 'control' to drag rather than re-define subsets. [#689]
+- Users should now press 'control' to drag rather than re-define subsets. [#689]
 
-v0.5 (2015-07-03)
------------------
+## [v0.5](https://github.com/glue-viz/glue/compare/v0.4...v0.5) - 2015-07-03
 
-* Improvements to the PyQt/PySide wrapper module (now maintained in a separate repository). [#671]
+### What's Changed
 
-* Fixed broken links on website. [#678]
+- Improvements to the PyQt/PySide wrapper module (now maintained in a separate repository). [#671]
 
-* Added the ability to discover plugins via entry points. [#677]
+- Fixed broken links on website. [#678]
 
-* Added the ability to include float and string UI elements in custom
+- Added the ability to discover plugins via entry points. [#677]
+
+- Added the ability to include float and string UI elements in custom
   viewers. [#653]
 
-* Added an option to bundle all data in .glu session files. [#661]
+- Added an option to bundle all data in .glu session files. [#661]
 
-* Added a ``menu_plugin`` registry to add custom tools to the registry. [#644]
+- Added a ``menu_plugin`` registry to add custom tools to the registry. [#644]
 
-* Support for 'lazy-loading' plugins which means their import is deferred
+- Support for 'lazy-loading' plugins which means their import is deferred
   until they are needed. [#590]
 
-* Support for connecting custom importers. [#593]
+- Support for connecting custom importers. [#593]
 
-* ``qglue`` now correctly interprets HDUList objects. [#598]
+- ``qglue`` now correctly interprets HDUList objects. [#598]
 
-* Internal improvements to organization of domain-specific code (such as the
+- Internal improvements to organization of domain-specific code (such as the
   Astronomy coordinate conversions and ginga data viewer). [#488, #585]
 
-* Astronomy coordinate conversions now include more coordinate frames. [#578]
+- Astronomy coordinate conversions now include more coordinate frames. [#578]
 
-* ``load_ui`` now checks whether ``.ui`` file exists locally before
+- ``load_ui`` now checks whether ``.ui`` file exists locally before
   retrieving it from the ``glue.qt.ui`` sub-package. [#599]
 
-* Improved interface for adding new components, with syntax highlighting
+- Improved interface for adding new components, with syntax highlighting
   and tab-completion. [#572, #575]
 
-* Improved error/warning messages. [#582]
+- Improved error/warning messages. [#582]
 
-* Miscellaneous bug fixes. [#637, #636, #608]
+- Miscellaneous bug fixes. [#637, #636, #608]
 
-* The error console log is now available through the View menu
+- The error console log is now available through the View menu
 
-* Improved under-the-hood handling of categorical ROIs. [#601]
+- Improved under-the-hood handling of categorical ROIs. [#601]
 
-* Fixed compatibility with Python 2.6. [#540]
+- Fixed compatibility with Python 2.6. [#540]
 
-* Python 3.x support is now stable. [#576]
+- Python 3.x support is now stable. [#576]
 
-* Fixed the ability to copy detailed error messages. [#675]
+- Fixed the ability to copy detailed error messages. [#675]
 
-* Added instructions on how to make a fully-customized Qt viewer. [#619]
+- Added instructions on how to make a fully-customized Qt viewer. [#619]
 
-* Fixes to the ginga plugin to support the latest version. [#584, #656]
+- Fixes to the ginga plugin to support the latest version. [#584, #656]
 
-* Added the ability to drag circular, rectangular, and lasso selections. [#657]
+- Added the ability to drag circular, rectangular, and lasso selections. [#657]
 
-* Added the ability to reset a session. [#630]
+- Added the ability to reset a session. [#630]
 
-v0.4 (Released December 22, 2015)
----------------------------------
+## [v0.4](https://github.com/glue-viz/glue/releases/tag/v0.4) (Released December 22, 2015)
 
-Release Highlights:
- * Introduced custom viewers
- * Ginga-based image viewer
- * Experimental Python 3.x support
+### Release Highlights:
 
-Other Notes
- * Better testing for support of optional dependencies
- * Refactored spectrum and position-velocity features from the Image widget into plugin tools
- * Adopted contracts for contracters to add optional runtime type checking
- * Added ability to export collapsed cubes as 2D fits files
- * More flexible data parsing in qglue utility
- * Numerous bugfixes
+- Introduced custom viewers
+- Ginga-based image viewer
+- Experimental Python 3.x support
+
+### Other Notes
+
+- Better testing for support of optional dependencies
+- Refactored spectrum and position-velocity features from the Image widget into plugin tools
+- Adopted contracts for contracters to add optional runtime type checking
+- Added ability to export collapsed cubes as 2D fits files
+- More flexible data parsing in qglue utility
+- Numerous bugfixes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,13 +8,13 @@
 
 - Added rotation angle ``theta`` as a property to regions of interest,
   to be set on instantiation or modified using the ``rotate_to`` and
-  ``rotate_by`` methods. [#2235]
+  ``rotate_by`` methods. https://github.com/glue-viz/glue/pull/2235
 
 #### Bug Fixes
 
 - Fixed a bug on setting a return view in ``compute_statistic`` when a subset
   is defined, resulting in a broadcast error in arrays large enough to need
-  chunking. [#2302]
+  chunking. https://github.com/glue-viz/glue/pull/2302
 
 ## [v1.4.0](https://github.com/glue-viz/glue/compare/v1.3.0...v1.4.0) - 2022-05-31
 
@@ -22,14 +22,14 @@
 
 #### New Features
 
-- Add support for specifying visual attributes when creating a subset group. [#2297]
+- Add support for specifying visual attributes when creating a subset group. https://github.com/glue-viz/glue/pull/2297
 
-- Add support for using degrees in full-sphere projections. [#2279]
+- Add support for using degrees in full-sphere projections. https://github.com/glue-viz/glue/pull/2279
 
 #### Bug Fixes
 
 - Modify profile viewer so that when in 'Sum' mode, parts of profiles
-  with no valid values are NaN rather than zero. [#2298]
+  with no valid values are NaN rather than zero. https://github.com/glue-viz/glue/pull/2298
 
 ## [v1.3.0](https://github.com/glue-viz/glue/compare/v1.2.4...v1.3.0) - 2022-04-22
 
@@ -38,23 +38,23 @@
 #### New Features
 
 - Modify scatter viewer so that axis labels are shown in tick marks
-  when in polar mode. [#2267]
+  when in polar mode. https://github.com/glue-viz/glue/pull/2267
 
-- Support toggling plotting profile viewer layer as steps. [#2292]
+- Support toggling plotting profile viewer layer as steps. https://github.com/glue-viz/glue/pull/2292
 
 #### Bug Fixes
 
-- Reset limits in profile viewer when changing collapse function. [#2277]
+- Reset limits in profile viewer when changing collapse function. https://github.com/glue-viz/glue/pull/2277
 
 - Fixed a bug that caused an error when the table viewer tried to show
-  disabled layers. [#2286]
+  disabled layers. https://github.com/glue-viz/glue/pull/2286
 
-- Fixed an issue where glue modified global logging settings. [#2281]
+- Fixed an issue where glue modified global logging settings. https://github.com/glue-viz/glue/pull/2281
 
 #### Other Changes
 
 - Remove bundled version of pvextractor and include it as a proper
-  dependency. [#2252]
+  dependency. https://github.com/glue-viz/glue/pull/2252
 
 ## [v1.2.4](https://github.com/glue-viz/glue/compare/v1.2.3...v1.2.4) - 2022-01-27
 
@@ -63,15 +63,15 @@
 #### Bug Fixes
 
 - Fixed a bug that caused selections to no longer work
-  in a scatter viewer once its projection had been changed. [#2262]
+  in a scatter viewer once its projection had been changed. https://github.com/glue-viz/glue/pull/2262
 
 - Fixed a bug which prevented serialization for polar plots in degree
-  mode. [#2259]
+  mode. https://github.com/glue-viz/glue/pull/2259
 
 - Fixed a bug that caused histograms and density maps to not work
-  correctly with attributes linked using ``join_on_key``. [#2242]
+  correctly with attributes linked using ``join_on_key``. https://github.com/glue-viz/glue/pull/2242
 
-- Fixed issues in viewers when dask arrays were used. [#2249]
+- Fixed issues in viewers when dask arrays were used. https://github.com/glue-viz/glue/pull/2249
 
 ## [v1.2.3](https://github.com/glue-viz/glue/compare/v1.2.2...v1.2.3) - 2021-11-14
 
@@ -79,14 +79,14 @@
 
 #### Bug Fixes
 
-- Fixed compatibility with Matplotlib 3.5.0. [#2250]
+- Fixed compatibility with Matplotlib 3.5.0. https://github.com/glue-viz/glue/pull/2250
 
-- Fixed compatibility with Python 3.10 and recent versions of PyQt. [#2258]
+- Fixed compatibility with Python 3.10 and recent versions of PyQt. https://github.com/glue-viz/glue/pull/2258
 
 #### Other Changes
 
 - Remove bottleneck dependency as it is no longer maintained. Certain
-  array operations may be slower as a result. [#2258]
+  array operations may be slower as a result. https://github.com/glue-viz/glue/pull/2258
 
 ## [v1.2.2](https://github.com/glue-viz/glue/compare/v1.2.1...v1.2.2) - 2021-09-16
 
@@ -95,15 +95,15 @@
 #### Bug Fixes
 
 - Prevent resetting of image viewer limits when adding a dataset to the
-  viewer. [#2232]
+  viewer. https://github.com/glue-viz/glue/pull/2232
 
-- Fixed home button for resetting limits in profile viewer. [#2233]
+- Fixed home button for resetting limits in profile viewer. https://github.com/glue-viz/glue/pull/2233
 
 - Fixed a bug that caused the visibility checkbox of layers in the profile
-  viewer to not always correctly. [#2233]
+  viewer to not always correctly. https://github.com/glue-viz/glue/pull/2233
 
 - Fixed a bug that caused the profile viewer limits to be unecessarily
-  changed every time a subset was updated or a dataset was added. [#2233]
+  changed every time a subset was updated or a dataset was added. https://github.com/glue-viz/glue/pull/2233
 
 ## [v1.2.1](https://github.com/glue-viz/glue/compare/v1.2.0...v1.2.1) - 2021-08-24
 
@@ -112,7 +112,7 @@
 #### Bug Fixes
 
 - Fixed a bug that caused issues with packages depending on glue which
-  defined layer artists with no zorder on the artist class. [#2226, #2227]
+  defined layer artists with no zorder on the artist class. https://github.com/glue-viz/glue/pull/2226, https://github.com/glue-viz/glue/pull/2227
 
 ## [v1.2.0](https://github.com/glue-viz/glue/compare/v1.1.0...v1.2.0) - 2021-08-14
 
@@ -121,18 +121,18 @@
 #### New Features
 
 - Added a new ``WCSLink.as_affine_link`` method which can be used to find
-  an affine approximation to a WCSLink. [#2219]
+  an affine approximation to a WCSLink. https://github.com/glue-viz/glue/pull/2219
 
 - Expose ``DataCollection.delay_link_manager_update`` which can be used
-  to delay any updating to the link tree when adding datasets. [#2225]
+  to delay any updating to the link tree when adding datasets. https://github.com/glue-viz/glue/pull/2225
 
-- Allow CategoricalComponents to be n-dimensional. [#2214]
+- Allow CategoricalComponents to be n-dimensional. https://github.com/glue-viz/glue/pull/2214
 
-- Improve usability of 2D scatter plot in non-cartesian projection. [#2200]
+- Improve usability of 2D scatter plot in non-cartesian projection. https://github.com/glue-viz/glue/pull/2200
 
 #### Bug Fixes
 
-- Avoid duplicate update of layer artist when creating a new layer. [#2220]
+- Avoid duplicate update of layer artist when creating a new layer. https://github.com/glue-viz/glue/pull/2220
 
 ## [v1.1.0](https://github.com/glue-viz/glue/compare/v1.0.1...v1.1.0) - 2021-07-21
 
@@ -140,114 +140,114 @@
 
 #### Bug Fixes
 
-- Fix compatibility with xlrd 2.0 and require openpyxl for .xlsx input. [#2196]
+- Fix compatibility with xlrd 2.0 and require openpyxl for .xlsx input. https://github.com/glue-viz/glue/pull/2196
 
-- Fixed compatibility with recent releases of Matplotlib. [#2196]
+- Fixed compatibility with recent releases of Matplotlib. https://github.com/glue-viz/glue/pull/2196
 
-- Avoid warnings with recent releases of astropy. [#2212]
+- Avoid warnings with recent releases of astropy. https://github.com/glue-viz/glue/pull/2212
 
-- Fixed compatibility of auto-linking with all APE 14 WCSes. [#2209]
+- Fixed compatibility of auto-linking with all APE 14 WCSes. https://github.com/glue-viz/glue/pull/2209
 
 #### Other Changes
 
-- Dropped support for Python 3.6. [#2196]
+- Dropped support for Python 3.6. https://github.com/glue-viz/glue/pull/2196
 
 ## [v1.0.1](https://github.com/glue-viz/glue/compare/v1.0.0...v1.0.1) - 2020-11-10
 
 ### What's Changed
 
-- Updated supported versions of ``jupyter_client``. [#2175]
+- Updated supported versions of ``jupyter_client``. https://github.com/glue-viz/glue/pull/2175
 
 ## [v1.0.0](https://github.com/glue-viz/glue/compare/v0.15.7...v1.0.0) - 2020-09-17
 
 ### What's Changed
 
-- Remove bundled echo package and list as a dependency. [#2125]
+- Remove bundled echo package and list as a dependency. https://github.com/glue-viz/glue/pull/2125
 
-- Add the ability to export Python scripts for the profile viewer. [#2082]
+- Add the ability to export Python scripts for the profile viewer. https://github.com/glue-viz/glue/pull/2082
 
 - Add support for polar and other non-rectilinear projections in
-  2-d scatter viewer [#2170]
+  2-d scatter viewer https://github.com/glue-viz/glue/pull/2170
 
-- Add legend for matplotlib viewers (in qt and in export scripts) [#2097, #2144, #2146]
+- Add legend for matplotlib viewers (in qt and in export scripts) https://github.com/glue-viz/glue/pull/2097, https://github.com/glue-viz/glue/pull/2144, https://github.com/glue-viz/glue/pull/2146
 
-- Add new registry to apply in-place patches to the session file [#2127]
+- Add new registry to apply in-place patches to the session file https://github.com/glue-viz/glue/pull/2127
 
-- Initial support for dask arrays. [#2137, #2149]
+- Initial support for dask arrays. https://github.com/glue-viz/glue/pull/2137, https://github.com/glue-viz/glue/pull/2149
 
-- Don't sync color and transparency of image layers by default. [#2116]
+- Don't sync color and transparency of image layers by default. https://github.com/glue-viz/glue/pull/2116
 
-- Python 2.7 and 3.5 are no longer supported. [#2075]
+- Python 2.7 and 3.5 are no longer supported. https://github.com/glue-viz/glue/pull/2075
 
-- Always use replace mode when creating a new subset. [#2090]
+- Always use replace mode when creating a new subset. https://github.com/glue-viz/glue/pull/2090
 
 - Fixed bugs in the profile viewer that occurred when using the profile viewer and
-  setting ``reference_data`` to a different value than the default one. [#2078]
+  setting ``reference_data`` to a different value than the default one. https://github.com/glue-viz/glue/pull/2078
 
-- Updated the data loader to be able to select directories. [#2077,#2080]
+- Updated the data loader to be able to select directories. https://github.com/glue-viz/glue/pull/2077, https://github.com/glue-viz/glue/pull/2080
 
-- Move spectral-cube data loader to glue-astronomy plugin package. [#2077]
+- Move spectral-cube data loader to glue-astronomy plugin package. https://github.com/glue-viz/glue/pull/2077
 
-- Show session filename path in window title. [#2096]
+- Show session filename path in window title. https://github.com/glue-viz/glue/pull/2096
 
 - Change ``Data.coords`` API to now rely on the API described in
-  https://github.com/astropy/astropy-APEs/blob/master/APE14.rst [#2079]
+  https://github.com/astropy/astropy-APEs/blob/master/APE14.rst https://github.com/glue-viz/glue/pull/2079
 
-- Update minimum required version of Astropy to 4.0. [#2079]
+- Update minimum required version of Astropy to 4.0. https://github.com/glue-viz/glue/pull/2079
 
-- Added a ``DataCollection.clear()`` method to remove all datasets. [#2079]
+- Added a ``DataCollection.clear()`` method to remove all datasets. https://github.com/glue-viz/glue/pull/2079
 
 - Fixed a bug that caused profiles of subsets to not be hidden if an
-  existing subset was emptied. [#2095]
+  existing subset was emptied. https://github.com/glue-viz/glue/pull/2095
 
-- Improved ``IndexedData`` so that world coordinates can now be shown. [#2081]
+- Improved ``IndexedData`` so that world coordinates can now be shown. https://github.com/glue-viz/glue/pull/2081
 
-- Make loading Qt plugins optional when calling ``load_plugins``. [#2112]
+- Make loading Qt plugins optional when calling ``load_plugins``. https://github.com/glue-viz/glue/pull/2112
 
-- Preserve ``RectangularROI`` rather than converting them to ``PolygonalROI``. [#2112]
+- Preserve ``RectangularROI`` rather than converting them to ``PolygonalROI``. https://github.com/glue-viz/glue/pull/2112
 
 - Significantly improve performance of ``compute_fixed_resolution_buffer`` when
-  using linked datasets with some axes uncorrelated. [#2115]
+  using linked datasets with some axes uncorrelated. https://github.com/glue-viz/glue/pull/2115
 
-- Improve performance of profile viewer when not all layers are visible. [#2115]
+- Improve performance of profile viewer when not all layers are visible. https://github.com/glue-viz/glue/pull/2115
 
-- Fixed missing .units on ``CoordinateComponent``. [#2117]
+- Fixed missing .units on ``CoordinateComponent``. https://github.com/glue-viz/glue/pull/2117
 
-- Improve auto-linking of astronomical datasets with WCS information. [#2161]
+- Improve auto-linking of astronomical datasets with WCS information. https://github.com/glue-viz/glue/pull/2161
 
 - Fix bug that occurred when using the GUI link editor when links had
-  been defined programmatically. [#2166]
+  been defined programmatically. https://github.com/glue-viz/glue/pull/2166
 
 - Add the ability to programmatically set the preferred colormap for a
-  dataset using ``Data.visual.preferred_cmap`` [#2131, #2168]
+  dataset using ``Data.visual.preferred_cmap`` https://github.com/glue-viz/glue/pull/2131, https://github.com/glue-viz/glue/pull/2168
 
-- Fix bug that caused incorrect unit to be shown on slider for images. [#2159]
+- Fix bug that caused incorrect unit to be shown on slider for images. https://github.com/glue-viz/glue/pull/2159
 
-- Improve performance of ``Data.compute_statistic`` for subsets. [#2147]
+- Improve performance of ``Data.compute_statistic`` for subsets. https://github.com/glue-viz/glue/pull/2147
 
-- Fix a bug where ``x_att`` and ``y_att`` could end up being out of sync in image viewer. [#2141]
+- Fix a bug where ``x_att`` and ``y_att`` could end up being out of sync in image viewer. https://github.com/glue-viz/glue/pull/2141
 
 ## [v0.15.7](https://github.com/glue-viz/glue/compare/v0.15.6...v0.15.7) - 2020-03-12
 
 ### What's Changed
 
 - Fix bug that caused an infinite loop in the table viewer and caused glue to
-  hang if too many incompatible subsets were in a table viewer. [#2105]
+  hang if too many incompatible subsets were in a table viewer. https://github.com/glue-viz/glue/pull/2105
 
 - Fixed a bug that caused an error when an invalid data was added to the table
-  viewer and the table viewer was then automatically closed. [#2103]
+  viewer and the table viewer was then automatically closed. https://github.com/glue-viz/glue/pull/2103
 
 - Fixed the dropdowns for vector and error markers to not include datetime
-  components (since they represent absolute times, not deltas). [#2102]
+  components (since they represent absolute times, not deltas). https://github.com/glue-viz/glue/pull/2102
 
 - Fixed a bug that caused session files that were saved with LinkCollection to
-  not work correctly when re-loaded. [#2100]
+  not work correctly when re-loaded. https://github.com/glue-viz/glue/pull/2100
 
 - Fixed a bug that caused issues when saving and re-loading sessions that were
-  originally created using Excel data with string columns. [#2101]
+  originally created using Excel data with string columns. https://github.com/glue-viz/glue/pull/2101
 
 - Avoid converting circular selections in Matplotlib plots to polygons if
-  it can be avoided. [#2094]
+  it can be avoided. https://github.com/glue-viz/glue/pull/2094
 
 ## [v0.15.6](https://github.com/glue-viz/glue/compare/v0.15.5...v0.15.6) - 2019-08-22
 
@@ -256,36 +256,36 @@
 - Fixed bugs related to auto-linking of astronomical data with WCS information. In
   particular, links between datasets with celestial coordinates in a different order
   or links between some higher dimensional datasets with celestial axes did not
-  always work correctly. [#2052]
+  always work correctly. https://github.com/glue-viz/glue/pull/2052
 
 - Fixed a bug that caused the auto-linking framework to not run when opening glue from
-  the ``qglue()`` function. [#2052]
+  the ``qglue()`` function. https://github.com/glue-viz/glue/pull/2052
 
 - Fixed a limitation that caused pixel selections to not propagate to other datasets.
-  [#2052]
+  https://github.com/glue-viz/glue/pull/2052
 
-- Fixed a deprecation warning related to ``add_datasets``. [#2052]
+- Fixed a deprecation warning related to ``add_datasets``. https://github.com/glue-viz/glue/pull/2052
 
-- Fixed compatibility with Python 3.7.4. [#2060]
+- Fixed compatibility with Python 3.7.4. https://github.com/glue-viz/glue/pull/2060
 
-- Fixed performance issue with arrays that were not in native C order. [#2056]
+- Fixed performance issue with arrays that were not in native C order. https://github.com/glue-viz/glue/pull/2056
 
 ## [v0.15.5](https://github.com/glue-viz/glue/compare/v0.15.4...v0.15.5) - 2019-07-09
 
 ### What's Changed
 
-- Fixed bug with density map visibility when using color-coding. [#2041]
+- Fixed bug with density map visibility when using color-coding. https://github.com/glue-viz/glue/pull/2041
 
-- Fixed bug with incompatible subsets and density maps. [#2041]
+- Fixed bug with incompatible subsets and density maps. https://github.com/glue-viz/glue/pull/2041
 
-- Make sure that lines/errors/vectors are disabled when in density map mode. [#2041]
+- Make sure that lines/errors/vectors are disabled when in density map mode. https://github.com/glue-viz/glue/pull/2041
 
 ## [v0.15.4](https://github.com/glue-viz/glue/compare/v0.15.3...v0.15.4) - 2019-07-08
 
 ### What's Changed
 
 - Fixed bug that occurred when trying to add a subset to a new table
-  viewer (without the parent data). [#2038]
+  viewer (without the parent data). https://github.com/glue-viz/glue/pull/2038
 
 ## [v0.15.3](https://github.com/glue-viz/glue/compare/v0.15.2...v0.15.3) - 2019-06-27
 
@@ -294,7 +294,7 @@
 - Fixed bugs related to the preferences dialog - first, the dialog would
   not open if no auto-linkers were present, and second, the preferences
   dialog would sometimes get sent behind the main application when editing
-  the color. [#2034]
+  the color. https://github.com/glue-viz/glue/pull/2034
 
 ## [v0.15.2](https://github.com/glue-viz/glue/compare/v0.15.1...v0.15.2) - 2019-06-24
 
@@ -302,18 +302,18 @@
 
 - Fixed a bug in ``autoconnect_callbacks_to_qt`` which caused some widgets
   to not stay connect to state callback properties if a callback property
-  was linked to multiple widgets. [#2032]
+  was linked to multiple widgets. https://github.com/glue-viz/glue/pull/2032
 
 ## [v0.15.1](https://github.com/glue-viz/glue/compare/v0.15.0...v0.15.1) - 2019-06-24
 
 ### What's Changed
 
-- Fixed ``__version__`` variable. [#2031]
+- Fixed ``__version__`` variable. https://github.com/glue-viz/glue/pull/2031
 
-- Fixed tox configuration. [#2031]
+- Fixed tox configuration. https://github.com/glue-viz/glue/pull/2031
 
 - Improve error message if loading a session file that uses WCS auto-linking
-  but the installed version of astropy is too old. [#2031]
+  but the installed version of astropy is too old. https://github.com/glue-viz/glue/pull/2031
 
 ## [v0.15.0](https://github.com/glue-viz/glue/compare/v0.14.2...v0.15.0) - 2019-06-23
 
@@ -321,164 +321,164 @@
 
 - Added a new ``glue.core.coordinates.AffineCoordinates`` class for common
   affine transformations, and also added documentation on defining custom
-  coordinates. [#1994]
+  coordinates. https://github.com/glue-viz/glue/pull/1994
 
 - Rewrote ``SubsetFacet`` (now ``SubsetFacetDialog``), and updated the
-  available colormaps. [#1998]
+  available colormaps. https://github.com/glue-viz/glue/pull/1998
 
-- Removed the ``ComponentSelector`` class. [#1998]
+- Removed the ``ComponentSelector`` class. https://github.com/glue-viz/glue/pull/1998
 
 - Make it possible to view only a subset of data in the table
-  viewer. [#1988]
+  viewer. https://github.com/glue-viz/glue/pull/1988
 
-- Show dataset name in table viewer title. [#1973]
+- Show dataset name in table viewer title. https://github.com/glue-viz/glue/pull/1973
 
 - Expose an option (``inherit_tools``) on data viewer classes
   related to whether tools should be inherited or not from
-  parent classes. [#1972]
+  parent classes. https://github.com/glue-viz/glue/pull/1972
 
 - Added a new method ``compute_fixed_resolution_buffer`` to data
   objects (including the base data class) and use this for the
   image viewer. This improves the case where images are reprojected
   as they are now all reprojected to the screen resolution rather
   than the resolution of the reference data, and this also opens
-  up the possibility of doing n-dimensional reprojection. [#1895]
+  up the possibility of doing n-dimensional reprojection. https://github.com/glue-viz/glue/pull/1895
 
 - Added initial infrastructure for developing auto-linking helpers
-  and implement an initial astronomy WCS auto-linker. [#1933]
+  and implement an initial astronomy WCS auto-linker. https://github.com/glue-viz/glue/pull/1933
 
 - Improve the user interface for the link editor. [#1934, #1998]
 
 - Added a new ``IndexedData`` class to represent a derived dataset produced
-  by indexing a higher-dimensional dataset. [#1953]
+  by indexing a higher-dimensional dataset. https://github.com/glue-viz/glue/pull/1953
 
 - Removed plot.ly export plugin - this is now part of the glue-plotly
-  package. [#1999]
+  package. https://github.com/glue-viz/glue/pull/1999
 
 - Fix path to data bundle when exporting Python scripts to another directory
-  than the one glue was run from. [#2023]
+  than the one glue was run from. https://github.com/glue-viz/glue/pull/2023
 
 - Added a ``--faulthandler`` command-line flag to help debug segmentation
-  faults. [#1974]
+  faults. https://github.com/glue-viz/glue/pull/1974
 
 - Removed ``glue.core.qt.roi`` submodule. This provided faster versions of
   the Matplotlib ROI classes in ``glue.core.roi`` but the latter are now
-  efficient enough that the Qt-specific versions are no longer needed. [#1983]
+  efficient enough that the Qt-specific versions are no longer needed. https://github.com/glue-viz/glue/pull/1983
 
 - Moved ``glue.viewers.common.qt.tool`` to ``glue.viewers.common.tool``;
   ``glue.viewers.common.qt.mouse_mode`` to ``glue.viewers.matplotlib.mouse_mode``;
   and ``glue.viewers.common.qt.toolbar_mode`` to ``glue.viewers.matplotlib.toolbar_mode``
-  and ``glue.viewers.matplotlib.qt.toolbar_mode``. [#1984]
+  and ``glue.viewers.matplotlib.qt.toolbar_mode``. https://github.com/glue-viz/glue/pull/1984
 
-- Implement a human-readable str/repr for State objects. [#2021]
+- Implement a human-readable str/repr for State objects. https://github.com/glue-viz/glue/pull/2021
 
 - Avoiding importing Qt when using the base histogram and profile layer artists.
-  [#2012]
+  https://github.com/glue-viz/glue/pull/2012
 
 - Fixed a bug that caused error bars to be colored incorrectly if NaN values
-  were present. [#2020]
+  were present. https://github.com/glue-viz/glue/pull/2020
 
-- Fixed compatibility with the latest versions of Matplotlib and Astropy. [#2020]
+- Fixed compatibility with the latest versions of Matplotlib and Astropy. https://github.com/glue-viz/glue/pull/2020
 
 - No longer suggest merging data by default whenever datasets are added to
   the session. Merging different datasets should now be done manually through
-  the GUI. [#2020]
+  the GUI. https://github.com/glue-viz/glue/pull/2020
 
-- Fixed compatibility with Numpy 1.16.x. [#1989]
+- Fixed compatibility with Numpy 1.16.x. https://github.com/glue-viz/glue/pull/1989
 
 - Improve tab-completion of attribute names in Data to not include
-  non-relevant items. [#1971]
+  non-relevant items. https://github.com/glue-viz/glue/pull/1971
 
 - Fix an error that occurred if creating a new viewer was
-  cancelled. [#1952]
+  cancelled. https://github.com/glue-viz/glue/pull/1952
 
-- Fix error in image viewer when using ``update_values_from_data``. [#1975]
+- Fix error in image viewer when using ``update_values_from_data``. https://github.com/glue-viz/glue/pull/1975
 
-- Exclude problematic versions of ipykernel from dependencies. [#1952]
+- Exclude problematic versions of ipykernel from dependencies. https://github.com/glue-viz/glue/pull/1952
 
 - Make sure that scrolling above a viewer does not result in the
-  whole canvas also scrolling. [#1919]
+  whole canvas also scrolling. https://github.com/glue-viz/glue/pull/1919
 
 - Fix bug that caused date/time columns in Excel files to not be
   read in correctly.
 
-- Improve performance when reading in large non-FITS files. [#1920]
+- Improve performance when reading in large non-FITS files. https://github.com/glue-viz/glue/pull/1920
 
-- Fix bug that caused log parameter to be ignore for density plots. [#1963]
+- Fix bug that caused log parameter to be ignore for density plots. https://github.com/glue-viz/glue/pull/1963
 
 - Fix bug that caused an error when using the profile collapse tool and
-  dragging from right to left. [#2002]
+  dragging from right to left. https://github.com/glue-viz/glue/pull/2002
 
 - Fix bug that caused labels on the x-axis of the histogram viewer to
   be incorrectly set to numbers instead of strings when showing a
-  histogram of a string variable and saving/reloading session. [#2009]
+  histogram of a string variable and saving/reloading session. https://github.com/glue-viz/glue/pull/2009
 
 ## [v0.14.2](https://github.com/glue-viz/glue/compare/v0.14.2...v0.14.1) - 2019-02-04
 
 ### What's Changed
 
 - Fix bug that caused demo VO Table to not be read in correctly with
-  recent versions of Numpy and Astropy. [#1911]
+  recent versions of Numpy and Astropy. https://github.com/glue-viz/glue/pull/1911
 
 ## [v0.14.1](https://github.com/glue-viz/glue/compare/v0.14.0...v0.14.1) - 2018-11-23
 
 ### What's Changed
 
 - Fix bug that caused the links based on ``join_on_key`` to not
-  always work. [#1902]
+  always work. https://github.com/glue-viz/glue/pull/1902
 
 ## [v0.14.0](https://github.com/glue-viz/glue/compare/v0.13.4...v0.14.0) - 2018-11-14
 
 ### What's Changed
 
 - Improved how we handle equal aspect ratio to not depend on
-  Matplotlib. [#1894]
+  Matplotlib. https://github.com/glue-viz/glue/pull/1894
 
-- Avoid showing a warning when closing an empty tab. [#1890]
+- Avoid showing a warning when closing an empty tab. https://github.com/glue-viz/glue/pull/1890
 
 - Fix bug that caused component arithmetic to not work if
-  Numpy was imported in user's config.py file. [#1887]
+  Numpy was imported in user's config.py file. https://github.com/glue-viz/glue/pull/1887
 
 - Added the ability to define custom layer artist makers to
-  override default layer artists in viewers. [#1850]
+  override default layer artists in viewers. https://github.com/glue-viz/glue/pull/1850
 
 - Fix Plot.ly exporter for categorical components and histogram
-  viewer. [#1886]
+  viewer. https://github.com/glue-viz/glue/pull/1886
 
-- Fix issues with reading very large FITS files on some systems. [#1884]
+- Fix issues with reading very large FITS files on some systems. https://github.com/glue-viz/glue/pull/1884
 
-- Added documentation about plugins. [#1837]
+- Added documentation about plugins. https://github.com/glue-viz/glue/pull/1837
 
 - Better isolate code related to pixel selection tool in image
-  viewer that depended on Qt. [#1763]
+  viewer that depended on Qt. https://github.com/glue-viz/glue/pull/1763
 
-- Improve handling of units in FITS files. [#1723]
+- Improve handling of units in FITS files. https://github.com/glue-viz/glue/pull/1723
 
 - Added documentation about creating viewers for glue using the
-  new state-based infrastructure. [#1740]
+  new state-based infrastructure. https://github.com/glue-viz/glue/pull/1740
 
 - Make it possible to pass the initial state of a viewer to an
-  application's ``new_data_viewer`` method. [#1877]
+  application's ``new_data_viewer`` method. https://github.com/glue-viz/glue/pull/1877
 
 - Ensure that glue can be imported if QtPy is installed but PyQt
   and PySide aren't. [#1865, #1836]
 
 - Fix unit display for coordinates from WCS headers that don't have
-  CTYPE but have CUNIT. [#1856]
+  CTYPE but have CUNIT. https://github.com/glue-viz/glue/pull/1856
 
-- Enable tab completion on Data objects. [#1874]
+- Enable tab completion on Data objects. https://github.com/glue-viz/glue/pull/1874
 
-- Automatically select datasets in link editor if there are only two. [#1837]
+- Automatically select datasets in link editor if there are only two. https://github.com/glue-viz/glue/pull/1837
 
 - Change 'Export Session' dialog to offer to save with relative paths to data
-  by default instead of absolute paths. [#1803]
+  by default instead of absolute paths. https://github.com/glue-viz/glue/pull/1803
 
 - Added a new method ``screenshot`` on ``GlueApplication`` to save a
-  screenshot of the current view. [#1808]
+  screenshot of the current view. https://github.com/glue-viz/glue/pull/1808
 
-- Show the active subset in the toolbar. [#1797]
+- Show the active subset in the toolbar. https://github.com/glue-viz/glue/pull/1797
 
-- Refactored the viewer class base classes [#1746]:
+- Refactored the viewer class base classes https://github.com/glue-viz/glue/pull/1746:
 
   - ``glue.core.application_base.ViewerBase`` has been removed in favor of
     ``glue.viewers.common.viewer.BaseViewer`` and
@@ -492,380 +492,380 @@
 
 - Make it so that the modest image only resamples the data when the
   mouse is no longer pressed - this avoids too many refreshes when
-  panning/zooming. [#1866]
+  panning/zooming. https://github.com/glue-viz/glue/pull/1866
 
-- Make it possible to unglue multiple links in one go. [#1809]
+- Make it possible to unglue multiple links in one go. https://github.com/glue-viz/glue/pull/1809
 
 - Make it so that adding a subset to a viewer no longer adds the
   associated data, since in some cases the viewer can handle the
-  subset size, but not the full data. [#1807]
+  subset size, but not the full data. https://github.com/glue-viz/glue/pull/1807
 
 - Defined a new abstract base class for all datasets, ``BaseData``,
   and a base class ``BaseCartesianData``,
   which can be used to implement interfaces to datasets that may be
-  remote or may not be stored as regular cartesian data. [#1768]
+  remote or may not be stored as regular cartesian data. https://github.com/glue-viz/glue/pull/1768
 
 - Add a new method ``Data.compute_statistic`` which can be used
   to find scalar and array statistics on the data, and use for
-  the profile viewer and the state limits helpers. [#1737]
+  the profile viewer and the state limits helpers. https://github.com/glue-viz/glue/pull/1737
 
 - Add a new method ``Data.compute_histogram`` which can be used
   to find histograms of specific components, with or without
-  subsets applied. [#1739]
+  subsets applied. https://github.com/glue-viz/glue/pull/1739
 
 - Removed ``Data.get_pixel_component_ids`` and ``Data.get_world_component_ids``
   in favor of ``Data.pixel_component_ids`` and ``Data.world_component_ids``.
-  [#1784]
+  https://github.com/glue-viz/glue/pull/1784
 
-- Deprecated ``Data.visible_components`` and ``Data.primary_components``. [#1788]
+- Deprecated ``Data.visible_components`` and ``Data.primary_components``. https://github.com/glue-viz/glue/pull/1788
 
 - Speed up histogram calculations by using the fast-histogram package instead of
-  np.histogram. [#1806]
+  np.histogram. https://github.com/glue-viz/glue/pull/1806
 
 - In the case of categorical attributes, ``Data[name]`` now returns a
   ``categorical_ndarray`` object rather than the indices of the categories. You
   can access the indices with ``Data[name].codes`` and the unique categories
-  with ``Data[name].categories``.  [#1784]
+  with ``Data[name].categories``.  https://github.com/glue-viz/glue/pull/1784
 
 - Compute profiles and histograms asynchronously when dataset is large
   to avoid holding up the UI, and compute profiles in chunks to avoid
   excessive memory usage. [#1736, #1764]
 
-- Improved naming of components when merging datasets. [#1249]
+- Improved naming of components when merging datasets. https://github.com/glue-viz/glue/pull/1249
 
 - Fixed an issue that caused residual references to viewers
   after they were closed if they were accessed through the
-  IPython console. [#1770]
+  IPython console. https://github.com/glue-viz/glue/pull/1770
 
-- Don't show layer edit options if layer is not visible. [#1805]
+- Don't show layer edit options if layer is not visible. https://github.com/glue-viz/glue/pull/1805
 
 - Make the Matplotlib viewer code that doesn't depend on Qt accessible
-  to non-Qt frontends. [#1841]
+  to non-Qt frontends. https://github.com/glue-viz/glue/pull/1841
 
-- Avoid repeated coordinate components in merged datasets. [#1792]
+- Avoid repeated coordinate components in merged datasets. https://github.com/glue-viz/glue/pull/1792
 
 - Fix bug that caused new subset to be created when dragging an existing
-  subset in an image viewer. [#1793]
+  subset in an image viewer. https://github.com/glue-viz/glue/pull/1793
 
 - Better preserve data types when exporting data/subsets to FITS
-  and HDF5 formats. [#1800]
+  and HDF5 formats. https://github.com/glue-viz/glue/pull/1800
 
 ## [v0.13.4](https://github.com/glue-viz/glue/compare/v0.13.3...v0.13.4) - 2018-10-19
 
 ### What's Changed
 
-- Fix bug that caused .svg icons to not be correctly installed. [#1882]
+- Fix bug that caused .svg icons to not be correctly installed. https://github.com/glue-viz/glue/pull/1882
 
 - Fix bug that occurred in certain cases when using the state attribute limit
-  helper with a state class that did not have a log attribute. [#1842]
+  helper with a state class that did not have a log attribute. https://github.com/glue-viz/glue/pull/1842
 
-- Fix HDF5 reader for string columns. [#1840]
+- Fix HDF5 reader for string columns. https://github.com/glue-viz/glue/pull/1840
 
 - Fix visual bug in link editor in advanced mode when resizing window.
 
-- Fixed a bug that caused custom data importers to no longer work. [#1813]
+- Fixed a bug that caused custom data importers to no longer work. https://github.com/glue-viz/glue/pull/1813
 
 - Fixed a bug that caused ROIs to not be erased after selection if the
-  active subset was not in the list of layers for the viewer. [#1801]
+  active subset was not in the list of layers for the viewer. https://github.com/glue-viz/glue/pull/1801
 
-- Always returned to last used folder when opening/saving files. [#1794]
+- Always returned to last used folder when opening/saving files. https://github.com/glue-viz/glue/pull/1794
 
 - Show correct dataset when using control-click to select to add
-  arithmetic attributes or rename/reorder components. [#1802]
+  arithmetic attributes or rename/reorder components. https://github.com/glue-viz/glue/pull/1802
 
 - Improve performance when updating links and changing attributes
-  on subsets. [#1716]
+  on subsets. https://github.com/glue-viz/glue/pull/1716
 
 - Fix errors that happened when clicking on the 'Export Data' and
   'Define arithmetic attributes' buttons when no data was present,
   and fixed Qt errors that happened if the data collection changed
-  after the 'Export Data' dialog was opened. [#1795]
+  after the 'Export Data' dialog was opened. https://github.com/glue-viz/glue/pull/1795
 
-- Fixed parsing of AVM meta-data from images. [#1732]
+- Fixed parsing of AVM meta-data from images. https://github.com/glue-viz/glue/pull/1732
 
-- Fixed compatibility with Matplotlib 3.0. [#1875]
+- Fixed compatibility with Matplotlib 3.0. https://github.com/glue-viz/glue/pull/1875
 
 ## [v0.13.3](https://github.com/glue-viz/glue/compare/v0.13.2...v0.13.3) - 2018-05-08
 
 ### What's Changed
 
 - Fixed a bug that caused the expression for derived attributes to
-  not immediately be updated in the list of derived attributes. [#1708]
+  not immediately be updated in the list of derived attributes. https://github.com/glue-viz/glue/pull/1708
 
 - Fixed a bug that caused combo boxes with Data objects to not update
-  when a data label was changed. [#1704]
+  when a data label was changed. https://github.com/glue-viz/glue/pull/1704
 
 - Fixed a bug related to callback functions when restoring sessions.
-  [#1695]
+  https://github.com/glue-viz/glue/pull/1695
 
 - Fixed a bug that meant that setting Data.coords after adding
-  components didn't work as expected. [#1196]
+  components didn't work as expected. https://github.com/glue-viz/glue/pull/1196
 
 - Fixed bugs related to components with only NaN or Inf values.
-  [#1712]
+  https://github.com/glue-viz/glue/pull/1712
 
 - Fixed a bug that caused an error when the zoom or pan tools were
-  active and the viewer was closed. [#1712]
+  active and the viewer was closed. https://github.com/glue-viz/glue/pull/1712
 
 - Fixed a Qt-related segmentation fault that occurred during the
-  testing process and may also affect users. [#1703]
+  testing process and may also affect users. https://github.com/glue-viz/glue/pull/1703
 
-- Show image layer attribute in list of layers. [#1706]
+- Show image layer attribute in list of layers. https://github.com/glue-viz/glue/pull/1706
 
 - Fixed a bug that caused scatter plots to not revert to fixed color
-  mode after being in linear color mode. [#1705]
+  mode after being in linear color mode. https://github.com/glue-viz/glue/pull/1705
 
 ## [v0.13.2](https://github.com/glue-viz/glue/compare/v0.13.1...v0.13.2) - 2018-05-01
 
 ### What's Changed
 
 - Fixed a bug that caused the EditSubsetMode toolbar to not change
-  when EditSubsetMode.mode was changed programatically. [#1684]
+  when EditSubsetMode.mode was changed programatically. https://github.com/glue-viz/glue/pull/1684
 
 - Fixed unintuitive behavior of single-pixel selection tool - now
-  moving the crosshairs requires clicking and dragging. [#1684]
+  moving the crosshairs requires clicking and dragging. https://github.com/glue-viz/glue/pull/1684
 
 - Fixed bug that caused crosshairs to not be hidden when a layer was
-  set to not be visible [#1684]
+  set to not be visible https://github.com/glue-viz/glue/pull/1684
 
 - Fixed a bug that caused viewers to be closed without warning when
-  pressing delete. [#1684]
+  pressing delete. https://github.com/glue-viz/glue/pull/1684
 
 ## [v0.13.1](https://github.com/glue-viz/glue/compare/v0.13.0...v0.13.1) - 2018-04-29
 
 ### What's Changed
 
-- Fixed resetting and opening of sessions which caused Glue to quit. [#1681]
+- Fixed resetting and opening of sessions which caused Glue to quit. https://github.com/glue-viz/glue/pull/1681
 
 - Fixed serialization of Data.meta when non-serializable keys or values
-  are present. [#1681]
+  are present. https://github.com/glue-viz/glue/pull/1681
 
 ## [v0.13.0](https://github.com/glue-viz/glue/compare/v0.12.5...v0.13.0) - 2018-04-27
 
 ### What's Changed
 
-- Added new perceptually uniform Matplotlib colormaps. [#1679]
+- Added new perceptually uniform Matplotlib colormaps. https://github.com/glue-viz/glue/pull/1679
 
 - Fixed a bug that caused vectors to not correctly be flipped when
-  flipping the x/y limits of the plot. [#1677]
+  flipping the x/y limits of the plot. https://github.com/glue-viz/glue/pull/1677
 
-- Added a CSV and HDF5 data/subset exporter. [#1676]
+- Added a CSV and HDF5 data/subset exporter. https://github.com/glue-viz/glue/pull/1676
 
 - Started adding helpful information dialogs that can be
-  hidden. [#1669]
+  hidden. https://github.com/glue-viz/glue/pull/1669
 
-- Make it possible to have a 'None' entry in the ComponentIDComboHelper. [#1661]
+- Make it possible to have a 'None' entry in the ComponentIDComboHelper. https://github.com/glue-viz/glue/pull/1661
 
-- Added a new metadata/header viewer for datasets/subsets. [#1659]
+- Added a new metadata/header viewer for datasets/subsets. https://github.com/glue-viz/glue/pull/1659
 
 - Re-write spectrum viewer into a generic profile viewer that uses
   subsets to define the areas in which to compute profiles rather
-  than custom ROIs. [#1635]
+  than custom ROIs. https://github.com/glue-viz/glue/pull/1635
 
 - Added support for PySide2 and remove support for PyQt4 and
-  PySide. [#1662]
+  PySide. https://github.com/glue-viz/glue/pull/1662
 
-- Remove support for Matplotlib 1.5. [#1662]
+- Remove support for Matplotlib 1.5. https://github.com/glue-viz/glue/pull/1662
 
 - Renamed ``qt4_to_mpl_color`` to ``qt_to_mpl_color`` and
-  ``mpl_to_qt4_color`` to ``mpl_to_qt_color``. [#1662]
+  ``mpl_to_qt4_color`` to ``mpl_to_qt_color``. https://github.com/glue-viz/glue/pull/1662
 
 - Improve performance when changing visual attributes of subsets.
-  [#1617]
+  https://github.com/glue-viz/glue/pull/1617
 
 - Removed ``glue.core.qt.data_combo_helper`` (we now recommend using
   the GUI framework-independent equivalent in
-  ``glue.core.data_combo_helper``). [#1625]
+  ``glue.core.data_combo_helper``). https://github.com/glue-viz/glue/pull/1625
 
 - Removed ``glue.viewers.common.qt.attribute_limits_helper`` in favor
-  of ``glue.core.state_objects``. [#1625]
+  of ``glue.core.state_objects``. https://github.com/glue-viz/glue/pull/1625
 
-- Removed unused function ``glue.utils.misc.defer``. [#1625]
+- Removed unused function ``glue.utils.misc.defer``. https://github.com/glue-viz/glue/pull/1625
 
 - Added a new ``FloodFillSubsetState`` class to represent and
-  calculate subsets made by a flood-fill algorithm. [#1616]
+  calculate subsets made by a flood-fill algorithm. https://github.com/glue-viz/glue/pull/1616
 
 - Added the ability to easily create viewer tools with dropdown
-  menus. [#1634]
+  menus. https://github.com/glue-viz/glue/pull/1634
 
 - Remove the ``MatplotlibViewerToolbar`` class as it is now no
   longer needed - instead you can just list the matplotlib tools
-  directly in the ``tools`` attribute of the viewer. [#1634]
+  directly in the ``tools`` attribute of the viewer. https://github.com/glue-viz/glue/pull/1634
 
 - Improve hiding/showing of side-panels. No longer hide side-panels
-  when glue application goes out of focus. [#1535]
+  when glue application goes out of focus. https://github.com/glue-viz/glue/pull/1535
 
 - Use memory-mapping with contiguous arrays in HDF5 files, resulting
-  in improved performance for large files. [#1628]
+  in improved performance for large files. https://github.com/glue-viz/glue/pull/1628
 
 - Deselect tools when the viewer focus changes. [#1584, #1608]
 
-- Added support for whether symbols are shown filled or not. [#1559]
+- Added support for whether symbols are shown filled or not. https://github.com/glue-viz/glue/pull/1559
 
-- Improved link editor to include a graph of links. [#1534]
+- Improved link editor to include a graph of links. https://github.com/glue-viz/glue/pull/1534
 
 - Improve mouse interaction with ROIs in image viewers, including
   click-and-drag relocation. Allow for more customization of mouse/toolbar
-  modes. [#1515]
+  modes. https://github.com/glue-viz/glue/pull/1515
 
 - Add a toolbar item to save data. [#1516, #1519, #1575]
 
-- Give instructions for how to move selections in status tip. [#1504]
+- Give instructions for how to move selections in status tip. https://github.com/glue-viz/glue/pull/1504
 
 - Improve the display of data cube slice labels to include only the
   precision required given the separation of world coordinate values.
   [#1500, #1660]
 
 - Removed the ability to edit the marker symbol in the style dialog
-  since this isn't recognized by any viewer anymore. [#1560]
+  since this isn't recognized by any viewer anymore. https://github.com/glue-viz/glue/pull/1560
 
 - Remove back/forward tools in Matplotlib viewer toolbars to
-  declutter. [#1505]
+  declutter. https://github.com/glue-viz/glue/pull/1505
 
 - Added a new component manager that makes it possible to rename,
   reorder, and remove components, as well as better manage derived
-  components, including editing previous equations. [#1479]
+  components, including editing previous equations. https://github.com/glue-viz/glue/pull/1479
 
 - Added new messages ``DataReorderComponentMessage`` and
-  ``DataRenameComponentMessage`` which can be subscribed to. [#1479]
+  ``DataRenameComponentMessage`` which can be subscribed to. https://github.com/glue-viz/glue/pull/1479
 
 - Add support for the datetime64 dtype in Data objects, and adjust
-  Matplotlib viewers to correctly show this data. [#1510]
+  Matplotlib viewers to correctly show this data. https://github.com/glue-viz/glue/pull/1510
 
 - Make it possible to reorder components in ``Data`` using the new
-  ``Data.reorder_components`` method. [#1479]
+  ``Data.reorder_components`` method. https://github.com/glue-viz/glue/pull/1479
 
 - The default order of components has changed - coordinate components
-  will now always come first (rather than second). [#1479]
+  will now always come first (rather than second). https://github.com/glue-viz/glue/pull/1479
 
 - Added support for scatter density maps, which is useful when making
-  scatter plots of many points. [#1461]
+  scatter plots of many points. https://github.com/glue-viz/glue/pull/1461
 
 - Improve how ComponentIDComboHelper deals with non-primary components.
   The .visible property has been removed, and a new .derived property
   has been added (to show/hide derived components). Components are now
-  split up into sections in the combo boxes. [#1476]
+  split up into sections in the combo boxes. https://github.com/glue-viz/glue/pull/1476
 
 - Fixed a bug that caused ghost components to be added when creating a
-  derived component with data[...] = ... [#1476]
+  derived component with data[...] = ... https://github.com/glue-viz/glue/pull/1476
 
 - Fixed a bug that caused errors when removing items from a selection
-  property linked to a QComboBox. [#1476]
+  property linked to a QComboBox. https://github.com/glue-viz/glue/pull/1476
 
 - Added initial support for customizing keyboard shortcuts. [#1475, #1514, #1524]
 
-- Added support for using relative paths in session files. [#1537]
+- Added support for using relative paths in session files. https://github.com/glue-viz/glue/pull/1537
 
-- Remember last session filename and filter used. [#1537]
+- Remember last session filename and filter used. https://github.com/glue-viz/glue/pull/1537
 
 - EditSubsetMode is now no longer a singleton class and is
-  instead instantiated at the Application/Session level. [#1530]
+  instead instantiated at the Application/Session level. https://github.com/glue-viz/glue/pull/1530
 
-- Improve performance of image viewer. [#1558]
+- Improve performance of image viewer. https://github.com/glue-viz/glue/pull/1558
 
 - Added new ``Projected3dROI`` and ``RoiSubsetState3d`` classes
-  to represent 3D selections made in the projection plane. [#1522]
+  to represent 3D selections made in the projection plane. https://github.com/glue-viz/glue/pull/1522
 
-- Fixed saving of sessions with ``BinaryComponentLink``. [#1533]
+- Fixed saving of sessions with ``BinaryComponentLink``. https://github.com/glue-viz/glue/pull/1533
 
 - Refactored/simplified handling of links between datasets and
   fixed performance issues when adding/removing links or loading
   data collections with many links. [#1531, #1533]
 
 - Significantly improve performance of link computations when the
-  links depend only on pixel or world coordinate components. [#1585]
+  links depend only on pixel or world coordinate components. https://github.com/glue-viz/glue/pull/1585
 
 - Added the ability to customize the appearance of tick and axis
-  labels in Matplotlib plots. [#1511]
+  labels in Matplotlib plots. https://github.com/glue-viz/glue/pull/1511
 
 - Added the ability to export Python scripts from the main
-  Matplotlib-based viewers. [#1511]
+  Matplotlib-based viewers. https://github.com/glue-viz/glue/pull/1511
 
 - Added a new selection mode that always forces the creation of a new subset.
-  [#1525]
+  https://github.com/glue-viz/glue/pull/1525
 
 - Added a mouse over pixel selection tool, which creates a one pixel subset
-  under the mouse cursor. [#1619]
+  under the mouse cursor. https://github.com/glue-viz/glue/pull/1619
 
 - Fixed an issue that caused sliders to not be correctly updated when
-  switching reference data in the image viewer. [#1665]
+  switching reference data in the image viewer. https://github.com/glue-viz/glue/pull/1665
 
 - Fixed a bug that caused Data.meta to not be saved/restored from session
-  files. [#1668]
+  files. https://github.com/glue-viz/glue/pull/1668
 
 - Fixed an issue that caused an IndexError when quitting glue in some
-  cases. [#1657]
+  cases. https://github.com/glue-viz/glue/pull/1657
 
-- Fixed a bug that caused matplotlibrc files to not be ignored. [#1649]
+- Fixed a bug that caused matplotlibrc files to not be ignored. https://github.com/glue-viz/glue/pull/1649
 
 - Fixed a non-deterministic error that happened when closing the
-  TableViewer. [#7310]
+  TableViewer. https://github.com/glue-viz/glue/pull/7310
 
-- Fixed size of markers when value for size is out of vmin/vmax range. [#1609]
+- Fixed size of markers when value for size is out of vmin/vmax range. https://github.com/glue-viz/glue/pull/1609
 
 - Fix a bug that caused viewer limits to be calculated incorrectly if
-  inf/-inf values were present in the data. [#1614]
+  inf/-inf values were present in the data. https://github.com/glue-viz/glue/pull/1614
 
 - Fixed a bug which caused the y-axis in the PV slice viewer to be
-  incorrect if the WCS could not be computed. [#1615]
+  incorrect if the WCS could not be computed. https://github.com/glue-viz/glue/pull/1615
 
 - Fixed a bug that caused the WCS of a PV slice to be incorrect if the
   user has selected a custom order of the axes of a cube in the image
-  viewer. [#1615]
+  viewer. https://github.com/glue-viz/glue/pull/1615
 
-- Fixed ticks on log x-axis in histogram viewer. [#7310]
+- Fixed ticks on log x-axis in histogram viewer. https://github.com/glue-viz/glue/pull/7310
 
 - Fixed a bug that led to poor performance when slicing through data cubes.
-  [#1554]
+  https://github.com/glue-viz/glue/pull/1554
 
 ## [v0.12.5](https://github.com/glue-viz/glue/compare/v0.12.4...v0.12.5) - 2018-03-10
 
 ### What's Changed
 
 - Fixed a bug which caused the current slices to be lost when adding a second
-  dataset to the image viewer. [#1581]
+  dataset to the image viewer. https://github.com/glue-viz/glue/pull/1581
 
 - Fixed a bug when two datasets with a different number of dimensions
-  were in an image viewer and a subset was created. [#1577]
+  were in an image viewer and a subset was created. https://github.com/glue-viz/glue/pull/1577
 
-- Fixed issues when attempting to close a viewer with the delete key. [#1574]
+- Fixed issues when attempting to close a viewer with the delete key. https://github.com/glue-viz/glue/pull/1574
 
-- Disabled default Matplotlib key bindings. [#1574]
+- Disabled default Matplotlib key bindings. https://github.com/glue-viz/glue/pull/1574
 
-- Fix compatibility with Matplotlib 2.2. [#1566]
+- Fix compatibility with Matplotlib 2.2. https://github.com/glue-viz/glue/pull/1566
 
-- Fix compatibility with some versions of pytest. [#1520]
+- Fix compatibility with some versions of pytest. https://github.com/glue-viz/glue/pull/1520
 
 - Fix calculation of ``dependent_axes`` to account for cases where there
   are some non-zero non-diagonal PC values. Previously any such values
   resulted in all axes being returned as dependent axes even though this
-  isn't necessary. [#1552]
+  isn't necessary. https://github.com/glue-viz/glue/pull/1552
 
 - Avoid prompting users multiple times to merge data when dragging
-  and dropping multiple data files onto glue. [#1564]
+  and dropping multiple data files onto glue. https://github.com/glue-viz/glue/pull/1564
 
-- Improve error message in PV slicer when ``_slice_index`` fails. [#1536]
+- Improve error message in PV slicer when ``_slice_index`` fails. https://github.com/glue-viz/glue/pull/1536
 
 - Fixed a bug that caused an error when trying to save a session that
-  included an image viewer with an aggregated slice. [#1561]
+  included an image viewer with an aggregated slice. https://github.com/glue-viz/glue/pull/1561
 
 - Fixed a bug that caused an error in the terminal if creating a data
-  viewer failed properly (with a GUI error message). [#1501]
+  viewer failed properly (with a GUI error message). https://github.com/glue-viz/glue/pull/1501
 
 - Fixed a bug that caused performance issues when hiding all image
   layers from an image viewer. [#1557, #1562]
 
 - Fixed a bug that caused layers to not always be properly removed
-  when deleting a row from the layer list. [#1502]
+  when deleting a row from the layer list. https://github.com/glue-viz/glue/pull/1502
 
-- Make JSON circular reference errors more explicit. [#1529]
+- Make JSON circular reference errors more explicit. https://github.com/glue-viz/glue/pull/1529
 
 ## [v0.12.4](https://github.com/glue-viz/glue/compare/v0.12.3...v0.12.4) - 2018-01-09
 
 ### What's Changed
 
 - Improve plugin loading to be less sensitive to exact versions of
-  installed dependencies for plugins. [#1487]
+  installed dependencies for plugins. https://github.com/glue-viz/glue/pull/1487
 
 ## [v0.12.3](https://github.com/glue-viz/glue/compare/v0.12.3...v0.12.2) - 2017-11-14
 
@@ -878,13 +878,13 @@
 
 ### What's Changed
 
-- Fix a bug when renaming tabs through the UI. [#1470]
+- Fix a bug when renaming tabs through the UI. https://github.com/glue-viz/glue/pull/1470
 
 - Fix a bug that caused the 1D and 2D viewers to not update correctly
-  when the numerical values in data were changed. [#1471]
+  when the numerical values in data were changed. https://github.com/glue-viz/glue/pull/1471
 
 - Fix a bug that caused exporting of subsets to not work with integer
-  data. [#1472]
+  data. https://github.com/glue-viz/glue/pull/1472
 
 ## [v0.12.1](https://github.com/glue-viz/glue/compare/v0.12.0...v0.12.1) - 2017-10-30
 
@@ -898,145 +898,145 @@
 ### What's Changed
 
 - Show a GUI error message when restoring a session via drag-and-drop
-  if session loading fails. [#1454]
+  if session loading fails. https://github.com/glue-viz/glue/pull/1454
 
 - Don't disable layer completely if it is not enabled, just disable checkbox.
-  Also show warnings instead of layer style editor. [#1451]
+  Also show warnings instead of layer style editor. https://github.com/glue-viz/glue/pull/1451
 
 - Generalize registry for data/subset actions to replace the former
   ``single_subset_action`` registry (which applied only to single subset selections).
-  Layer actions can now be registered with the ``@layer_action`` decorator. [#1396]
+  Layer actions can now be registered with the ``@layer_action`` decorator. https://github.com/glue-viz/glue/pull/1396
 
-- Added support for plotting vectors in the scatter plot viewer. [#1410]
+- Added support for plotting vectors in the scatter plot viewer. https://github.com/glue-viz/glue/pull/1410
 
-- Added glue plugins to the Version Information dialog. [#1427]
+- Added glue plugins to the Version Information dialog. https://github.com/glue-viz/glue/pull/1427
 
-- Added the ability to create fixed layout tabs. [#1403]
+- Added the ability to create fixed layout tabs. https://github.com/glue-viz/glue/pull/1403
 
-- Fix selection in custom viewers. [#1453]
+- Fix selection in custom viewers. https://github.com/glue-viz/glue/pull/1453
 
-- Fix a bug that caused the home/reset limits button to not work correctly. [#1452]
+- Fix a bug that caused the home/reset limits button to not work correctly. https://github.com/glue-viz/glue/pull/1452
 
 - Fix a bug that caused the wrong layers to be enabled when mixing image and
-  scatter layers and setting up links. [#1451]
+  scatter layers and setting up links. https://github.com/glue-viz/glue/pull/1451
 
-- Remove 'sep' from menu on Linux. [#1394]
+- Remove 'sep' from menu on Linux. https://github.com/glue-viz/glue/pull/1394
 
 - Fixed bug in spectrum tool that caused the upper range in aggregations
-  to be incorrectly calculated. [#1402]
+  to be incorrectly calculated. https://github.com/glue-viz/glue/pull/1402
 
 - Fixed icon for scatter plot layer when a colormap is used, and fix issues with
-  viewer layer icons not updating immediately. [#1425]
+  viewer layer icons not updating immediately. https://github.com/glue-viz/glue/pull/1425
 
 - Fixed dragging and dropping session files onto glue (this now loads the session
   rather than trying to load it as a dataset). Also now show a warning when
   the application is about to be reset to open a new session. [#1425, #1448]
 
-- Make sure no errors happen if making a selection in an empty viewer. [#1425]
+- Make sure no errors happen if making a selection in an empty viewer. https://github.com/glue-viz/glue/pull/1425
 
-- Fix creating faceted subsets on Python 3.x when no dataset is selected. [#1425]
+- Fix creating faceted subsets on Python 3.x when no dataset is selected. https://github.com/glue-viz/glue/pull/1425
 
-- Fix issues with overlaying a scatter layer on an image. [#1425]
+- Fix issues with overlaying a scatter layer on an image. https://github.com/glue-viz/glue/pull/1425
 
 - Fix issues with labels for categorical axes in the scatter and histogram
   viewers, in particular when loading viewers with categorical axes from
-  session files. [#1425]
+  session files. https://github.com/glue-viz/glue/pull/1425
 
 - Make sure a GUI error message is shown when adding non-1-dimensional data
-  to a table viewer. [#1425]
+  to a table viewer. https://github.com/glue-viz/glue/pull/1425
 
 - Fix issues when trying to launch glue multiple times from a Jupyter session.
-  [#1425]
+  https://github.com/glue-viz/glue/pull/1425
 
 - Remove the ability to define the color of a subset differ from that of a
   subset group it belongs to - this was virtually never needed but could
-  cause issues. [#1426]
+  cause issues. https://github.com/glue-viz/glue/pull/1426
 
 - Fixed a bug that caused a previously disabled image subset layer to not
-  become visible when shown again. [#1450]
+  become visible when shown again. https://github.com/glue-viz/glue/pull/1450
 
-- Added the ability to rename tabs programmatically. [#1405]
+- Added the ability to rename tabs programmatically. https://github.com/glue-viz/glue/pull/1405
 
 ## [v0.11.1](https://github.com/glue-viz/glue/compare/v0.11.0...v0.11.1) - 2017-08-25
 
 ### What's Changed
 
 - Fixed bug that caused ModestImage references to not be properly deleted, in
-  turn leading to issues/crashes when removing subsets from image viewers. [#1390]
+  turn leading to issues/crashes when removing subsets from image viewers. https://github.com/glue-viz/glue/pull/1390
 
-- Fixed bug with reading in old session files with a table viewer. [#1389]
+- Fixed bug with reading in old session files with a table viewer. https://github.com/glue-viz/glue/pull/1389
 
 ## [v0.11.0](https://github.com/glue-viz/glue/compare/v0.10.4...v0.11.0) - 2017-08-22
 
 ### What's Changed
 
-- Added splash screen. [#694]
+- Added splash screen. https://github.com/glue-viz/glue/pull/694
 
-- Make file extension check case-insensitive. [#1275]
+- Make file extension check case-insensitive. https://github.com/glue-viz/glue/pull/1275
 
-- Fixed bug that caused table viewer to not update when adding components. [#1386]
+- Fixed bug that caused table viewer to not update when adding components. https://github.com/glue-viz/glue/pull/1386
 
 - Fixed loading of plain (non-structured) arrays from Numpy files. [#1314, #1385]
 
-- Disabled layer artists can no longer be selected to avoid any confusion. [#1367]
+- Disabled layer artists can no longer be selected to avoid any confusion. https://github.com/glue-viz/glue/pull/1367
 
-- Layer artist icons can now show colormaps when appropriate. [#1367]
+- Layer artist icons can now show colormaps when appropriate. https://github.com/glue-viz/glue/pull/1367
 
 - Fix behavior of data wizard so that it doesn't overwrite labels set by data
-  factories. [#1367]
+  factories. https://github.com/glue-viz/glue/pull/1367
 
-- Add a status tip for all ROI selection tools. [#1367]
+- Add a status tip for all ROI selection tools. https://github.com/glue-viz/glue/pull/1367
 
 - Fixed a bug that caused the terminal to not be available after
-  resetting or opening a session. [#1366]
+  resetting or opening a session. https://github.com/glue-viz/glue/pull/1366
 
 - If a subset's visual properties are changed, change the visual
-  properties of the parent SubsetGroup. [#1365]
+  properties of the parent SubsetGroup. https://github.com/glue-viz/glue/pull/1365
 
 - Give an error if the user selects a session file when going through
-  the 'Open Data Set' menu. [#1364]
+  the 'Open Data Set' menu. https://github.com/glue-viz/glue/pull/1364
 
 - Improved scatter plot viewer to be able to show points with color or
   size based on other attributes. Also added a 'line' style to make line
-  plots, and added the ability to show error bars. [#1358]
+  plots, and added the ability to show error bars. https://github.com/glue-viz/glue/pull/1358
 
 - Changed order of arguments for data exporters from (data, filename)
-  to (filename, data). [#1251]
+  to (filename, data). https://github.com/glue-viz/glue/pull/1251
 
 - Added registry decorators to define subset mask importers and
-  exporters. [#1251]
+  exporters. https://github.com/glue-viz/glue/pull/1251
 
 - Get rid of QTimers for updating the data collection and layer artist
   lists, and instead refresh whenever a message is sent from the hub
   (which results in immediate changes rather than waiting up to a
-   second for things to change). [#1343]
+   second for things to change). https://github.com/glue-viz/glue/pull/1343
 
 - Made it possible to delay callbacks from the Hub using the
   ``Hub.delay_callbacks`` context manager. Also fixed the Hub so that
-  it uses weak references to classes and methods wherever possible. [#1339]
+  it uses weak references to classes and methods wherever possible. https://github.com/glue-viz/glue/pull/1339
 
 - Added a new method ``DataCollection.remove_link`` to match existing
-  ``DataCollection.add_link``. [#1339]
+  ``DataCollection.add_link``. https://github.com/glue-viz/glue/pull/1339
 
 - Fix a bug that caused no messages to be emitted when components were
   removed from Data objects, and add a new DataRemoveComponentMesssage.
-  [#1339]
+  https://github.com/glue-viz/glue/pull/1339
 
 - Fix a long-standing bug which caused performance issues after linking
-  coordinate or derived components between datasets. [#1339]
+  coordinate or derived components between datasets. https://github.com/glue-viz/glue/pull/1339
 
 - Added a function ``is_equivalent_cid`` that can be used to determine whether
-  two component IDs in a dataset are equivalent. [#1339]
+  two component IDs in a dataset are equivalent. https://github.com/glue-viz/glue/pull/1339
 
 - The image contrast and bias can now be set with the left click as well
-  as right click. [#1323]
+  as right click. https://github.com/glue-viz/glue/pull/1323
 
 - Updated ComponentIDComboHelper so that it can work with single datasets
-  that aren't necessarily attached to a DataCollection. [#1296]
+  that aren't necessarily attached to a DataCollection. https://github.com/glue-viz/glue/pull/1296
 
 - Updated bundled version of echo to include fixes to avoid circular
   references, which in turn caused some callback functions to not be
-  cleaned up. [#1281]
+  cleaned up. https://github.com/glue-viz/glue/pull/1281
 
 - Rewrote the histogram, scatter, and image viewers to use the new state
   infrastructure. This significantly simplifies the actual histogram viewer code
@@ -1047,72 +1047,72 @@
   attribute - instead, the current list of subsets being edited is kept in
   EditSubsetMode itself. We also update the subset state only once on each
   subset group, rather than once per dataset, which avoids doing the same
-  update to each dataset multiple times. [#1338]
+  update to each dataset multiple times. https://github.com/glue-viz/glue/pull/1338
 
 - Remove the ability to create a new viewer by right-clicking on the canvas,
   since this causes confusion when trying to control-click to paste in the
-  IPython terminal. [#1342]
+  IPython terminal. https://github.com/glue-viz/glue/pull/1342
 
-- Make ``process_dialog`` more robust. [#1333]
+- Make ``process_dialog`` more robust. https://github.com/glue-viz/glue/pull/1333
 
-- Fix example of setting up a custom preferences pane. [#1326]
+- Fix example of setting up a custom preferences pane. https://github.com/glue-viz/glue/pull/1326
 
 - Fix a bug that caused links to not get removed if associated datasets
-  were removed. [#1329]
+  were removed. https://github.com/glue-viz/glue/pull/1329
 
 - Fixed a bug that meant that the table viewer did not update when
-  a ``NumericalDataChangedMessage`` message was emitted. [#1378]
+  a ``NumericalDataChangedMessage`` message was emitted. https://github.com/glue-viz/glue/pull/1378
 
 - Added new combo helpers in ``glue.core.data_combo_helper`` which
   are similar to those in ``glue.core.qt.data_combo_helper`` but
   operate on ``SelectionCallbackProperty`` and are Qt-independent.
-  [#1346]
+  https://github.com/glue-viz/glue/pull/1346
 
-- Rewrote installation instructions. [#1330]
+- Rewrote installation instructions. https://github.com/glue-viz/glue/pull/1330
 
 ## [v0.10.4](https://github.com/glue-viz/glue/compare/v0.10.3...v0.10.4) - 2017-05-23
 
 ### What's Changed
 
 - Fixed a bug that caused merged datasets to crash viewers (because
-  the ``visible_components`` attribute returned an empty list). [#1288]
+  the ``visible_components`` attribute returned an empty list). https://github.com/glue-viz/glue/pull/1288
 
 ## [v0.10.3](https://github.com/glue-viz/glue/compare/v0.10.2...v0.10.3) - 2017-04-20
 
 ### What's Changed
 
-- Fixed bugs with saving and restoring of various types of subset states. [#1285]
+- Fixed bugs with saving and restoring of various types of subset states. https://github.com/glue-viz/glue/pull/1285
 
-- Fixed a bug that caused glue to not open when IPython 4.0 was installed. [#1287]
+- Fixed a bug that caused glue to not open when IPython 4.0 was installed. https://github.com/glue-viz/glue/pull/1287
 
 ## [v0.10.2](https://github.com/glue-viz/glue/compare/v0.10.1...v0.10.2) - 2017-03-22
 
 ### What's Changed
 
 - Fixed a bug that caused components that were linked to then disappear from
-  drop-down lists of available components in new viewers. [#1270]
+  drop-down lists of available components in new viewers. https://github.com/glue-viz/glue/pull/1270
 
 - Fixed a bug that caused ``Data.find_component_id`` to return incorrect results
-  when string components were present in the data. [#1269]
+  when string components were present in the data. https://github.com/glue-viz/glue/pull/1269
 
 - Fixed a bug that caused errors to appear in the console log after a
-  table viewer was closed. [#1267]
+  table viewer was closed. https://github.com/glue-viz/glue/pull/1267
 
 - Fixed a bug that caused error message dialogs to not work correctly with
-  Qt4. [#1262]
+  Qt4. https://github.com/glue-viz/glue/pull/1262
 
-- Fixed a deprecation warning for pandas >= 0.19. [#1263]
+- Fixed a deprecation warning for pandas >= 0.19. https://github.com/glue-viz/glue/pull/1263
 
-- Hide common Matplotlib warnings when min/max along an axis are equal. [#1268]
+- Hide common Matplotlib warnings when min/max along an axis are equal. https://github.com/glue-viz/glue/pull/1268
 
 - Fixed a bug that caused sessions with table viewers that had no subsets
-  to not be restored correctly. [#1271]
+  to not be restored correctly. https://github.com/glue-viz/glue/pull/1271
 
 ## [v0.10.1](https://github.com/glue-viz/glue/compare/v0.10.0...v0.10.1) - 2017-03-16
 
 ### What's Changed
 
-- Fixed compatibility with session files from before v0.8. [#1243]
+- Fixed compatibility with session files from before v0.8. https://github.com/glue-viz/glue/pull/1243
 
 - Renamed package to glue-core, since glueviz is now a meta-package (no need
   for a new major version since this change should be seamless to users).
@@ -1122,21 +1122,21 @@
 ### What's Changed
 
 - The ``GlueApplication.add_data`` and ``load_data`` methods now return the
-  loaded data objects. [#1239]
+  loaded data objects. https://github.com/glue-viz/glue/pull/1239
 
-- Change default name of subsets to include the word 'Subset'. [#1234]
+- Change default name of subsets to include the word 'Subset'. https://github.com/glue-viz/glue/pull/1234
 
 - Removed ginga plugin from core package and moved it to a separate repository
   at https://github.com/ejeschke/glue-ginga.
 
 - Switch from using bundled WCSAxes to using the version in Astropy, and fixed
-  an issue that caused the frame of the axes to be too thick. [#1231]
+  an issue that caused the frame of the axes to be too thick. https://github.com/glue-viz/glue/pull/1231
 
 - Make it possible to define a default index for DataComboHelper - this makes
   it possible for viewers to have three DataComboHelper and ensure that they
-  default to different attributes. [#1163]
+  default to different attributes. https://github.com/glue-viz/glue/pull/1163
 
-- Deal properly with adding Subset objects to DataComboHelper. [#1163]
+- Deal properly with adding Subset objects to DataComboHelper. https://github.com/glue-viz/glue/pull/1163
 
 - Added the ability to export data and subset from the data collection view via
   contextual menus. It was previously possible to export only the mask itself,
@@ -1150,24 +1150,24 @@
   merging was good for performance but made it impossible to undo the linking by
   un-glueing. Derived components created by links are now hidden by default.
   Finally, ``ComponentID`` objects now hold a reference to the first parent data
-  they are used in. [#1189]
+  they are used in. https://github.com/glue-viz/glue/pull/1189
 
 - Added a decorator that can be used to avoid circular calling of methods (can
-  occur when dealing with callbacks). [#1207]
+  occur when dealing with callbacks). https://github.com/glue-viz/glue/pull/1207
 
 - Drop support for IPython 3.x and below, and make IPython and qtconsole into
-  required dependencies. [#1145]
+  required dependencies. https://github.com/glue-viz/glue/pull/1145
 
 - Added new classes that can be used to hold the state of e.g. viewers and other
   objects. These classes allow callbacks to be attached to various properties,
   and can be used to define logical relations between different attributes
   in a GUI-independent way.
 
-- Fix selections when using Matplotlib 2.x, PyQt5 and a retina display. [#1236]
+- Fix selections when using Matplotlib 2.x, PyQt5 and a retina display. https://github.com/glue-viz/glue/pull/1236
 
 - Updated ComponentIDComboHelper to no longer store ``(cid, data)`` as the
   ``userData`` but instead just the ``cid`` (the data is now accessible via
-  ``cid.parent``). [#1212]
+  ``cid.parent``). https://github.com/glue-viz/glue/pull/1212
 
 - Avoid duplicate toolbar in dendrogram viewer. [#1213, #1237]
 
@@ -1176,20 +1176,20 @@
 
 - Fixed bug that caused coordinate information to be lost when merging datasets.
   The original behavior of keeping the coordinate information from the first
-  dataset has been restored. [#1186]
+  dataset has been restored. https://github.com/glue-viz/glue/pull/1186
 
 - Fix ``Data.update_values_from_data`` to make sure that original component order
-  is preserved. [#1238]
+  is preserved. https://github.com/glue-viz/glue/pull/1238
 
 - Fix Data.components to return original component order, not alphabetical order.
-  [#1238]
+  https://github.com/glue-viz/glue/pull/1238
 
-- Fix significant performance bottlenecks with WCS coordinate conversions. [#1185]
+- Fix significant performance bottlenecks with WCS coordinate conversions. https://github.com/glue-viz/glue/pull/1185
 
 - Fix error when changing the contrast radio button the RGB image viewer mode,
-  and also fix bugs with setting the range of values manually. [#1187]
+  and also fix bugs with setting the range of values manually. https://github.com/glue-viz/glue/pull/1187
 
-- Fix a bug that caused coordinate axis labels to be lost during merging. [#1195]
+- Fix a bug that caused coordinate axis labels to be lost during merging. https://github.com/glue-viz/glue/pull/1195
 
 - Fix a bug that caused tab names to not be saved and restored to/from session
   files. [#1241, #1242]
@@ -1199,19 +1199,19 @@
 ### What's Changed
 
 - Fixed loading of session files made with earlier versions of glue that
-  contained selections made in 3D viewers. [#1160]
+  contained selections made in 3D viewers. https://github.com/glue-viz/glue/pull/1160
 
 - Fixed plotting of fit on spectrum to make sure that the two are properly
-  aligned. [#1158]
+  aligned. https://github.com/glue-viz/glue/pull/1158
 
 - Made it possible to now create InequalitySubsetStates for
-  categorical components using e.g. d.id['a'] == 'string'. [#1153]
+  categorical components using e.g. d.id['a'] == 'string'. https://github.com/glue-viz/glue/pull/1153
 
 - Fixed a bug that caused selections to not propagate properly between
-  linked images and cubes. [#1144]
+  linked images and cubes. https://github.com/glue-viz/glue/pull/1144
 
 - Make last interval of faceted subsets inclusive so as to make sure all values
-  in the faceted subset range end up in a subset. [#1154]
+  in the faceted subset range end up in a subset. https://github.com/glue-viz/glue/pull/1154
 
 ## [v0.9.0](https://github.com/glue-viz/glue/compare/v0.8.2...v0.9.0) - 2016-10-10
 
@@ -1223,36 +1223,36 @@
   method with the components separated into left/right and the methods for
   forward/backward transformation. The original behavior can be retained
   by using the ``multi_link`` function instead of the ``MultiLink`` class.
-  [#1139]
+  https://github.com/glue-viz/glue/pull/1139
 
-- Improve support for spectral cubes. [#1075]
+- Improve support for spectral cubes. https://github.com/glue-viz/glue/pull/1075
 
 - Allow link functions/helpers to define a category using the ``category=``
   argument (which defaults to ``General``), and make it possible to filter
-  by category in the link editor. [#1141]
+  by category in the link editor. https://github.com/glue-viz/glue/pull/1141
 
-- Only show the 'waiting' cursor when glue is doing something. [#1097]
+- Only show the 'waiting' cursor when glue is doing something. https://github.com/glue-viz/glue/pull/1097
 
 - Make sure that the scatter layer artist style editor is shown when overplotting
-  a scatter plot on top of an image. [#1134]
+  a scatter plot on top of an image. https://github.com/glue-viz/glue/pull/1134
 
 - Data viewers can now make ``layer_style_widget_cls`` a dictionary in cases
-  where multiple layer artist types are supported. [#1134]
+  where multiple layer artist types are supported. https://github.com/glue-viz/glue/pull/1134
 
-- Fix compatibility of test suite with pytest 3.x. [#1116]
+- Fix compatibility of test suite with pytest 3.x. https://github.com/glue-viz/glue/pull/1116
 
-- Updated bundled version of WCSAxes to v0.9. [#1089]
+- Updated bundled version of WCSAxes to v0.9. https://github.com/glue-viz/glue/pull/1089
 
-- Fix compatibility with pre-releases of Matplotlib 2.0. [#1115]
+- Fix compatibility with pre-releases of Matplotlib 2.0. https://github.com/glue-viz/glue/pull/1115
 
 - Implement new widget with better control over exporting to Plotly. The
   preference pane for Plotly export has now been removed in favor of this new
-  way to set the options. [#1057]
+  way to set the options. https://github.com/glue-viz/glue/pull/1057
 
 - Renamed the ``ComponentIDComboHelper`` and ``ManualDataComboHelper``
   ``append`` methods to ``append_data`` and the ``remove`` methods to
   ``remove_data``, and added a new ``ComponentIDComboHelper.set_multiple_data``
-  method. [#1060]
+  method. https://github.com/glue-viz/glue/pull/1060
 
 - Fixed reading of units from FITS and VO tables, and display units in
   table viewer. [#1135, #1137]
@@ -1267,91 +1267,91 @@
   categorical components.
 
 - Added a new Data method, ``update_values_from_data``, that can be used to replicate
-  components from one dataset into another. [#1112]
+  components from one dataset into another. https://github.com/glue-viz/glue/pull/1112
 
 - Refactored code related to toolbars in order to make it easier to define
   toolbars and toolbar modes that aren't Matplotlib-specific. [#1085, #1120]
 
 - Added a new table viewer. [#1084, #1123]
 
-- Fix saving/loading of categorical components. [#1084]
+- Fix saving/loading of categorical components. https://github.com/glue-viz/glue/pull/1084
 
-- Make it possible for tools to define a status bar message. [#1084]
+- Make it possible for tools to define a status bar message. https://github.com/glue-viz/glue/pull/1084
 
 - Added a command-line option, ``--no-maximized``, that prevents glue
   from opening up with the application window maximized. [#1093, #1126]
 
 - When opening multiple files in one go, if one of the files fails to
-  read, the error will now indicate which file failed. [#1104]
+  read, the error will now indicate which file failed. https://github.com/glue-viz/glue/pull/1104
 
 - Fixed a bug that caused new subset colors to incorrectly start from the start
-  of the color cycle after loading a session. [#1055]
+  of the color cycle after loading a session. https://github.com/glue-viz/glue/pull/1055
 
 - Fixed a bug that caused the functionality to execute scripts (glue -x) to not
   work in Python 3. [#1101, #1114]
 
 - The minimum supported version of Astropy is now 1.0, and the minimum
-  supported version of IPython is now 1.0. [#1076]
+  supported version of IPython is now 1.0. https://github.com/glue-viz/glue/pull/1076
 
 - Show world coordinates and units in the cube slicer. [#1059, #1068]
 
-- Fix errors that occurred when selecting categorical data. [#1069]
+- Fix errors that occurred when selecting categorical data. https://github.com/glue-viz/glue/pull/1069
 
-- Added experimental support for joining on multiple keys in ``join_on_key``. [#974]
+- Added experimental support for joining on multiple keys in ``join_on_key``. https://github.com/glue-viz/glue/pull/974
 
-- Fix compatibility with the latest version of ginga. [#1063]
+- Fix compatibility with the latest version of ginga. https://github.com/glue-viz/glue/pull/1063
 
 ## [v0.8.2](https://github.com/glue-viz/glue/compare/v0.8.1...v0.8.2) - 2016-07-06
 
 ### What's Changed
 
-- Implement missing MaskSubsetState.copy. [#1033]
+- Implement missing MaskSubsetState.copy. https://github.com/glue-viz/glue/pull/1033
 
-- Ensure that failing data factory identifier functions are skipped. [#1029]
+- Ensure that failing data factory identifier functions are skipped. https://github.com/glue-viz/glue/pull/1029
 
 - The naming of pixel axes is now more consistent between data with 3 or
   fewer dimensions, and data with more than 3 dimensions. The naming is now
   always ``Pixel Axis ?`` where ``?`` is the index of the array, and for
   datasets with 1 to 3 dimensions, we add a suffix e.g. ``[x]`` to indicate
-  the traditional axes. [#1029]
+  the traditional axes. https://github.com/glue-viz/glue/pull/1029
 
 - Implemented a number of performance improvements, including for: the check
   of whether points are in polygon (``points_inside_poly``), the selection of
   polygonal regions in multi-dimentional cubes when the selections are along
   pixel axes, the selection of points in scatter plots with one or two
   categorical components for rectangular, circular, and polygonal regions.
-  [#1029]
+  https://github.com/glue-viz/glue/pull/1029
 
 - Fix a bug that caused multiple custom viewer classes to not work properly
   if the user did not override ``_custom_functions`` (which was private).
-  [#810]
+  https://github.com/glue-viz/glue/pull/810
 
 - Make sure histograms are updated if only the attribute changes and the
-  limits and number of bins stay the same. [#1012]
+  limits and number of bins stay the same. https://github.com/glue-viz/glue/pull/1012
 
 - Fix a bug on Windows that caused drag and dropping files onto the glue
-  application to not work. [#1007]
+  application to not work. https://github.com/glue-viz/glue/pull/1007
 
-- Fix compatibility with PyQt5. [#1015]
+- Fix compatibility with PyQt5. https://github.com/glue-viz/glue/pull/1015
 
 - Fix a bug that caused ComponentIDComboHelper to not take into account the
-  numeric and categorical options in ``__init__``. [#1014]
+  numeric and categorical options in ``__init__``. https://github.com/glue-viz/glue/pull/1014
 
-- Fix a bug that caused saving of scatter plots to SVG files to crash. [#984]
+- Fix a bug that caused saving of scatter plots to SVG files to crash. https://github.com/glue-viz/glue/pull/984
 
 ## [v0.8.1](https://github.com/glue-viz/glue/compare/v0.8...v0.8.1) - 2016-05-25
 
 ### What's Changed
 
 - Fixed a bug in the memoize function that caused selections using
-  ElementSubsetState to fail when using views on the data. [#1004]
+  ElementSubsetState to fail when using views on the data. https://github.com/glue-viz/glue/pull/1004
 
 - Explicitly set the icon size for the slicing playback controls to avoid
-  issues when using a mix of retina and non-retina displays. [#1005]
+  issues when using a mix of retina and non-retina displays. https://github.com/glue-viz/glue/pull/1005
 
 - Fixed a bug that caused ``add_datasets`` to crash if ``datasets`` was a list of
   lists of data, which is possible if a data factory returns more than one data
-  object. [#1006]
+  object. https://github.com/glue-viz/glue/pull/1006
 
 ## [v0.8](https://github.com/glue-viz/glue/compare/v0.7.3...v0.8) - 2016-05-23
 
@@ -1360,78 +1360,78 @@
 - Add support for circular and polygonal spectrum extraction. [#994, #1003]
 
 - Fix compatibility with latest developer version of Numpy which does not allow
-  non-integer indices for arrays. [#1002]
+  non-integer indices for arrays. https://github.com/glue-viz/glue/pull/1002
 
 - Add a new method ``add_data`` to application instances. This allows for
   example additional data to be passed to glue after being launched by
-  ``qglue``. [#993]
+  ``qglue``. https://github.com/glue-viz/glue/pull/993
 
-- Add playback controls to slice widget. [#971]
+- Add playback controls to slice widget. https://github.com/glue-viz/glue/pull/971
 
 - Add tooltip for data labels so that long labels can be more easily
-  inspected. [#912]
+  inspected. https://github.com/glue-viz/glue/pull/912
 
 - Added a new helper class ``AttributeLimitsHelper`` to link widgets related to
   setting limits and handle the caching of the limits as a function of
-  attribute. [#872]
+  attribute. https://github.com/glue-viz/glue/pull/872
 
-- Add Quit menu item for Linux and Windows. [#926]
+- Add Quit menu item for Linux and Windows. https://github.com/glue-viz/glue/pull/926
 
 - Refactored the window for sending feedback to include more version
   information, and also to have a separate form for feedback and crash
-  reports. [#955]
+  reports. https://github.com/glue-viz/glue/pull/955
 
-- Add log= option to ValueProperty and remove mapping= option. [#965]
+- Add log= option to ValueProperty and remove mapping= option. https://github.com/glue-viz/glue/pull/965
 
-- Added helper classes for ComponentID and Data combo boxes. [#891]
+- Added helper classes for ComponentID and Data combo boxes. https://github.com/glue-viz/glue/pull/891
 
 - Improved new component window: expressions can now include math or numpy
   functions by default, and expressions are tested on-the-fly to check that
-  there are no issues with syntax or undefined variables. [#956]
+  there are no issues with syntax or undefined variables. https://github.com/glue-viz/glue/pull/956
 
-- Fixed D3PO export when using Python 3. [#989]
+- Fixed D3PO export when using Python 3. https://github.com/glue-viz/glue/pull/989
 
-- Fixed display of certain error messages when using Python 3. [#989]
+- Fixed display of certain error messages when using Python 3. https://github.com/glue-viz/glue/pull/989
 
-- Add an extensible preferences window. [#988]
+- Add an extensible preferences window. https://github.com/glue-viz/glue/pull/988
 
 - Add the ability to change the foreground and background color for viewers.
-  [#988]
+  https://github.com/glue-viz/glue/pull/988
 
 - Fixed a bug that caused images to appear over-pixellated on the edges when
-  zooming in. [#1000]
+  zooming in. https://github.com/glue-viz/glue/pull/1000
 
-- Added an option to control whether warnings are shown when passing large data objects to viewers. [#999]
+- Added an option to control whether warnings are shown when passing large data objects to viewers. https://github.com/glue-viz/glue/pull/999
 
 ## [v0.7.3](https://github.com/glue-viz/glue/compare/v0.7.2...v0.7.3) - 2016-05-04
 
 ### What's Changed
 
 - Remove icons for actions that appear in contextual menus, since these
-  appear too large due to a Qt bug. [#911]
+  appear too large due to a Qt bug. https://github.com/glue-viz/glue/pull/911
 
 - Add missing ``find_spec`` for import hook, to avoid issues when trying to set
-  colormap. [#930]
+  colormap. https://github.com/glue-viz/glue/pull/930
 
 - Ignore extra dimensions in WCS (for instance, if the data is 3D and the
-  header is 4D, ignore the 4th dimension in the WCS). [#935]
+  header is 4D, ignore the 4th dimension in the WCS). https://github.com/glue-viz/glue/pull/935
 
 - Fix a bug that caused the merge window to appear multiple times, make sure
   that all components named PRIMARY get renamed after merging, and make sure
   that the merge mechanism is also triggered when opening datasets from the
-  command-line. [#936]
+  command-line. https://github.com/glue-viz/glue/pull/936
 
 - Remove the scrollbars added in v0.7.1 since they cause issues on certain
-  systems. [#953]
+  systems. https://github.com/glue-viz/glue/pull/953
 
-- Fix saving of ElementSubsetState to session files. [#966]
+- Fix saving of ElementSubsetState to session files. https://github.com/glue-viz/glue/pull/966
 
-- Fix saving of Matplotlib colormaps to session files. [#967]
+- Fix saving of Matplotlib colormaps to session files. https://github.com/glue-viz/glue/pull/967
 
-- Fix the selection of the default viewer based on the data shape. [#968]
+- Fix the selection of the default viewer based on the data shape. https://github.com/glue-viz/glue/pull/968
 
 - Make sure that no combo boxes get resized based on the content (unless
-  strictly needed). [#978]
+  strictly needed). https://github.com/glue-viz/glue/pull/978
 
 ## [v0.7.2](https://github.com/glue-viz/glue/compare/v0.7.1...v0.7.2) - 2016-04-05
 
@@ -1439,52 +1439,52 @@
 
 - Fix a bug that caused string columns in FITS files to not be read
   correctly, and updated ``coerce_numeric`` to give a ``ValueError`` for string
-  columns that can't be convered. [#919]
+  columns that can't be convered. https://github.com/glue-viz/glue/pull/919
 
-- Make sure main window title is set. [#914]
+- Make sure main window title is set. https://github.com/glue-viz/glue/pull/914
 
-- Fix issue with FITS files that are missing an END card. [#915]
+- Fix issue with FITS files that are missing an END card. https://github.com/glue-viz/glue/pull/915
 
 - Fix a bug that caused values in exponential notation in text fields to lose
-  a trailing zero (e.g. 1.000e+10 would become 1.000e+1). [#925]
+  a trailing zero (e.g. 1.000e+10 would become 1.000e+1). https://github.com/glue-viz/glue/pull/925
 
 ## [v0.7.1](https://github.com/glue-viz/glue/compare/v0.7...v0.7.1) - 2016-03-30
 
 ### What's Changed
 
 - Fix issue with small screens and layer and viewer options by adding
-  scrollbars. [#902]
+  scrollbars. https://github.com/glue-viz/glue/pull/902
 
-- Fixed a failure due to a missing Qt import in glue.core.roi. [#901]
+- Fixed a failure due to a missing Qt import in glue.core.roi. https://github.com/glue-viz/glue/pull/901
 
 - Fixed a bug that caused an abort trap if the filename specified on the
-  command line did not exist. [#903]
+  command line did not exist. https://github.com/glue-viz/glue/pull/903
 
-- Gracefully skip vector columnns when reading in FITS files. [#896]
+- Gracefully skip vector columnns when reading in FITS files. https://github.com/glue-viz/glue/pull/896
 
-- Change default gray color to work on black and white backgrounds. [#906]
+- Change default gray color to work on black and white backgrounds. https://github.com/glue-viz/glue/pull/906
 
 - Fixed a bug that caused the color in the scatter and histogram style
-  editors to not show the correct initial color. [#907]
+  editors to not show the correct initial color. https://github.com/glue-viz/glue/pull/907
 
 ## [v0.7](https://github.com/glue-viz/glue/compare/v0.6...v0.7) - 2016-03-10
 
 ### What's Changed
 
-- Python 2.6 is no longer supported. [#804]
+- Python 2.6 is no longer supported. https://github.com/glue-viz/glue/pull/804
 
 - Added a generic QColorBox widget to pick colors, and an associated
-  ``connect_color`` helper for callback properties. [#864]
+  ``connect_color`` helper for callback properties. https://github.com/glue-viz/glue/pull/864
 
 - Added a generic QColormapCombo widget to pick colormaps.
 
 - The ``artist_container`` argument to client classes has been renamed to
-  ``layer_artist_container``. [#814]
+  ``layer_artist_container``. https://github.com/glue-viz/glue/pull/814
 
 - Added documentation about how to use layer artists in custom Qt data viewers.
-  [#814]
+  https://github.com/glue-viz/glue/pull/814
 
-- Fixed missing newline in ``Data.__str__``. [#877]
+- Fixed missing newline in ``Data.__str__``. https://github.com/glue-viz/glue/pull/877
 
 - A large fraction of the code has been re-organized, which may lead to some
   imports in ``config.py`` files no longer working. However, no functionality
@@ -1541,7 +1541,7 @@
   ``glue.qt.glue_toolbar``                           | ``glue.viewers.common.qt.toolbar``
   ``glue.qt.custom_viewer``                          | ``glue.viewers.custom.qt``
 
-  [#835]
+  https://github.com/glue-viz/glue/pull/835
 
   ``glue.qt.glue_application.GlueApplication``       | ``glue.app.qt.application.GlueApplication``
   ``glue.qt.plugin_manager.QtPluginManager``         | ``glue.app.qt.plugin_manager.QtPluginManager``
@@ -1577,63 +1577,63 @@
   ``glue.qt.qtutil.action``                          | ``glue.app.qt.actions.action``
   ``glue.qt.qt_backend.Timer``                       | ``glue.backends.QtTimer``
 
-  [#845]
+  https://github.com/glue-viz/glue/pull/845
 
-- Improved under-the-hood creation of ROIs for Scatter and Histogram Clients. [#676]
+- Improved under-the-hood creation of ROIs for Scatter and Histogram Clients. https://github.com/glue-viz/glue/pull/676
 
 - Data viewers can now define a layer artist style editor class that appears
-  under the list of layer artists. [#852]
+  under the list of layer artists. https://github.com/glue-viz/glue/pull/852
 
-- Properties of the VisualAttributes class are now callback properties. [#852]
+- Properties of the VisualAttributes class are now callback properties. https://github.com/glue-viz/glue/pull/852
 
 - Add ``glue.utils.qt.widget_properties.connect_value`` function which can take
   an optional ``value_range`` and log option to scale the Qt values to a custom
-  range of values (optionally in log space). [#852]
+  range of values (optionally in log space). https://github.com/glue-viz/glue/pull/852
 
-- Make list of data viewers sorted alphabetically. [#866]
+- Make list of data viewers sorted alphabetically. https://github.com/glue-viz/glue/pull/866
 
 ## [v0.6](https://github.com/glue-viz/glue/compare/v0.5.2...v0.6) - 2015-11-20
 
 ### What's Changed
 
-- Added experimental support for PyQt5. [#663]
+- Added experimental support for PyQt5. https://github.com/glue-viz/glue/pull/663
 
-- Fix ``glue -t`` option. [#791]
+- Fix ``glue -t`` option. https://github.com/glue-viz/glue/pull/791
 
-- Updated ``glue-deps`` to show PyQt/PySide versions. [#796]
+- Updated ``glue-deps`` to show PyQt/PySide versions. https://github.com/glue-viz/glue/pull/796
 
 - Fix bug that caused viewers to be restored with the wrong size. [#781, #783]
 
-- Fixed compatibility with the latest stable version of ginga. [#797]
+- Fixed compatibility with the latest stable version of ginga. https://github.com/glue-viz/glue/pull/797
 
 - Prevent axes from moving around when data viewers are being resized, and
-  instead make the absolute margins between axes and figure edge fixed. [#745]
+  instead make the absolute margins between axes and figure edge fixed. https://github.com/glue-viz/glue/pull/745
 
 - Fixed a bug that caused image plots to not be updated immediately when
   changing component, and fixed a bug that caused data and attribute combo
   boxes to not update correctly when showing multiple datasets in an
-  ImageWidget. [#755]
+  ImageWidget. https://github.com/glue-viz/glue/pull/755
 
 - Added tests to ensure that we remain backward-compatible with old session
   files for the FITS and HDF5 factories. [#736, #748]
 
 - When a box has been drawn to extract a spectrum from a cube, the box can
-  then be moved by pressing the control key and dragging it. [#707]
+  then be moved by pressing the control key and dragging it. https://github.com/glue-viz/glue/pull/707
 
-- Refactored ASCII I/O to include more Astropy table formats. [#762]
+- Refactored ASCII I/O to include more Astropy table formats. https://github.com/glue-viz/glue/pull/762
 
 - When saving a session, if no extension is specified, the .glu extension is
-  added. [#729]
+  added. https://github.com/glue-viz/glue/pull/729
 
-- Added a GUI plugin manager in the 'Plugins' menu. [#682]
+- Added a GUI plugin manager in the 'Plugins' menu. https://github.com/glue-viz/glue/pull/682
 
 - Added an option to specify whether to use an automatic aspect ratio for image
-  data or whether to enforce square pixels. [#717]
+  data or whether to enforce square pixels. https://github.com/glue-viz/glue/pull/717
 
 - Data factories can now be given priorities to determine which ones should
   take precedence in ambiguous cases. The ``set_default_factory`` and
   ``get_default_factory`` functions are now deprecated since it is possible to
-  achieve this solely with priorities. [#719]
+  achieve this solely with priorities. https://github.com/glue-viz/glue/pull/719
 
 - Improved cube slider to include editable slice value as well as
   first/previous/next/last buttons, and improved spacing of sliders for 4+
@@ -1641,47 +1641,47 @@
 
 - Registering data factories should now always be done with the
   ``@data_factory`` decorator, and not by adding functions to
-  ``__factories__``, as was possible in early versions of Glue. [#724]
+  ``__factories__``, as was possible in early versions of Glue. https://github.com/glue-viz/glue/pull/724
 
 - Made the Excel spreadsheet reader more robust: column headers no longer have
   to be strings, and the reader no longer expects the first sheet to be called
   'Sheet1'. All sheets are now read by default. Datasets are now named as
-  filename:sheetname. [#726]
+  filename:sheetname. https://github.com/glue-viz/glue/pull/726
 
-- Fix compatibility with IPython 4. [#733]
+- Fix compatibility with IPython 4. https://github.com/glue-viz/glue/pull/733
 
 - Improved reading of FITS files - all HDUs are now read by default. [#704, #732]
 
 - Added new widget property classes, for combo boxes (based on label instead of
-  data) and for tab widgets. [#752]
+  data) and for tab widgets. https://github.com/glue-viz/glue/pull/752
 
 - Improved reading of HDF5 files - all datasets in an HDF5 file are now read by
-  default. [#747]
+  default. https://github.com/glue-viz/glue/pull/747
 
-- Fix a bug that caused images to not be shown at full resolution after resizing. [#768]
+- Fix a bug that caused images to not be shown at full resolution after resizing. https://github.com/glue-viz/glue/pull/768
 
 - Fix a bug that caused the color of an extracted spectrum to vary if extracted
-  multiple times. [#743]
+  multiple times. https://github.com/glue-viz/glue/pull/743
 
 - Fixed a bug that caused compressed image HDUs to not be read correctly.
-  [#767]
+  https://github.com/glue-viz/glue/pull/767
 
 - Added two new settings ``settings.SUBSET_COLORS`` and ``settings.DATA_COLOR``
-  that can be used to customize the default subset and data colors. [#742]
+  that can be used to customize the default subset and data colors. https://github.com/glue-viz/glue/pull/742
 
 ## v0.5.3 (unreleased)
 
 ### What's Changed
 
-- Fix selection in scatter plots when categorical data are present. [#727]
+- Fix selection in scatter plots when categorical data are present. https://github.com/glue-viz/glue/pull/727
 
 ## [v0.5.2](https://github.com/glue-viz/glue/compare/v0.5.1...v0.5.2) - 2015-08-13
 
 ### What's Changed
 
-- Fix loading of plugins with setuptools < 11.3 [#699]
+- Fix loading of plugins with setuptools < 11.3 https://github.com/glue-viz/glue/pull/699
 
-- Fix loading of plugins when using glue programmatically rather than through the GUI [#698]
+- Fix loading of plugins when using glue programmatically rather than through the GUI https://github.com/glue-viz/glue/pull/698
 
 - Backward-compatibility fixes after refactoring ``data_factories`` [#696, #703]
 
@@ -1689,69 +1689,69 @@
 
 ### What's Changed
 
-- Fixed treatment of newlines when copying detailed error. [#687]
+- Fixed treatment of newlines when copying detailed error. https://github.com/glue-viz/glue/pull/687
 
 - Fix a bug that prevented sessions from being saved with embedded files if
-  component units were Astropy units. [#686]
+  component units were Astropy units. https://github.com/glue-viz/glue/pull/686
 
-- Users should now press 'control' to drag rather than re-define subsets. [#689]
+- Users should now press 'control' to drag rather than re-define subsets. https://github.com/glue-viz/glue/pull/689
 
 ## [v0.5](https://github.com/glue-viz/glue/compare/v0.4...v0.5) - 2015-07-03
 
 ### What's Changed
 
-- Improvements to the PyQt/PySide wrapper module (now maintained in a separate repository). [#671]
+- Improvements to the PyQt/PySide wrapper module (now maintained in a separate repository). https://github.com/glue-viz/glue/pull/671
 
-- Fixed broken links on website. [#678]
+- Fixed broken links on website. https://github.com/glue-viz/glue/pull/678
 
-- Added the ability to discover plugins via entry points. [#677]
+- Added the ability to discover plugins via entry points. https://github.com/glue-viz/glue/pull/677
 
 - Added the ability to include float and string UI elements in custom
-  viewers. [#653]
+  viewers. https://github.com/glue-viz/glue/pull/653
 
-- Added an option to bundle all data in .glu session files. [#661]
+- Added an option to bundle all data in .glu session files. https://github.com/glue-viz/glue/pull/661
 
-- Added a ``menu_plugin`` registry to add custom tools to the registry. [#644]
+- Added a ``menu_plugin`` registry to add custom tools to the registry. https://github.com/glue-viz/glue/pull/644
 
 - Support for 'lazy-loading' plugins which means their import is deferred
-  until they are needed. [#590]
+  until they are needed. https://github.com/glue-viz/glue/pull/590
 
-- Support for connecting custom importers. [#593]
+- Support for connecting custom importers. https://github.com/glue-viz/glue/pull/593
 
-- ``qglue`` now correctly interprets HDUList objects. [#598]
+- ``qglue`` now correctly interprets HDUList objects. https://github.com/glue-viz/glue/pull/598
 
 - Internal improvements to organization of domain-specific code (such as the
   Astronomy coordinate conversions and ginga data viewer). [#488, #585]
 
-- Astronomy coordinate conversions now include more coordinate frames. [#578]
+- Astronomy coordinate conversions now include more coordinate frames. https://github.com/glue-viz/glue/pull/578
 
 - ``load_ui`` now checks whether ``.ui`` file exists locally before
-  retrieving it from the ``glue.qt.ui`` sub-package. [#599]
+  retrieving it from the ``glue.qt.ui`` sub-package. https://github.com/glue-viz/glue/pull/599
 
 - Improved interface for adding new components, with syntax highlighting
   and tab-completion. [#572, #575]
 
-- Improved error/warning messages. [#582]
+- Improved error/warning messages. https://github.com/glue-viz/glue/pull/582
 
 - Miscellaneous bug fixes. [#637, #636, #608]
 
 - The error console log is now available through the View menu
 
-- Improved under-the-hood handling of categorical ROIs. [#601]
+- Improved under-the-hood handling of categorical ROIs. https://github.com/glue-viz/glue/pull/601
 
-- Fixed compatibility with Python 2.6. [#540]
+- Fixed compatibility with Python 2.6. https://github.com/glue-viz/glue/pull/540
 
-- Python 3.x support is now stable. [#576]
+- Python 3.x support is now stable. https://github.com/glue-viz/glue/pull/576
 
-- Fixed the ability to copy detailed error messages. [#675]
+- Fixed the ability to copy detailed error messages. https://github.com/glue-viz/glue/pull/675
 
-- Added instructions on how to make a fully-customized Qt viewer. [#619]
+- Added instructions on how to make a fully-customized Qt viewer. https://github.com/glue-viz/glue/pull/619
 
 - Fixes to the ginga plugin to support the latest version. [#584, #656]
 
-- Added the ability to drag circular, rectangular, and lasso selections. [#657]
+- Added the ability to drag circular, rectangular, and lasso selections. https://github.com/glue-viz/glue/pull/657
 
-- Added the ability to reset a session. [#630]
+- Added the ability to reset a session. https://github.com/glue-viz/glue/pull/630
 
 ## [v0.4](https://github.com/glue-viz/glue/releases/tag/v0.4) (Released December 22, 2015)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1339,7 +1339,7 @@
 
 - Fix a bug that caused saving of scatter plots to SVG files to crash. https://github.com/glue-viz/glue/pull/984
 
-## [v0.8.1](https://github.com/glue-viz/glue/compare/v0.8...v0.8.1) - 2016-05-25
+## [v0.8.1](https://github.com/glue-viz/glue/compare/v0.8.0...v0.8.1) - 2016-05-25
 
 ### What's Changed
 
@@ -1353,7 +1353,7 @@
   lists of data, which is possible if a data factory returns more than one data
   object. https://github.com/glue-viz/glue/pull/1006
 
-## [v0.8](https://github.com/glue-viz/glue/compare/v0.7.3...v0.8) - 2016-05-23
+## [v0.8.0](https://github.com/glue-viz/glue/compare/v0.7.3...v0.8.0) - 2016-05-23
 
 ### What's Changed
 
@@ -1448,7 +1448,7 @@
 - Fix a bug that caused values in exponential notation in text fields to lose
   a trailing zero (e.g. 1.000e+10 would become 1.000e+1). https://github.com/glue-viz/glue/pull/925
 
-## [v0.7.1](https://github.com/glue-viz/glue/compare/v0.7...v0.7.1) - 2016-03-30
+## [v0.7.1](https://github.com/glue-viz/glue/compare/v0.7.0...v0.7.1) - 2016-03-30
 
 ### What's Changed
 
@@ -1467,7 +1467,7 @@
 - Fixed a bug that caused the color in the scatter and histogram style
   editors to not show the correct initial color. https://github.com/glue-viz/glue/pull/907
 
-## [v0.7](https://github.com/glue-viz/glue/compare/v0.6...v0.7) - 2016-03-10
+## [v0.7.0](https://github.com/glue-viz/glue/compare/v0.6.0...v0.7.0) - 2016-03-10
 
 ### What's Changed
 
@@ -1592,7 +1592,7 @@
 
 - Make list of data viewers sorted alphabetically. https://github.com/glue-viz/glue/pull/866
 
-## [v0.6](https://github.com/glue-viz/glue/compare/v0.5.2...v0.6) - 2015-11-20
+## [v0.6.0](https://github.com/glue-viz/glue/compare/v0.5.2...v0.6.0) - 2015-11-20
 
 ### What's Changed
 
@@ -1685,7 +1685,7 @@
 
 - Backward-compatibility fixes after refactoring ``data_factories`` [#696, #703]
 
-## [v0.5.1](https://github.com/glue-viz/glue/compare/v0.5...v0.5.1) - 2015-07-06
+## [v0.5.1](https://github.com/glue-viz/glue/compare/v0.5.0...v0.5.1) - 2015-07-06
 
 ### What's Changed
 
@@ -1696,7 +1696,7 @@
 
 - Users should now press 'control' to drag rather than re-define subsets. https://github.com/glue-viz/glue/pull/689
 
-## [v0.5](https://github.com/glue-viz/glue/compare/v0.4...v0.5) - 2015-07-03
+## [v0.5.0](https://github.com/glue-viz/glue/compare/v0.4.0...v0.5.0) - 2015-07-03
 
 ### What's Changed
 
@@ -1753,7 +1753,7 @@
 
 - Added the ability to reset a session. https://github.com/glue-viz/glue/pull/630
 
-## [v0.4](https://github.com/glue-viz/glue/releases/tag/v0.4) (Released December 22, 2015)
+## [v0.4.0](https://github.com/glue-viz/glue/releases/tag/v0.4.0) (Released December 22, 2015)
 
 ### Release Highlights:
 

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,28 +1,11 @@
 How to release a new version of Glue
 ====================================
 
-#. Edit the ``CHANGES.rst`` file to add the release date for the release
-   you want to make and make sure the changelog is complete.
+#. Follow the instructions in the `Glue documentation
+   <http://docs.glueviz.org/en/stable/developer_guide/release.html>`_
+   to create a release using the `GitHub menu
+   <https://github.com/glue-viz/glue/releases/new>`_.
 
-#. Commit the changes using::
-
-    git commit -m "Preparing release v..."
-
-   where v... is the version you are releasing and push to main::
-
-    git push upstream main
-
-#. Tag the release you want to make, optionally signing it (``-s``)::
-
-    git tag -m v1.5.1 v1.5.1
-
-   and push the tag::
-
-    git push upstream v1.5.1
-
-#. At this point, the release sdist and wheel will be built on by GitHub
-   Actions and automatically uploaded to PyPI. You can check the build
-   for the release commit `here <https://github.com/glue-viz/glue/actions/>`_
-   and if there are any issues you can delete the tag, fix the issues
-   (preferably via a pull request) and then try the release process
-   again.
+#. Have a beverage of your choosing while you can check the build progress
+   `here <https://github.com/glue-viz/glue/actions/>`_.
+   (Note that the wheels may take some time to build).

--- a/doc/developer_guide/developer_guide.rst
+++ b/doc/developer_guide/developer_guide.rst
@@ -23,3 +23,4 @@ The following pages provide logistical information about the layout of the code,
    qt_development.rst
    coding_guidelines.rst
    testing.rst
+   release.rst

--- a/doc/developer_guide/release.rst
+++ b/doc/developer_guide/release.rst
@@ -1,5 +1,5 @@
-How to release a new version of a Glue package
-==============================================
+Releasing a new package version
+===============================
 
 A new release of packages in the `glue-viz <https://glueviz.org/>`_ ecosystem is
 now almost fully automated.

--- a/doc/developer_guide/release.rst
+++ b/doc/developer_guide/release.rst
@@ -1,0 +1,27 @@
+How to release a new version of a Glue package
+==============================================
+
+A new release of packages in the `glue-viz <https://glueviz.org/>`_ ecosystem is
+now almost fully automated.
+For maintainers it should be nice and simple to do, especially if all merged PRs
+have informative titles and are correctly labelled.
+
+Here is the process to follow to create a new release:
+
+#. Go through all the PRs since the last release, make sure they have
+   descriptive titles (as these will become the auto-generated changelog entries)
+   and are labelled correctly - preferably identifying them as one of
+   `bug`, `enhancement` or `documentation`.
+
+#. Go to the GitHub releases interface and draft a new release; new tags should
+   include the trailing patch version ``.0`` (e.g. ``1.6.0``, not ``1.6``) on
+   `major.minor` releases (early releases of most packages did not).
+
+#. Use the GitHub autochange log generator; this should use the configuration in
+   `.github/release.yml <https://github.com/glue-viz/glue/.github/release.yml>`_
+   to make headings based on labels.
+
+#. Edit the draft release notes as required, particularly to call out major
+   changes at the top.
+
+#. Publish the release.


### PR DESCRIPTION
## Description

Adding workflow and configuration for updating changelog automatically from PR titles and labels, using GH actions.

The next release action should thus create entries for these PRs (+ any to come until then), to be verified:
```
### v1.6.0 (unreleased)

### What's Changed

#### Bug Fixes

- Modify scatter viewer to not prepend axis labels with 'Log' when using log scale axes. [#2323]

- Fixed a bug where minor tick marks were not respecting the settings colors. [#2305]

- Fix an issue where the histogram layer artist would not redraw if
  the histogram sum was zero. [#2300]
```