### PR TITLE
Allow specifying visual attributes when creating subset

### DIFF
--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -179,7 +179,7 @@ class BaseData(object, metaclass=abc.ABCMeta):
               color='color|None',
               label='string|None',
               returns=Subset)
-    def new_subset(self, subset=None, color=None, label=None, **kwargs):
+    def new_subset(self, subset=None, **kwargs):
         """
         Create a new subset, and attach to self.
 
@@ -200,9 +200,9 @@ class BaseData(object, metaclass=abc.ABCMeta):
         Manually-instantiated subsets will **not** be represented properly by the UI.
         """
         nsub = len(self.subsets)
-        color = color or settings.SUBSET_COLORS[nsub % len(settings.SUBSET_COLORS)]
-        label = label or "%s.%i" % (self.label, nsub + 1)
-        new_subset = Subset(self, color=color, label=label, **kwargs)
+        kwargs.setdefault("color", settings.SUBSET_COLORS[nsub % len(settings.SUBSET_COLORS)])
+        kwargs.setdefault("label", "%s.%i" % (self.label, nsub + 1))
+        new_subset = Subset(self, **kwargs)
         if subset is not None:
             new_subset.subset_state = subset.subset_state.copy()
 

--- a/glue/core/subset.py
+++ b/glue/core/subset.py
@@ -56,7 +56,7 @@ class Subset(object):
               color='color',
               alpha=float,
               label='string|None')
-    def __init__(self, data, color=settings.SUBSET_COLORS[0], alpha=0.5, label=None):
+    def __init__(self, data, **kwargs):
         """Create a new subset object.
 
         Note: the preferred way for creating subsets is via
@@ -68,15 +68,17 @@ class Subset(object):
         self._broadcasting = False  # must be first def
 
         self.data = data
-        self.label = label  # trigger disambiguation
+        self.label = kwargs.get("label", None)  # trigger disambiguation
 
         self.subset_state = SubsetState()  # calls proper setter method
 
-        self.style = VisualAttributes(parent=self)
-        self.style.markersize *= 2.5
-        self.style.linewidth *= 2.5
-        self.style.color = color
-        self.style.alpha = alpha
+        visual_args = {k: v for k, v in kwargs.items() if k in VisualAttributes.DEFAULT_ATTS}
+        visual_args.setdefault("color", settings.SUBSET_COLORS[0])
+        visual_args.setdefault("alpha", 0.5)
+        visual_args.setdefault("linewidth", 2.5)
+        visual_args.setdefault("markersize", 7)
+
+        self.style = VisualAttributes(parent=self, **visual_args)
 
         # We assign a UUID which can then be used for example in equations
         # for derived components - the idea is that this doesn't change over

--- a/glue/core/tests/test_subset.py
+++ b/glue/core/tests/test_subset.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock
 from glue.tests.helpers import requires_astropy, requires_scipy, SCIPY_INSTALLED
 from ..exceptions import IncompatibleAttribute
 from .. import DataCollection, ComponentLink
+from ...config import settings
 from ..data import Data, Component
 from ..roi import CategoricalROI, RectangularROI, Projected3dROI, CircularROI
 from ..message import SubsetDeleteMessage
@@ -193,6 +194,37 @@ class TestSubset(object):
         s = Subset(Data())
         with pytest.raises(TypeError):
             s.subset_state = 5
+
+    def test_visual_attributes_default(self):
+        s = Subset(Data())
+        expected_color = settings.SUBSET_COLORS[0].lower()
+        style = s.style
+        assert style.color == expected_color
+        assert style.alpha == 0.5
+        assert style.linewidth == 2.5
+        assert style.markersize == 7
+        assert style.linestyle == 'solid'
+        assert style.marker == 'o'
+        assert style.preferred_cmap is None
+
+    def test_visual_attributes(self):
+        visual_attributes = dict(
+            color="#ff7f00",
+            alpha=0.3,
+            linewidth=4,
+            markersize=10,
+            marker='x',
+            linestyle='dashed',
+            preferred_cmap='viridis'
+        )
+        d = Data(x=[1, 2, 3])
+        s = d.new_subset(**visual_attributes)
+        for attr, value in visual_attributes.items():
+            if attr == 'preferred_cmap':
+                from matplotlib.cm import get_cmap
+                assert s.style.preferred_cmap == get_cmap(visual_attributes[attr])
+            else:
+                assert getattr(s.style, attr, None) == value
 
 
 target_states = ((op.and_, AndState),


### PR DESCRIPTION
This PR adds essentially the same logic as in #2297, but for subsets this time (rather than subset groups as in that PR). As before, the intended use case here would be a dashboard-style application that controls which selections and subsets can be created and their styling (i.e. Cosmic Data Stories). I don't think `new_subset` is called at all in the desktop glue workflow, but it's useful in a dashboard-style app for subsets that users don't manipulate, so that they don't automatically appear in other viewers with linked data.