### PR TITLE
Require Python>=3.8 and PyQt5/PySide5>=5.14

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -40,10 +40,6 @@ jobs:
         - linux: py38-test-pyside514
         - linux: py39-test-pyqt515
         - linux: py39-test-pyside515
-        - linux: py310-test-pyside63
-        - linux: py310-test-pyqt63-all
-        - linux: py310-test-pyside64
-        - linux: py310-test-pyqt64-all
 
         # Documentation build
         - linux: py38-docs-pyqt514
@@ -54,54 +50,43 @@ jobs:
           coverage: false
 
         # Test a few configurations on MacOS X
-        - macos: py38-test-pyqt514
+        - macos: py38-test-pyqt514-all
         - macos: py310-test-pyqt515
-        - macos: py310-test-pyside63
-        - macos: py310-test-pyqt63
 
         # Test some configurations on Windows
         - windows: py38-test-pyqt514
-        - windows: py310-test-pyqt515
+        - windows: py310-test-pyqt515-all
+
+  allowed_failures:
+    needs: initial_checks
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    with:
+      coverage: codecov
+      display: true
+      # Linux PyQt 5.15 and 6.3 installations require apt-getting xcb and EGL deps
+      libraries: |
+        apt:
+          - '^libxcb.*-dev'
+          - libxkbcommon-x11-dev
+          - libegl1-mesa
+        brew:
+          - enchant
+      envs: |
+        # Some (PySide2 in particular) envs are failing with runtime errors;
+        # PyQt6 and PySide6 support in progress
+        - linux: py310-test-pyside63
+        - linux: py310-test-pyqt63-all
+        - linux: py310-test-pyside64
+        - linux: py310-test-pyqt64-all
+
+        - macos: py310-test-pyside63
+        - macos: py310-test-pyqt64
+
         - windows: py310-test-pyqt63
         - windows: py310-test-pyside64
 
-  # allowed_failures:
-  #   needs: initial_checks
-  #   uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
-  #   with:
-  #     coverage: codecov
-  #     display: true
-  #     # Linux PyQt 5.15 and 6.3 installations require apt-getting xcb and EGL deps
-  #     libraries: |
-  #       apt:
-  #         - '^libxcb.*-dev'
-  #         - libxkbcommon-x11-dev
-  #         - libegl1-mesa
-  #       brew:
-  #         - enchant
-  #     envs: |
-  #       # Some (PySide2 in particular) envs are failing with runtime errors;
-  #       # PyQt6 and PySide6 support in progress
-  #       # - linux: py38-test-pyside514
-  #       # - linux: py310-test-pyqt63-all
-  #       # - linux: py310-test-pyside63
-  #       # - linux: py310-test-pyside515-all
-  #       # - linux: py310-test-pyqt513-lts
-  #       # - linux: py310-test-pyqt515-lts
-
-  #       # Test against latest developer versions of some packages
-  #       - linux: py310-test-pyqt515-dev-all
-
-  #       # - macos: py38-test-pyside514
-  #       # - macos: py310-test-pyqt515-all
-  #       # - macos: py310-test-pyqt63
-  #       # - macos: py310-test-pyside63
-
-  #       # - windows: py38-test-pyqt514-all
-  #       # - windows: py39-test-pyside515-all
-  #       # - windows: py310-test-pyqt63
-  #       # - windows: py310-test-pyside63
-
+        # Test against latest developer versions of some packages
+        - linux: py310-test-pyqt515-dev-all
 
   publish:
     needs: tests

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -53,7 +53,9 @@ jobs:
 
         # Test some configurations on Windows
         - windows: py38-test-pyqt514
-        - windows: py310-test-pyqt515-all
+
+        # Test against latest developer versions of some packages
+        - linux: py310-test-pyqt515-dev-all
 
   allowed_failures:
     needs: initial_checks
@@ -83,12 +85,12 @@ jobs:
         - windows: py310-test-pyqt63
         - windows: py310-test-pyside64
 
-        # Test against latest developer versions of some packages
-        - linux: py310-test-pyqt515-dev-all
-
         # Windows docs build
         - windows: py310-docs-pyqt515
           coverage: false
+
+        # Failure in test_close_tab
+        - windows: py310-test-pyqt515-all
 
   publish:
     needs: tests

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -46,7 +46,7 @@ jobs:
           coverage: false
         - macos: py39-docs-pyqt515
           coverage: false
-        - windows: py310-docs-pyqt63
+        - windows: py310-docs-pyqt515
           coverage: false
 
         # Test a few configurations on MacOS X

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -46,8 +46,6 @@ jobs:
           coverage: false
         - macos: py39-docs-pyqt515
           coverage: false
-        - windows: py310-docs-pyqt515
-          coverage: false
 
         # Test a few configurations on MacOS X
         - macos: py38-test-pyqt514-all
@@ -87,6 +85,10 @@ jobs:
 
         # Test against latest developer versions of some packages
         - linux: py310-test-pyqt515-dev-all
+
+        # Windows docs build
+        - windows: py310-docs-pyqt515
+          coverage: false
 
   publish:
     needs: tests

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -36,71 +36,71 @@ jobs:
         # Standard tests
         # Linux builds - test on all supported PyQt5 and PySide2 versions,
         # and include all dependencies in some builds
-        - linux: py37-test-pyqt510
-        - linux: py37-test-pyqt511-all
-        - linux: py37-test-pyqt512
-        - linux: py37-test-pyqt513-all
-        - linux: py37-test-pyside513-all
+        - linux: py38-test-pyqt514-all
         - linux: py38-test-pyside514
         - linux: py39-test-pyqt515
+        - linux: py39-test-pyside515
+        - linux: py310-test-pyside63
+        - linux: py310-test-pyqt63-all
+        - linux: py310-test-pyside64
+        - linux: py310-test-pyqt64-all
 
-        # Try out documentation build on Linux and macOS
-        - linux: py37-docs-pyqt513
+        # Documentation build
+        - linux: py38-docs-pyqt514
+          coverage: false
+        - macos: py39-docs-pyqt515
+          coverage: false
+        - windows: py310-docs-pyqt63
           coverage: false
 
-        # Test a few configurations on MacOS X (Big Sur/Monterey on arm64 for py310)
-        - macos: py37-test-pyqt513
+        # Test a few configurations on MacOS X
         - macos: py38-test-pyqt514
-          PLAT: arm64
-
-        # Try out documentation build on macOS
-        - macos: py37-docs-pyqt513
-          coverage: false
+        - macos: py310-test-pyqt515
+        - macos: py310-test-pyside63
+        - macos: py310-test-pyqt63
 
         # Test some configurations on Windows
-        - windows: py37-test-pyqt510
+        - windows: py38-test-pyqt514
         - windows: py310-test-pyqt515
-
-        # Try out documentation build on Windows
-        - windows: py38-docs-pyqt513
-          coverage: false
-
-  allowed_failures:
-    needs: initial_checks
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
-    with:
-      coverage: codecov
-      display: true
-      # Linux PyQt 5.15 and 6.3 installations require apt-getting xcb and EGL deps
-      libraries: |
-        apt:
-          - '^libxcb.*-dev'
-          - libxkbcommon-x11-dev
-          - libegl1-mesa
-        brew:
-          - enchant
-      envs: |
-        # Some (PySide2 in particular) envs are failing with runtime errors;
-        # PyQt6 and PySide6 support in progress
-        - linux: py38-test-pyside514
-        - linux: py310-test-pyqt63-all
-        - linux: py310-test-pyside63
-        - linux: py310-test-pyside515-all
-        - linux: py310-test-pyqt513-lts
-        - linux: py310-test-pyqt515-lts
-
-        # Test against latest developer versions of some packages
-        - linux: py310-test-pyqt515-dev-all
-
-        - macos: py38-test-pyside514
-        - macos: py310-test-pyqt515-all
-        - macos: py310-test-pyqt63
-        - macos: py310-test-pyside63
-
-        - windows: py38-test-pyqt514-all
-        - windows: py39-test-pyside515-all
         - windows: py310-test-pyqt63
-        - windows: py310-test-pyside63
+        - windows: py310-test-pyside64
+
+  # allowed_failures:
+  #   needs: initial_checks
+  #   uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+  #   with:
+  #     coverage: codecov
+  #     display: true
+  #     # Linux PyQt 5.15 and 6.3 installations require apt-getting xcb and EGL deps
+  #     libraries: |
+  #       apt:
+  #         - '^libxcb.*-dev'
+  #         - libxkbcommon-x11-dev
+  #         - libegl1-mesa
+  #       brew:
+  #         - enchant
+  #     envs: |
+  #       # Some (PySide2 in particular) envs are failing with runtime errors;
+  #       # PyQt6 and PySide6 support in progress
+  #       # - linux: py38-test-pyside514
+  #       # - linux: py310-test-pyqt63-all
+  #       # - linux: py310-test-pyside63
+  #       # - linux: py310-test-pyside515-all
+  #       # - linux: py310-test-pyqt513-lts
+  #       # - linux: py310-test-pyqt515-lts
+
+  #       # Test against latest developer versions of some packages
+  #       - linux: py310-test-pyqt515-dev-all
+
+  #       # - macos: py38-test-pyside514
+  #       # - macos: py310-test-pyqt515-all
+  #       # - macos: py310-test-pyqt63
+  #       # - macos: py310-test-pyside63
+
+  #       # - windows: py38-test-pyqt514-all
+  #       # - windows: py39-test-pyside515-all
+  #       # - windows: py310-test-pyqt63
+  #       # - windows: py310-test-pyside63
 
 
   publish:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,7 @@ build:
   image: latest
 
 python:
-  version: 3.7
+  version: 3.8
   install:
     - method: pip
       path: .

--- a/doc/installation/dependencies.rst
+++ b/doc/installation/dependencies.rst
@@ -5,7 +5,7 @@ Full list of dependencies
 
 Glue has the following required dependencies:
 
-* Python 3.6 or later
+* Python 3.8 or later
 * `Numpy <https://www.numpy.org>`_ 1.16 or later
 * `Matplotlib <https://matplotlib.org/>`_ 3.2 or later
 * `SciPy <https://www.scipy.org>`_ 1.0 or later
@@ -13,7 +13,7 @@ Glue has the following required dependencies:
 * `Astropy <https://www.astropy.org>`_ 4.0 or higher
 * `setuptools <https://setuptools.readthedocs.io>`_ 30.3 or later
 * Either `PyQt5 <https://www.riverbankcomputing.com/software/pyqt/intro>`__ or
-  `PySide2 <https://wiki.qt.io/PySide2>`__
+  `PySide2 <https://wiki.qt.io/PySide2>`__ 5.14 or later
 * `QtPy <https://pypi.org/project/QtPy/>`__ 1.9 or later - this is an
   abstraction layer for the Python Qt packages
 * `IPython <https://ipython.org>`_ 4.0 or later

--- a/glue/utils/qt/python_list_model.py
+++ b/glue/utils/qt/python_list_model.py
@@ -105,7 +105,7 @@ class PythonListModel(QtCore.QAbstractListModel):
             Which row to remove. Default=last
 
         Returns
-        --------
+        -------
         popped : object
         """
         if row is None:

--- a/glue/viewers/scatter/layer_artist.py
+++ b/glue/viewers/scatter/layer_artist.py
@@ -315,13 +315,13 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
 
             if self.state.xerr_visible and self.state.xerr_att is not None:
                 xerr = ensure_numerical(self.layer[self.state.xerr_att].ravel()).copy()
-                keep &= ~np.isnan(xerr)
+                keep &= ~np.isnan(xerr) & (xerr >= 0.)
             else:
                 xerr = None
 
             if self.state.yerr_visible and self.state.yerr_att is not None:
                 yerr = ensure_numerical(self.layer[self.state.yerr_att].ravel()).copy()
-                keep &= ~np.isnan(yerr)
+                keep &= ~np.isnan(yerr) & (yerr >= 0.)
             else:
                 yerr = None
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ long_description = file: README.rst
 [options]
 zip_safe = False
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 setup_requires = setuptools_scm
 install_requires =
     numpy>=1.17
@@ -91,7 +91,7 @@ astronomy =
 recommended =
     scikit-image
 qt =
-    PyQt5>=5.9
+    PyQt5>=5.14
 test =
     pytest
     pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{37,38,39,310}-{codestyle,test,docs}-{pyqt59,pyqt510,pyqt511,pyqt512,pyqt513,pyside511,pyside512,pyside513,pyside514,pyside515,pyqt63,pyside63}-all-{dev,legacy}
+    py{38,39,310}-{codestyle,test,docs}-{pyqt514,pyqt515,pyside514,pyside515,pyqt63,pyside63}-all-{dev,legacy}
 requires = pip >= 18.0
            setuptools >= 30.3.0
 
@@ -21,20 +21,14 @@ changedir =
     test: .tmp/{envname}
     docs: doc
 deps =
-    pyqt59: PyQt5==5.9.*
-    pyqt510: PyQt5==5.10.*
-    pyqt511: PyQt5==5.11.*
-    pyqt512: PyQt5==5.12.*
-    pyqt513: PyQt5==5.13.*
     pyqt514: PyQt5==5.14.*
     pyqt515: PyQt5==5.15.*
     pyqt63: PyQt6==6.3.*
-    pyside511: PySide2==5.11.*
-    pyside512: PySide2==5.12.*
-    pyside513: PySide2==5.13.*
+    pyqt64: PyQt6==6.4.*
     pyside514: PySide2==5.14.*
     pyside515: PySide2==5.15.*
     pyside63: PySide6==6.3.*
+    pyside64: PySide6==6.4.*
     dev: git+https://github.com/numpy/numpy
     dev: git+https://github.com/astropy/astropy
     lts: astropy==5.0.*


### PR DESCRIPTION
As it's becoming increasingly hard to test against all version combinations, I think it's reasonable to now bump the minimum required Python and PyQt/PySide (and looks like PyQt5 5.15 is now the latest version on conda as of a few months ago).

I have tried to simplify the build matrix a bit - and for now I've disabled the allowed failures and will add things back there if they do indeed fail.