### PR TITLE
Fix export to Python script to correctly use `Coordinates` or `WCS` in `reference_data`

### DIFF
--- a/glue/viewers/image/qt/tests/test_python_export.py
+++ b/glue/viewers/image/qt/tests/test_python_export.py
@@ -41,23 +41,23 @@ class TestExportPython(BaseTestExportPython):
     @pytest.mark.parametrize('wcs', [False, True])
     def test_simple(self, tmpdir, wcs):
         if wcs:
-            self.viewer = self.app.new_data_viewer(ImageViewer)
             self.viewer.add_data(self.data_wcs)
+            self.viewer.remove_data(self.data)
         self.assert_same(tmpdir)
 
     @pytest.mark.parametrize('wcs', [False, True])
     def test_simple_legend(self, tmpdir, wcs):
         if wcs:
-            self.viewer = self.app.new_data_viewer(ImageViewer)
             self.viewer.add_data(self.data_wcs)
+            self.viewer.remove_data(self.data)
         self.viewer.state.show_legend = True
         self.assert_same(tmpdir)
 
     @pytest.mark.parametrize('wcs', [False, True])
     def test_simple_att(self, tmpdir, wcs):
         if wcs:
-            self.viewer = self.app.new_data_viewer(ImageViewer)
             self.viewer.add_data(self.data_wcs)
+            self.viewer.remove_data(self.data)
         self.viewer.state.x_att = self.data.pixel_component_ids[1]
         self.viewer.state.y_att = self.data.pixel_component_ids[0]
         self.assert_same(tmpdir)
@@ -65,8 +65,8 @@ class TestExportPython(BaseTestExportPython):
     @pytest.mark.parametrize('wcs', [False, True])
     def test_simple_visual(self, tmpdir, wcs):
         if wcs:
-            self.viewer = self.app.new_data_viewer(ImageViewer)
             self.viewer.add_data(self.data_wcs)
+            self.viewer.remove_data(self.data)
         self.viewer.state.legend.visible = True
         self.viewer.state.layers[0].cmap = plt.cm.RdBu
         self.viewer.state.layers[0].v_min = 0.2
@@ -91,17 +91,35 @@ class TestExportPython(BaseTestExportPython):
         self.data_collection.new_subset_group('mysubset', self.data.id['cube'] > 0.5)
         self.assert_same(tmpdir)
 
-    def test_subset_legend(self, tmpdir):
+    @pytest.mark.parametrize('wcs', [False, True])
+    def test_subset_legend(self, tmpdir, wcs):
+        if wcs:
+            self.viewer.add_data(self.data_wcs)
+            self.viewer.remove_data(self.data)
+            self.data_collection.new_subset_group('mysubset', self.data_wcs.id['cube'] > 0.5)
+        else:
+            self.data_collection.new_subset_group('mysubset', self.data.id['cube'] > 0.5)
         self.viewer.state.legend.visible = True
-        self.data_collection.new_subset_group('mysubset', self.data.id['cube'] > 0.5)
         self.assert_same(tmpdir, tol=0.15)  # transparency and such
 
-    def test_subset_slice(self, tmpdir):
-        self.data_collection.new_subset_group('mysubset', self.data.id['cube'] > 0.5)
+    @pytest.mark.parametrize('wcs', [False, True])
+    def test_subset_slice(self, tmpdir, wcs):
+        if wcs:
+            self.viewer.add_data(self.data_wcs)
+            self.viewer.remove_data(self.data)
+            self.data_collection.new_subset_group('mysubset', self.data_wcs.id['cube'] > 0.5)
+        else:
+            self.data_collection.new_subset_group('mysubset', self.data.id['cube'] > 0.5)
         self.test_slice(tmpdir)
 
-    def test_subset_transposed(self, tmpdir):
+    @pytest.mark.parametrize('wcs', [False, True])
+    def test_subset_transposed(self, tmpdir, wcs):
+        if wcs:
+            self.viewer.add_data(self.data_wcs)
+            self.viewer.remove_data(self.data)
+            self.data_collection.new_subset_group('mysubset', self.data_wcs.id['cube'] > 0.5)
+        else:
+            self.data_collection.new_subset_group('mysubset', self.data.id['cube'] > 0.5)
         self.viewer.state.x_att = self.data.pixel_component_ids[0]
         self.viewer.state.y_att = self.data.pixel_component_ids[1]
-        self.data_collection.new_subset_group('mysubset', self.data.id['cube'] > 0.5)
         self.assert_same(tmpdir)

--- a/glue/viewers/image/qt/tests/test_python_export.py
+++ b/glue/viewers/image/qt/tests/test_python_export.py
@@ -43,40 +43,34 @@ class TestExportPython(BaseTestExportPython):
     def assert_same(self, tmpdir, tol=0.1):
         BaseTestExportPython.assert_same(self, tmpdir, tol=tol)
 
-    @pytest.mark.parametrize('coords', [None, 'wcs', 'affine'])
-    def test_simple(self, tmpdir, coords):
+    def viewer_load(self, coords):
         if coords is not None:
             self.viewer.add_data(getattr(self, f'data_{coords}'))
             self.viewer.remove_data(self.data)
+
+    @pytest.mark.parametrize('coords', [None, 'wcs', 'affine'])
+    def test_simple(self, tmpdir, coords):
+        self.viewer_load(coords)
         self.assert_same(tmpdir)
 
     @pytest.mark.parametrize('coords', [None, 'wcs', 'affine'])
     def test_simple_legend(self, tmpdir, coords):
-        if coords is not None:
-            self.viewer.add_data(getattr(self, f'data_{coords}'))
-            self.viewer.remove_data(self.data)
+        self.viewer_load(coords)
         self.viewer.state.show_legend = True
         self.assert_same(tmpdir)
 
     @pytest.mark.parametrize('coords', [None, 'wcs', 'affine'])
     def test_simple_att(self, tmpdir, coords):
-        if coords is None:
-            data = self.data
-        else:
-            data = getattr(self, f'data_{coords}')
-            self.viewer.add_data(data)
-            self.viewer.remove_data(self.data)
-        self.viewer.state.x_att = data.pixel_component_ids[1]
-        self.viewer.state.y_att = data.pixel_component_ids[0]
+        self.viewer_load(coords)
+        self.viewer.state.x_att = self.viewer.state.reference_data.pixel_component_ids[1]
+        self.viewer.state.y_att = self.viewer.state.reference_data.pixel_component_ids[0]
         if coords == 'affine':
             pytest.xfail('Known issue with axis label rendering')
         self.assert_same(tmpdir)
 
     @pytest.mark.parametrize('coords', [None, 'wcs', 'affine'])
     def test_simple_visual(self, tmpdir, coords):
-        if coords is not None:
-            self.viewer.add_data(getattr(self, f'data_{coords}'))
-            self.viewer.remove_data(self.data)
+        self.viewer_load(coords)
         self.viewer.state.legend.visible = True
         self.viewer.state.layers[0].cmap = plt.cm.RdBu
         self.viewer.state.layers[0].v_min = 0.2
@@ -89,15 +83,9 @@ class TestExportPython(BaseTestExportPython):
 
     @pytest.mark.parametrize('coords', [None, 'wcs', 'affine'])
     def test_slice(self, tmpdir, coords):
-        if coords is None:
-            data = self.data
-        else:
-            data = getattr(self, f'data_{coords}')
-            self.viewer.add_data(data)
-            self.viewer.remove_data(self.data)
-
-        self.viewer.state.x_att = data.pixel_component_ids[1]
-        self.viewer.state.y_att = data.pixel_component_ids[0]
+        self.viewer_load(coords)
+        self.viewer.state.x_att = self.viewer.state.reference_data.pixel_component_ids[1]
+        self.viewer.state.y_att = self.viewer.state.reference_data.pixel_component_ids[0]
         self.viewer.state.slices = (2, 3, 4)
         if coords == 'affine':
             pytest.xfail('Known issue with axis label rendering')
@@ -105,52 +93,34 @@ class TestExportPython(BaseTestExportPython):
 
     @pytest.mark.parametrize('coords', [None, 'wcs', 'affine'])
     def test_aspect(self, tmpdir, coords):
-        if coords is not None:
-            self.viewer.add_data(getattr(self, f'data_{coords}'))
-            self.viewer.remove_data(self.data)
+        self.viewer_load(coords)
         self.viewer.state.aspect = 'auto'
         self.assert_same(tmpdir)
 
     @pytest.mark.parametrize('coords', [None, 'wcs', 'affine'])
     def test_subset(self, tmpdir, coords):
-        if coords is not None:
-            self.viewer.add_data(getattr(self, f'data_{coords}'))
-            self.viewer.remove_data(self.data)
+        self.viewer_load(coords)
         self.data_collection.new_subset_group('mysubset', self.data.id['cube'] > 0.5)
         self.assert_same(tmpdir)
 
     @pytest.mark.parametrize('coords', [None, 'wcs', 'affine'])
     def test_subset_legend(self, tmpdir, coords):
-        if coords is None:
-            data = self.data
-        else:
-            data = getattr(self, f'data_{coords}')
-            self.viewer.add_data(data)
-            self.viewer.remove_data(self.data)
-        self.data_collection.new_subset_group('mysubset', data.id['cube'] > 0.5)
+        self.viewer_load(coords)
+        self.data_collection.new_subset_group('mysubset',
+                                              self.viewer.state.reference_data.id['cube'] > 0.5)
         self.viewer.state.legend.visible = True
         self.assert_same(tmpdir, tol=0.15)  # transparency and such
 
     @pytest.mark.parametrize('coords', [None, 'wcs', 'affine'])
     def test_subset_slice(self, tmpdir, coords):
-        if coords is None:
-            data = self.data
-        else:
-            data = getattr(self, f'data_{coords}')
-            self.viewer.add_data(data)
-            self.viewer.remove_data(self.data)
-        self.data_collection.new_subset_group('mysubset', data.id['cube'] > 0.5)
+        self.viewer_load(coords)
+        self.data_collection.new_subset_group('mysubset', self.data.id['cube'] > 0.5)
         self.test_slice(tmpdir, coords)
 
     @pytest.mark.parametrize('coords', [None, 'wcs', 'affine'])
     def test_subset_transposed(self, tmpdir, coords):
-        if coords is None:
-            data = self.data
-        else:
-            data = getattr(self, f'data_{coords}')
-            self.viewer.add_data(data)
-            self.viewer.remove_data(self.data)
-        self.data_collection.new_subset_group('mysubset', data.id['cube'] > 0.5)
+        self.viewer_load(coords)
+        self.data_collection.new_subset_group('mysubset', self.data.id['cube'] > 0.5)
         self.viewer.state.x_att = self.data.pixel_component_ids[0]
         self.viewer.state.y_att = self.data.pixel_component_ids[1]
         self.assert_same(tmpdir)

--- a/glue/viewers/image/qt/tests/test_python_export.py
+++ b/glue/viewers/image/qt/tests/test_python_export.py
@@ -1,6 +1,8 @@
+import pytest
 import numpy as np
 import matplotlib.pyplot as plt
 from astropy.utils import NumpyRNGContext
+from astropy.wcs import WCS
 
 from glue.core import Data, DataCollection
 from glue.app.qt.application import GlueApplication
@@ -14,7 +16,9 @@ class TestExportPython(BaseTestExportPython):
 
         with NumpyRNGContext(12345):
             self.data = Data(cube=np.random.random((30, 50, 20)))
-        self.data_collection = DataCollection([self.data])
+        # Create data version with WCS coordinates
+        self.data_wcs = Data(label='cube', cube=self.data['cube'], coords=WCS(naxis=3))
+        self.data_collection = DataCollection([self.data, self.data_wcs])
         self.app = GlueApplication(self.data_collection)
         self.viewer = self.app.new_data_viewer(ImageViewer)
         self.viewer.add_data(self.data)
@@ -34,19 +38,35 @@ class TestExportPython(BaseTestExportPython):
     def assert_same(self, tmpdir, tol=0.1):
         BaseTestExportPython.assert_same(self, tmpdir, tol=tol)
 
-    def test_simple(self, tmpdir):
+    @pytest.mark.parametrize('wcs', [False, True])
+    def test_simple(self, tmpdir, wcs):
+        if wcs:
+            self.viewer = self.app.new_data_viewer(ImageViewer)
+            self.viewer.add_data(self.data_wcs)
         self.assert_same(tmpdir)
 
-    def test_simple_legend(self, tmpdir):
+    @pytest.mark.parametrize('wcs', [False, True])
+    def test_simple_legend(self, tmpdir, wcs):
+        if wcs:
+            self.viewer = self.app.new_data_viewer(ImageViewer)
+            self.viewer.add_data(self.data_wcs)
         self.viewer.state.show_legend = True
         self.assert_same(tmpdir)
 
-    def test_simple_att(self, tmpdir):
+    @pytest.mark.parametrize('wcs', [False, True])
+    def test_simple_att(self, tmpdir, wcs):
+        if wcs:
+            self.viewer = self.app.new_data_viewer(ImageViewer)
+            self.viewer.add_data(self.data_wcs)
         self.viewer.state.x_att = self.data.pixel_component_ids[1]
         self.viewer.state.y_att = self.data.pixel_component_ids[0]
         self.assert_same(tmpdir)
 
-    def test_simple_visual(self, tmpdir):
+    @pytest.mark.parametrize('wcs', [False, True])
+    def test_simple_visual(self, tmpdir, wcs):
+        if wcs:
+            self.viewer = self.app.new_data_viewer(ImageViewer)
+            self.viewer.add_data(self.data_wcs)
         self.viewer.state.legend.visible = True
         self.viewer.state.layers[0].cmap = plt.cm.RdBu
         self.viewer.state.layers[0].v_min = 0.2

--- a/glue/viewers/image/viewer.py
+++ b/glue/viewers/image/viewer.py
@@ -223,17 +223,12 @@ class MatplotlibImageMixin(object):
 
         script += f"ref_data = data_collection[{dindex}]\n"
 
-        ref_coords = self.state.reference_data.coords
-
-        if isinstance(ref_coords, WCS):
-            script += f"ax.reset_wcs(slices={self.state.wcsaxes_slice}, wcs=ref_data.coords)\n"
-        elif hasattr(ref_coords, 'wcs'):
-            script += f"ax.reset_wcs(slices={self.state.wcsaxes_slice}, wcs=ref_data.coords.wcs)\n"
-        elif hasattr(ref_coords, 'wcsaxes_dict'):
-            raise NotImplementedError()
-        else:
+        if isinstance(self.state.reference_data.coords, (LegacyCoordinates, type(None))):
             imports.append('from glue.viewers.image.viewer import get_identity_wcs')
-            script += f"ax.reset_wcs(slices={self.state.wcsaxes_slice}, wcs=get_identity_wcs(ref_data.ndim))\n"
+            ref_wcs = "get_identity_wcs(ref_data.ndim)"
+        else:
+            ref_wcs = "ref_data.coords"
+        script += f"ax.reset_wcs(slices={self.state.wcsaxes_slice}, wcs={ref_wcs})\n"
 
         script += "# for the legend\n"
         script += "legend_handles = []\n"

--- a/glue/viewers/image/viewer.py
+++ b/glue/viewers/image/viewer.py
@@ -214,24 +214,26 @@ class MatplotlibImageMixin(object):
 
         script = ""
         script += "fig, ax = init_mpl(wcs=True)\n"
-        script += "ax.set_aspect('{0}')\n".format(self.state.aspect)
+        script += f"ax.set_aspect('{self.state.aspect}')\n"
 
         script += '\ncomposite = CompositeArray()\n'
-        script += "image = imshow(ax, composite, origin='lower', interpolation='nearest', aspect='{0}')\n\n".format(self.state.aspect)
+        script += f"image = imshow(ax, composite, origin='lower', interpolation='nearest', aspect='{self.state.aspect}')\n\n"
 
         dindex = self.session.data_collection.index(self.state.reference_data)
 
-        script += "ref_data = data_collection[{0}]\n".format(dindex)
+        script += f"ref_data = data_collection[{dindex}]\n"
 
         ref_coords = self.state.reference_data.coords
 
-        if hasattr(ref_coords, 'wcs'):
-            script += "ax.reset_wcs(slices={0}, wcs=ref_data.coords.wcs)\n".format(self.state.wcsaxes_slice)
+        if isinstance(ref_coords, WCS):
+            script += f"ax.reset_wcs(slices={self.state.wcsaxes_slice}, wcs=ref_data.coords)\n"
+        elif hasattr(ref_coords, 'wcs'):
+            script += f"ax.reset_wcs(slices={self.state.wcsaxes_slice}, wcs=ref_data.coords.wcs)\n"
         elif hasattr(ref_coords, 'wcsaxes_dict'):
             raise NotImplementedError()
         else:
             imports.append('from glue.viewers.image.viewer import get_identity_wcs')
-            script += "ax.reset_wcs(slices={0}, wcs=get_identity_wcs(ref_data.ndim))\n".format(self.state.wcsaxes_slice)
+            script += f"ax.reset_wcs(slices={self.state.wcsaxes_slice}, wcs=get_identity_wcs(ref_data.ndim))\n"
 
         script += "# for the legend\n"
         script += "legend_handles = []\n"


### PR DESCRIPTION
## Description
This fixes an issue I found when trying to use the `Save Python script` function on a viewer using a dataset with a standard (Astropy) WCS, such as the example `w5.fits` data. The script thus created failed with an
> AttributeError: 'astropy.wcs.Wcsprm' object has no attribute 'pixel_n_dim'

on `ax.reset_wcs(slices=['x', 'y', 0], wcs=ref_data.coords.wcs)` as `ref_data.coords` itself is already the WCS.

The fix, to test for that case first in the exporter, seems quite straightforward.
I've parametrised some test to run on a dataset with WCS; could think about running this with all tests, or always adding a WCS in `self.data.coords`; however `test_subset_legend` still fails with this patch, as the version with WCS somehow is not including the subset label:
![expected](https://user-images.githubusercontent.com/709020/195915629-2263f57c-333e-4eff-9d73-9effbcc74ad8.png)
![glue_plot](https://user-images.githubusercontent.com/709020/195915743-5615bc80-4579-4f4b-8e21-1f4126e2ae46.png)

Basically in the latter case the script is missing these lines:
```python
## Layer 2: mysubset

layer_data = data_collection[0].subsets[0]

# Define a function that will get a fixed resolution buffer of the mask
handle = mpatches.Patch(color='#e31a1c', alpha=0.5)
legend_handles.append(handle)
legend_labels.append(layer_data.label)
```
so this looks like another actual bug in the exporter (those lines were already missing before this change), as if in
https://github.com/glue-viz/glue/blob/aabb5ebb1b5227f973a99f9aa905d6bfe6988b0b/glue/viewers/common/viewer.py#L447

the subset layer is not `visible and enabled` when a WCS ist present (indeed `layer.enabled = False`), but I could not yet figure out why.

Actually comparing to the non-WCS plot it does not seem like the subset is really displayed in the WCS version:
![glue_plot](https://user-images.githubusercontent.com/709020/195943832-8ac30883-40f9-464f-b90f-3cdd11ee4ebe.png)
