### PR TITLE
Update changelog order in `release.yml`, deprecate Azure badge.

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -7,12 +7,12 @@ changelog:
       - skip-changelog
 
   categories:
-    - title: Bug Fixes
-      labels:
-        - bug
     - title: New Features
       labels:
         - enhancement
+    - title: Bug Fixes
+      labels:
+        - bug
     - title: Documentation
       labels:
         - documentation

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-|Azure Status| |Coverage Status| |DOI| |User mailing list| |Developer mailing list|
+|Actions Status| |Coverage Status| |DOI| |User mailing list| |Developer mailing list|
 
 Glue
 ====
@@ -46,8 +46,9 @@ License
 Glue is licensed under the `BSD
 License <https://github.com/glue-viz/glue/blob/master/LICENSE>`__.
 
-.. |Azure Status| image:: https://dev.azure.com/glue-viz/glue/_apis/build/status/glue-viz.glue?branchName=master
-   :target: https://dev.azure.com/glue-viz/glue/_build/latest?definitionId=4&branchName=master
+.. |Actions Status| image:: https://github.com/glue-viz/glue/workflows/CI%20Workflows/badge.svg
+    :target: https://github.com/glue-viz/glue/actions
+    :alt: Glue's GitHub Actions CI Status
 .. |Coverage Status| image:: https://codecov.io/gh/glue-viz/glue/branch/master/graph/badge.svg
    :target: https://codecov.io/gh/glue-viz/glue
 .. |DOI| image:: https://zenodo.org/badge/doi/10.5281/zenodo.13866.svg


### PR DESCRIPTION
## Description
The new Release docs recommend to put important changes first, but the `release.yml` rules are adding Bug Fixes first, then New Features.
Reversing this and also deprecating the `Azure` badge in the README for `CI Workflows`.