### PR TITLE
Only install h5py for Python less than 3.11

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Scientific/Engineering :: Visualization
     License :: OSI Approved :: BSD License
 description = Multidimensional data visualization across files
@@ -41,7 +42,7 @@ install_requires =
     dill>=0.2
     xlrd>=1.2
     openpyxl>=3.0
-    h5py>=2.10
+    h5py>=2.10 ; python<3.11
     mpl-scatter-density>=0.7
     pvextractor>=0.2
 


### PR DESCRIPTION
## Description

As @astrofrog suggested in https://github.com/glue-viz/glue/issues/2340#issuecomment-1289518970

Temporarily workaround for #2340