### PR TITLE
Fix typo in dialog message.

### DIFF
--- a/glue/core/qt/dialogs.py
+++ b/glue/core/qt/dialogs.py
@@ -23,7 +23,7 @@ def dialog(title, text, icon, setting=None, default=None):
         return True
 
     check = QCheckBox()
-    check.setText('Dont show this message again (can be reset via the preferences)')
+    check.setText('Don\'t show this message again (can be reset via the preferences)')
 
     info = QMessageBox()
     info.setIcon(icon)


### PR DESCRIPTION
This is a tiny PR to scratch a personal itch. There's a typo in the warning dialog (which I'd been seeing a lot lately from some of the Plotly exporter work).