### PR TITLE
Performance improvements for CompositeArray

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -58,7 +58,6 @@ jobs:
         # Test a few configurations on macOS
         - macos: py38-test-pyqt514-all
         - macos: py310-test-pyqt515
-        - macos: py310-test-pyside63
         - macos: py310-test-pyqt64
         - macos: py311-test-pyqt515
 
@@ -92,9 +91,10 @@ jobs:
         # Python 3.11.0 failing on Windows in test_image.py on
         # > assert df.find_factory(fname) is df.img_data
         - linux: py310-test-pyside64
-        - windows: py310-test-pyside64
         - linux: py311-test-pyside64
+        - macos: py310-test-pyside63
         - macos: py311-test-pyside64
+        - windows: py310-test-pyside64
         - windows: py311-test-pyqt515
 
         # Windows docs build

--- a/glue/plugins/tools/pv_slicer/qt/tests/test_pv_slicer.py
+++ b/glue/plugins/tools/pv_slicer/qt/tests/test_pv_slicer.py
@@ -77,7 +77,7 @@ class TestStandaloneImageViewer(object):
         cm_mode = self.w.toolbar.tools['image:colormap']
         act = cm_mode.menu_actions()[1]
         act.trigger()
-        assert self.w._composite.layers['image']['color'] is act.cmap
+        assert self.w._composite.layers['image']['cmap'] is act.cmap
 
     def test_double_set_image(self):
         assert len(self.w._axes.images) == 1

--- a/glue/viewers/image/composite_array.py
+++ b/glue/viewers/image/composite_array.py
@@ -83,7 +83,7 @@ class CompositeArray(object):
         visible_layers = 0
 
         # We first check that layers are either all colormaps or all single
-        # colors, and at the same time, if we use colormaps we ccheck what
+        # colors, and at the same time, if we use colormaps we check what
         # the smallest alpha value is - if it is 1 then colormaps do not change
         # transparency and this allows us to speed things up a little.
 

--- a/glue/viewers/image/composite_array.py
+++ b/glue/viewers/image/composite_array.py
@@ -110,13 +110,12 @@ class CompositeArray(object):
         # affect the output, assuming also that the colormaps do not change the
         # alpha
         if self.mode == 'colormap':
-            start = 0
-            for i in range(len(sorted_uuids)):
+            for i in range(len(sorted_uuids) - 1, -1, -1):
                 layer = self.layers[sorted_uuids[i]]
                 if layer['visible']:
-                    if layer['alpha'] * layer['cmap'](CMAP_SAMPLING)[:, 3].min() == 1:
-                        start = i
-            sorted_uuids = sorted_uuids[start:]
+                    if layer['alpha'] == 1 and layer['cmap'](CMAP_SAMPLING)[:, 3].min() == 1:
+                        sorted_uuids = sorted_uuids[i:]
+                        break
 
         for uuid in sorted_uuids:
 

--- a/glue/viewers/image/composite_array.py
+++ b/glue/viewers/image/composite_array.py
@@ -101,20 +101,10 @@ class CompositeArray(object):
         img = None
         visible_layers = 0
 
-        # We first check that layers are either all colormaps or all single
-        # colors, and at the same time, if we use colormaps we check what
-        # the smallest alpha value is - if it is 1 then colormaps do not change
-        # transparency and this allows us to speed things up a little.
-
-        minimum_cmap_alpha = 1
-        if self.mode == 'colormap':
-            for layer in self.layers.values():
-                minimum_cmap_alpha = min(layer['cmap'](CMAP_SAMPLING)[:, 3].min(),
-                                            minimum_cmap_alpha)
-
         # Get a sorted list of UUIDs with the top layers last
         sorted_uuids = sorted(self.layers, key=lambda x: self.layers[x]['zorder'])
 
+        # We first check that layers are either all colormaps or all single colors.
         # In the case where we are dealing with colormaps, we can start from
         # the last layer that has an opacity of 1 because layers below will not
         # affect the output, assuming also that the colormaps do not change the
@@ -166,7 +156,11 @@ class CompositeArray(object):
                 # Compute colormapped image
                 plane = layer['cmap'](data)
 
-                if minimum_cmap_alpha == 1.:
+                # Check what the smallest colormap alpha value for this layer is
+                # - if it is 1 then this colormap does not change transparency,
+                # and this allows us to speed things up a little.
+
+                if layer['cmap'](CMAP_SAMPLING)[:, 3].min() == 1:
 
                     if layer['alpha'] == 1:
                         img[...] = 0

--- a/glue/viewers/image/composite_array.py
+++ b/glue/viewers/image/composite_array.py
@@ -115,8 +115,10 @@ class CompositeArray(object):
         if mode == 'colormap' and minimum_cmap_alpha == 1.:
             start = 0
             for i in range(len(sorted_uuids)):
-                if self.layers[sorted_uuids[i]]['alpha'] == 1:
-                    start = i
+                layer = self.layers[sorted_uuids[i]]
+                if layer['visible']:
+                    if layer['alpha'] == 1:
+                        start = i
             sorted_uuids = sorted_uuids[start:]
 
         for uuid in sorted_uuids:

--- a/glue/viewers/image/composite_array.py
+++ b/glue/viewers/image/composite_array.py
@@ -119,12 +119,12 @@ class CompositeArray(object):
         # the last layer that has an opacity of 1 because layers below will not
         # affect the output, assuming also that the colormaps do not change the
         # alpha
-        if self.mode == 'colormap' and minimum_cmap_alpha == 1.:
+        if self.mode == 'colormap':
             start = 0
             for i in range(len(sorted_uuids)):
                 layer = self.layers[sorted_uuids[i]]
                 if layer['visible']:
-                    if layer['alpha'] == 1:
+                    if layer['alpha'] * layer['cmap'](CMAP_SAMPLING)[:, 3].min() == 1:
                         start = i
             sorted_uuids = sorted_uuids[start:]
 

--- a/glue/viewers/image/layer_artist.py
+++ b/glue/viewers/image/layer_artist.py
@@ -156,15 +156,16 @@ class ImageLayerArtist(BaseImageLayerArtist):
             return
 
         if self._viewer_state.color_mode == 'Colormaps':
-            color = self.state.cmap
+            self.composite.mode = 'colormap'
         else:
-            color = self.state.color
+            self.composite.mode = 'color'
 
         self.composite.set(self.uuid,
                            clim=(self.state.v_min, self.state.v_max),
                            visible=self.state.visible,
                            zorder=self.state.zorder,
-                           color=color,
+                           color=self.state.color,
+                           cmap=self.state.cmap,
                            contrast=self.state.contrast,
                            bias=self.state.bias,
                            alpha=self.state.alpha,

--- a/glue/viewers/image/python_export.py
+++ b/glue/viewers/image/python_export.py
@@ -30,15 +30,16 @@ def python_export_image_layer(layer, *args):
     script += "composite.allocate('{0}')\n".format(layer.uuid)
 
     if layer._viewer_state.color_mode == 'Colormaps':
-        color = code('plt.cm.' + layer.state.cmap.name)
+        script += "composite.mode = 'colormap'\n"
     else:
-        color = layer.state.color
+        script += "composite.mode = 'color'\n"
 
     options = dict(array=code('array_maker'),
                    clim=(layer.state.v_min, layer.state.v_max),
                    visible=layer.state.visible,
                    zorder=layer.state.zorder,
-                   color=color,
+                   color=layer.state.color,
+                   cmap=code('plt.cm.' + layer.state.cmap.name),
                    contrast=layer.state.contrast,
                    bias=layer.state.bias,
                    alpha=layer.state.alpha,

--- a/glue/viewers/image/tests/test_composite_array.py
+++ b/glue/viewers/image/tests/test_composite_array.py
@@ -49,14 +49,16 @@ class TestCompositeArray(object):
 
     def test_cmap_blending(self):
 
+        self.composite.mode = 'colormap'
+
         self.composite.allocate('a')
         self.composite.allocate('b')
 
         self.composite.set('a', zorder=0, visible=True, array=self.array1,
-                           color=cm.Blues, clim=(0, 2))
+                           cmap=cm.Blues, clim=(0, 2))
 
         self.composite.set('b', zorder=1, visible=True, array=self.array2,
-                           color=cm.Reds, clim=(0, 1))
+                           cmap=cm.Reds, clim=(0, 1))
 
         # Determine expected result for each layer individually in the absence
         # of transparency

--- a/glue/viewers/image/tests/test_composite_array.py
+++ b/glue/viewers/image/tests/test_composite_array.py
@@ -93,6 +93,15 @@ class TestCompositeArray(object):
         assert_allclose(self.composite(bounds=self.default_bounds),
                         [[expected_a[0, 0], expected_b[0, 1]], expected_a[1]])
 
+        # For the same case with the top layer alpha=0.5 that value should become an equal
+        # blend of both layers again
+
+        self.composite.set('b', alpha=0.5)
+
+        assert_allclose(self.composite(bounds=self.default_bounds),
+                        [[expected_a[0, 0], 0.5 * (expected_a[0, 1] + expected_b[0, 1])],
+                         expected_a[1]])
+
         # For only the bottom layer having such colormap, the top layer should appear just the same
 
         self.composite.set('a', alpha=1., cmap=lambda x: cm.Blues(x, alpha=abs(np.nan_to_num(x))))

--- a/glue/viewers/image/tests/test_composite_array.py
+++ b/glue/viewers/image/tests/test_composite_array.py
@@ -85,10 +85,30 @@ class TestCompositeArray(object):
 
         assert_allclose(self.composite(bounds=self.default_bounds), 0.5 * (expected_b + expected_a))
 
+    def test_cmap_alphas(self):
+
+        self.composite.mode = 'colormap'
+
+        self.composite.allocate('a')
+        self.composite.allocate('b')
+
+        self.composite.set('a', zorder=0, visible=True, array=self.array1,
+                           cmap=cm.Blues, clim=(0, 2))
+
+        self.composite.set('b', zorder=1, visible=True, array=self.array2,
+                           cmap=lambda x: cm.Reds(x, alpha=abs(np.nan_to_num(x))), clim=(0, 1))
+
+        # Determine expected result for each layer individually in the absence
+        # of transparency
+
+        expected_a = np.array([[cm.Blues(1.), cm.Blues(0.5)],
+                               [cm.Blues(0.), cm.Blues(0.)]])
+
+        expected_b = np.array([[cm.Reds(0.), cm.Reds(1.)],
+                               [cm.Reds(0.), cm.Reds(0.)]])
+
         # If the top layer has alpha=1 with a colormap alpha fading proportional to absval,
         # it should be visible only at the nonzero value [0, 1]
-
-        self.composite.set('b', alpha=1., cmap=lambda x: cm.Reds(x, alpha=abs(np.nan_to_num(x))))
 
         assert_allclose(self.composite(bounds=self.default_bounds),
                         [[expected_a[0, 0], expected_b[0, 1]], expected_a[1]])
@@ -102,10 +122,26 @@ class TestCompositeArray(object):
                         [[expected_a[0, 0], 0.5 * (expected_a[0, 1] + expected_b[0, 1])],
                          expected_a[1]])
 
+        # A third layer added at the bottom should not be visible in the output
+
+        self.composite.allocate('c')
+        self.composite.set('c', zorder=-1, visible=True, array=self.array3,
+                           cmap=cm.Greens, clim=(0, 2))
+
+        assert_allclose(self.composite(bounds=self.default_bounds),
+                        [[expected_a[0, 0], 0.5 * (expected_a[0, 1] + expected_b[0, 1])],
+                         expected_a[1]])
+
         # For only the bottom layer having such colormap, the top layer should appear just the same
 
         self.composite.set('a', alpha=1., cmap=lambda x: cm.Blues(x, alpha=abs(np.nan_to_num(x))))
         self.composite.set('b', alpha=1., cmap=cm.Reds)
+
+        assert_allclose(self.composite(bounds=self.default_bounds), expected_b)
+
+        # Settin the third layer on top with alpha=0 should not affect the appearance
+
+        self.composite.set('c', zorder=2, alpha=0.)
 
         assert_allclose(self.composite(bounds=self.default_bounds), expected_b)
 

--- a/glue/viewers/image/tests/test_composite_array.py
+++ b/glue/viewers/image/tests/test_composite_array.py
@@ -85,6 +85,21 @@ class TestCompositeArray(object):
 
         assert_allclose(self.composite(bounds=self.default_bounds), 0.5 * (expected_b + expected_a))
 
+        # If the top layer has alpha=1 with a colormap alpha fading proportional to absval,
+        # it should be visible only at the nonzero value [0, 1]
+
+        self.composite.set('b', alpha=1., cmap=lambda x: cm.Reds(x, alpha=abs(np.nan_to_num(x))))
+
+        assert_allclose(self.composite(bounds=self.default_bounds),
+                        [[expected_a[0, 0], expected_b[0, 1]], expected_a[1]])
+
+        # For only the bottom layer having such colormap, the top layer should appear just the same
+
+        self.composite.set('a', alpha=1., cmap=lambda x: cm.Blues(x, alpha=abs(np.nan_to_num(x))))
+        self.composite.set('b', alpha=1., cmap=cm.Reds)
+
+        assert_allclose(self.composite(bounds=self.default_bounds), expected_b)
+
     def test_color_blending(self):
 
         self.composite.allocate('a')


### PR DESCRIPTION
This attempts to speed up CompositeArray by using several tricks:

* When using colormaps, we don't need to care about layers below the top-most layer that has alpha=1 since it will block everything below - this should speed up viewers with multiple images open.
* When using colormaps and assuming the colormaps don't have any transparency, we can avoid a bunch of temporary array creations.
* We make use of out= in the contrast/bias and stretch to avoid more temporary array creation.