### PR TITLE
Relax longitude range in fullsphere projections

### DIFF
--- a/glue/viewers/scatter/layer_artist.py
+++ b/glue/viewers/scatter/layer_artist.py
@@ -240,7 +240,7 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
                 # The full-sphere projections expect longitude angles in the range [-pi, pi]
                 # so we wrap angles to accommodate this
                 if full_sphere:
-                    x = np.arctan2(np.sin(x), np.cos(x))
+                    x = np.mod(x + np.pi, 2 * np.pi) - np.pi
 
                 self.density_artist.set_label(None)
                 if self._use_plot_artist():

--- a/glue/viewers/scatter/layer_artist.py
+++ b/glue/viewers/scatter/layer_artist.py
@@ -230,13 +230,17 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
                 self.plot_artist.set_data([], [])
                 self.scatter_artist.set_offsets(np.zeros((0, 2)))
             else:
-
                 full_sphere = getattr(self._viewer_state, 'using_full_sphere', False)
                 degrees = getattr(self._viewer_state, 'using_degrees', False)
                 if degrees:
                     x = np.radians(x)
                     if full_sphere:
                         y = np.radians(y)
+
+                # The full-sphere projections expect longitude angles in the range [-pi, pi]
+                # so we wrap angles to accommodate this
+                if full_sphere:
+                    x = np.arctan2(np.sin(x), np.cos(x))
 
                 self.density_artist.set_label(None)
                 if self._use_plot_artist():

--- a/glue/viewers/scatter/python_export.py
+++ b/glue/viewers/scatter/python_export.py
@@ -35,6 +35,10 @@ def python_export_scatter_layer(layer, *args):
     script += "y = {0}layer_data['{1}']{2}\n".format(y_transform_open, layer._viewer_state.y_att.label, y_transform_close)
     if full_sphere:
         script += "x = np.mod(x + np.pi, 2 * np.pi) - np.pi\n"
+        if layer._viewer_state.x_min > layer._viewer_state.x_max:
+            script += "x = np.negative(x)\n"
+        if layer._viewer_state.y_min > layer._viewer_state.y_max:
+            script += "y = np.negative(y)\n"
     script += "keep = ~np.isnan(x) & ~np.isnan(y)\n\n"
     if polar:
         script += 'ax.xaxis.set_major_locator(ThetaLocator(AutoLocator()))\n'

--- a/glue/viewers/scatter/python_export.py
+++ b/glue/viewers/scatter/python_export.py
@@ -34,7 +34,7 @@ def python_export_scatter_layer(layer, *args):
     script += "x = {0}layer_data['{1}']{2}\n".format(x_transform_open, layer._viewer_state.x_att.label, x_transform_close)
     script += "y = {0}layer_data['{1}']{2}\n".format(y_transform_open, layer._viewer_state.y_att.label, y_transform_close)
     if full_sphere:
-        script += "x = np.arctan2(np.sin(x), np.cos(x))\n"
+        script += "x = np.mod(x + np.pi, 2 * np.pi) - np.pi\n"
     script += "keep = ~np.isnan(x) & ~np.isnan(y)\n\n"
     if polar:
         script += 'ax.xaxis.set_major_locator(ThetaLocator(AutoLocator()))\n'

--- a/glue/viewers/scatter/python_export.py
+++ b/glue/viewers/scatter/python_export.py
@@ -33,6 +33,8 @@ def python_export_scatter_layer(layer, *args):
     y_transform_close = ")" if degrees and full_sphere else ""
     script += "x = {0}layer_data['{1}']{2}\n".format(x_transform_open, layer._viewer_state.x_att.label, x_transform_close)
     script += "y = {0}layer_data['{1}']{2}\n".format(y_transform_open, layer._viewer_state.y_att.label, y_transform_close)
+    if full_sphere:
+        script += "x = np.arctan2(np.sin(x), np.cos(x))\n"
     script += "keep = ~np.isnan(x) & ~np.isnan(y)\n\n"
     if polar:
         script += 'ax.xaxis.set_major_locator(ThetaLocator(AutoLocator()))\n'

--- a/glue/viewers/scatter/qt/options_widget.py
+++ b/glue/viewers/scatter/qt/options_widget.py
@@ -88,10 +88,8 @@ class ScatterOptionsWidget(QtWidgets.QWidget):
         is_polar = self.viewer_state.using_polar
         is_rect = self.viewer_state.using_rectilinear
         self.ui.valuetext_x_min.setEnabled(lim_enabled)
-        self.ui.button_flip_x.setEnabled(lim_enabled)
         self.ui.valuetext_x_max.setEnabled(lim_enabled)
         self.ui.valuetext_y_min.setEnabled(lim_enabled)
-        self.ui.button_flip_y.setEnabled(lim_enabled)
         self.ui.valuetext_y_max.setEnabled(lim_enabled)
         self.ui.button_full_circle.setVisible(False)
         self.ui.angle_unit_lab.setVisible(not is_rect)

--- a/glue/viewers/scatter/qt/tests/test_data_viewer.py
+++ b/glue/viewers/scatter/qt/tests/test_data_viewer.py
@@ -891,10 +891,10 @@ class TestScatterViewer(object):
             assert not ui.bool_y_log.isEnabled(), error_msg
             assert not ui.bool_y_log_.isEnabled(), error_msg
             assert not ui.valuetext_x_min.isEnabled(), error_msg
-            assert not ui.button_flip_x.isEnabled(), error_msg
+            assert ui.button_flip_x.isEnabled(), error_msg
             assert not ui.valuetext_x_max.isEnabled(), error_msg
             assert not ui.valuetext_y_min.isEnabled(), error_msg
-            assert not ui.button_flip_y.isEnabled(), error_msg
+            assert ui.button_flip_y.isEnabled(), error_msg
             assert not ui.valuetext_y_max.isEnabled(), error_msg
             assert ui.button_full_circle.isHidden(), error_msg
 

--- a/glue/viewers/scatter/qt/tests/test_python_export.py
+++ b/glue/viewers/scatter/qt/tests/test_python_export.py
@@ -1,3 +1,5 @@
+from itertools import product
+
 import numpy as np
 import matplotlib.pyplot as plt
 from astropy.utils import NumpyRNGContext
@@ -242,43 +244,38 @@ class TestExportPython(BaseTestExportPython):
         self.viewer.state.y_att = self.data.id['d']
         self.assert_same(tmpdir)
 
+    def _fullsphere_common_test(self, tmpdir):
+        # Note that all the full-sphere projections have the same bounds,
+        # so we can use the same sets of min/max values
+        x_bounds = self.viewer.state.x_min, self.viewer.state.x_max
+        y_bounds = self.viewer.state.y_min, self.viewer.state.y_max
+        for order in product([True, False], repeat=2):
+            self.viewer.state.x_min, self.viewer.state.x_max = sorted(x_bounds, reverse=order[0])
+            self.viewer.state.y_min, self.viewer.state.y_max = sorted(y_bounds, reverse=order[1])
+            self.viewer.state.plot_mode = 'aitoff'
+            self.viewer.state.x_att = self.data.id['c']
+            self.viewer.state.y_att = self.data.id['d']
+            self.assert_same(tmpdir)
+            self.viewer.state.plot_mode = 'hammer'
+            self.viewer.state.x_att = self.data.id['e']
+            self.viewer.state.y_att = self.data.id['f']
+            self.assert_same(tmpdir)
+            self.viewer.state.plot_mode = 'lambert'
+            self.viewer.state.x_att = self.data.id['g']
+            self.viewer.state.y_att = self.data.id['h']
+            self.assert_same(tmpdir)
+            self.viewer.state.plot_mode = 'mollweide'
+            self.viewer.state.x_att = self.data.id['a']
+            self.viewer.state.y_att = self.data.id['b']
+            self.assert_same(tmpdir)
+
     def test_full_sphere_degrees(self, tmpdir):
         self.viewer.state.angle_unit = 'degrees'
-        self.viewer.state.plot_mode = 'aitoff'
-        self.viewer.state.x_att = self.data.id['c']
-        self.viewer.state.y_att = self.data.id['d']
-        self.assert_same(tmpdir)
-        self.viewer.state.plot_mode = 'hammer'
-        self.viewer.state.x_att = self.data.id['e']
-        self.viewer.state.y_att = self.data.id['f']
-        self.assert_same(tmpdir)
-        self.viewer.state.plot_mode = 'lambert'
-        self.viewer.state.x_att = self.data.id['g']
-        self.viewer.state.y_att = self.data.id['h']
-        self.assert_same(tmpdir)
-        self.viewer.state.plot_mode = 'mollweide'
-        self.viewer.state.x_att = self.data.id['a']
-        self.viewer.state.y_att = self.data.id['b']
-        self.assert_same(tmpdir)
+        self._fullsphere_common_test(tmpdir)
 
     def test_full_sphere_radians(self, tmpdir):
         self.viewer.state.angle_unit = 'radians'
-        self.viewer.state.plot_mode = 'aitoff'
-        self.viewer.state.x_att = self.data.id['c']
-        self.viewer.state.y_att = self.data.id['d']
-        self.assert_same(tmpdir)
-        self.viewer.state.plot_mode = 'hammer'
-        self.viewer.state.x_att = self.data.id['e']
-        self.viewer.state.y_att = self.data.id['f']
-        self.assert_same(tmpdir)
-        self.viewer.state.plot_mode = 'lambert'
-        self.viewer.state.x_att = self.data.id['g']
-        self.viewer.state.y_att = self.data.id['h']
-        self.assert_same(tmpdir)
-        self.viewer.state.plot_mode = 'mollweide'
-        self.viewer.state.x_att = self.data.id['a']
-        self.viewer.state.y_att = self.data.id['b']
-        self.assert_same(tmpdir)
+        self._fullsphere_common_test(tmpdir)
 
     def test_cmap_size_noncartesian(self, tmpdir):
         self.viewer.state.layers[0].size_mode = 'Linear'

--- a/glue/viewers/scatter/viewer.py
+++ b/glue/viewers/scatter/viewer.py
@@ -22,8 +22,8 @@ class MatplotlibScatterMixin(object):
 
         self.state.add_callback('x_min', self._x_limits_to_mpl)
         self.state.add_callback('x_max', self._x_limits_to_mpl)
-        self.state.add_callback('y_min', self.limits_to_mpl)
-        self.state.add_callback('y_max', self.limits_to_mpl)
+        self.state.add_callback('y_min', self._y_limits_to_mpl)
+        self.state.add_callback('y_max', self._y_limits_to_mpl)
         self.state.add_callback('x_axislabel', self._update_polar_ticks)
         self.state.add_callback('y_axislabel', self._update_polar_ticks)
         self._update_axes()
@@ -97,6 +97,9 @@ class MatplotlibScatterMixin(object):
     def using_polar(self):
         return self.state.plot_mode == 'polar'
 
+    def using_fullsphere(self):
+        return self.state.plot_mode in ['aitoff', 'hammer', 'lambert', 'mollweide']
+
     def _update_angle_unit(self, *args):
         self._update_axes()
         for layer in self.layers:
@@ -105,6 +108,13 @@ class MatplotlibScatterMixin(object):
     def _x_limits_to_mpl(self, *args, **kwargs):
         if self.using_polar():
             self.state.full_circle()
+        elif self.using_fullsphere():
+            return
+        self.limits_to_mpl()
+
+    def _y_limits_to_mpl(self, *args, **kwargs):
+        if self.using_fullsphere():
+            return
         self.limits_to_mpl()
 
     def update_x_axislabel(self, *event):


### PR DESCRIPTION
As noticed by Alyssa and Theo, longitude angles in the full-sphere projections of the scatter viewer are currently restricted to [-π, π]. This PR relaxes this restriction by mapping the longitude component into this range as appropriate (for example, 3π/2 is mapped to -π/2).

Additionally, as longitude is defined differently for Earth and sky, this PR adds the ability to reverse the full-sphere axes. Matplotlib doesn't let us change bounds in these projections, so this PR mimics this adding a "flip" option in the UI which negates the relevant values. The intended use case here is for longitude, but I don't see a reason not to offer the same option for latitude as well. The buttons in the UI that allow this flipping are only visible when in a full-sphere projection.