### PR TITLE
Represent `None` `component.units` as empty strings

### DIFF
--- a/glue/core/component.py
+++ b/glue/core/component.py
@@ -54,7 +54,7 @@ class Component(object):
 
     @property
     def units(self):
-        return self._units
+        return self._units or ''
 
     @units.setter
     def units(self, value):
@@ -226,7 +226,7 @@ class CoordinateComponent(Component):
     @property
     def units(self):
         if self.world:
-            return self._data.coords.world_axis_units[self._data.ndim - 1 - self.axis]
+            return self._data.coords.world_axis_units[self._data.ndim - 1 - self.axis] or ''
         else:
             return ''
 
@@ -514,7 +514,7 @@ class DaskComponent(Component):
 
     @property
     def units(self):
-        return self._units
+        return self._units or ''
 
     @units.setter
     def units(self, value):


### PR DESCRIPTION
## Description

To fix issues as in spacetelescope/jdaviz#1909 where `f'{unit}'` returns unexpected results, this returns `self._units` of `None` as `''` for all `Component` subclasses. This is analogous to how these are already handled in `Coordinates`.
In case the internal value of `self._units == None` is still required somewhere, the second commit reverses the transformation on setting units, but it does not seem to be required for passing tests.