### PR TITLE
Add pretransform for full-sphere selection

### DIFF
--- a/glue/core/roi_pretransforms.py
+++ b/glue/core/roi_pretransforms.py
@@ -57,3 +57,25 @@ class RadianTransform(object):
     def __setgluestate__(cls, rec, context):
         state = context.object(rec['state'])
         return cls(state['coords'], state['next_transform'])
+
+
+class FullSphereLongitudeTransform(object):
+
+    def __init__(self, next_transform=None):
+        self._next_transform = next_transform
+        self._state = {"next_transform": next_transform}
+
+    def __call__(self, x, y):
+        x = np.mod(x + np.pi, 2 * np.pi) - np.pi
+        if self._next_transform is not None:
+            return self._next_transform(x, y)
+        else:
+            return x, y
+
+    @classmethod
+    def __setgluestate__(cls, rec, context):
+        state = context.object(rec['state'])
+        return cls(state['next_transform'])
+
+    def __gluestate__(self, context):
+        return dict(state=context.do(self._state))

--- a/glue/viewers/scatter/qt/tests/test_data_viewer.py
+++ b/glue/viewers/scatter/qt/tests/test_data_viewer.py
@@ -914,7 +914,7 @@ class TestScatterViewer(object):
             assert ui.valuetext_y_max.isEnabled()
             assert ui.button_full_circle.isHidden()
 
-    @pytest.mark.parametrize('angle_unit,expected_mask', [('radians', [0, 0, 0, 1]), ('degrees', [0, 0, 0, 1])])
+    @pytest.mark.parametrize('angle_unit,expected_mask', [('radians', [0, 0, 0, 1]), ('degrees', [1, 1, 0, 1])])
     def test_apply_roi_polar(self, angle_unit, expected_mask):
         self.viewer.add_data(self.data)
         viewer_state = self.viewer.state

--- a/glue/viewers/scatter/qt/tests/test_data_viewer.py
+++ b/glue/viewers/scatter/qt/tests/test_data_viewer.py
@@ -12,7 +12,7 @@ from glue.config import colormaps
 from glue.core.message import SubsetUpdateMessage
 from glue.core import HubListener, Data
 from glue.core.roi import XRangeROI, RectangularROI, CircularROI
-from glue.core.roi_pretransforms import ProjectionMplTransform
+from glue.core.roi_pretransforms import ProjectionMplTransform, FullSphereLongitudeTransform
 from glue.core.subset import RoiSubsetState, AndState
 from glue import core
 from glue.core.component_id import ComponentID
@@ -965,7 +965,7 @@ class TestScatterViewer(object):
             assert isinstance(state, RoiSubsetState)
             assert state.pretransform
             pretrans = state.pretransform
-            assert isinstance(pretrans, ProjectionMplTransform)
+            assert isinstance(pretrans, FullSphereLongitudeTransform)
             assert pretrans._state['projection'] == proj
             assert_allclose(pretrans._state['x_lim'], [viewer_state.x_min, viewer_state.x_max])
             assert_allclose(pretrans._state['y_lim'], [viewer_state.y_min, viewer_state.y_max])

--- a/glue/viewers/scatter/viewer.py
+++ b/glue/viewers/scatter/viewer.py
@@ -1,6 +1,6 @@
 from glue.core.subset import roi_to_subset_state
 from glue.core.util import update_ticks
-from glue.core.roi_pretransforms import ProjectionMplTransform, RadianTransform
+from glue.core.roi_pretransforms import FullSphereLongitudeTransform, ProjectionMplTransform, RadianTransform
 
 from glue.utils import mpl_to_datetime64
 from glue.viewers.scatter.compat import update_scatter_viewer_state
@@ -170,6 +170,8 @@ class MatplotlibScatterMixin(object):
             if self.state.using_degrees:
                 coords = ['x'] if self.using_polar() else ['x', 'y']
                 transform = RadianTransform(coords=coords, next_transform=transform)
+            if self.state.using_full_sphere:
+                transform = FullSphereLongitudeTransform(next_transform=transform)
             subset_state.pretransform = transform
 
         self.apply_subset_state(subset_state, override_mode=override_mode)

--- a/glue/viewers/scatter/viewer.py
+++ b/glue/viewers/scatter/viewer.py
@@ -167,11 +167,11 @@ class MatplotlibScatterMixin(object):
                                                                self.axes.get_yscale())
 
             # If we're using degrees, we need to staple on the degrees -> radians conversion beforehand
+            if self.state.using_full_sphere:
+                transform = FullSphereLongitudeTransform(next_transform=transform)
             if self.state.using_degrees:
                 coords = ['x'] if self.using_polar() else ['x', 'y']
                 transform = RadianTransform(coords=coords, next_transform=transform)
-            if self.state.using_full_sphere:
-                transform = FullSphereLongitudeTransform(next_transform=transform)
             subset_state.pretransform = transform
 
         self.apply_subset_state(subset_state, override_mode=override_mode)


### PR DESCRIPTION
I realized that I missed one thing in #2348 with regards to selection. Any points whose latitudes were wrapped back into [-π,π] won't be selected when making a ROI selection because the scatter viewer's `apply_roi` doesn't know about that transformation. This PR adds a pretransform that lets it know about what happens with longitudes.