### PR TITLE
MNT: drop runtime dependency on pkg_resources (setuptools)

### DIFF
--- a/glue/__init__.py
+++ b/glue/__init__.py
@@ -6,12 +6,9 @@ import os
 
 import sys
 
-from pkg_resources import get_distribution, DistributionNotFound
+import importlib.metadata
 
-try:
-    __version__ = get_distribution('glue-core').version
-except DistributionNotFound:
-    __version__ = 'undefined'
+__version__ = importlib.metadata.version('glue-core')
 
 from ._mpl_backend import MatplotlibBackendSetter
 sys.meta_path.append(MatplotlibBackendSetter())

--- a/glue/_deps.py
+++ b/glue/_deps.py
@@ -213,8 +213,8 @@ def plugins():
     modules = []
     dependencies = []
     for entry_point in iter_plugin_entry_points():
-        module_name = entry_point.module_name.split('.')[0]
-        package = entry_point.dist.project_name
+        module_name, _, _ = entry_point.module.partition('.')
+        package = entry_point.dist.name
         modules.append((module_name, package))
     for module, package in sorted(set(modules)):
         dependencies.append(Dependency(module, '', package=package))

--- a/glue/_plugin_helpers.py
+++ b/glue/_plugin_helpers.py
@@ -7,12 +7,18 @@
 # wouldn't be used.
 
 import os
+import sys
 from collections import defaultdict
+from importlib.metadata import entry_points
 
 
 def iter_plugin_entry_points():
-    from pkg_resources import iter_entry_points
-    return iter_entry_points(group='glue.plugins', name=None)
+    if sys.version_info >= (3, 10):
+        plugins = entry_points(group='glue.plugins')
+    else:
+        plugins = entry_points().get('glue.plugins', [])
+
+    return iter(plugins)
 
 
 class PluginConfig(object):

--- a/glue/icons/__init__.py
+++ b/glue/icons/__init__.py
@@ -1,6 +1,10 @@
-import os
+import sys
 
-import pkg_resources
+if sys.version_info >= (3, 9):
+    import importlib.resources as importlib_resources
+else:
+    import importlib_resources
+
 
 __all__ = ['icon_path']
 
@@ -24,12 +28,8 @@ def icon_path(icon_name, icon_format='png'):
 
     icon_name += '.{0}'.format(icon_format)
 
-    try:
-        if pkg_resources.resource_exists('glue.icons', icon_name):
-            return pkg_resources.resource_filename('glue.icons', icon_name)
-        else:
-            raise RuntimeError("Icon does not exist: %s" % icon_name)
-    except NotImplementedError:  # workaround for mac app
-        result = os.path.dirname(__file__)
-        return os.path.join(result.replace('site-packages.zip', 'glue'),
-                            icon_name)
+    icon_file = importlib_resources.files("glue") / "icons" / icon_name
+    if icon_file.is_file():
+        return str(icon_file)
+    else:
+        raise RuntimeError("Icon does not exist: %s" % icon_name)

--- a/glue/main.py
+++ b/glue/main.py
@@ -295,11 +295,10 @@ def load_plugins(splash=None, require_qt_plugins=False):
     n_plugins = len(list(iter_plugin_entry_points()))
 
     for iplugin, item in enumerate(iter_plugin_entry_points()):
-
-        if item.module_name not in _installed_plugins:
+        if item.module not in _installed_plugins:
             _installed_plugins.add(item.name)
 
-        if item.module_name in _loaded_plugins:
+        if item.module in _loaded_plugins:
             logger.info("Plugin {0} already loaded".format(item.name))
             continue
 
@@ -321,22 +320,22 @@ def load_plugins(splash=None, require_qt_plugins=False):
         # older pip version.
 
         try:
-            module = import_module(item.module_name)
-            function = getattr(module, item.attrs[0])
+            module = import_module(item.module)
+            function = getattr(module, item.attr)
             function()
         except Exception as exc:
             # Here we check that some of the 'core' plugins load well and
             # raise an actual exception if not.
-            if item.module_name in REQUIRED_PLUGINS:
+            if item.module in REQUIRED_PLUGINS:
                 raise
-            elif item.module_name in REQUIRED_PLUGINS_QT and require_qt_plugins:
+            elif item.module in REQUIRED_PLUGINS_QT and require_qt_plugins:
                 raise
             else:
                 logger.info("Loading plugin {0} failed "
                             "(Exception: {1})".format(item.name, exc))
         else:
             logger.info("Loading plugin {0} succeeded".format(item.name))
-            _loaded_plugins.add(item.module_name)
+            _loaded_plugins.add(item.module)
 
         if splash is not None:
             splash.set_progress(100. * iplugin / float(n_plugins))

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,6 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -44,6 +43,7 @@ install_requires =
     openpyxl>=3.0
     mpl-scatter-density>=0.7
     pvextractor>=0.2
+    importlib_resources>=1.3; python_version<'3.9'
 
 [options.entry_points]
 glue.plugins =


### PR DESCRIPTION
## Description

resolves #2364

I left one call to `pkg_resources.get_distribution` in `doc/conf` because I don't know how to replace it without requiring `glue` be installed to build docs, and anyway it's not an issue for downstream code.