### PR TITLE
Only recreate table model when Data layer changes

### DIFF
--- a/glue/viewers/table/qt/data_viewer.py
+++ b/glue/viewers/table/qt/data_viewer.py
@@ -166,7 +166,7 @@ class DataTableModel(QtCore.QAbstractTableModel):
         visible = np.zeros(self.order.shape, dtype=bool)
         for layer_artist in self._table_viewer.layers:
             if layer_artist.visible:
-                mask = layer_artist.layer.to_mask()
+                mask = layer_artist.layer.to_mask()[self.order]
                 if DASK_INSTALLED and isinstance(mask, da.Array):
                     mask = mask.compute()
                 visible |= mask
@@ -295,6 +295,13 @@ class TableViewer(DataViewer):
                 break
         else:
             return
+
+        # If we aren't changing the data layer, we don't need to
+        # reset the model, just update visible rows
+        if layer_state.layer == self.data:
+            self.model._update_visible()
+            return
+
         self.data = layer_state.layer
         self.setUpdatesEnabled(False)
         self.model = DataTableModel(self)

--- a/glue/viewers/table/qt/tests/test_data_viewer.py
+++ b/glue/viewers/table/qt/tests/test_data_viewer.py
@@ -549,3 +549,65 @@ def test_table_with_dask_column():
     colors = ['#aa0000', '#aa0000', '#aa0000', None, None]
 
     check_values_and_color(model, data, colors)
+
+
+def test_table_preserve_model_after_selection():
+
+    # Regression test for a bug that caused table viewers to return
+    # to default sorting after a new subset was created with the row
+    # selection tool. This occurred because the model was reset.
+
+    app = get_qapp()  # noqa
+
+    d = Data(a=[1, 2, 3, 4, 5],
+             b=[3.2, 1.2, 4.5, 3.3, 2.2],
+             c=['e', 'b', 'c', 'a', 'f'], label='test')
+
+    dc = DataCollection([d])
+
+    gapp = GlueApplication(dc)
+
+    viewer = gapp.new_data_viewer(TableViewer)
+    viewer.add_data(d)
+
+    model = viewer.ui.table.model()
+
+    model.sort(1, Qt.AscendingOrder)
+
+    data = {'a': [2, 5, 1, 4, 3],
+            'b': [1.2, 2.2, 3.2, 3.3, 4.5],
+            'c': ['b', 'f', 'e', 'a', 'c']}
+    colors = [None for _ in range(5)]
+
+    check_values_and_color(model, data, colors)
+
+    # Create a new subset using the row selection tool
+
+    subset_mode = gapp._session.edit_subset_mode
+    subset_mode.edit_subset = None
+    viewer.toolbar.actions['table:rowselect'].toggle()
+
+    def press_key(key):
+        event = QtGui.QKeyEvent(QtCore.QEvent.KeyPress, key, Qt.NoModifier)
+        app.postEvent(viewer.ui.table, event)
+        app.processEvents()
+
+    # Select the second row
+    press_key(Qt.Key_Tab)
+    press_key(Qt.Key_Down)
+    press_key(Qt.Key_Enter)
+
+    process_events()
+
+    # Check that the table model is still the same, which it
+    # should be since we aren't changing the viewer Data
+
+    post_model = viewer.ui.table.model()
+    assert post_model == model
+
+    # Check that the order is still the same
+
+    color = d.subsets[0].style.color
+    colors[1] = color
+
+    check_values_and_color(post_model, data, colors)


### PR DESCRIPTION
This PR implements a change(/bugfix?) requested by @aagoodman. Currently, after a user makes a selection to create a new subset after having sorted the table, the sorting is undone once the subset is created. This leads to a not-great UX - if one is trying to create multiple selections based on a column's values, having to re-sort each time is annoying.

The reason for this is that the table model is recreated any time the layers change, which resets any sorting. This PR modifies the layer changed callback to only recreate the table model if the actual `Data` layer has changed - otherwise, we just call the model's `_update_visible`. This also necessitates making the masks in `_update_visible` aware of the current order.