### PR TITLE
WIP: Add extended component

### DIFF
--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -1429,6 +1429,8 @@ class Data(BaseCartesianData):
             return 'numerical'
         elif comp.categorical:
             return 'categorical'
+        elif comp.extended:
+            return 'extended'
         else:
             raise TypeError("Unknown data kind")
 
@@ -2049,6 +2051,19 @@ class Data(BaseCartesianData):
         warnings.warn('Data.visible_components is deprecated', UserWarning)
         return [cid for cid, comp in self._components.items()
                 if not isinstance(comp, CoordinateComponent) and cid.parent is self]
+
+
+class RegionData(Data):
+    """
+    Data that describes a set of regions and properties of those regions.
+
+    extended_component needs to be created as a component and passed into
+    the constructor
+    """
+
+    def __init__(self, label="", coords=None, extended_component=None, **kwargs):
+        self.extended_component = extended_component
+        super().__init__(label=label, coords=coords, **kwargs)
 
 
 @contract(i=int, ndim=int)

--- a/glue/viewers/image/qt/data_viewer.py
+++ b/glue/viewers/image/qt/data_viewer.py
@@ -27,7 +27,7 @@ class ImageViewer(MatplotlibImageMixin, MatplotlibDataViewer):
     _layer_style_widget_cls = {ImageLayerArtist: ImageLayerStyleEditor,
                                ImageSubsetLayerArtist: ImageLayerSubsetStyleEditor,
                                ScatterLayerArtist: ScatterLayerStyleEditor,
-                               ScatterRegionLayerArtist: ScatterRegionLayerStyleEditor,  # Need to override this with custom version
+                               ScatterRegionLayerArtist: ScatterRegionLayerStyleEditor,
                                }
     _state_cls = ImageViewerState
     _options_cls = ImageOptionsWidget

--- a/glue/viewers/image/qt/data_viewer.py
+++ b/glue/viewers/image/qt/data_viewer.py
@@ -1,6 +1,6 @@
 from glue.viewers.matplotlib.qt.data_viewer import MatplotlibDataViewer
-from glue.viewers.scatter.qt.layer_style_editor import ScatterLayerStyleEditor
-from glue.viewers.scatter.layer_artist import ScatterLayerArtist
+from glue.viewers.scatter.qt.layer_style_editor import ScatterLayerStyleEditor, ScatterRegionLayerStyleEditor
+from glue.viewers.scatter.layer_artist import ScatterLayerArtist, ScatterRegionLayerArtist
 from glue.viewers.image.qt.layer_style_editor import ImageLayerStyleEditor
 from glue.viewers.image.qt.layer_style_editor_subset import ImageLayerSubsetStyleEditor
 from glue.viewers.image.layer_artist import ImageLayerArtist, ImageSubsetLayerArtist
@@ -26,7 +26,9 @@ class ImageViewer(MatplotlibImageMixin, MatplotlibDataViewer):
     _default_mouse_mode_cls = RoiClickAndDragMode
     _layer_style_widget_cls = {ImageLayerArtist: ImageLayerStyleEditor,
                                ImageSubsetLayerArtist: ImageLayerSubsetStyleEditor,
-                               ScatterLayerArtist: ScatterLayerStyleEditor}
+                               ScatterLayerArtist: ScatterLayerStyleEditor,
+                               ScatterRegionLayerArtist: ScatterRegionLayerStyleEditor,  # Need to override this with custom version
+                               }
     _state_cls = ImageViewerState
     _options_cls = ImageOptionsWidget
 

--- a/glue/viewers/image/qt/tests/test_extended_component.py
+++ b/glue/viewers/image/qt/tests/test_extended_component.py
@@ -1,0 +1,122 @@
+# pylint: disable=I0011,W0613,W0201,W0212,E1101,E1103
+
+import os
+
+import numpy as np
+from shapely.geometry import MultiPolygon, Polygon
+
+
+from glue.core.data import RegionData, Data
+from glue.core.component import Component, ExtendedComponent
+from glue.core.component_id import ComponentID
+from glue.utils.qt import combo_as_string
+from glue.app.qt import GlueApplication
+from glue.core.fixed_resolution_buffer import ARRAY_CACHE, PIXEL_CACHE
+from glue.core.link_helpers import LinkSame
+
+from ..data_viewer import ImageViewer
+
+DATA = os.path.join(os.path.dirname(__file__), 'data')
+
+
+class TestScatterViewer(object):
+
+    def setup_method(self, method):
+
+        poly_1 = Polygon([(20, 20), (60, 20), (60, 40), (20, 40)])
+        poly_2 = Polygon([(60, 50), (60, 70), (80, 70), (80, 50)])
+        poly = Polygon([(10, 10), (15, 10), (15, 15), (10, 15)])
+        poly3 = Polygon([(10, 20), (15, 20), (15, 30), (10, 30), (12, 25)])
+
+        polygons = MultiPolygon([poly_1, poly_2])
+
+        my_geoms = np.array([poly, polygons, poly3])
+
+        representative_points = [s.representative_point() for s in my_geoms]
+
+        center_x_id = ComponentID('x')
+        center_y_id = ComponentID('y')
+
+        center_x = Component(np.array([s.x for s in representative_points]))
+        center_y = Component(np.array([s.y for s in representative_points]))
+
+        region_component = ExtendedComponent(my_geoms, parent_component_ids=[center_x_id, center_y_id])
+
+        cell_number = Component(np.array([1, 2, 3]))
+
+        self.region_data = RegionData(regions=region_component,
+                                      cell_number=cell_number,
+                                      extended_component=region_component)
+        # This is one way to add these components is a way that we can easily check their IDs
+        self.region_data.add_component(center_x, center_x_id)
+        self.region_data.add_component(center_y, center_y_id)
+
+        random_2d_array = np.random.randint(1, 20, size=(100, 100))
+        self.data_2d = Data(label='image_data', z=random_2d_array)
+        self.catalog = Data(label='catalog', c=[1, 3, 2], d=[4, 3, 3])
+
+        self.application = GlueApplication()
+
+        self.session = self.application.session
+
+        self.hub = self.session.hub
+
+        self.data_collection = self.session.data_collection
+        self.data_collection.append(self.region_data)
+        self.data_collection.append(self.data_2d)
+        self.data_collection.append(self.catalog)
+
+        self.viewer = self.application.new_data_viewer(ImageViewer)
+
+        self.data_collection.register_to_hub(self.hub)
+        self.viewer.register_to_hub(self.hub)
+
+        self.options_widget = self.viewer.options_widget()
+
+    def teardown_method(self, method):
+
+        # Properly close viewer and application
+        self.viewer.close()
+        self.viewer = None
+        self.application.close()
+        self.application = None
+
+        # Make sure cache is empty
+        if len(PIXEL_CACHE) > 0:
+            raise Exception("Pixel cache contains {0} elements".format(len(PIXEL_CACHE)))
+        if len(ARRAY_CACHE) > 0:
+            raise Exception("Array cache contains {0} elements".format(len(ARRAY_CACHE)))
+
+    def test_basic(self):
+
+        # Check defaults when we add data
+
+        self.viewer.add_data(self.data_2d)
+
+        assert combo_as_string(self.options_widget.ui.combosel_x_att_world) == 'Coordinate components:Pixel Axis 0 [y]:Pixel Axis 1 [x]'
+        assert combo_as_string(self.options_widget.ui.combosel_y_att_world) == 'Coordinate components:Pixel Axis 0 [y]:Pixel Axis 1 [x]'
+
+        assert self.viewer.axes.get_xlabel() == 'Pixel Axis 1 [x]'
+        assert self.viewer.state.x_att_world is self.data_2d.id['Pixel Axis 1 [x]']
+        assert self.viewer.state.x_att is self.data_2d.pixel_component_ids[1]
+
+        assert self.viewer.axes.get_ylabel() == 'Pixel Axis 0 [y]'
+        assert self.viewer.state.y_att_world is self.data_2d.id['Pixel Axis 0 [y]']
+        assert self.viewer.state.y_att is self.data_2d.pixel_component_ids[0]
+
+        assert not self.viewer.state.x_log
+        assert not self.viewer.state.y_log
+
+        assert len(self.viewer.state.layers) == 1
+
+        link1 = LinkSame(self.region_data.id['y'], self.data_2d.pixel_component_ids[0])
+        link2 = LinkSame(self.region_data.id['x'], self.data_2d.pixel_component_ids[1])
+
+        self.data_collection.add_link(link1)
+        self.data_collection.add_link(link2)
+
+        self.viewer.add_data(self.region_data)
+
+        assert len(self.viewer.state.layers) == 2
+        assert self.viewer.layers[0].enabled  # image
+        assert self.viewer.layers[1].enabled  # scatter

--- a/glue/viewers/image/viewer.py
+++ b/glue/viewers/image/viewer.py
@@ -5,8 +5,11 @@ from astropy.wcs import WCS
 from glue.core.subset import roi_to_subset_state
 from glue.core.coordinates import Coordinates, LegacyCoordinates
 from glue.core.coordinate_helpers import dependent_axes
+from glue.core.data import RegionData
 
 from glue.viewers.scatter.layer_artist import ScatterLayerArtist
+from glue.viewers.scatter.layer_artist import ScatterRegionLayerArtist
+
 from glue.viewers.image.layer_artist import ImageLayerArtist, ImageSubsetLayerArtist
 from glue.viewers.image.compat import update_image_viewer_state
 
@@ -168,15 +171,24 @@ class MatplotlibImageMixin(object):
             raise Exception("Can only add a scatter plot overlay once an image is present")
         return ScatterLayerArtist(axes, state, layer=layer, layer_state=None)
 
+    def _region_artist(self, axes, state, layer=None, layer_state=None):
+        if len(self._layer_artist_container) == 0:
+            raise Exception("Can only add a region plot overlay once an image is present")
+        return ScatterRegionLayerArtist(axes, state, layer=layer, layer_state=None)
+
     def get_data_layer_artist(self, layer=None, layer_state=None):
-        if layer.ndim == 1:
+        if isinstance(layer, RegionData):
+            cls = self._region_artist
+        elif layer.ndim == 1:
             cls = self._scatter_artist
         else:
             cls = ImageLayerArtist
         return self.get_layer_artist(cls, layer=layer, layer_state=layer_state)
 
     def get_subset_layer_artist(self, layer=None, layer_state=None):
-        if layer.ndim == 1:
+        if isinstance(layer.data, RegionData):
+            cls = self._region_artist
+        elif layer.ndim == 1:
             cls = self._scatter_artist
         else:
             cls = ImageSubsetLayerArtist

--- a/glue/viewers/scatter/layer_artist.py
+++ b/glue/viewers/scatter/layer_artist.py
@@ -80,6 +80,14 @@ def set_mpl_artist_cmap(artist, values, state=None, cmap=None, vmin=None, vmax=N
 
 
 class UpdatablePatchCollection(PatchCollection):
+    """
+    I'm not sure if we generally need this, it depends what properties of polygons
+    we're going to need to update.
+
+    For circles we might be able to just set_radius
+    Taken from https://stackoverflow.com/a/11041426
+    """
+
     def __init__(self, patches, *args, **kwargs):
         self.patches = patches
         PatchCollection.__init__(self, patches, *args, **kwargs)

--- a/glue/viewers/scatter/layer_artist.py
+++ b/glue/viewers/scatter/layer_artist.py
@@ -612,9 +612,6 @@ class ScatterRegionLayerArtist(MatplotlibLayerArtist):
         super().__init__(axes, viewer_state,
                             layer_state=layer_state, layer=layer)
 
-        # Watch for changes in the viewer state which would require the
-        # layers to be redrawn
-
         if isinstance(layer, BaseData):
             data = layer
         else:

--- a/glue/viewers/scatter/layer_artist.py
+++ b/glue/viewers/scatter/layer_artist.py
@@ -168,7 +168,6 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
         self.vector_artist = None
         self.line_collection = ColoredLineCollection([], [])
         self.axes.add_collection(self.line_collection)
-        self.axes.add_collection(self.region_collection)
 
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", message='All-NaN slice encountered')
@@ -650,7 +649,7 @@ class ScatterRegionLayerArtist(MatplotlibLayerArtist):
             # These must be special attributes that are linked to a region_att
             # Getting both arrays and checking that they are the same is an
             # expensive way to do this. There is probably a better way to check
-            # if the component IDs are linked
+            # if the component IDs are the same/linked
             x_att = self.layer[self._viewer_state.x_att]
             if not np.array_equal(x_att, self.layer[self.region_x_att]):
                 raise IncompatibleAttribute

--- a/glue/viewers/scatter/plot_polygons.py
+++ b/glue/viewers/scatter/plot_polygons.py
@@ -1,0 +1,319 @@
+"""
+A lightly modified version of geopandas.plotting.py for efficiently 
+plotting multiple polygons in matplotlib.
+"""
+# Copyright (c) 2013-2022, GeoPandas developers.
+# All rights reserved.
+# 
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 
+#  * Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of GeoPandas nor the names of its contributors may
+#   be used to endorse or promote products derived from this software without
+#   specific prior written permission.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+
+import numpy as np
+import pandas as pd
+from matplotlib.collections import PatchCollection
+
+
+import shapely
+from shapely.geometry.base import BaseMultipartGeometry
+
+from packaging.version import Version
+
+class UpdatablePatchCollection(PatchCollection):
+    """
+    Allow properties of PatchCollection to be modified after creation.
+    """
+
+    def __init__(self, patches, *args, **kwargs):
+        self.patches = patches
+        PatchCollection.__init__(self, patches, *args, **kwargs)
+
+    def get_paths(self):
+        self.set_paths(self.patches)
+        return self._paths
+
+class UpdateableRegionCollection(UpdatablePatchCollection):
+
+    def set_centers(self, x, y):
+        if len(x) == 0:
+            self.patches = []
+            return
+        offsets = np.vstack((x, y)).transpose()
+        self.patches.set_offsets(offsets)
+
+
+def _sanitize_geoms(geoms, prefix="Multi"):
+    """
+    Returns Series like geoms and index, except that any Multi geometries
+    are split into their components and indices are repeated for all component
+    in the same Multi geometry. At the same time, empty or missing geometries are
+    filtered out.  Maintains 1:1 matching of geometry to value.
+    Prefix specifies type of geometry to be flatten. 'Multi' for MultiPoint and similar,
+    "Geom" for GeometryCollection.
+    Returns
+    -------
+    components : list of geometry
+    component_index : index array
+        indices are repeated for all components in the same Multi geometry
+    """
+    # TODO(shapely) look into simplifying this with
+    # shapely.get_parts(geoms, return_index=True) from shapely 2.0
+    components, component_index = [], []
+
+    geom_types = get_geometry_type(geoms).astype('str')
+
+    if (
+        not np.char.startswith(geom_types, prefix).any()
+        #and not geoms.is_empty.any()
+        #and not geoms.isna().any()
+    ):
+        return geoms, np.arange(len(geoms))
+
+    for ix, (geom, geom_type) in enumerate(zip(geoms, geom_types)):
+        if geom is not None and geom_type.startswith(prefix):
+            for poly in geom.geoms:
+                components.append(poly)
+                component_index.append(ix)
+        elif geom is None:
+            continue
+        else:
+            components.append(geom)
+            component_index.append(ix)
+
+    return components, np.array(component_index)
+
+
+
+def get_geometry_type(data):
+    _names = {
+    "MISSING": None,
+    "NAG": None,
+    "POINT": "Point",
+    "LINESTRING": "LineString",
+    "LINEARRING": "LinearRing",
+    "POLYGON": "Polygon",
+    "MULTIPOINT": "MultiPoint",
+    "MULTILINESTRING": "MultiLineString",
+    "MULTIPOLYGON": "MultiPolygon",
+    "GEOMETRYCOLLECTION": "GeometryCollection",
+}
+
+    type_mapping = {p.value: _names[p.name] for p in shapely.GeometryType}
+    geometry_type_ids = list(type_mapping.keys())
+    geometry_type_values = np.array(list(type_mapping.values()), dtype=object)
+    res = shapely.get_type_id(data)
+    return geometry_type_values[np.searchsorted(geometry_type_ids, res)]
+
+
+def plot_series(
+    s, ax, cmap=None, color=None, empty=False, **style_kwds
+):
+    """
+    Plot a GeoSeries.
+    Generate a plot of a GeoSeries geometry with matplotlib.
+    Parameters
+    ----------
+    s : Series
+        The GeoSeries to be plotted. Currently Polygon,
+        MultiPolygon, LineString, MultiLineString, Point and MultiPoint
+        geometries can be plotted.
+    ax : matplotlib.pyplot.Artist
+        axes on which to draw the plot
+    cmap : str (default None)
+        The name of a colormap recognized by matplotlib. Any
+        colormap will work, but categorical colormaps are
+        generally recommended. Examples of useful discrete
+        colormaps include:
+            tab10, tab20, Accent, Dark2, Paired, Pastel1, Set1, Set2
+    color : str, np.array, pd.Series, List (default None)
+        If specified, all objects will be colored uniformly.
+    **style_kwds : dict
+        Color options to be passed on to the actual plot function, such
+        as ``linewidth``, ``alpha``.
+    Returns
+    -------
+    ax : matplotlib axes instance
+    """
+
+    # have colors been given for all geometries?
+    color_given = pd.api.types.is_list_like(color) and len(color) == len(s)
+
+    # if cmap is specified, create range of colors based on cmap
+    values = None
+    if cmap is not None:
+        values = np.arange(len(s))
+        if hasattr(cmap, "N"):
+            values = values % cmap.N
+        style_kwds["vmin"] = style_kwds.get("vmin", values.min())
+        style_kwds["vmax"] = style_kwds.get("vmax", values.max())
+
+    # decompose GeometryCollections
+    s_geometry = get_geometry_type(s)
+    geoms, multiindex = _sanitize_geoms(s, prefix="Geom")
+    values = np.take(values, multiindex, axis=0) if cmap else None
+    # ensure indexes are consistent
+    if color_given and isinstance(color, pd.Series):
+        color = color.reindex(s.index)
+    expl_color = np.take(color, multiindex, axis=0) if color_given else color
+    expl_series = geoms
+
+    geom_types = get_geometry_type(expl_series)
+    poly_idx = np.asarray((geom_types == "Polygon") | (geom_types == "MultiPolygon"))
+    line_idx = np.asarray(
+        (geom_types == "LineString")
+        | (geom_types == "MultiLineString")
+        | (geom_types == "LinearRing")
+    )
+    point_idx = np.asarray((geom_types == "Point") | (geom_types == "MultiPoint"))
+
+    # plot all Polygons and all MultiPolygon components in the same collection
+    polys = expl_series[poly_idx]
+    color_ = expl_color[poly_idx] if color_given else color
+
+    values_ = values[poly_idx] if cmap else None
+    _plot_polygon_collection(
+        ax, polys, values_, color=color_, cmap=cmap, empty=empty, **style_kwds
+    )
+    return ax
+
+
+def _plot_polygon_collection(
+    ax, geoms, values=None, color=None, cmap=None, vmin=None, vmax=None, empty=False, **kwargs
+):
+    """
+    Plots a collection of Polygon and MultiPolygon geometries to `ax`
+    Parameters
+    ----------
+    ax : matplotlib.axes.Axes
+        where shapes will be plotted
+    geoms : a sequence of `N` Polygons and/or MultiPolygons (can be mixed)
+    values : a sequence of `N` values, optional
+        Values will be mapped to colors using vmin/vmax/cmap. They should
+        have 1:1 correspondence with the geometries (not their components).
+        Otherwise plot using `color`.
+    color : single color or sequence of `N` colors
+        Sets both `edgecolor` and `facecolor`
+    cmap : str (default None)
+        The name of a colormap recognized by matplotlib.
+    vmin : float
+    vmax : float
+    empty : bool
+        Whether to plot just the outline of the polygons 
+    **kwargs
+        Additional keyword arguments passed to the collection
+    Returns
+    -------
+    collection : matplotlib.collections.Collection that was plotted
+    """
+    from matplotlib.collections import PatchCollection
+
+    geoms, multiindex = _sanitize_geoms(geoms)
+    if values is not None:
+        values = np.take(values, multiindex, axis=0)
+
+    # PatchCollection does not accept some kwargs.
+    kwargs = {
+        att: value
+        for att, value in kwargs.items()
+        if att not in ["markersize", "marker"]
+    }
+
+    # Add to kwargs for easier checking below.
+    if color is not None:
+        kwargs["color"] = color
+
+    _expand_kwargs(kwargs, multiindex)
+
+    collection = PatchCollection([_PolygonPatch(poly) for poly in geoms], **kwargs)
+
+    if values is not None:
+        collection.set_array(np.asarray(values))
+        collection.set_cmap(cmap)
+        if "norm" not in kwargs:
+            collection.set_clim(vmin, vmax)
+
+    if empty:
+        collection.set_facecolor('none')
+    ax.add_collection(collection, autolim=True)
+    ax.autoscale_view()
+    return collection
+
+def _PolygonPatch(polygon, **kwargs):
+    """Constructs a matplotlib patch from a Polygon geometry
+    The `kwargs` are those supported by the matplotlib.patches.PathPatch class
+    constructor. Returns an instance of matplotlib.patches.PathPatch.
+    Example (using Shapely Point and a matplotlib axes)::
+        b = shapely.geometry.Point(0, 0).buffer(1.0)
+        patch = _PolygonPatch(b, fc='blue', ec='blue', alpha=0.5)
+        ax.add_patch(patch)
+    GeoPandas originally relied on the descartes package by Sean Gillies
+    (BSD license, https://pypi.org/project/descartes) for PolygonPatch, but
+    this dependency was removed in favor of the below matplotlib code.
+    """
+    from matplotlib.patches import PathPatch
+    from matplotlib.path import Path
+
+    path = Path.make_compound_path(
+        Path(np.asarray(polygon.exterior.coords)[:, :2]),
+        *[Path(np.asarray(ring.coords)[:, :2]) for ring in polygon.interiors],
+    )
+    return PathPatch(path, **kwargs)
+
+def _expand_kwargs(kwargs, multiindex):
+    """
+    Most arguments to the plot functions must be a (single) value, or a sequence
+    of values. This function checks each key-value pair in 'kwargs' and expands
+    it (in place) to the correct length/formats with help of 'multiindex', unless
+    the value appears to already be a valid (single) value for the key.
+    """
+    import matplotlib
+    from matplotlib.colors import is_color_like
+    from typing import Iterable
+
+    mpl = Version(matplotlib.__version__)
+    if mpl >= Version("3.4"):
+        # alpha is supported as array argument with matplotlib 3.4+
+        scalar_kwargs = ["marker", "path_effects"]
+    else:
+        scalar_kwargs = ["marker", "alpha", "path_effects"]
+
+    for att, value in kwargs.items():
+        if "color" in att:  # color(s), edgecolor(s), facecolor(s)
+            if is_color_like(value):
+                continue
+        elif "linestyle" in att:  # linestyle(s)
+            # A single linestyle can be 2-tuple of a number and an iterable.
+            if (
+                isinstance(value, tuple)
+                and len(value) == 2
+                and isinstance(value[1], Iterable)
+            ):
+                continue
+        elif att in scalar_kwargs:
+            # For these attributes, only a single value is allowed, so never expand.
+            continue
+
+        if pd.api.types.is_list_like(value):
+            kwargs[att] = np.take(value, multiindex, axis=0)
+

--- a/glue/viewers/scatter/qt/data_viewer.py
+++ b/glue/viewers/scatter/qt/data_viewer.py
@@ -15,7 +15,9 @@ __all__ = ['ScatterViewer']
 class ScatterViewer(MatplotlibScatterMixin, MatplotlibDataViewer):
 
     LABEL = '2D Scatter'
-    _layer_style_widget_cls = ScatterLayerStyleEditor
+    _layer_style_widget_cls = {
+        ScatterLayerArtist: ScatterLayerStyleEditor,
+    }
     _state_cls = ScatterViewerState
     _options_cls = ScatterOptionsWidget
     _data_artist_cls = ScatterLayerArtist

--- a/glue/viewers/scatter/qt/layer_style_editor.py
+++ b/glue/viewers/scatter/qt/layer_style_editor.py
@@ -226,3 +226,45 @@ class ScatterLayerStyleEditor(QtWidgets.QWidget):
             self.ui.combodata_cmap.show()
             self.ui.label_colormap.show()
             self.ui.color_color.hide()
+
+
+class ScatterRegionLayerStyleEditor(QtWidgets.QWidget):
+
+    def __init__(self, layer, parent=None):
+
+        super().__init__(parent=parent)
+
+        self.ui = load_ui('region_layer_style_editor.ui', self,
+                          directory=os.path.dirname(__file__))
+
+        connect_kwargs = {'alpha': dict(value_range=(0, 1))}
+        self._connections = autoconnect_callbacks_to_qt(layer.state, self.ui, connect_kwargs)
+
+        self.layer_state = layer.state
+
+        self.layer_state.add_callback('cmap_mode', self._update_cmap_mode)
+
+        self._update_cmap_mode()
+
+    def _update_cmap_mode(self, cmap_mode=None):
+
+        if self.layer_state.cmap_mode == 'Fixed':
+            self.ui.label_cmap_attribute.hide()
+            self.ui.combosel_cmap_att.hide()
+            self.ui.label_cmap_limits.hide()
+            self.ui.valuetext_cmap_vmin.hide()
+            self.ui.valuetext_cmap_vmax.hide()
+            self.ui.button_flip_cmap.hide()
+            self.ui.combodata_cmap.hide()
+            self.ui.label_colormap.hide()
+            self.ui.color_color.show()
+        else:
+            self.ui.label_cmap_attribute.show()
+            self.ui.combosel_cmap_att.show()
+            self.ui.label_cmap_limits.show()
+            self.ui.valuetext_cmap_vmin.show()
+            self.ui.valuetext_cmap_vmax.show()
+            self.ui.button_flip_cmap.show()
+            self.ui.combodata_cmap.show()
+            self.ui.label_colormap.show()
+            self.ui.color_color.hide()

--- a/glue/viewers/scatter/qt/region_layer_style_editor.ui
+++ b/glue/viewers/scatter/qt/region_layer_style_editor.ui
@@ -1,0 +1,231 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>329</width>
+    <height>295</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="1">
+    <widget class="QLabel" name="label_10">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>color</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="2">
+    <widget class="QComboBox" name="combosel_cmap_mode">
+     <property name="maximumSize">
+      <size>
+       <width>80</width>
+       <height>16777215</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="2">
+    <widget class="QLabel" name="label_cmap_attribute">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>attribute</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QLabel" name="label_cmap_limits">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>limits</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="2">
+    <widget class="QLineEdit" name="valuetext_cmap_vmin"/>
+   </item>
+   <item row="2" column="3">
+    <widget class="QToolButton" name="button_flip_cmap">
+     <property name="styleSheet">
+      <string notr="true">padding: 0px</string>
+     </property>
+     <property name="text">
+      <string>⇄</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="4">
+    <widget class="QLineEdit" name="valuetext_cmap_vmax"/>
+   </item>
+   <item row="3" column="0" colspan="2">
+    <widget class="QLabel" name="label_colormap">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>colormap</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0" colspan="2">
+    <widget class="QLabel" name="label_7">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>opacity</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="2">
+    <widget class="QSlider" name="value_alpha">
+     <property name="maximum">
+      <number>100</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <widget class="QLabel" name="label_fill">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>fill</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="2">
+    <widget class="QCheckBox" name="bool_fill">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>85</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="6" column="1" colspan="4">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>256</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="1" column="2" colspan="2">
+    <widget class="QComboBox" name="combosel_cmap_att">
+     <property name="sizeAdjustPolicy">
+      <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="2" colspan="2">
+    <widget class="QColormapCombo" name="combodata_cmap">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="sizeAdjustPolicy">
+      <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="3" colspan="2">
+    <widget class="QColorBox" name="color_color">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QColormapCombo</class>
+   <extends>QComboBox</extends>
+   <header>glue.utils.qt.colors</header>
+  </customwidget>
+  <customwidget>
+   <class>QColorBox</class>
+   <extends>QLabel</extends>
+   <header>glue.utils.qt.colors</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/glue/viewers/scatter/state.py
+++ b/glue/viewers/scatter/state.py
@@ -16,7 +16,7 @@ from glue.core.exceptions import IncompatibleAttribute
 
 from matplotlib.projections import get_projection_names
 
-__all__ = ['ScatterViewerState', 'ScatterLayerState']
+__all__ = ['ScatterViewerState', 'ScatterLayerState', 'ScatterRegionLayerState']
 
 
 class ScatterViewerState(MatplotlibDataViewerState):
@@ -504,8 +504,6 @@ class ScatterRegionLayerState(MatplotlibLayerState):
     """
     A state class that includes all the attributes for layers in a scatter region layer.
     """
-    markers_visible = DDCProperty(True, docstring="Whether to show markers")
-
     # Color
 
     cmap_mode = DDSCProperty(docstring="Whether to use color to encode an attribute")
@@ -534,7 +532,6 @@ class ScatterRegionLayerState(MatplotlibLayerState):
             self.viewer_state.add_callback('x_att', self._on_xy_change, priority=10000)
             self.viewer_state.add_callback('y_att', self._on_xy_change, priority=10000)
             self._on_xy_change()
-
 
         self.add_callback('layer', self._on_layer_change)
         if layer is not None:


### PR DESCRIPTION
# Pull Request Template

## Description

Here is one approach to displaying many regions (e.g. regions-as-data) in glue (ala #2351). I've implemented this for the first place I wanted it, which is as a different kind of ScatterLayer in the ImageViewer. 

The pieces are basically:

- An `ExtendedComponent(Component)` which is a list of Shapely geometries
- A `RegionData(Data)` which is probably unnecessary (more `Data` types are hard to support) but for now is used to determine if a `Data` object should be plotted as regions or as points.
- `ScatterRegionLayerState` and `ScatterRegionLayerArtist` classes to deal with actually configuring and plotting regions
- Some code from GeoPandas (with LICENSE) for the actual plotting/updating of arbitrary polygons. 

Major unfinished things
- [ ] Projections/transformations don't work on regions (would need to apply transformation to all points in the region definition)
- [ ] Regions can be displayed and selected, but cannot be used for logical operations
- [ ] Regions are selected into subsets based on their representative point (a cheap centroid that must be inside the geometry). This might not always be the desired behavior.
- [ ] It's much less clear what the best behavior is when adding RegionData to a scatterplot. The assumption is that if you have regions, you want to plot regions on an image (perhaps color-coded by another component). If you have a table of data about regions you *might* want to make a scatterplot that just shows those regions (i.e. you don't have an image and just want to see the geometry) or you *might* want to make a scatterplot 2 components of those regions.

