### PR TITLE
Fix broken link editor under Qt5

### DIFF
--- a/glue/dialogs/link_editor/qt/data_graph.py
+++ b/glue/dialogs/link_editor/qt/data_graph.py
@@ -363,8 +363,12 @@ class DataGraphWidget(QGraphicsView):
 
     def find_object(self, event):
         for obj in list(self.nodes) + self.edges:
-            if obj.contains(event.position()):
-                return obj
+            try:  # event.position() is Qt6 
+                if obj.contains(event.position()):
+                    return obj
+            except AttributeError:  # event.pos() is Qt5
+                if obj.contains(event.pos()):
+                    return obj
 
     def mouseMoveEvent(self, event):
 

--- a/glue/dialogs/link_editor/qt/data_graph.py
+++ b/glue/dialogs/link_editor/qt/data_graph.py
@@ -363,7 +363,7 @@ class DataGraphWidget(QGraphicsView):
 
     def find_object(self, event):
         for obj in list(self.nodes) + self.edges:
-            try:  # event.position() is Qt6 
+            try:  # event.position() is Qt6
                 if obj.contains(event.position()):
                     return obj
             except AttributeError:  # event.pos() is Qt5


### PR DESCRIPTION
# Fixes a bug where the link editor did not allow you to select nodes under Qt5

## Description

Close #2374 by simply using try/except to do both the Qt6 and Qt5 methods.