### PR TITLE
Save legend state

### DIFF
--- a/glue/viewers/matplotlib/state.py
+++ b/glue/viewers/matplotlib/state.py
@@ -259,6 +259,18 @@ class MatplotlibDataViewerState(ViewerState):
         else:
             return 1
 
+    def __gluestate__(self, context):
+        state = super(MatplotlibDataViewerState, self).__gluestate__(context)
+        state["legend"] = self.legend.as_dict()
+        return state
+
+    @classmethod
+    def __setgluestate__(cls, rec, context):
+        state = super(MatplotlibDataViewerState, cls).__setgluestate__(rec, context)
+        if "legend" in rec:
+            state.legend.update_from_dict(rec["legend"])
+        return state
+
 
 class MatplotlibLayerState(LayerState):
     """

--- a/glue/viewers/matplotlib/tests/test_state.py
+++ b/glue/viewers/matplotlib/tests/test_state.py
@@ -1,7 +1,35 @@
-from ..state import MatplotlibLegendState
+from ..state import MatplotlibLegendState, MatplotlibDataViewerState
 from glue.config import settings
+from glue.core.tests.test_state import clone
 
 from matplotlib.colors import to_rgba
+
+
+class TestMatplotlibDataViewerState:
+    def setup_method(self, method):
+        self.state = MatplotlibDataViewerState()
+
+    def test_legend_serialization(self):
+        legend_state = self.state.legend
+        legend_state.visible = True
+        legend_state.location = "best"
+        legend_state.title = "Legend"
+        legend_state.fontsize = 13
+        legend_state.alpha = 0.7
+        legend_state.frame_color = "#1e00f1"
+        legend_state.show_edge = False
+        legend_state.text_color = "#fad8f1"
+
+        new_state = clone(self.state)
+        new_legend_state = new_state.legend
+        assert new_legend_state.visible
+        assert new_legend_state.location == "best"
+        assert new_legend_state.title == "Legend"
+        assert new_legend_state.fontsize == 13
+        assert new_legend_state.alpha == 0.7
+        assert new_legend_state.frame_color == "#1e00f1"
+        assert not new_legend_state.show_edge
+        assert new_legend_state.text_color == "#fad8f1"
 
 
 class TestMatplotlibLegendState:


### PR DESCRIPTION
While we were dealing with the issues with legends and matplotlib 3.7, I noticed that we don't save the legend state of the matplotlib viewers. This PR adds functionality to do that, which gives a small but nice UX improvement. This shouldn't have any effect on loading existing sessions, since then the relevant record won't have a `"legend"` key and the new code in `__setgluestate__` won't run.