### PR TITLE
Use new location for pandas.testing

### DIFF
--- a/glue/core/tests/test_pandas.py
+++ b/glue/core/tests/test_pandas.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 from unittest.mock import MagicMock
-from pandas.util.testing import (assert_series_equal,
+from pandas.testing import (assert_series_equal,
                                  assert_frame_equal)
 
 from ..component import Component, DerivedComponent, CategoricalComponent


### PR DESCRIPTION
# Update pandas.testing location

## Description

With pandas 2.0, the deprecated location pandas.util.testing must now be imported as pandas.testing.

https://github.com/pandas-dev/pandas/pull/30745
