### PR TITLE
Fix bad connections in tutorial examples

### DIFF
--- a/doc/customizing_guide/mpl_viewer/config.py
+++ b/doc/customizing_guide/mpl_viewer/config.py
@@ -124,7 +124,7 @@ class TutorialLayerStateWidget(QWidget):
         self.setLayout(layout)
 
         self.layer_state = layer_artist.state
-        connect_checkable_button(self.layer_state, 'fill', self.checkbox)
+        self._connection = connect_checkable_button(self.layer_state, 'fill', self.checkbox)
 
 
 class TutorialDataViewer(MatplotlibDataViewer):

--- a/doc/customizing_guide/qt_viewer.rst
+++ b/doc/customizing_guide/qt_viewer.rst
@@ -51,7 +51,7 @@ with the ``fill`` option. You could implement a layer options widget by doing::
              self.setLayout(layout)
 
              self.layer_state = layer_artist.state
-             connect_checkable_button(self.layer_state, 'fill', self.checkbox)
+             self._connection = connect_checkable_button(self.layer_state, 'fill', self.checkbox)
 
 In the above example, you can see that we use the
 :class:`~echo.qt.connect_checkable_button` function to link the

--- a/doc/customizing_guide/state_viewer/config.py
+++ b/doc/customizing_guide/state_viewer/config.py
@@ -129,7 +129,7 @@ class TutorialLayerStateWidget(QWidget):
         self.setLayout(layout)
 
         self.layer_state = layer_artist.state
-        connect_checkable_button(self.layer_state, 'fill', self.checkbox)
+        self._connection = connect_checkable_button(self.layer_state, 'fill', self.checkbox)
 
 
 class TutorialDataViewer(DataViewer):


### PR DESCRIPTION
This PR fixes #2388 by retaining a reference to the checkbox connection created in the tutorial examples.