### PR TITLE
Make ROI.move_to() behave consistently and expose it at subset_state level

### DIFF
--- a/glue/core/roi.py
+++ b/glue/core/roi.py
@@ -1706,7 +1706,7 @@ class MplPolygonalROI(AbstractMplRoi):
             xval, yval = axes_trans.transform([event.x, event.y])
 
         if self._scrubbing:
-            old_x, old_y = self._roi.centroid()
+            old_x, old_y = self._roi.center()
             new_x = old_x + xval - self._cx
             new_y = old_y + yval - self._cy
             self._roi.move_to(new_x, new_y)

--- a/glue/core/roi.py
+++ b/glue/core/roi.py
@@ -878,7 +878,12 @@ class PolygonalROI(VertexROIBase):
         return np.dot(xs, dxy) * scl + x0, np.dot(ys, dxy) * scl + y0
 
     def center(self):
-        return self.centroid()  # centroid is more robust than mean
+        # centroid is more robust than mean, but
+        # for linear (1D) "polygons" centroid is not defined.
+        if self.area() == 0:
+            return self.mean()
+        else:
+            return self.centroid()
 
     def move_to(self, new_x, new_y):
         xcen, ycen = self.center()
@@ -902,12 +907,7 @@ class PolygonalROI(VertexROIBase):
         """
 
         theta = 0 if theta is None else theta
-        # For linear (1D) "polygons" centroid is not defined.
-        if center is None:
-            if self.area() == 0:
-                center = self.mean()
-            else:
-                center = self.centroid()
+        center = self.center() if center is None else center
         dtheta = theta - self.theta
 
         if self.defined() and not np.isclose(dtheta % np.pi, 0.0, atol=1e-9):

--- a/glue/core/subset.py
+++ b/glue/core/subset.py
@@ -441,6 +441,10 @@ class SubsetState(object):
     def subset_state(self):  # convenience method, mimic interface of Subset
         return self
 
+    def move_to(self, *args):
+        """Move any underlying ROI to the new given center."""
+        pass  # no-op until explicitly implemented by subclass
+
     @contract(data='isinstance(Data)')
     def to_index_list(self, data):
         return np.where(data.get_mask(self.subset_state).flat)[0]
@@ -537,6 +541,9 @@ class RoiSubsetStateNd(SubsetState):
     @property
     def attributes(self):
         return tuple(self._atts)
+
+    def move_to(self, *args):
+        self._roi.move_to(*args)
 
     @contract(data='isinstance(Data)', view='array_view')
     def to_mask(self, data, view=None):
@@ -1078,6 +1085,12 @@ class CompositeSubsetState(SubsetState):
 
     def copy(self):
         return type(self)(self.state1, self.state2)
+
+    def move_to(self, *args):
+        """Move any underlying ROI to the new given center."""
+        self.state1.move_to(*args)
+        if self.state2:
+            self.state2.move_to(*args)
 
     @property
     def attributes(self):

--- a/glue/core/subset.py
+++ b/glue/core/subset.py
@@ -441,6 +441,10 @@ class SubsetState(object):
     def subset_state(self):  # convenience method, mimic interface of Subset
         return self
 
+    def center(self):
+        """Return center of underlying ROI, if any."""
+        return  # None until explicitly implemented by subclass
+
     def move_to(self, *args):
         """Move any underlying ROI to the new given center."""
         pass  # no-op until explicitly implemented by subclass
@@ -541,6 +545,9 @@ class RoiSubsetStateNd(SubsetState):
     @property
     def attributes(self):
         return tuple(self._atts)
+
+    def center(self):
+        return self._roi.center()
 
     def move_to(self, *args):
         self._roi.move_to(*args)
@@ -1086,11 +1093,27 @@ class CompositeSubsetState(SubsetState):
     def copy(self):
         return type(self)(self.state1, self.state2)
 
+    def center(self):
+        cen = self.state1.center()
+        if cen is None and self.state2:
+            cen = self.state2.center()
+        return cen
+
     def move_to(self, *args):
         """Move any underlying ROI to the new given center."""
-        self.state1.move_to(*args)
         if self.state2:
-            self.state2.move_to(*args)
+            cen1 = self.state1.center()
+            cen2 = self.state2.center()
+            if cen2 is not None and cen1 is not None:
+                offset = np.asarray(cen2) - np.asarray(cen1)
+                if np.isscalar(offset):
+                    mt_args = (args[0] + offset, )
+                else:
+                    mt_args = tuple(map(operator.add, args, offset))
+            else:
+                mt_args = args
+            self.state2.move_to(*mt_args)
+        self.state1.move_to(*args)
 
     @property
     def attributes(self):

--- a/glue/core/tests/test_roi.py
+++ b/glue/core/tests/test_roi.py
@@ -273,16 +273,16 @@ class TestCircle(object):
             self.roi.contains(1, 1)
 
     def test_set_center(self):
-        self.roi.set_center(0, 0)
+        self.roi.move_to(0, 0)
         self.roi.set_radius(1)
         assert self.roi.contains(0, 0)
         assert not self.roi.contains(2, 2)
-        self.roi.set_center(2, 2)
+        self.roi.move_to(2, 2)
         assert not self.roi.contains(0, 0)
         assert self.roi.contains(2, 2)
 
     def test_set_radius(self):
-        self.roi.set_center(0, 0)
+        self.roi.move_to(0, 0)
         self.roi.set_radius(1)
         assert not self.roi.contains(1.5, 0)
         self.roi.set_radius(5)
@@ -291,14 +291,14 @@ class TestCircle(object):
     def test_contains_many(self):
         x = [0, 0, 0, 0, 0]
         y = [0, 0, 0, 0, 0]
-        self.roi.set_center(0, 0)
+        self.roi.move_to(0, 0)
         self.roi.set_radius(1)
         assert all(self.roi.contains(x, y))
         assert all(self.roi.contains(np.asarray(x), np.asarray(y)))
         assert not any(self.roi.contains(np.asarray(x) + 10, y))
 
     def test_poly(self):
-        self.roi.set_center(0, 0)
+        self.roi.move_to(0, 0)
         self.roi.set_radius(1)
         x, y = self.roi.to_polygon()
         poly = PolygonalROI(vx=x, vy=y)
@@ -312,7 +312,7 @@ class TestCircle(object):
 
     def test_reset(self):
         assert not self.roi.defined()
-        self.roi.set_center(0, 0)
+        self.roi.move_to(0, 0)
         assert not self.roi.defined()
         self.roi.set_radius(2)
         assert self.roi.defined()
@@ -320,7 +320,7 @@ class TestCircle(object):
         assert not self.roi.defined()
 
     def test_multidim(self):
-        self.roi.set_center(0, 0)
+        self.roi.move_to(0, 0)
         self.roi.set_radius(1)
         x = np.array([.1, .2, .3, .4]).reshape(2, 2)
         y = np.array([-.1, -.2, -.3, -.4]).reshape(2, 2)
@@ -329,7 +329,7 @@ class TestCircle(object):
         assert self.roi.contains(x, y).shape == (2, 2)
 
     def test_serialization(self):
-        self.roi.set_center(3, 4)
+        self.roi.move_to(3, 4)
         self.roi.set_radius(5)
         new_roi = roundtrip_roi(self.roi)
         assert_almost_equal(new_roi.xc, 3)

--- a/glue/core/tests/test_subset.py
+++ b/glue/core/tests/test_subset.py
@@ -14,7 +14,7 @@ from ..exceptions import IncompatibleAttribute
 from .. import DataCollection, ComponentLink
 from ...config import settings
 from ..data import Data, Component
-from ..roi import CategoricalROI, RectangularROI, Projected3dROI, CircularROI
+from ..roi import CategoricalROI, RectangularROI, Projected3dROI, CircularROI, EllipticalROI, RangeROI
 from ..message import SubsetDeleteMessage
 from ..registry import Registry
 from ..link_helpers import LinkSame
@@ -932,6 +932,43 @@ class TestCloneSubsetStates():
         subset.subset_state = RoiSubsetState(xatt=data_clone.id['a'], yatt=data_clone.id['c'],
                                              roi=roi)
         assert_equal(data_clone.subsets[1].to_mask(), [0, 0, 0, 1])
+
+        # Also test move_to for simple subset state
+        theta = roi.theta
+        assert subset.subset_state.center() == roi.center()
+        subset.subset_state.move_to(2, 3)
+        assert_allclose(subset.subset_state.center(), (2, 3))
+        assert_allclose(subset.subset_state._roi.center(), (2, 3))
+        assert_allclose(subset.subset_state._roi.theta, theta)
+
+    def test_roi_subset_state_composite_move_to(self):
+        xatt = self.data.id['a']
+        yatt = self.data.id['c']
+        roi_1 = RectangularROI(xmin=0, xmax=4, ymin=1, ymax=5)  # xc=2, yc=3
+        roi_2 = CircularROI(xc=1, yc=1, radius=2)
+        roi_3 = EllipticalROI(xc=3, yc=4, radius_x=2, radius_y=3, theta=0.785)
+        subset_state = AndState(
+            AndState(RoiSubsetState(xatt=xatt, yatt=yatt, roi=roi_1),
+                     RoiSubsetState(xatt=xatt, yatt=yatt, roi=roi_2)),
+            InvertState(RoiSubsetState(xatt=xatt, yatt=yatt, roi=roi_3)))
+        assert_allclose(subset_state.center(), (2, 3))
+
+        subset_state.move_to(20, 30)
+        assert_allclose(subset_state.center(), (20, 30))
+        assert_allclose(subset_state.state1.state1.center(), (20, 30))  # RectangularROI
+        assert_allclose(subset_state.state1.state2.center(), (19, 28))  # CircularROI
+        assert_allclose(subset_state.state2.state1.center(), (21, 31))  # EllipticalROI
+        assert_allclose(subset_state.state2.state1._roi.theta, 0.785)
+        assert not subset_state.state2.state2
+
+    def test_roi_subset_state_1d_move_to(self):
+        roi = RangeROI('x', min=0, max=5)
+        subset_state = RoiSubsetState(xatt=self.data.id['a'], yatt=self.data.id['c'], roi=roi)
+        assert_allclose(subset_state.center(), 2.5)
+
+        subset_state.move_to(3)
+        assert_allclose(subset_state.center(), 3)
+        assert_allclose((subset_state._roi.min, subset_state._roi.max), (0.5, 5.5))
 
 
 @requires_scipy

--- a/glue/core/tests/test_subset.py
+++ b/glue/core/tests/test_subset.py
@@ -221,8 +221,8 @@ class TestSubset(object):
         s = d.new_subset(**visual_attributes)
         for attr, value in visual_attributes.items():
             if attr == 'preferred_cmap':
-                from matplotlib.cm import get_cmap
-                assert s.style.preferred_cmap == get_cmap(visual_attributes[attr])
+                import matplotlib
+                assert s.style.preferred_cmap == matplotlib.colormaps[visual_attributes[attr]]
             else:
                 assert getattr(s.style, attr, None) == value
 

--- a/glue/utils/geometry.py
+++ b/glue/utils/geometry.py
@@ -156,7 +156,7 @@ def polygon_line_intersections(px, py, xval=None, yval=None):
 
 def floodfill(data, start_coords, threshold):
 
-    from scipy.ndimage.measurements import label
+    from scipy.ndimage import label
 
     # Determine value at the starting coordinates
     value = data[start_coords]


### PR DESCRIPTION
Make `ROI.move_to()` behave consistently such that all of them take absolute coords now, not some absolute and some delta. Also expose `move_to` machinery at `subset_state` level so we can move ROIs in composite subset all at once.

The main motivation is so I can have user click to recenter a subset that can be a simple shape with single ROI or an annulus that is actually a subset state with 2 attached ROIs (https://github.com/glue-viz/glue-astronomy/pull/90).

I don't know why some `move_to` expects only delta but that kind of inconsistent behavior is more of a bug than feature from my perspective.
