### PR TITLE
Add filter/search to table viewer

### DIFF
--- a/glue/viewers/table/compat.py
+++ b/glue/viewers/table/compat.py
@@ -22,7 +22,7 @@ def update_table_viewer_state(rec, context):
         rec['state'] = {}
         rec['state']['values'] = {}
 
-        properties = rec.pop('properties')
+        _ = rec.pop('properties')
 
         layer_states = []
 

--- a/glue/viewers/table/compat.py
+++ b/glue/viewers/table/compat.py
@@ -22,7 +22,10 @@ def update_table_viewer_state(rec, context):
         rec['state'] = {}
         rec['state']['values'] = {}
 
-        rec.pop('properties')
+        properties = rec.pop('properties')
+        viewer_state = rec['state']['values']
+        viewer_state['filter_att'] = properties['filter_att']
+        viewer_state['filter'] = properties['filter']
 
         layer_states = []
 

--- a/glue/viewers/table/compat.py
+++ b/glue/viewers/table/compat.py
@@ -23,9 +23,6 @@ def update_table_viewer_state(rec, context):
         rec['state']['values'] = {}
 
         properties = rec.pop('properties')
-        viewer_state = rec['state']['values']
-        viewer_state['filter_att'] = properties['filter_att']
-        viewer_state['filter'] = properties['filter']
 
         layer_states = []
 

--- a/glue/viewers/table/qt/data_viewer.py
+++ b/glue/viewers/table/qt/data_viewer.py
@@ -293,15 +293,6 @@ class TableViewer(DataViewer):
         self.state.add_callback('layers', self._on_layers_changed)
         self._on_layers_changed()
 
-    def get_col(self, cid):
-        """
-        Get the column id for a ComponentID, necessary for QtFilterProxy
-        """
-        for i, comp in enumerate(self.model.columns):
-            if comp == cid:
-                return i
-        return -1  # This defaults to searching all columns
-
     def selection_changed(self):
         app = get_qapp()
         if app.queryKeyboardModifiers() == Qt.AltModifier:

--- a/glue/viewers/table/qt/data_viewer.py
+++ b/glue/viewers/table/qt/data_viewer.py
@@ -263,7 +263,7 @@ class TableViewer(DataViewer):
         self.data = None
         self.model = None
 
-        self.proxyModel = QtCore.QSortFilterProxyModel(self)
+        self.proxy_model = QtCore.QSortFilterProxyModel(self)
 
         self._connection1 = connect_combo_selection(self.state, 'filter_att', self.ui.combosel_filter_att)
         self._connection2 = connect_text(self.state, 'filter', self.ui.valuetext_filter)
@@ -309,11 +309,11 @@ class TableViewer(DataViewer):
             self.ui.table.blockSignals(False)
 
     def _on_filter_changed(self, *args):
-        if (self.proxyModel is None) or (self.model is None):
+        if (self.proxy_model is None) or (self.model is None):
             return
-        self.proxyModel.invalidateFilter()
-        self.proxyModel.setFilterFixedString(self.state.filter)
-        self.proxyModel.setFilterKeyColumn(self.get_col(self.state.filter_att))
+        self.proxy_model.invalidateFilter()
+        self.proxy_model.setFilterFixedString(self.state.filter)
+        self.proxy_model.setFilterKeyColumn(self.get_col(self.state.filter_att))
 
     def _on_layers_changed(self, *args):
         for layer_state in self.state.layers:
@@ -333,11 +333,11 @@ class TableViewer(DataViewer):
 
         self.setUpdatesEnabled(False)
         self.model = DataTableModel(self)
-        self.proxyModel.invalidateFilter()
-        self.proxyModel.setSourceModel(self.model)
-        self.proxyModel.setFilterFixedString(self.state.filter)
-        self.proxyModel.setFilterKeyColumn(self.get_col(self.state.filter_att))
-        self.ui.table.setModel(self.proxyModel)
+        self.proxy_model.invalidateFilter()
+        self.proxy_model.setSourceModel(self.model)
+        self.proxy_model.setFilterFixedString(self.state.filter)
+        self.proxy_model.setFilterKeyColumn(self.get_col(self.state.filter_att))
+        self.ui.table.setModel(self.proxy_model)
         self.setUpdatesEnabled(True)
 
     @messagebox_on_error("Failed to add data")

--- a/glue/viewers/table/qt/data_viewer.py
+++ b/glue/viewers/table/qt/data_viewer.py
@@ -155,6 +155,9 @@ class DataTableModel(QtCore.QAbstractTableModel):
         self.layoutChanged.emit()
 
     def get_filter_mask(self):
+        if (self._state.filter is None) or (self._state.filter_att is None):
+            self.filter_mask = np.ones(self.order.shape, dtype=bool)
+            return
         p = re.compile(self._state.filter)
         comp = self._data.get_component(self._state.filter_att)
         self.filter_mask = np.array([bool(p.search(x)) for x in comp.data])
@@ -346,6 +349,8 @@ class TableViewer(DataViewer):
 
         self.setUpdatesEnabled(False)
         self.model = DataTableModel(self)
+        self.model.get_filter_mask()
+
         self.ui.table.setModel(self.model)
         self.setUpdatesEnabled(True)
 

--- a/glue/viewers/table/qt/data_viewer.py
+++ b/glue/viewers/table/qt/data_viewer.py
@@ -158,8 +158,7 @@ class DataTableModel(QtCore.QAbstractTableModel):
         p = re.compile(self._state.filter)
         comp = self._data.get_component(self._state.filter_att)
         self.filter_mask = np.array([bool(p.search(x)) for x in comp.data])
-        self.data_changed() # This might be overkill
-
+        self.data_changed()  # This might be overkill
 
     def _update_visible(self):
         """

--- a/glue/viewers/table/qt/data_viewer.py
+++ b/glue/viewers/table/qt/data_viewer.py
@@ -343,7 +343,6 @@ class TableViewer(DataViewer):
             return
 
         self.data = layer_state.layer
-        self.state.filter_att_helper.set_multiple_data([self.data])
 
         self.setUpdatesEnabled(False)
         self.model = DataTableModel(self)

--- a/glue/viewers/table/qt/data_viewer.py
+++ b/glue/viewers/table/qt/data_viewer.py
@@ -260,6 +260,7 @@ class TableViewer(DataViewer):
         self.data = None
         self.model = None
 
+
         self.ui.table.selection_changed.connect(self.selection_changed)
 
         self.state.add_callback('layers', self._on_layers_changed)
@@ -305,8 +306,13 @@ class TableViewer(DataViewer):
         self.data = layer_state.layer
         self.setUpdatesEnabled(False)
         self.model = DataTableModel(self)
-        self.ui.table.setModel(self.model)
+        
         self.setUpdatesEnabled(True)
+        self.proxyModel = QtCore.QSortFilterProxyModel(self)
+        self.proxyModel.setSourceModel(self.model)
+        self.proxyModel.setFilterFixedString("cat")
+        self.proxyModel.setFilterKeyColumn(1)
+        self.ui.table.setModel(self.proxyModel)
 
     @messagebox_on_error("Failed to add data")
     def add_data(self, data):

--- a/glue/viewers/table/qt/data_viewer.py
+++ b/glue/viewers/table/qt/data_viewer.py
@@ -8,7 +8,7 @@ from qtpy.QtCore import Qt
 from qtpy import QtCore, QtGui, QtWidgets
 from matplotlib.colors import ColorConverter
 
-from echo.qt import connect_combo_selection, connect_text, connect_checkable_button
+from echo.qt import autoconnect_callbacks_to_qt
 from glue.utils.qt import get_qapp
 from glue.config import viewer_tool
 from glue.core import BaseData, Data
@@ -290,9 +290,7 @@ class TableViewer(DataViewer):
         self.data = None
         self.model = None
 
-        self._connection1 = connect_combo_selection(self.state, 'filter_att', self.ui.combosel_filter_att)
-        self._connection2 = connect_text(self.state, 'filter', self.ui.valuetext_filter)
-        self._connection3 = connect_checkable_button(self.state, 'regex', self.ui.bool_regex)
+        self._connections = autoconnect_callbacks_to_qt(self.state, self.ui)
 
         self.state.add_callback('regex', self._on_filter_changed)
         self.state.add_callback('filter', self._on_filter_changed)

--- a/glue/viewers/table/qt/data_viewer.ui
+++ b/glue/viewers/table/qt/data_viewer.ui
@@ -15,6 +15,23 @@
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="filter_label">
+       <property name="text">
+        <string>Filter/Search</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="valuetext_filter"/>
+     </item>
+     <item>
+      <widget class="QComboBox" name="combosel_filter_att"/>
+     </item>
+    </layout>
+   </item>
+   <item row="1" column="0">
     <layout class="QVBoxLayout" name="verticalLayout">
      <item>
       <widget class="TableViewWithSelectionSignal" name="table">

--- a/glue/viewers/table/qt/data_viewer.ui
+++ b/glue/viewers/table/qt/data_viewer.ui
@@ -37,7 +37,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QLineEdit" name="valuetext_filter"/>
+      <widget class="QLineEdit" name="text_filter"/>
      </item>
      <item>
       <widget class="QLabel" name="filter_label_2">

--- a/glue/viewers/table/qt/data_viewer.ui
+++ b/glue/viewers/table/qt/data_viewer.ui
@@ -49,6 +49,13 @@
      <item>
       <widget class="QComboBox" name="combosel_filter_att"/>
      </item>
+     <item>
+      <widget class="QCheckBox" name="bool_regex">
+       <property name="text">
+        <string>Use regex</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
    <item row="1" column="0">

--- a/glue/viewers/table/qt/data_viewer.ui
+++ b/glue/viewers/table/qt/data_viewer.ui
@@ -17,14 +17,34 @@
    <item row="0" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>60</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
       <widget class="QLabel" name="filter_label">
        <property name="text">
-        <string>Filter/Search</string>
+        <string>Search:</string>
        </property>
       </widget>
      </item>
      <item>
       <widget class="QLineEdit" name="valuetext_filter"/>
+     </item>
+     <item>
+      <widget class="QLabel" name="filter_label_2">
+       <property name="text">
+        <string>in</string>
+       </property>
+      </widget>
      </item>
      <item>
       <widget class="QComboBox" name="combosel_filter_att"/>

--- a/glue/viewers/table/qt/tests/test_data_viewer.py
+++ b/glue/viewers/table/qt/tests/test_data_viewer.py
@@ -643,6 +643,8 @@ def test_table_widget_filter(tmpdir):
 
     # Test matching regular expressions
     widget.state.filter_att = d.components[3]
+    widget.state.regex = True
+
     widget.state.filter = '^[a-z]{1}o'
     np.testing.assert_equal(model.filter_mask, [False, True, False, False, True])
 
@@ -655,6 +657,16 @@ def test_table_widget_filter(tmpdir):
     colors = [None, '#aa0000']
 
     check_values_and_color(model, data, colors)
+
+    widget.state.regex = False
+    widget.state.filter = '^[a-z]{1}o'
+    np.testing.assert_equal(model.filter_mask, [False, False, False, False, False])
+
+    # Check that changing the filter disables the rowselect tool
+    widget.toolbar.actions['table:rowselect'].toggle()
+    process_events()
+    widget.state.filter_att = d.components[2]
+    assert widget.toolbar.active_tool is None
 
 
 def test_table_widget_session_filter(tmpdir):

--- a/glue/viewers/table/state.py
+++ b/glue/viewers/table/state.py
@@ -20,5 +20,25 @@ class TableViewerState(ViewerState):
         super(TableViewerState, self).__init__()
 
         self.filter_att_helper = ComponentIDComboHelper(self, 'filter_att', categorical=True, numeric=False)
+        self.add_callback('layers', self._layers_changed)
 
         self.update_from_dict(kwargs)
+
+    def _layers_changed(self, *args):
+
+        layers_data = self.layers_data
+
+        layers_data_cache = getattr(self, '_layers_data_cache', [])
+
+        if layers_data == layers_data_cache:
+            return
+
+        self.filter_att_helper.set_multiple_data(self.layers_data)
+
+        self._layers_data_cache = layers_data
+
+    def _update_priority(self, name):
+        if name == 'layers':
+            return 2
+        else:
+            return 1

--- a/glue/viewers/table/state.py
+++ b/glue/viewers/table/state.py
@@ -14,11 +14,11 @@ class TableViewerState(ViewerState):
 
     filter_att = SelectionCallbackProperty(docstring='The component/column to filter/search on', default_index=0)
     filter = CallbackProperty(docstring='The text string to filter/search on')
+    regex = CallbackProperty(docstring='Whether to apply regex to filter/search', default=False)
 
     def __init__(self, **kwargs):
 
         super(TableViewerState, self).__init__()
-
         self.filter_att_helper = ComponentIDComboHelper(self, 'filter_att', categorical=True, numeric=False)
         self.add_callback('layers', self._layers_changed)
 

--- a/glue/viewers/table/state.py
+++ b/glue/viewers/table/state.py
@@ -22,4 +22,3 @@ class TableViewerState(ViewerState):
         self.filter_att_helper = ComponentIDComboHelper(self, 'filter_att', categorical=True, numeric=False)
 
         self.update_from_dict(kwargs)
-

--- a/glue/viewers/table/state.py
+++ b/glue/viewers/table/state.py
@@ -12,14 +12,14 @@ class TableViewerState(ViewerState):
     A state class that includes all the attributes for a table viewer.
     """
 
-    filter_att = SelectionCallbackProperty(docstring='The component/column to filter/search on')
+    filter_att = SelectionCallbackProperty(docstring='The component/column to filter/search on', default_index=0)
     filter = CallbackProperty(docstring='The text string to filter/search on')
 
     def __init__(self, **kwargs):
 
         super(TableViewerState, self).__init__()
 
-        self.filter_att_helper = ComponentIDComboHelper(self, 'filter_att', none=True, categorical=True, numeric=False)
+        self.filter_att_helper = ComponentIDComboHelper(self, 'filter_att', categorical=True, numeric=False)
 
         self.update_from_dict(kwargs)
 

--- a/glue/viewers/table/state.py
+++ b/glue/viewers/table/state.py
@@ -1,0 +1,25 @@
+from echo import CallbackProperty, SelectionCallbackProperty
+from glue.core.data_combo_helper import ComponentIDComboHelper
+
+from glue.viewers.common.state import ViewerState
+
+
+__all__ = ['TableViewerState']
+
+
+class TableViewerState(ViewerState):
+    """
+    A state class that includes all the attributes for a table viewer.
+    """
+
+    filter_att = SelectionCallbackProperty(docstring='The component/column to filter/search on')
+    filter = CallbackProperty(docstring='The text string to filter/search on')
+
+    def __init__(self, **kwargs):
+
+        super(TableViewerState, self).__init__()
+
+        self.filter_att_helper = ComponentIDComboHelper(self, 'filter_att', none=True, categorical=True, numeric=False)
+
+        self.update_from_dict(kwargs)
+


### PR DESCRIPTION
# Add filter/search to the Table Viewer


![table_filter](https://user-images.githubusercontent.com/3639698/234683280-b4ca2b5d-0c14-48db-8d9b-fd36cc08d646.gif)

## Description

This PR adds a search/filter field and component selection widget to the Table Viewer. The displayed elements in the table are then filtered based on applying `re.search()` to the selected component. The primary motivation is to allow the user to use the GUI to find matching rows in a dataset and create a subset from those rows. I limit the user to searching on categorical components.

This necessitated adding a TableViewerState in order to keep track of the things going into the filter. 

I experimented with using `QSortFilterProxyModel` just for the filtering and although I was able to get a working implementation, I was then getting frequent segfaults that I was unable to diagnose. Since we are already doing sort within our custom `DataTableModel` it was easy enough to apply the filtering here as well. (I also that using `QSortFilterProxyModel` was rejected in b7a0f67500 for performance concerns, but performance seemed okay for the filtering component).

Still to do:

- [x] Save/restore tests are failing
- [x] Add tests specific to the filtering

Closes #2386 