### PR TITLE
Fix subset creation with unit flip

### DIFF
--- a/glue/core/tests/test_link_helpers.py
+++ b/glue/core/tests/test_link_helpers.py
@@ -14,6 +14,18 @@ from ..link_helpers import (LinkTwoWay, MultiLink,
                             LinkSameWithUnits)
 
 
+def setup_function(func):
+    func.ORIGINAL_UNIT_CONVERTER = settings.UNIT_CONVERTER
+
+
+def teardown_function(func):
+    settings.UNIT_CONVERTER = func.ORIGINAL_UNIT_CONVERTER
+
+
+def teardown_module():
+    unit_converter._members.pop('test-spectral1')
+
+
 R, D, L, B = (ComponentID('ra'), ComponentID('dec'),
               ComponentID('lon'), ComponentID('lat'))
 
@@ -158,7 +170,7 @@ def test_link_units_invalid():
         LinkSameWithUnits(data1.id['weight_kg'], data2.id['distance_m'])
 
 
-@unit_converter('test-spectral')
+@unit_converter('test-spectral1')
 class SpectralUnitConverter:
 
     def equivalent_units(self, data, cid, units):
@@ -179,7 +191,7 @@ def test_link_units_custom():
     with pytest.raises(u.UnitConversionError, match='not convertible'):
         LinkSameWithUnits(data1.id['wav_mm'], data2.id['freq_ghz'])
 
-    settings.UNIT_CONVERTER = 'test-spectral'
+    settings.UNIT_CONVERTER = 'test-spectral1'
 
     links = LinkSameWithUnits(data1.id['wav_mm'], data2.id['freq_ghz'])
     dc = DataCollection([data1, data2])

--- a/glue/viewers/profile/viewer.py
+++ b/glue/viewers/profile/viewer.py
@@ -42,9 +42,16 @@ class MatplotlibProfileMixin(object):
 
         # Apply inverse unit conversion, converting from display to native units
         converter = UnitConverter()
-        roi.min, roi.max = converter.to_native(self.state.reference_data,
-                                               self.state.x_att, np.array([roi.min, roi.max]),
-                                               self.state.x_display_unit)
+        cmin, cmax = converter.to_native(self.state.reference_data,
+                                         self.state.x_att, np.array([roi.min, roi.max]),
+                                         self.state.x_display_unit)
+
+        # Sometimes unit conversions can cause the min/max to be swapped
+        if cmin > cmax:
+            cmin, cmax = cmax, cmin
+
+        roi.min = cmin
+        roi.max = cmax
 
         subset_state = roi_to_subset_state(roi, x_att=self.state.x_att)
         self.apply_subset_state(subset_state, override_mode=override_mode)


### PR DESCRIPTION
Fix bug that caused subsets to not be created correctly in the profile viewer if unit conversion caused a flip in direction (e.g. wavelength -> frequency)
