### PR TITLE
Disallow broken qtconsole 5.4.2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     qtpy>=1.9
     ipython>=4.0
     ipykernel>=4.0,!=5.0.0,!=5.1.0
-    qtconsole>=4.3
+    qtconsole>=4.3,!=5.4.2
     dill>=0.2
     h5py>=2.10; python_version<'3.11'
     xlrd>=1.2


### PR DESCRIPTION
# Disallow qtconsole 5.4.2

## Description

qtconsole 5.4.2 does not work within glue, and this just prevents installing this broken version. 

Closes #2382 
