### PR TITLE
Make sure __getitem__ always returns a numpy array

### DIFF
--- a/glue/core/component.py
+++ b/glue/core/component.py
@@ -536,7 +536,7 @@ class DaskComponent(Component):
         return len(self._data.shape)
 
     def __getitem__(self, key):
-        return self._data[key].compute()
+        return np.array(self._data[key].compute())
 
     @property
     def numeric(self):


### PR DESCRIPTION
# Pull Request Template

## Description

In some circumstances, dask.compute() can still return a dask array (rather than the desired numpy array). I was able to trigger this with an external data loader library that presumably falls foul of [this bug](https://stackoverflow.com/questions/56944723/why-sometimes-do-i-have-to-call-compute-twice-on-dask-delayed-functions). Explicit to np.array fixes this for my use case and seems otherwise totally innocuous. 

I am not providing a new unit test because I'm not sure how to reliably reproduce the extra-lazy dask array outside of the specific data loading library I was using.

Fixes #2397 