### PR TITLE
Add center and move_to methods to RangeSubsetState

### DIFF
--- a/glue/core/subset.py
+++ b/glue/core/subset.py
@@ -808,6 +808,9 @@ class RangeSubsetState(SubsetState):
         result = (x >= self.lo) & (x <= self.hi)
         return result
 
+    def center(self):
+        return (self.hi - self.lo) * 0.5 + self.lo
+
     def copy(self):
         return RangeSubsetState(self.lo, self.hi, self.att)
 

--- a/glue/core/subset.py
+++ b/glue/core/subset.py
@@ -811,6 +811,11 @@ class RangeSubsetState(SubsetState):
     def center(self):
         return (self.hi - self.lo) * 0.5 + self.lo
 
+    def move_to(self, new_cen):
+        dx = new_cen - self.center()
+        self.lo = self.lo + dx
+        self.hi = self.hi + dx
+
     def copy(self):
         return RangeSubsetState(self.lo, self.hi, self.att)
 

--- a/glue/core/tests/test_subset.py
+++ b/glue/core/tests/test_subset.py
@@ -835,6 +835,11 @@ class TestCloneSubsetStates():
 
         assert_equal(data_clone.subsets[0].to_mask(), [1, 1, 0, 0])
 
+        # Also test moving it.
+        subset.subset_state.move_to(2)
+        assert_allclose((subset.subset_state.lo, subset.subset_state.hi), (1.85, 2.15))
+        assert_allclose(subset.subset_state.center(), 2)
+
     def test_and_subset_state(self):
 
         subset = self.data.new_subset()

--- a/glue/core/tests/test_subset.py
+++ b/glue/core/tests/test_subset.py
@@ -828,6 +828,7 @@ class TestCloneSubsetStates():
 
         subset = self.data.new_subset()
         subset.subset_state = RangeSubsetState(1.1, 1.4, self.data.id['c'])
+        assert_allclose(subset.subset_state.center(), 1.25)
         assert_equal(self.data.subsets[0].to_mask(), [1, 1, 0, 0])
 
         data_clone = clone(self.data)


### PR DESCRIPTION
Motivation: Jdaviz currently has to have special logic to calculate center for `RangeSubsetState`. But after #2391 , there is no reason for it not to be part of the unifed `obj.center()` API to get center.