### PR TITLE
Avoid over-aggressive link deletion on data removal

### DIFF
--- a/glue/core/link_manager.py
+++ b/glue/core/link_manager.py
@@ -160,8 +160,12 @@ class LinkManager(HubListener):
         for link in self._external_links:
             for cid in msg.data.components:
                 if cid in link and cid.parent is msg.data:
-                    remove.append(link)
-                    break
+                    needed_by_subset = [[cid in s.attributes and s.data != msg.data for
+                                         s in sg.subsets] for sg in
+                                            self.data_collection.subset_groups]
+                    if not np.any(needed_by_subset):
+                        remove.append(link)
+                        break
         for link in remove:
             self.remove_link(link)
 


### PR DESCRIPTION
This fixes the bug shown in https://github.com/spacetelescope/jdaviz/pull/2194#issuecomment-1553077073, although I suspect that a better fix may lie elsewhere, possibly in the subset code rather than the link code. Essentially, we were seeing that after removal of the original data from the data collection, subset layers that applied to other data were no longer appearing, because their attributes were still set to the components of the removed data, but the links between those components and the components of the remaining data had been removed. This adds a check to see if any subsets are still using the links before removing them.

As I said, I suspect that a better fix would be to update the attributes of the remaining subsets to the components of remaining data when the original data is removed, but this is the first thing I could get working to fix this. So, feel free to reject this if it doesn't seem like a good solution.