### PR TITLE
Fix filter logic when underlying data set is not visible

### DIFF
--- a/glue/core/__init__.py
+++ b/glue/core/__init__.py
@@ -11,6 +11,7 @@ from .session import Session  # noqa
 from .subset import Subset  # noqa
 from .subset_group import SubsetGroup  # noqa
 from .visual import VisualAttributes  # noqa
+from .regions import layer_to_subset # noqa
 
 # We import this last to avoid circular imports
 from .application_base import Application  # noqa

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -36,7 +36,7 @@ from glue.core.coordinate_helpers import axis_label
 # Note: leave all the following imports for component and component_id since
 # they are here for backward-compatibility (the code used to live in this
 # file)
-from glue.core.component import Component, CoordinateComponent, DerivedComponent
+from glue.core.component import Component, CoordinateComponent, DerivedComponent, ExtendedComponent
 from glue.core.component_id import ComponentID, ComponentIDDict, PixelComponentID
 
 try:
@@ -1429,6 +1429,8 @@ class Data(BaseCartesianData):
             return 'numerical'
         elif comp.categorical:
             return 'categorical'
+        elif comp.extended:
+            return 'extended'
         else:
             raise TypeError("Unknown data kind")
 
@@ -1545,7 +1547,7 @@ class Data(BaseCartesianData):
 
         # alert hub of the change
         if self.hub is not None:
-            msg = NumericalDataChangedMessage(self)
+            msg = NumericalDataChangedMessage(self, components_changed=list(mapping.keys()))
             self.hub.broadcast(msg)
 
         for subset in self.subsets:
@@ -2049,6 +2051,63 @@ class Data(BaseCartesianData):
         warnings.warn('Data.visible_components is deprecated', UserWarning)
         return [cid for cid, comp in self._components.items()
                 if not isinstance(comp, CoordinateComponent) and cid.parent is self]
+
+
+class RegionData(Data):
+    """
+    Data that describes a set of regions and (potentially) the properties of
+    those regions.
+
+    Components describing regions must be explicitly created as ExtendedComponents
+    and passed into this object at initialization time.
+    """
+
+    def __init__(self, label="", coords=None, **kwargs):
+        self._extended_component_ids = ComponentIDList()
+        self.ext_x = None
+        self.ext_y = None
+
+        # __init__ calls add_component which deals with ExtendedComponent logic
+        super().__init__(label=label, coords=coords, **kwargs)
+
+    def check_extended_components(self):
+        for compid, comp in self._components.items():
+            if isinstance(comp, ExtendedComponent):
+                self._extended_component_ids.append(compid)
+                self.ext_x = self.get_component(compid).parent_component_id_x
+                self.ext_y = self.get_component(compid).parent_component_id_y
+
+        num_ext = len(self._extended_component_ids)
+        if num_ext > 1:
+            raise Exception("RegionData has {0} extended_components, but should only have 1".format(num_ext))
+        elif num_ext < 1:
+            raise Exception("RegionData must be created with 1 extended_component")
+
+    @contract(component='component_like', label='cid_like')
+    def add_component(self, component, label):
+        """ Add a new component to this data set, allowing only one ExtendedComponent
+
+        Parameters
+        ----------
+        component : :class:`~glue.core.component.Component` or array-like
+            Object to add.
+        label : `str` or :class:`~glue.core.component_id.ComponentID`
+              The label. If this is a string, a new
+              :class:`glue.core.component_id.ComponentID`
+              with this label will be created and associated with the Component.
+
+        Raises
+        ------
+           `ValueError`, if the RegionData already has an extended component
+        """
+        if isinstance(component, ExtendedComponent):
+            if len(self._extended_component_ids) > 0:
+                raise ValueError("Cannot add a derived component as a first component")
+            else:
+                super().add_component(component, label)
+                self.check_extended_components()
+        else:
+            super().add_component(component, label)
 
 
 @contract(i=int, ndim=int)

--- a/glue/core/layer_artist.py
+++ b/glue/core/layer_artist.py
@@ -228,6 +228,12 @@ class LayerArtistBase(PropertySetMixin, metaclass=ABCMeta):
             self._changed = True
             self._state = state
 
+    def update_component_limits(self, components_changed):
+        """
+        Update component limits for this layer
+        """
+        pass
+
     def __str__(self):
         return "%s for %s" % (self.__class__.__name__, self.layer.label)
 

--- a/glue/core/message.py
+++ b/glue/core/message.py
@@ -182,7 +182,10 @@ class DataUpdateMessage(DataMessage):
 
 
 class NumericalDataChangedMessage(DataMessage):
-    pass
+
+    def __init__(self, sender, components_changed, tag=None):
+        super(NumericalDataChangedMessage, self).__init__(sender, tag=tag)
+        self.components_changed = components_changed
 
 
 class DataCollectionMessage(Message):

--- a/glue/core/regions.py
+++ b/glue/core/regions.py
@@ -1,0 +1,41 @@
+"""
+Functions to support data that defines regions
+"""
+import numpy as np
+
+from glue.core.roi import PolygonalROI
+from glue.core.data import RegionData
+
+from glue.config import layer_action
+from glue.core.subset import RoiSubsetState, MultiOrState
+
+
+def reg_to_roi(reg):
+    if reg.geom_type == "Polygon":
+        ext_coords = np.array(reg.exterior.coords.xy)
+        roi = PolygonalROI(vx=ext_coords[0], vy=ext_coords[1])  # Need to account for interior rings
+    return roi
+
+
+@layer_action(label='Convert regions to subset', single=True, subset=True)
+def layer_to_subset(layer, data_collection):
+    """
+    This should be limited to the case where subset.Data is RegionData
+    and/or return a warning when applied to some other kind of data.
+    """
+    if isinstance(layer.data, RegionData):
+
+        extended_comp = layer.data._extended_component_ids[0]
+        regions = layer[extended_comp]
+        list_of_rois = [reg_to_roi(region) for region in regions]
+
+        roisubstates = [RoiSubsetState(layer.data.ext_x,
+                                       layer.data.ext_y,
+                                       roi=roi
+                                       )
+                        for roi in list_of_rois]
+        if len(list_of_rois) > 1:
+            composite_substate = MultiOrState(roisubstates)
+        else:
+            composite_substate = roisubstates[0]
+        subset_group = data_collection.new_subset_group(subset_state=composite_substate)

--- a/glue/core/state.py
+++ b/glue/core/state.py
@@ -1197,7 +1197,7 @@ def _save_session(session, context):
 @loader(np.ndarray)
 def _load_numpy(rec, context):
     s = BytesIO(b64decode(rec['data']))
-    return np.load(s)
+    return np.load(s, allow_pickle=True)
 
 
 @saver(np.ndarray)

--- a/glue/core/tests/test_data_region.py
+++ b/glue/core/tests/test_data_region.py
@@ -1,0 +1,111 @@
+import pytest
+import numpy as np
+from shapely.geometry import MultiPolygon, Polygon, Point, LineString
+
+from glue.core.data import RegionData
+from glue.core.component import (Component, ExtendedComponent)
+from glue.core.component_id import ComponentID
+from glue.app.qt import GlueApplication
+from glue.core.state import GlueUnSerializer
+
+
+def set_up_extended_comp(shapely_array, cen_x_name, cen_y_name=None):
+    representative_points = [s.representative_point() for s in shapely_array]
+    cen_x_id = ComponentID(cen_x_name)
+    center_x = Component(np.array([s.x for s in representative_points]))
+
+    if cen_y_name is not None:
+        cen_y_id = ComponentID(cen_y_name)
+        center_y = Component(np.array([s.y for s in representative_points]))
+        extend_comp = ExtendedComponent(shapely_array, parent_component_ids=[cen_x_id, cen_y_id])
+    else:
+        cen_y_id = None
+        center_y = []
+        extend_comp = ExtendedComponent(shapely_array, parent_component_ids=[cen_x_id])
+    return (extend_comp, cen_x_id, cen_y_id, center_x, center_y)
+
+
+def set_up_region_data(shapely_array, cen_x_name, cen_y_name=None, **kwargs):
+    extend_comp, cen_x_id, cen_y_id, center_x, center_y = set_up_extended_comp(shapely_array, cen_x_name, cen_y_name)
+    region_data = RegionData(regions=extend_comp, **kwargs)
+    # This is one way to add these components is a way that we can easily check their IDs
+    region_data.add_component(center_x, cen_x_name)
+    if cen_y_name is not None:
+        region_data.add_component(center_y, cen_y_name)
+    return (region_data, cen_x_id, cen_y_id)
+
+
+class TestRegionData:
+
+    def setup_class(self):
+
+        poly_1 = Polygon([(20, 20), (60, 20), (60, 40), (20, 40)])
+        poly_2 = Polygon([(60, 50), (60, 70), (80, 70), (80, 50)])
+        poly_3 = Polygon([(10, 10), (15, 10), (15, 15), (10, 15)])
+        poly_4 = Polygon([(10, 20), (15, 20), (15, 30), (10, 30), (12, 25)])
+
+        poly_3_4 = MultiPolygon([poly_3, poly_4])
+
+        polys = np.array([poly_1, poly_2, poly_3_4])
+        self.polys_2d, self.x_id, self.y_id = set_up_region_data(polys, 'x', 'y')
+
+        circle_1 = Point(1.0, 0.0).buffer(1)
+        circle_2 = Point(2.0, 3.0).buffer(2)
+
+        circles = np.array([circle_1, circle_2])
+        self.circles, self.x_id_circles, self.y_id_circles = set_up_region_data(circles, 'xx', 'yy')
+
+        range_1 = LineString([[1.0, 0.0], [3.0, 0.0]])
+        range_2 = LineString([[5.0, 0.0], [9.0, 0.0]])
+
+        ranges = np.array([range_1, range_2])
+        self.ranges, self.x_id_ranges, self.y_id_ranges = set_up_region_data(ranges, 'x')
+
+    def test_basic_properties(self):
+        assert self.polys_2d.ext_x == self.x_id
+        assert self.polys_2d.ext_y == self.y_id
+        assert len(self.polys_2d._extended_component_ids) == 1
+        assert self.polys_2d.ndim == 1  # The data array is 1D, although the extended component describes 2D shapes
+
+        assert self.circles.ext_x == self.x_id_circles
+        assert self.circles.ext_y == self.y_id_circles
+        assert len(self.circles._extended_component_ids) == 1
+        assert self.circles.ndim == 1  # The data array is 1D, although the extended component describes 2D shapes
+
+        assert self.ranges.ext_x == self.x_id_ranges
+        assert self.ranges.ext_y is None
+        assert len(self.ranges._extended_component_ids) == 1
+        assert self.ranges.ndim == 1
+
+    def test_error_on_wrong_num_extended_components(self):
+
+        circle_1 = Point(3.0, 4.0).buffer(1)
+        circle_2 = Point(2.0, 6.0).buffer(2)
+
+        more_circles = np.array([circle_1, circle_2])
+
+        extend_comp, cen_x_id, cen_y_id, center_x, center_y = set_up_extended_comp(more_circles, 'x2', 'y2')
+        self.circles.add_component(center_x, 'x2')
+        self.circles.add_component(center_y, 'y2')
+        with pytest.raises(ValueError):
+            self.circles.add_component(extend_comp, 'new_extended')
+
+    def test_save_restore(self, tmpdir):
+
+        self.app = GlueApplication()
+        self.session = self.app.session
+        self.hub = self.session.hub
+        self.data_collection = self.session.data_collection
+
+        self.data_collection.append(self.polys_2d)
+        assert len(self.data_collection) == 1
+
+        filename = tmpdir.join("test_regiondata_save_restore_session.glu").strpath
+        self.session.application.save_session(filename)
+        with open(filename, "r") as f:
+            session = f.read()
+
+        state = GlueUnSerializer.loads(session)
+        ga = state.object("__main__")
+        dc = ga.session.data_collection
+        assert len(dc) == 1

--- a/glue/viewers/common/viewer.py
+++ b/glue/viewers/common/viewer.py
@@ -288,9 +288,19 @@ class Viewer(BaseViewer):
                 if isinstance(layer_artist.layer, Subset):
                     if layer_artist.layer.data is message.data:
                         layer_artist.update()
+                        try:
+                            components_changed = message.components_changed
+                            layer_artist.update_component_limits(components_changed)
+                        except AttributeError:
+                            pass
                 else:
                     if layer_artist.layer is message.data:
                         layer_artist.update()
+                        try:
+                            components_changed = message.components_changed
+                            layer_artist.update_component_limits(components_changed)
+                        except AttributeError:
+                            pass
 
     def _update_subset(self, message):
         if message.attribute == 'style':

--- a/glue/viewers/image/qt/data_viewer.py
+++ b/glue/viewers/image/qt/data_viewer.py
@@ -1,6 +1,6 @@
 from glue.viewers.matplotlib.qt.data_viewer import MatplotlibDataViewer
-from glue.viewers.scatter.qt.layer_style_editor import ScatterLayerStyleEditor
-from glue.viewers.scatter.layer_artist import ScatterLayerArtist
+from glue.viewers.scatter.qt.layer_style_editor import ScatterLayerStyleEditor, ScatterRegionLayerStyleEditor
+from glue.viewers.scatter.layer_artist import ScatterLayerArtist, ScatterRegionLayerArtist
 from glue.viewers.image.qt.layer_style_editor import ImageLayerStyleEditor
 from glue.viewers.image.qt.layer_style_editor_subset import ImageLayerSubsetStyleEditor
 from glue.viewers.image.layer_artist import ImageLayerArtist, ImageSubsetLayerArtist
@@ -26,7 +26,9 @@ class ImageViewer(MatplotlibImageMixin, MatplotlibDataViewer):
     _default_mouse_mode_cls = RoiClickAndDragMode
     _layer_style_widget_cls = {ImageLayerArtist: ImageLayerStyleEditor,
                                ImageSubsetLayerArtist: ImageLayerSubsetStyleEditor,
-                               ScatterLayerArtist: ScatterLayerStyleEditor}
+                               ScatterLayerArtist: ScatterLayerStyleEditor,
+                               ScatterRegionLayerArtist: ScatterRegionLayerStyleEditor,
+                               }
     _state_cls = ImageViewerState
     _options_cls = ImageOptionsWidget
 

--- a/glue/viewers/image/qt/tests/test_extended_component.py
+++ b/glue/viewers/image/qt/tests/test_extended_component.py
@@ -1,0 +1,168 @@
+# pylint: disable=I0011,W0613,W0201,W0212,E1101,E1103
+
+import os
+
+import numpy as np
+from shapely.geometry import MultiPolygon, Polygon
+
+
+from glue.core.data import RegionData, Data
+from glue.core.component import Component, ExtendedComponent
+from glue.core.component_id import ComponentID
+from glue.utils.qt import combo_as_string, process_events
+from glue.app.qt import GlueApplication
+from glue.core.fixed_resolution_buffer import ARRAY_CACHE, PIXEL_CACHE
+from glue.core.link_helpers import LinkSame
+
+from ..data_viewer import ImageViewer
+
+DATA = os.path.join(os.path.dirname(__file__), 'data')
+
+
+class TestRegionScatterViewer(object):
+
+    def setup_method(self, method):
+
+        poly_1 = Polygon([(20, 20), (60, 20), (60, 40), (20, 40)])
+        poly_2 = Polygon([(60, 50), (60, 70), (80, 70), (80, 50)])
+        poly_3 = Polygon([(10, 10), (15, 10), (15, 15), (10, 15)])
+        poly_4 = Polygon([(10, 20), (15, 20), (15, 30), (10, 30), (12, 25)])
+
+        polygons = MultiPolygon([poly_3, poly_4])
+
+        my_geoms = np.array([poly_1, poly_2, polygons])
+
+        representative_points = [s.representative_point() for s in my_geoms]
+
+        center_x_id = ComponentID('x')
+        center_y_id = ComponentID('y')
+
+        center_x = Component(np.array([s.x for s in representative_points]))
+        center_y = Component(np.array([s.y for s in representative_points]))
+
+        region_component = ExtendedComponent(my_geoms, parent_component_ids=[center_x_id, center_y_id])
+
+        cell_number = Component(np.array([1, 2, 3]))
+
+        self.region_data = RegionData(regions=region_component,
+                                      cell_number=cell_number)
+
+        # This is one way to add these components is a way that we can easily check their IDs
+        self.region_data.add_component(center_x, center_x_id)
+        self.region_data.add_component(center_y, center_y_id)
+
+        random_2d_array = np.random.randint(1, 20, size=(100, 100))
+        self.data_2d = Data(label='image_data', z=random_2d_array)
+        self.catalog = Data(label='catalog', c=[1, 3, 2], d=[4, 3, 3])
+
+        self.application = GlueApplication()
+
+        self.session = self.application.session
+
+        self.hub = self.session.hub
+
+        self.data_collection = self.session.data_collection
+        self.data_collection.append(self.region_data)
+        self.data_collection.append(self.data_2d)
+        self.data_collection.append(self.catalog)
+
+        self.viewer = self.application.new_data_viewer(ImageViewer)
+
+        self.data_collection.register_to_hub(self.hub)
+        self.viewer.register_to_hub(self.hub)
+
+        self.options_widget = self.viewer.options_widget()
+
+    def teardown_method(self, method):
+
+        # Properly close viewer and application
+        self.viewer.close()
+        self.viewer = None
+        self.application.close()
+        self.application = None
+
+        # Make sure cache is empty
+        if len(PIXEL_CACHE) > 0:
+            raise Exception("Pixel cache contains {0} elements".format(len(PIXEL_CACHE)))
+        if len(ARRAY_CACHE) > 0:
+            raise Exception("Array cache contains {0} elements".format(len(ARRAY_CACHE)))
+
+    def test_link_first_then_add(self):
+
+        # Check defaults when we add data
+
+        self.viewer.add_data(self.data_2d)
+        link1 = LinkSame(self.region_data.id['y'], self.data_2d.pixel_component_ids[0])
+        link2 = LinkSame(self.region_data.id['x'], self.data_2d.pixel_component_ids[1])
+
+        self.data_collection.add_link(link1)
+        self.data_collection.add_link(link2)
+        process_events()
+
+        assert len(self.viewer.state.layers) == 1
+
+        self.viewer.add_data(self.region_data)
+
+        assert len(self.viewer.state.layers) == 2
+        assert self.viewer.layers[0].enabled  # image
+        assert self.viewer.layers[1].enabled  # regions
+
+    def test_add_first_then_link(self):
+
+        # Check defaults when we add data
+
+        self.viewer.add_data(self.data_2d)
+
+        assert combo_as_string(self.options_widget.ui.combosel_x_att_world) == 'Coordinate components:Pixel Axis 0 [y]:Pixel Axis 1 [x]'
+        assert combo_as_string(self.options_widget.ui.combosel_y_att_world) == 'Coordinate components:Pixel Axis 0 [y]:Pixel Axis 1 [x]'
+
+        assert self.viewer.axes.get_xlabel() == 'Pixel Axis 1 [x]'
+        assert self.viewer.state.x_att_world is self.data_2d.id['Pixel Axis 1 [x]']
+        assert self.viewer.state.x_att is self.data_2d.pixel_component_ids[1]
+
+        assert self.viewer.axes.get_ylabel() == 'Pixel Axis 0 [y]'
+        assert self.viewer.state.y_att_world is self.data_2d.id['Pixel Axis 0 [y]']
+        assert self.viewer.state.y_att is self.data_2d.pixel_component_ids[0]
+
+        assert not self.viewer.state.x_log
+        assert not self.viewer.state.y_log
+
+        assert len(self.viewer.state.layers) == 1
+
+        self.viewer.add_data(self.region_data)
+
+        assert len(self.viewer.state.layers) == 2
+        assert self.viewer.layers[0].enabled  # image
+        assert not self.viewer.layers[1].enabled  # regions
+
+        process_events()
+
+        link1 = LinkSame(self.region_data.id['y'], self.data_2d.pixel_component_ids[0])
+        link2 = LinkSame(self.region_data.id['x'], self.data_2d.pixel_component_ids[1])
+
+        self.data_collection.add_link(link1)
+        self.data_collection.add_link(link2)
+        process_events()
+
+        assert len(self.viewer.state.layers) == 2
+        assert self.viewer.layers[0].enabled  # image
+        assert self.viewer.layers[1].enabled  # regions
+
+    def test_subset(self):
+        self.viewer.add_data(self.data_2d)
+
+        self.viewer.add_data(self.region_data)
+        link1 = LinkSame(self.region_data.id['y'], self.data_2d.pixel_component_ids[0])
+        link2 = LinkSame(self.region_data.id['x'], self.data_2d.pixel_component_ids[1])
+
+        self.data_collection.add_link(link1)
+        self.data_collection.add_link(link2)
+
+        self.data_collection.new_subset_group(subset_state=self.region_data.id['x'] > 20)
+
+        process_events()
+
+        assert self.viewer.layers[0].enabled  # image
+        assert self.viewer.layers[1].enabled  # scatter
+        assert self.viewer.layers[2].enabled  # image subset
+        assert self.viewer.layers[3].enabled  # scatter subset

--- a/glue/viewers/image/viewer.py
+++ b/glue/viewers/image/viewer.py
@@ -5,8 +5,11 @@ from astropy.wcs import WCS
 from glue.core.subset import roi_to_subset_state
 from glue.core.coordinates import Coordinates, LegacyCoordinates
 from glue.core.coordinate_helpers import dependent_axes
+from glue.core.data import RegionData
 
 from glue.viewers.scatter.layer_artist import ScatterLayerArtist
+from glue.viewers.scatter.layer_artist import ScatterRegionLayerArtist
+
 from glue.viewers.image.layer_artist import ImageLayerArtist, ImageSubsetLayerArtist
 from glue.viewers.image.compat import update_image_viewer_state
 
@@ -172,15 +175,24 @@ class MatplotlibImageMixin(object):
             raise Exception("Can only add a scatter plot overlay once an image is present")
         return ScatterLayerArtist(axes, state, layer=layer, layer_state=None)
 
+    def _region_artist(self, axes, state, layer=None, layer_state=None):
+        if len(self._layer_artist_container) == 0:
+            raise Exception("Can only add a region plot overlay once an image is present")
+        return ScatterRegionLayerArtist(axes, state, layer=layer, layer_state=None)
+
     def get_data_layer_artist(self, layer=None, layer_state=None):
-        if layer.ndim == 1:
+        if isinstance(layer, RegionData):
+            cls = self._region_artist
+        elif layer.ndim == 1:
             cls = self._scatter_artist
         else:
             cls = ImageLayerArtist
         return self.get_layer_artist(cls, layer=layer, layer_state=layer_state)
 
     def get_subset_layer_artist(self, layer=None, layer_state=None):
-        if layer.ndim == 1:
+        if isinstance(layer.data, RegionData):
+            cls = self._region_artist
+        elif layer.ndim == 1:
             cls = self._scatter_artist
         else:
             cls = ImageSubsetLayerArtist

--- a/glue/viewers/scatter/layer_artist.py
+++ b/glue/viewers/scatter/layer_artist.py
@@ -10,10 +10,13 @@ from astropy.visualization import (ImageNormalize, LinearStretch, SqrtStretch,
                                    AsinhStretch, LogStretch)
 
 from glue.utils import defer_draw, ensure_numerical, datetime64_to_mpl
-from glue.viewers.scatter.state import ScatterLayerState
+from glue.viewers.scatter.state import ScatterLayerState, ScatterRegionLayerState
 from glue.viewers.scatter.python_export import python_export_scatter_layer
+from glue.viewers.scatter.plot_polygons import UpdateableRegionCollection, get_geometry_type, _sanitize_geoms, _PolygonPatch, transform_shapely
 from glue.viewers.matplotlib.layer_artist import MatplotlibLayerArtist
 from glue.core.exceptions import IncompatibleAttribute
+from glue.core import BaseData
+from glue.core.link_manager import is_equivalent_cid
 
 from matplotlib.lines import Line2D
 
@@ -150,6 +153,7 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
         self._set_axes(axes)
         self.errorbar_index = 2
         self.vector_index = 3
+        self.region_index = 6
 
         # NOTE: Matplotlib can't deal with NaN values in errorbar correctly, so
         # we need to prefilter values - the following variable is used to store
@@ -165,6 +169,7 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
         self.vector_artist = None
         self.line_collection = ColoredLineCollection([], [])
         self.axes.add_collection(self.line_collection)
+
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", message='All-NaN slice encountered')
             self.density_artist = GenericDensityArtist(self.axes, color='white',
@@ -596,3 +601,186 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
         res = self.state.cmap_mode == 'Fixed' and self.state.size_mode == 'Fixed'
         return res and (not hasattr(self._viewer_state, 'plot_mode') or
                         not self._viewer_state.plot_mode == 'polar')
+
+
+class ScatterRegionLayerArtist(MatplotlibLayerArtist):
+
+    _layer_state_cls = ScatterRegionLayerState
+    #  _python_exporter = python_export_scatter_layer # Need to do this at some point
+
+    def __init__(self, axes, viewer_state, layer_state=None, layer=None):
+
+        super().__init__(axes, viewer_state,
+                            layer_state=layer_state, layer=layer)
+
+        if isinstance(layer, BaseData):
+            data = layer
+        else:
+            data = layer.data
+
+        self.region_att = data._extended_component_ids[0]  # RegionData is only allowed to have a single Extended Component
+
+        self.region_comp = data.get_component(self.region_att)
+
+        self.region_x_att = self.region_comp.parent_component_id_x
+        self.region_y_att = self.region_comp.parent_component_id_y
+        self.region_xy_ids = [self.region_x_att, self.region_y_att]
+
+        self._viewer_state.add_global_callback(self._update_scatter_region)
+        self.state.add_global_callback(self._update_scatter_region)
+        self._set_axes(axes)
+
+    def _set_axes(self, axes):
+        self.axes = axes
+        self.region_collection = UpdateableRegionCollection([])
+        self.axes.add_collection(self.region_collection)
+        #  This is a little unnecessary, but keeps code more parallel
+        self.mpl_artists = [self.region_collection]
+
+    def check_if_region_cid(self, data, cid):
+        """
+        Check if a ComponentID is in the set of components that regions are over.
+        """
+        if isinstance(data, BaseData):
+            data = data
+        else:  # Subset
+            data = data.data
+        if is_equivalent_cid(data, cid, self.region_x_att) or is_equivalent_cid(data, cid, self.region_y_att):
+            return True
+        else:
+            return False
+
+    @defer_draw
+    def _update_data(self):
+
+        # Layer artist has been cleared already
+        if len(self.mpl_artists) == 0:
+            return
+
+        try:
+            # These must be special attributes that are linked to a region_att
+            if ((not self.check_if_region_cid(self.layer, self._viewer_state.x_att)) and
+                     (not self.check_if_region_cid(self.layer, self._viewer_state.x_att_world))):
+                raise IncompatibleAttribute
+            x = ensure_numerical(self.layer[self._viewer_state.x_att].ravel())
+        except (IncompatibleAttribute, IndexError):
+            # The following includes a call to self.clear()
+            self.disable_invalid_attributes(self._viewer_state.x_att)
+            return
+        else:
+            self.enable()
+
+        try:
+            # These must be special attributes that are linked to a region_att
+            if ((not self.check_if_region_cid(self.layer, self._viewer_state.y_att)) and
+                      (not self.check_if_region_cid(self.layer, self._viewer_state.y_att_world))):
+                raise IncompatibleAttribute
+            y = ensure_numerical(self.layer[self._viewer_state.y_att].ravel())
+        except (IncompatibleAttribute, IndexError):
+            # The following includes a call to self.clear()
+            self.disable_invalid_attributes(self._viewer_state.y_att)
+            return
+        else:
+            self.enable()
+
+        regions = self.layer[self.region_att]
+        # If we are using world coordinates (i.e. the regions are specified in world coordinates)
+        # we need to transform the geometries of the regions into pixel coordinates for display
+        # We should cache this, since it is a waste to recompute it for certain _update_data calls
+        if self._viewer_state._display_world:
+            world2pix = self._viewer_state.reference_data.coords.world_to_pixel_values
+            regions = np.array([transform_shapely(world2pix, g) for g in regions])
+        # decompose GeometryCollections
+        geoms, multiindex = _sanitize_geoms(regions, prefix="Geom")
+        self.multiindex_geometry = multiindex
+
+        geom_types = get_geometry_type(geoms)
+        poly_idx = np.asarray((geom_types == "Polygon") | (geom_types == "MultiPolygon"))
+        polys = geoms[poly_idx]
+
+        # decompose MultiPolygons
+        geoms, multiindex = _sanitize_geoms(polys, prefix="Multi")
+        self.region_collection.patches = [_PolygonPatch(poly) for poly in geoms]
+
+        self.geoms = geoms
+        self.multiindex = multiindex
+
+    @defer_draw
+    def _update_visual_attributes(self, changed, force=False):
+
+        if not self.enabled:
+            return
+
+        # TEMPORARY: Matplotlib has a bug that causes set_alpha to
+        # change the colors back: https://github.com/matplotlib/matplotlib/issues/8953
+        if 'alpha' in changed:
+            force = True
+
+        if self.state.cmap_mode == 'Fixed':
+            if force or 'color' in changed or 'cmap_mode' in changed or 'fill' in changed:
+                self.region_collection.set_array(None)
+                if self.state.fill:
+                    self.region_collection.set_facecolors(self.state.color)
+                    self.region_collection.set_edgecolors('none')
+                else:
+                    self.region_collection.set_facecolors('none')
+                    self.region_collection.set_edgecolors(self.state.color)
+        elif force or any(prop in changed for prop in CMAP_PROPERTIES) or 'fill' in changed:
+            self.region_collection.set_edgecolors(None)
+            self.region_collection.set_facecolors(None)
+            c = ensure_numerical(self.layer[self.state.cmap_att].ravel())
+            c_values = np.take(c, self.multiindex_geometry, axis=0)  # Decompose Geoms
+            c_values = np.take(c_values, self.multiindex, axis=0)  # Decompose MultiPolys
+            set_mpl_artist_cmap(self.region_collection, c_values, self.state)
+            if self.state.fill:
+                self.region_collection.set_edgecolors('none')
+            else:
+                self.region_collection.set_facecolors('none')
+
+        for artist in [self.region_collection]:
+
+            if artist is None:
+                continue
+
+            if force or 'alpha' in changed:
+                artist.set_alpha(self.state.alpha)
+
+            if force or 'zorder' in changed:
+                artist.set_zorder(self.state.zorder)
+
+            if force or 'visible' in changed:
+                artist.set_visible(self.state.visible)
+
+        self.redraw()
+
+    @defer_draw
+    def _update_scatter_region(self, force=False, **kwargs):
+
+        if (self._viewer_state.x_att is None or
+            self._viewer_state.y_att is None or
+                self.state.layer is None):
+            return
+
+        # NOTE: we need to evaluate this even if force=True so that the cache
+        # of updated properties is up to date after this method has been called.
+        changed = self.pop_changed_properties()
+
+        change_from_limits = len(changed & LIMIT_PROPERTIES) > 0
+        if force or change_from_limits or len(changed & DATA_PROPERTIES) > 0:
+            self._update_data()
+            force = True
+
+        if force or len(changed & VISUAL_PROPERTIES) > 0:
+            self._update_visual_attributes(changed, force=force)
+
+    @defer_draw
+    def update(self):
+        self._update_scatter_region(force=True)
+        self.redraw()
+
+    @defer_draw
+    def update_component_limits(self, components_changed):
+        for limit_helper in [self.state.cmap_lim_helper]:
+            if limit_helper.attribute in components_changed:
+                limit_helper.update_values(force=True)
+        self.redraw()

--- a/glue/viewers/scatter/plot_polygons.py
+++ b/glue/viewers/scatter/plot_polygons.py
@@ -1,0 +1,157 @@
+"""
+Some lightly edited code from geopandas.plotting.py for efficiently
+plotting multiple polygons in matplotlib.
+"""
+# Copyright (c) 2013-2022, GeoPandas developers.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of GeoPandas nor the names of its contributors may
+#   be used to endorse or promote products derived from this software without
+#   specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import numpy as np
+import shapely
+from matplotlib.collections import PatchCollection
+from shapely.errors import GeometryTypeError
+
+
+class UpdateableRegionCollection(PatchCollection):
+    """
+    Allow paths in PatchCollection to be modified after creation.
+    """
+
+    def __init__(self, patches, *args, **kwargs):
+        self.patches = patches
+        PatchCollection.__init__(self, patches, *args, **kwargs)
+
+    def get_paths(self):
+        self.set_paths(self.patches)
+        return self._paths
+
+
+def _sanitize_geoms(geoms, prefix="Multi"):
+    """
+    Returns Series like geoms and index, except that any Multi geometries
+    are split into their components and indices are repeated for all component
+    in the same Multi geometry. At the same time, empty or missing geometries are
+    filtered out.  Maintains 1:1 matching of geometry to value.
+    Prefix specifies type of geometry to be flatten. 'Multi' for MultiPoint and similar,
+    "Geom" for GeometryCollection.
+    Returns
+    -------
+    components : list of geometry
+    component_index : index array
+        indices are repeated for all components in the same Multi geometry
+    """
+    # TODO(shapely) look into simplifying this with
+    # shapely.get_parts(geoms, return_index=True) from shapely 2.0
+    components, component_index = [], []
+
+    geom_types = get_geometry_type(geoms).astype("str")
+
+    if (
+        not np.char.startswith(geom_types, prefix).any()
+        # and not geoms.is_empty.any()
+        # and not geoms.isna().any()
+    ):
+        return geoms, np.arange(len(geoms))
+
+    for ix, (geom, geom_type) in enumerate(zip(geoms, geom_types)):
+        if geom is not None and geom_type.startswith(prefix):
+            for poly in geom.geoms:
+                components.append(poly)
+                component_index.append(ix)
+        elif geom is None:
+            continue
+        else:
+            components.append(geom)
+            component_index.append(ix)
+
+    return components, np.array(component_index)
+
+
+def get_geometry_type(data):
+    _names = {
+        "MISSING": None,
+        "NAG": None,
+        "POINT": "Point",
+        "LINESTRING": "LineString",
+        "LINEARRING": "LinearRing",
+        "POLYGON": "Polygon",
+        "MULTIPOINT": "MultiPoint",
+        "MULTILINESTRING": "MultiLineString",
+        "MULTIPOLYGON": "MultiPolygon",
+        "GEOMETRYCOLLECTION": "GeometryCollection",
+    }
+
+    type_mapping = {p.value: _names[p.name] for p in shapely.GeometryType}
+    geometry_type_ids = list(type_mapping.keys())
+    geometry_type_values = np.array(list(type_mapping.values()), dtype=object)
+    res = shapely.get_type_id(data)
+    return geometry_type_values[np.searchsorted(geometry_type_ids, res)]
+
+
+def transform_shapely(func, geom):
+    """
+    A simplified/modified version of shapely.ops.transform where the func
+    call signature is tuned for the coordinate transform functions
+    coming from glue.
+    """
+    if geom.is_empty:
+        return geom
+    if geom.geom_type in ("Point", "LineString", "LinearRing", "Polygon"):
+        if geom.geom_type in ("Point", "LineString", "LinearRing"):
+            return type(geom)(func(geom.coords))
+        elif geom.geom_type == "Polygon":
+            shell = type(geom.exterior)(func(geom.exterior.coords))
+            holes = list(
+                type(ring)(func(ring.coords))
+                for ring in geom.interiors
+            )
+            return type(geom)(shell, holes)
+
+    elif geom.geom_type.startswith("Multi") or geom.geom_type == "GeometryCollection":
+        return type(geom)([transform_shapely(func, part) for part in geom.geoms])
+    else:
+        raise GeometryTypeError(f"Type {geom.geom_type!r} not recognized")
+
+
+def _PolygonPatch(polygon, **kwargs):
+    """Constructs a matplotlib patch from a Polygon geometry
+    The `kwargs` are those supported by the matplotlib.patches.PathPatch class
+    constructor. Returns an instance of matplotlib.patches.PathPatch.
+    Example (using Shapely Point and a matplotlib axes)::
+        b = shapely.geometry.Point(0, 0).buffer(1.0)
+        patch = _PolygonPatch(b, fc='blue', ec='blue', alpha=0.5)
+        ax.add_patch(patch)
+    GeoPandas originally relied on the descartes package by Sean Gillies
+    (BSD license, https://pypi.org/project/descartes) for PolygonPatch, but
+    this dependency was removed in favor of the below matplotlib code.
+    """
+    from matplotlib.patches import PathPatch
+    from matplotlib.path import Path
+
+    path = Path.make_compound_path(
+        Path(np.asarray(polygon.exterior.coords)[:, :2]),
+        *[Path(np.asarray(ring.coords)[:, :2]) for ring in polygon.interiors],
+    )
+    return PathPatch(path, **kwargs)

--- a/glue/viewers/scatter/qt/data_viewer.py
+++ b/glue/viewers/scatter/qt/data_viewer.py
@@ -15,7 +15,9 @@ __all__ = ['ScatterViewer']
 class ScatterViewer(MatplotlibScatterMixin, MatplotlibDataViewer):
 
     LABEL = '2D Scatter'
-    _layer_style_widget_cls = ScatterLayerStyleEditor
+    _layer_style_widget_cls = {
+        ScatterLayerArtist: ScatterLayerStyleEditor,
+    }
     _state_cls = ScatterViewerState
     _options_cls = ScatterOptionsWidget
     _data_artist_cls = ScatterLayerArtist

--- a/glue/viewers/scatter/qt/layer_style_editor.py
+++ b/glue/viewers/scatter/qt/layer_style_editor.py
@@ -226,3 +226,45 @@ class ScatterLayerStyleEditor(QtWidgets.QWidget):
             self.ui.combodata_cmap.show()
             self.ui.label_colormap.show()
             self.ui.color_color.hide()
+
+
+class ScatterRegionLayerStyleEditor(QtWidgets.QWidget):
+
+    def __init__(self, layer, parent=None):
+
+        super().__init__(parent=parent)
+
+        self.ui = load_ui('region_layer_style_editor.ui', self,
+                          directory=os.path.dirname(__file__))
+
+        connect_kwargs = {'alpha': dict(value_range=(0, 1))}
+        self._connections = autoconnect_callbacks_to_qt(layer.state, self.ui, connect_kwargs)
+
+        self.layer_state = layer.state
+
+        self.layer_state.add_callback('cmap_mode', self._update_cmap_mode)
+
+        self._update_cmap_mode()
+
+    def _update_cmap_mode(self, cmap_mode=None):
+
+        if self.layer_state.cmap_mode == 'Fixed':
+            self.ui.label_cmap_attribute.hide()
+            self.ui.combosel_cmap_att.hide()
+            self.ui.label_cmap_limits.hide()
+            self.ui.valuetext_cmap_vmin.hide()
+            self.ui.valuetext_cmap_vmax.hide()
+            self.ui.button_flip_cmap.hide()
+            self.ui.combodata_cmap.hide()
+            self.ui.label_colormap.hide()
+            self.ui.color_color.show()
+        else:
+            self.ui.label_cmap_attribute.show()
+            self.ui.combosel_cmap_att.show()
+            self.ui.label_cmap_limits.show()
+            self.ui.valuetext_cmap_vmin.show()
+            self.ui.valuetext_cmap_vmax.show()
+            self.ui.button_flip_cmap.show()
+            self.ui.combodata_cmap.show()
+            self.ui.label_colormap.show()
+            self.ui.color_color.hide()

--- a/glue/viewers/scatter/qt/region_layer_style_editor.ui
+++ b/glue/viewers/scatter/qt/region_layer_style_editor.ui
@@ -1,0 +1,231 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>329</width>
+    <height>295</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="1">
+    <widget class="QLabel" name="label_10">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>color</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="2">
+    <widget class="QComboBox" name="combosel_cmap_mode">
+     <property name="maximumSize">
+      <size>
+       <width>80</width>
+       <height>16777215</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="2">
+    <widget class="QLabel" name="label_cmap_attribute">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>attribute</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QLabel" name="label_cmap_limits">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>limits</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="2">
+    <widget class="QLineEdit" name="valuetext_cmap_vmin"/>
+   </item>
+   <item row="2" column="3">
+    <widget class="QToolButton" name="button_flip_cmap">
+     <property name="styleSheet">
+      <string notr="true">padding: 0px</string>
+     </property>
+     <property name="text">
+      <string>⇄</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="4">
+    <widget class="QLineEdit" name="valuetext_cmap_vmax"/>
+   </item>
+   <item row="3" column="0" colspan="2">
+    <widget class="QLabel" name="label_colormap">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>colormap</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0" colspan="2">
+    <widget class="QLabel" name="label_7">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>opacity</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="2">
+    <widget class="QSlider" name="value_alpha">
+     <property name="maximum">
+      <number>100</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <widget class="QLabel" name="label_fill">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>fill</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="2">
+    <widget class="QCheckBox" name="bool_fill">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>85</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="6" column="1" colspan="4">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>256</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="1" column="2" colspan="2">
+    <widget class="QComboBox" name="combosel_cmap_att">
+     <property name="sizeAdjustPolicy">
+      <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="2" colspan="2">
+    <widget class="QColormapCombo" name="combodata_cmap">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="sizeAdjustPolicy">
+      <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="3" colspan="2">
+    <widget class="QColorBox" name="color_color">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QColormapCombo</class>
+   <extends>QComboBox</extends>
+   <header>glue.utils.qt.colors</header>
+  </customwidget>
+  <customwidget>
+   <class>QColorBox</class>
+   <extends>QLabel</extends>
+   <header>glue.utils.qt.colors</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/glue/viewers/scatter/state.py
+++ b/glue/viewers/scatter/state.py
@@ -16,7 +16,7 @@ from glue.core.exceptions import IncompatibleAttribute
 
 from matplotlib.projections import get_projection_names
 
-__all__ = ['ScatterViewerState', 'ScatterLayerState']
+__all__ = ['ScatterViewerState', 'ScatterLayerState', 'ScatterRegionLayerState']
 
 
 class ScatterViewerState(MatplotlibDataViewerState):
@@ -498,3 +498,75 @@ class ScatterLayerState(MatplotlibLayerState):
                 rec['values']['markers_visible'] = False
                 rec['values']['line_visible'] = True
         return super(ScatterLayerState, cls).__setgluestate__(rec, context)
+
+
+class ScatterRegionLayerState(MatplotlibLayerState):
+    """
+    A state class that includes all the attributes for layers in a scatter region layer.
+    """
+    # Color
+
+    cmap_mode = DDSCProperty(docstring="Whether to use color to encode an attribute")
+    cmap_att = DDSCProperty(docstring="The attribute to use for the color")
+    cmap_vmin = DDCProperty(docstring="The lower level for the colormap")
+    cmap_vmax = DDCProperty(docstring="The upper level for the colormap")
+    cmap = DDCProperty(docstring="The colormap to use (when in colormap mode)")
+
+    fill = DDCProperty(True, docstring="Whether to fill the regions")
+
+    def __init__(self, viewer_state=None, layer=None, **kwargs):
+
+        super().__init__(viewer_state=viewer_state, layer=layer)
+        self.limits_cache = {}
+
+        self.cmap_lim_helper = StateAttributeLimitsHelper(self, attribute='cmap_att',
+                                                          lower='cmap_vmin', upper='cmap_vmax',
+                                                          limits_cache=self.limits_cache)
+        self.cmap_att_helper = ComponentIDComboHelper(self, 'cmap_att',
+                                                      numeric=True, datetime=False,
+                                                      categorical=True)
+
+        ScatterRegionLayerState.cmap_mode.set_choices(self, ['Fixed', 'Linear'])
+
+        if self.viewer_state is not None:
+            self.viewer_state.add_callback('x_att', self._on_xy_change, priority=10000)
+            self.viewer_state.add_callback('y_att', self._on_xy_change, priority=10000)
+            self._on_xy_change()
+
+        self.add_callback('layer', self._on_layer_change)
+        if layer is not None:
+            self._on_layer_change()
+
+        self.cmap = colormaps.members[0][1]
+
+        self.update_from_dict(kwargs)
+
+    def _on_layer_change(self, layer=None):
+
+        print("Got an _on_layer_change message...")
+        with delay_callback(self, 'cmap_vmin', 'cmap_vmax'):
+
+            if self.layer is None:
+                self.cmap_att_helper.set_multiple_data([])
+            else:
+                self.cmap_att_helper.set_multiple_data([self.layer])
+
+    def _on_xy_change(self, *event):
+
+        if self.viewer_state.x_att is None or self.viewer_state.y_att is None:
+            return
+
+        if isinstance(self.layer, BaseData):
+            layer = self.layer
+        else:
+            layer = self.layer.data
+
+    def flip_cmap(self):
+        """
+        Flip the cmap_vmin/cmap_vmax limits.
+        """
+        self.cmap_lim_helper.flip_limits()
+
+    @property
+    def cmap_name(self):
+        return colormaps.name_from_cmap(self.cmap)

--- a/glue/viewers/table/qt/data_viewer.py
+++ b/glue/viewers/table/qt/data_viewer.py
@@ -187,16 +187,15 @@ class DataTableModel(QtCore.QAbstractTableModel):
                     return
 
         # If not then we need to show only the rows with visible subsets
-        if self.filter_mask is None:
-            visible = np.zeros(self.order.shape, dtype=bool)
-        else:
-            visible = self.filter_mask[self.order]
+        visible = np.zeros(self.order.shape, dtype=bool)
         for layer_artist in self._table_viewer.layers:
             if layer_artist.visible:
                 mask = layer_artist.layer.to_mask()[self.order]
                 if DASK_INSTALLED and isinstance(mask, da.Array):
                     mask = mask.compute()
                 visible |= mask
+        if self.filter_mask is not None:
+            visible &= self.filter_mask[self.order]
 
         self.order_visible = self.order[visible]
 

--- a/glue/viewers/table/qt/data_viewer.py
+++ b/glue/viewers/table/qt/data_viewer.py
@@ -187,7 +187,10 @@ class DataTableModel(QtCore.QAbstractTableModel):
                     return
 
         # If not then we need to show only the rows with visible subsets
-        visible = np.zeros(self.order.shape, dtype=bool)
+        if self.filter_mask is None:
+            visible = np.zeros(self.order.shape, dtype=bool)
+        else:
+            visible = self.filter_mask[self.order]
         for layer_artist in self._table_viewer.layers:
             if layer_artist.visible:
                 mask = layer_artist.layer.to_mask()[self.order]

--- a/glue/viewers/table/qt/tests/test_data_viewer.py
+++ b/glue/viewers/table/qt/tests/test_data_viewer.py
@@ -683,6 +683,17 @@ def test_table_widget_filter(tmpdir):
 
     check_values_and_color(model, data, colors)
 
+    widget.state.filter_att = d.components[2]
+    widget.state.filter = 'cat'
+
+    data = {'a': [3],
+            'b': ['cat'],
+            'c': ['fluffball']}
+
+    colors = ['#aa0000']
+
+    check_values_and_color(model, data, colors)
+
 
 def test_table_widget_session_filter(tmpdir):
 

--- a/glue/viewers/table/qt/tests/test_data_viewer.py
+++ b/glue/viewers/table/qt/tests/test_data_viewer.py
@@ -6,7 +6,7 @@ from qtpy import QtCore, QtGui
 from qtpy.QtCore import Qt
 
 from glue.utils.qt import get_qapp, process_events
-from glue.core import Data, DataCollection
+from glue.core import Data, DataCollection, BaseData
 from glue.utils.qt import qt_to_mpl_color
 from glue.app.qt import GlueApplication
 
@@ -667,6 +667,21 @@ def test_table_widget_filter(tmpdir):
     process_events()
     widget.state.filter_att = d.components[2]
     assert widget.toolbar.active_tool is None
+
+    # Check that disabling the full dataset means we only see the subset
+    # This is a regression test since filtering originally broke this.
+    widget.state.filter = ''
+    for layer_artist in widget.layers:
+        if layer_artist.visible and isinstance(layer_artist.layer, BaseData):
+            layer_artist.visible = False
+
+    data = {'a': [3, 4, 5],
+            'b': ['cat', 'dog', 'fish'],
+            'c': ['fluffball', 'spot', 'moby']}
+
+    colors = ['#aa0000', '#aa0000', '#aa0000']
+
+    check_values_and_color(model, data, colors)
 
 
 def test_table_widget_session_filter(tmpdir):

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ install_requires =
     openpyxl>=3.0
     mpl-scatter-density>=0.7
     pvextractor>=0.2
+    shapely>=2.0
     importlib_resources>=1.3; python_version<'3.9'
     importlib_metadata>=3.6; python_version<'3.10'
 


### PR DESCRIPTION
# Fix Filtering and Underlying Data Not Visible

## Description

PR #2392 introduced a bug wherein making the underlying table dataset not visible did not remove it from the table model and display. This PR adds tests for this behavior and fixes the problem. 

A second PR to be posted shortly will fix the separate problem that under Qt6 you cannot re-enable a not-visible layer artist using the UI checkbox.
