### PR TITLE
Fix Qt6 bug that prevented layers from being re-enabled

### DIFF
--- a/glue/core/qt/layer_artist_model.py
+++ b/glue/core/qt/layer_artist_model.py
@@ -76,16 +76,19 @@ class LayerArtistModel(PythonListModel):
 
         return result
 
+
     def setData(self, index, value, role):
         if not index.isValid():
             return False
         if role == Qt.EditRole:
             self.change_label(index.row(), str(value))
         if role == Qt.CheckStateRole:
-            vis = value == Qt.Checked
+            if isinstance(value, int):
+                vis = value == Qt.Checked.value  # https://bugreports.qt.io/browse/QTBUG-104688
+            else:
+                vis = value == Qt.Checked
             self.artists[index.row()].visible = vis
             self.artists[index.row()].redraw()
-
         self.dataChanged.emit(index, index)
         return True
 

--- a/glue/core/qt/tests/test_layer_artist_model.py
+++ b/glue/core/qt/tests/test_layer_artist_model.py
@@ -194,13 +194,34 @@ def test_check_syncs_to_visible():
 
     m0.visible = True
     assert m0.visible
-    assert model.data(model.index(0), Qt.CheckStateRole) == Qt.Checked
+    assert model.data(model.index(0), Qt.CheckStateRole) == Qt.CheckState.Checked
     m0.visible = False
     assert not m0.visible
-    assert model.data(model.index(0), Qt.CheckStateRole) == Qt.Unchecked
+    assert model.data(model.index(0), Qt.CheckStateRole) == Qt.CheckState.Unchecked
 
-    model.setData(model.index(0), Qt.Checked, Qt.CheckStateRole)
+    model.setData(model.index(0), Qt.CheckState.Checked, Qt.CheckStateRole)
     assert m0.visible
+
+
+def test_artist_check_uncheck_works():
+    """
+    Because of https://bugreports.qt.io/browse/QTBUG-104688, under Qt6
+    the checkbox in the UI actually sends a bare integer (0 for unchecked,
+    2 for checked) so we have to check this against Qt.CheckState.Checked.value
+    in setData. This is a regression test for this behavior.
+    """
+    mgrs = [LayerArtist(Data(label='A'))]
+    mgrs[0].artists = [MagicMock()]
+
+    model = LayerArtistModel(mgrs)
+    mgrs[0].visible = True
+    assert model.data(model.index(0), Qt.CheckStateRole) == Qt.CheckState.Checked
+
+    model.setData(model.index(0), 0, Qt.CheckStateRole)
+    assert model.data(model.index(0), Qt.CheckStateRole) == Qt.CheckState.Unchecked
+
+    model.setData(model.index(0), 2, Qt.CheckStateRole)
+    assert model.data(model.index(0), Qt.CheckStateRole) == Qt.CheckState.Checked
 
 
 def test_data():


### PR DESCRIPTION
## Description

In Qt6, check boxes emit integers instead of the proper enum (https://bugreports.qt.io/browse/QTBUG-104688). Current logic for enabling/disabling layer artists checks the value emitted against the Qt.CheckState enum, which means that the user cannot make a layer artist they have turned not-visible visible again. 

This PR fixes this behavior in the layer artist view by checking for the type of the value emitted by the checkbox and adds a test for it. I have not exhaustively checked that this problem does not occur with other checkboxes elsewhere in the GUI with Qt 6. 
