### PR TITLE
Fix filter logic so that table viewer can hide main data layer

### DIFF
--- a/glue/viewers/table/qt/data_viewer.py
+++ b/glue/viewers/table/qt/data_viewer.py
@@ -187,16 +187,15 @@ class DataTableModel(QtCore.QAbstractTableModel):
                     return
 
         # If not then we need to show only the rows with visible subsets
-        if self.filter_mask is None:
-            visible = np.zeros(self.order.shape, dtype=bool)
-        else:
-            visible = self.filter_mask[self.order]
+        visible = np.zeros(self.order.shape, dtype=bool)
         for layer_artist in self._table_viewer.layers:
             if layer_artist.visible:
                 mask = layer_artist.layer.to_mask()[self.order]
                 if DASK_INSTALLED and isinstance(mask, da.Array):
                     mask = mask.compute()
                 visible |= mask
+        if self.filter_mask is not None:
+            visible &= self.filter_mask[self.order]
 
         self.order_visible = self.order[visible]
 

--- a/glue/viewers/table/qt/tests/test_data_viewer.py
+++ b/glue/viewers/table/qt/tests/test_data_viewer.py
@@ -683,6 +683,17 @@ def test_table_widget_filter(tmpdir):
 
     check_values_and_color(model, data, colors)
 
+    widget.state.filter_att = d.components[2]
+    widget.state.filter = 'cat'
+
+    data = {'a': [3],
+            'b': ['cat'],
+            'c': ['fluffball']}
+
+    colors = ['#aa0000']
+
+    check_values_and_color(model, data, colors)
+
 
 def test_table_widget_session_filter(tmpdir):
 

--- a/glue/viewers/table/qt/tests/test_data_viewer.py
+++ b/glue/viewers/table/qt/tests/test_data_viewer.py
@@ -6,7 +6,7 @@ from qtpy import QtCore, QtGui
 from qtpy.QtCore import Qt
 
 from glue.utils.qt import get_qapp, process_events
-from glue.core import Data, DataCollection
+from glue.core import Data, DataCollection, BaseData
 from glue.utils.qt import qt_to_mpl_color
 from glue.app.qt import GlueApplication
 
@@ -667,6 +667,21 @@ def test_table_widget_filter(tmpdir):
     process_events()
     widget.state.filter_att = d.components[2]
     assert widget.toolbar.active_tool is None
+
+    # Check that disabling the full dataset means we only see the subset
+    # This is a regression test since filtering originally broke this.
+    widget.state.filter = ''
+    for layer_artist in widget.layers:
+        if layer_artist.visible and isinstance(layer_artist.layer, BaseData):
+            layer_artist.visible = False
+
+    data = {'a': [3, 4, 5],
+            'b': ['cat', 'dog', 'fish'],
+            'c': ['fluffball', 'spot', 'moby']}
+
+    colors = ['#aa0000', '#aa0000', '#aa0000']
+
+    check_values_and_color(model, data, colors)
 
 
 def test_table_widget_session_filter(tmpdir):


### PR DESCRIPTION
## Description

PR https://github.com/glue-viz/glue/pull/2392 introduced a bug wherein making the underlying table dataset not visible did not remove it from the table model and display. This PR adds tests for this behavior and fixes the problem.