### PR TITLE
Ensure lazy dask arrays become numpy arrays in calculate_histogram

### DIFF
--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -1981,7 +1981,7 @@ class Data(BaseCartesianData):
         # For now, compute dask arrays at this point. In future we could delegate
         # the histogram calculation to dask. The extra call to
         # np.asarray is to coerce dask arrays read from
-        # disk with lazy loaders to definitely be numpy arrays 
+        # disk with lazy loaders to definitely be numpy arrays
         if DASK_INSTALLED:
             if isinstance(x, da.Array):
                 x = np.asarray(x.compute())

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -1979,14 +1979,16 @@ class Data(BaseCartesianData):
             w = w[keep]
 
         # For now, compute dask arrays at this point. In future we could delegate
-        # the histogram calculation to dask.
+        # the histogram calculation to dask. The extra call to
+        # np.asarray is to coerce dask arrays read from
+        # disk with lazy loaders to definitely be numpy arrays 
         if DASK_INSTALLED:
             if isinstance(x, da.Array):
-                x = x.compute()
+                x = np.asarray(x.compute())
             if ndim > 1 and isinstance(y, da.Array):
-                y = y.compute()
+                y = np.asarray(y.compute())
             if isinstance(w, da.Array):
-                w = w.compute()
+                w = np.asarray(w.compute())
 
         if len(x) == 0:
             return np.zeros(bins)


### PR DESCRIPTION
# Pull Request Template

## Description

Similar to #2399, dask arrays read from disk with particularly lazy loaders may return dask arrays even after calling compute. This applies the same fix in calculate_histogram, which I missed in #2399 of calling np.asarray() to make sure we always get a numpy array when we want one.