### PR TITLE
Dark mode for Qt application

### DIFF
--- a/glue/app/qt/application.py
+++ b/glue/app/qt/application.py
@@ -570,7 +570,7 @@ class GlueApplication(Application, QtWidgets.QMainWindow):
         # Update the background color of the data canvas on each tab
         for i in range(self.tab_count):
             tab = self.tab(i)
-            tab.setBackground(palette.color(QPalette.Window))
+            tab.setBackground(palette.color(QPalette.AlternateBase))
 
         if settings.APP_THEME == 'System default':
             # Try to identify whether we think the system theme is light or dark
@@ -584,7 +584,7 @@ class GlueApplication(Application, QtWidgets.QMainWindow):
             terminal = self._terminal.widget()
             terminal_colors = dict(
                 text_color='white' if dark else 'black',
-                bg_color='black' if dark else 'white',
+                bg_color='#282828' if dark else 'white',
                 in_prompt_color='deepskyblue' if dark else 'navy',
                 out_prompt_color='crimson' if dark else 'darkred'
             )

--- a/glue/app/qt/mdi_area.py
+++ b/glue/app/qt/mdi_area.py
@@ -24,7 +24,7 @@ class GlueMdiArea(QtWidgets.QMdiArea):
         self._application = weakref.ref(application)
         self.setAcceptDrops(True)
         self.setAttribute(Qt.WA_DeleteOnClose)
-        self.setBackground(QtGui.QBrush(QtGui.QColor(250, 250, 250)))
+        self.setBackground(QtGui.QBrush(application.app.palette().color(QtGui.QPalette.AlternateBase)))
         self.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)
         self.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
 

--- a/glue/app/qt/preferences.py
+++ b/glue/app/qt/preferences.py
@@ -182,7 +182,7 @@ class PreferencesDialog(QtWidgets.QDialog):
         app = self._app()
 
         if app is not None:
-            app._hub.broadcast(SettingsChangeMessage(self, ('FOREGROUND_COLOR', 'BACKGROUND_COLOR', 'FONT_SIZE', 'APP_THEME'))) 
+            app._hub.broadcast(SettingsChangeMessage(self, ('FOREGROUND_COLOR', 'BACKGROUND_COLOR', 'FONT_SIZE', 'APP_THEME')))
             if self.data_apply:  # If requested, trigger data to update color
                 app.set_data_color(settings.DATA_COLOR, settings.DATA_ALPHA)
 

--- a/glue/app/qt/preferences.py
+++ b/glue/app/qt/preferences.py
@@ -62,10 +62,10 @@ class AutolinkPreferencesPane(QtWidgets.QWidget):
 
 class PreferencesDialog(QtWidgets.QDialog):
 
+    app_theme = CurrentComboTextProperty('ui.combo_app_theme')
     theme = CurrentComboTextProperty('ui.combo_theme')
     background = ColorProperty('ui.color_background')
     foreground = ColorProperty('ui.color_foreground')
-    dark_mode = ButtonProperty('ui.checkbox_dark_mode')
     data_color = ColorProperty('ui.color_default_data')
     data_alpha = ValueProperty('ui.slider_alpha', value_range=(0, 1))
     data_apply = ButtonProperty('ui.checkbox_apply')
@@ -85,6 +85,7 @@ class PreferencesDialog(QtWidgets.QDialog):
         self.ui.ok.clicked.connect(self.accept)
 
         self.ui.combo_theme.currentIndexChanged.connect(self._update_colors_from_theme)
+        self.ui.combo_app_theme.currentIndexChanged.connect(self._update_app_theme)
 
         self.ui.button_reset_dialogs.clicked.connect(self._reset_dialogs)
 
@@ -101,10 +102,9 @@ class PreferencesDialog(QtWidgets.QDialog):
         self.data_color = settings.DATA_COLOR
         self.data_alpha = settings.DATA_ALPHA
         self.font_size = settings.FONT_SIZE
-        self.dark_mode = settings.DARK_MODE
+        self.app_theme = settings.APP_THEME
 
         self._update_theme_from_colors()
-        self.ui.checkbox_dark_mode.toggled.connect(self._toggle_dark_mode)
 
         self._autolink_pane = AutolinkPreferencesPane()
         self.ui.tab_widget.addTab(self._autolink_pane, 'Autolinking')
@@ -141,10 +141,10 @@ class PreferencesDialog(QtWidgets.QDialog):
         elif self.theme != 'Custom':
             raise ValueError("Unknown theme: {0}".format(self.theme))
 
-    def _toggle_dark_mode(self, *args):
-        if self.dark_mode and self.theme == 'Black on White':
+    def _update_app_theme(self, *args):
+        if self.app_theme == 'Dark' and self.theme == 'Black on White':
             self.theme = 'White on Black'
-        elif not self.dark_mode and self.theme == 'White on Black':
+        elif self.app_theme == 'Light' and self.theme == 'White on Black':
             self.theme = 'Black on White'
         self._update_colors_from_theme()
 
@@ -164,7 +164,7 @@ class PreferencesDialog(QtWidgets.QDialog):
         settings.DATA_COLOR = self.data_color
         settings.DATA_ALPHA = self.data_alpha
         settings.FONT_SIZE = self.font_size
-        settings.DARK_MODE = self.dark_mode
+        settings.APP_THEME = self.app_theme
 
         self._autolink_pane.finalize()
 
@@ -182,7 +182,7 @@ class PreferencesDialog(QtWidgets.QDialog):
         app = self._app()
 
         if app is not None:
-            app._hub.broadcast(SettingsChangeMessage(self, ('FOREGROUND_COLOR', 'BACKGROUND_COLOR', 'FONT_SIZE')))
+            app._hub.broadcast(SettingsChangeMessage(self, ('FOREGROUND_COLOR', 'BACKGROUND_COLOR', 'FONT_SIZE', 'APP_THEME'))) 
             if self.data_apply:  # If requested, trigger data to update color
                 app.set_data_color(settings.DATA_COLOR, settings.DATA_ALPHA)
 

--- a/glue/app/qt/preferences.py
+++ b/glue/app/qt/preferences.py
@@ -65,6 +65,7 @@ class PreferencesDialog(QtWidgets.QDialog):
     theme = CurrentComboTextProperty('ui.combo_theme')
     background = ColorProperty('ui.color_background')
     foreground = ColorProperty('ui.color_foreground')
+    dark_mode = ButtonProperty('ui.checkbox_dark_mode')
     data_color = ColorProperty('ui.color_default_data')
     data_alpha = ValueProperty('ui.slider_alpha', value_range=(0, 1))
     data_apply = ButtonProperty('ui.checkbox_apply')
@@ -100,8 +101,10 @@ class PreferencesDialog(QtWidgets.QDialog):
         self.data_color = settings.DATA_COLOR
         self.data_alpha = settings.DATA_ALPHA
         self.font_size = settings.FONT_SIZE
+        self.dark_mode = settings.DARK_MODE
 
         self._update_theme_from_colors()
+        self.ui.checkbox_dark_mode.toggled.connect(self._toggle_dark_mode)
 
         self._autolink_pane = AutolinkPreferencesPane()
         self.ui.tab_widget.addTab(self._autolink_pane, 'Autolinking')
@@ -138,6 +141,13 @@ class PreferencesDialog(QtWidgets.QDialog):
         elif self.theme != 'Custom':
             raise ValueError("Unknown theme: {0}".format(self.theme))
 
+    def _toggle_dark_mode(self, *args):
+        if self.dark_mode and self.theme == 'Black on White':
+            self.theme = 'White on Black'
+        elif not self.dark_mode and self.theme == 'White on Black':
+            self.theme = 'Black on White'
+        self._update_colors_from_theme()
+
     def _reset_dialogs(self, *args):
         from glue.config import settings
         for key, _, _ in settings:
@@ -154,6 +164,7 @@ class PreferencesDialog(QtWidgets.QDialog):
         settings.DATA_COLOR = self.data_color
         settings.DATA_ALPHA = self.data_alpha
         settings.FONT_SIZE = self.font_size
+        settings.DARK_MODE = self.dark_mode
 
         self._autolink_pane.finalize()
 

--- a/glue/app/qt/preferences.ui
+++ b/glue/app/qt/preferences.ui
@@ -71,14 +71,153 @@
        <string>User interface</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_2">
-       <item row="8" column="0">
+       <item row="1" column="1">
+        <widget class="QComboBox" name="combo_theme">
+         <property name="sizeAdjustPolicy">
+          <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+         </property>
+         <item>
+          <property name="text">
+           <string>Black on White</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>White on Black</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Custom</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="6" column="0">
+        <widget class="QLabel" name="label_4">
+         <property name="text">
+          <string>Default data color:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="1">
+        <widget class="QColorBox" name="color_default_data">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="10" column="0">
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="12" column="0">
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="2" column="0" colspan="2">
+        <widget class="Line" name="line">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="label_3">
+         <property name="text">
+          <string>Foreground color:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label_5">
+         <property name="text">
+          <string>Theme for viewers:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0" colspan="2">
+        <widget class="Line" name="line_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="0">
         <widget class="QLabel" name="label_7">
          <property name="text">
           <string>Global Font Size</string>
          </property>
         </widget>
        </item>
-       <item row="10" column="0" colspan="2">
+       <item row="9" column="1">
+        <widget class="QDoubleSpinBox" name="spinner_font_size">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Font size for most widgets (Default: 8.0)</string>
+         </property>
+         <property name="decimals">
+          <number>1</number>
+         </property>
+         <property name="minimum">
+          <double>8.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>56.000000000000000</double>
+         </property>
+         <property name="value">
+          <double>8.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="0">
+        <widget class="QLabel" name="label_6">
+         <property name="text">
+          <string>Apply to existing datasets:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="1">
+        <widget class="QSlider" name="slider_alpha">
+         <property name="maximum">
+          <number>100</number>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="0">
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>Default data transparency:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="0" colspan="2">
         <layout class="QHBoxLayout" name="horizontalLayout_2">
          <item>
           <spacer name="horizontalSpacer_2">
@@ -115,85 +254,7 @@
          </item>
         </layout>
        </item>
-       <item row="4" column="0" colspan="2">
-        <widget class="Line" name="line_2">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="0">
-        <widget class="QLabel" name="label_4">
-         <property name="text">
-          <string>Default data color:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="11" column="0">
-        <spacer name="verticalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="3" column="1">
-        <widget class="QColorBox" name="color_foreground">
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="1">
-        <widget class="QColorBox" name="color_default_data">
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="0">
-        <widget class="QLabel" name="label_6">
-         <property name="text">
-          <string>Apply to existing datasets:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="9" column="0">
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="3" column="0">
-        <widget class="QLabel" name="label_3">
-         <property name="text">
-          <string>Foreground color:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="1">
-        <widget class="QSlider" name="slider_alpha">
-         <property name="maximum">
-          <number>100</number>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="1">
+       <item row="8" column="1">
         <widget class="QCheckBox" name="checkbox_apply">
          <property name="text">
           <string/>
@@ -203,85 +264,31 @@
          </property>
         </widget>
        </item>
-       <item row="6" column="0">
-        <widget class="QLabel" name="label">
-         <property name="text">
-          <string>Default data transparency:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <widget class="QComboBox" name="combo_theme">
-         <property name="sizeAdjustPolicy">
-          <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
-         </property>
-         <item>
-          <property name="text">
-           <string>Black on White</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>White on Black</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Custom</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item row="1" column="0" colspan="2">
-        <widget class="Line" name="line">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="0">
-        <widget class="QLabel" name="label_2">
-         <property name="text">
-          <string>Background color:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="1">
+       <item row="3" column="1">
         <widget class="QColorBox" name="color_background">
          <property name="text">
           <string/>
          </property>
         </widget>
        </item>
-       <item row="0" column="0">
-        <widget class="QLabel" name="label_5">
+       <item row="3" column="0">
+        <widget class="QLabel" name="label_2">
          <property name="text">
-          <string>Theme for viewers:</string>
+          <string>Background color:</string>
          </property>
         </widget>
        </item>
-       <item row="8" column="1">
-        <widget class="QDoubleSpinBox" name="spinner_font_size">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
+       <item row="4" column="1">
+        <widget class="QColorBox" name="color_foreground">
+         <property name="text">
+          <string/>
          </property>
-         <property name="toolTip">
-          <string>Font size for most widgets (Default: 8.0)</string>
-         </property>
-         <property name="decimals">
-          <number>1</number>
-         </property>
-         <property name="minimum">
-          <double>8.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>56.000000000000000</double>
-         </property>
-         <property name="value">
-          <double>8.000000000000000</double>
+        </widget>
+       </item>
+       <item row="0" column="0">
+        <widget class="QCheckBox" name="checkbox_dark_mode">
+         <property name="text">
+          <string>Dark mode</string>
          </property>
         </widget>
        </item>
@@ -303,6 +310,7 @@
       <zorder>verticalSpacer_2</zorder>
       <zorder>label_7</zorder>
       <zorder>spinner_font_size</zorder>
+      <zorder>checkbox_dark_mode</zorder>
      </widget>
     </widget>
    </item>

--- a/glue/app/qt/preferences.ui
+++ b/glue/app/qt/preferences.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>462</width>
-    <height>375</height>
+    <height>377</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -71,103 +71,6 @@
        <string>User interface</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_2">
-       <item row="1" column="1">
-        <widget class="QComboBox" name="combo_theme">
-         <property name="sizeAdjustPolicy">
-          <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
-         </property>
-         <item>
-          <property name="text">
-           <string>Black on White</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>White on Black</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Custom</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item row="6" column="0">
-        <widget class="QLabel" name="label_4">
-         <property name="text">
-          <string>Default data color:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="1">
-        <widget class="QColorBox" name="color_default_data">
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
-       <item row="10" column="0">
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="12" column="0">
-        <spacer name="verticalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="2" column="0" colspan="2">
-        <widget class="Line" name="line">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="0">
-        <widget class="QLabel" name="label_3">
-         <property name="text">
-          <string>Foreground color:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="label_5">
-         <property name="text">
-          <string>Theme for viewers:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="0" colspan="2">
-        <widget class="Line" name="line_2">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="9" column="0">
-        <widget class="QLabel" name="label_7">
-         <property name="text">
-          <string>Global Font Size</string>
-         </property>
-        </widget>
-       </item>
        <item row="9" column="1">
         <widget class="QDoubleSpinBox" name="spinner_font_size">
          <property name="sizePolicy">
@@ -193,10 +96,67 @@
          </property>
         </widget>
        </item>
-       <item row="8" column="0">
-        <widget class="QLabel" name="label_6">
+       <item row="10" column="0">
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="3" column="1">
+        <widget class="QColorBox" name="color_background">
          <property name="text">
-          <string>Apply to existing datasets:</string>
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label_5">
+         <property name="text">
+          <string>Theme for viewers:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="0">
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>Default data transparency:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="1">
+        <widget class="QCheckBox" name="checkbox_apply">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="12" column="0">
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="2" column="0" colspan="2">
+        <widget class="Line" name="line">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
          </property>
         </widget>
        </item>
@@ -210,10 +170,31 @@
          </property>
         </widget>
        </item>
-       <item row="7" column="0">
-        <widget class="QLabel" name="label">
+       <item row="4" column="0">
+        <widget class="QLabel" name="label_3">
          <property name="text">
-          <string>Default data transparency:</string>
+          <string>Foreground color:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="0">
+        <widget class="QLabel" name="label_7">
+         <property name="text">
+          <string>Global Font Size</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="label_2">
+         <property name="text">
+          <string>Background color:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="0">
+        <widget class="QLabel" name="label_4">
+         <property name="text">
+          <string>Default data color:</string>
          </property>
         </widget>
        </item>
@@ -254,30 +235,6 @@
          </item>
         </layout>
        </item>
-       <item row="8" column="1">
-        <widget class="QCheckBox" name="checkbox_apply">
-         <property name="text">
-          <string/>
-         </property>
-         <property name="checked">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="1">
-        <widget class="QColorBox" name="color_background">
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="0">
-        <widget class="QLabel" name="label_2">
-         <property name="text">
-          <string>Background color:</string>
-         </property>
-        </widget>
-       </item>
        <item row="4" column="1">
         <widget class="QColorBox" name="color_foreground">
          <property name="text">
@@ -285,10 +242,72 @@
          </property>
         </widget>
        </item>
-       <item row="0" column="0">
-        <widget class="QCheckBox" name="checkbox_dark_mode">
+       <item row="5" column="0" colspan="2">
+        <widget class="Line" name="line_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QComboBox" name="combo_theme">
+         <property name="sizeAdjustPolicy">
+          <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+         </property>
+         <item>
+          <property name="text">
+           <string>Black on White</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>White on Black</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Custom</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="6" column="1">
+        <widget class="QColorBox" name="color_default_data">
          <property name="text">
-          <string>Dark mode</string>
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="0">
+        <widget class="QLabel" name="label_6">
+         <property name="text">
+          <string>Apply to existing datasets:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QComboBox" name="combo_app_theme">
+         <item>
+          <property name="text">
+           <string>Light</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Dark</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>System default</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_8">
+         <property name="text">
+          <string>Application theme:</string>
          </property>
         </widget>
        </item>
@@ -310,7 +329,8 @@
       <zorder>verticalSpacer_2</zorder>
       <zorder>label_7</zorder>
       <zorder>spinner_font_size</zorder>
-      <zorder>checkbox_dark_mode</zorder>
+      <zorder>combo_app_theme</zorder>
+      <zorder>label_8</zorder>
      </widget>
     </widget>
    </item>

--- a/glue/app/qt/preferences.ui
+++ b/glue/app/qt/preferences.ui
@@ -289,17 +289,17 @@
         <widget class="QComboBox" name="combo_app_theme">
          <item>
           <property name="text">
+           <string>System default</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
            <string>Light</string>
           </property>
          </item>
          <item>
           <property name="text">
            <string>Dark</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>System default</string>
           </property>
          </item>
         </widget>

--- a/glue/app/qt/tests/test_preferences.py
+++ b/glue/app/qt/tests/test_preferences.py
@@ -36,6 +36,7 @@ class TestPreferences():
             settings.DATA_COLOR = (1, 0.5, 0.25)
             settings.DATA_ALPHA = 0.3
             settings.FONT_SIZE = 8.0
+            settings.APP_THEME = 'System default'
 
             dialog = PreferencesDialog(self.app)
             dialog.show()
@@ -49,6 +50,7 @@ class TestPreferences():
             assert rgb(settings.DATA_COLOR) == (1, 0.5, 0.25)
             assert settings.DATA_ALPHA == 0.3
             assert settings.FONT_SIZE == 8.0
+            assert settings.APP_THEME == 'System default'
 
     def test_theme_autodetect(self):
 
@@ -61,6 +63,7 @@ class TestPreferences():
             settings.DATA_COLOR = '0.75'
             settings.DATA_ALPHA = 0.8
             settings.FONT_SIZE = 8.0
+            settings.APP_THEME = 'System default'
 
             dialog = PreferencesDialog(self.app)
             dialog.show()
@@ -72,13 +75,14 @@ class TestPreferences():
             settings.DATA_COLOR = '0.35'
             settings.DATA_ALPHA = 0.8
             settings.FONT_SIZE = 8.0
+            settings.APP_THEME = 'System default'
 
             dialog = PreferencesDialog(self.app)
             dialog.show()
             assert dialog.theme == 'Black on White'
             dialog.accept()
 
-    def test_themes(self):
+    def test_viewer_themes(self):
 
         # Check that themes work
 
@@ -89,6 +93,7 @@ class TestPreferences():
             settings.DATA_COLOR = (1, 0.5, 0.25)
             settings.DATA_ALPHA = 0.3
             settings.FONT_SIZE = 8.0
+            settings.APP_THEME = 'System default'
 
             dialog = PreferencesDialog(self.app)
             dialog.show()
@@ -99,7 +104,8 @@ class TestPreferences():
             assert rgb(settings.BACKGROUND_COLOR) == (0, 0, 0)
             assert rgb(settings.DATA_COLOR) == (0.75, 0.75, 0.75)
             assert settings.DATA_ALPHA == 0.8
-            settings.FONT_SIZE = 8.0
+            assert settings.FONT_SIZE == 8.0
+            assert settings.APP_THEME == 'System default'
 
             dialog = PreferencesDialog(self.app)
             dialog.show()
@@ -110,7 +116,72 @@ class TestPreferences():
             assert rgb(settings.BACKGROUND_COLOR) == (1, 1, 1)
             assert rgb(settings.DATA_COLOR) == (0.35, 0.35, 0.35)
             assert settings.DATA_ALPHA == 0.8
+            assert settings.FONT_SIZE == 8.0
+            assert settings.APP_THEME == 'System default'
+
+    def test_application_themes(self):
+
+        # Check that application themes work
+
+        with patch('glue.config.settings') as settings:
+
+            settings.FOREGROUND_COLOR = 'red'
+            settings.BACKGROUND_COLOR = (0, 0.5, 1)
+            settings.DATA_COLOR = (1, 0.5, 0.25)
+            settings.DATA_ALPHA = 0.3
             settings.FONT_SIZE = 8.0
+            settings.APP_THEME = 'System default'
+
+            dialog = PreferencesDialog(self.app)
+            dialog.show()
+            dialog.app_theme = 'Light'
+            dialog.accept()
+
+            assert rgb(settings.FOREGROUND_COLOR) == (1, 0, 0)
+            assert rgb(settings.BACKGROUND_COLOR) == (0, 0.5, 1)
+            assert rgb(settings.DATA_COLOR) == (1, 0.5, 0.25)
+            assert settings.DATA_ALPHA == 0.3
+            assert settings.FONT_SIZE == 8.0
+            assert settings.APP_THEME == 'Light'
+
+            dialog = PreferencesDialog(self.app)
+            dialog.show()
+            dialog.app_theme = 'Dark'
+            assert dialog.theme == 'White on Black'
+            dialog.accept()
+
+            assert rgb(settings.FOREGROUND_COLOR) == (1, 1, 1)
+            assert rgb(settings.BACKGROUND_COLOR) == (0, 0, 0)
+            assert rgb(settings.DATA_COLOR) == (0.75, 0.75, 0.75)
+            assert settings.DATA_ALPHA == 0.8
+            assert settings.FONT_SIZE == 8.0
+            assert settings.APP_THEME == 'Dark'
+
+            dialog = PreferencesDialog(self.app)
+            dialog.show()
+            dialog.app_theme = 'Light'
+            assert dialog.theme == 'Black on White'
+            dialog.accept()
+
+            assert rgb(settings.FOREGROUND_COLOR) == (0, 0, 0)
+            assert rgb(settings.BACKGROUND_COLOR) == (1, 1, 1)
+            assert rgb(settings.DATA_COLOR) == (0.35, 0.35, 0.35)
+            assert settings.DATA_ALPHA == 0.8
+            assert settings.FONT_SIZE == 8.0
+            assert settings.APP_THEME == 'Light'
+
+            dialog = PreferencesDialog(self.app)
+            dialog.show()
+            dialog.app_theme = 'System default'
+            assert dialog.theme == 'Black on White'
+            dialog.accept()
+
+            assert rgb(settings.FOREGROUND_COLOR) == (0, 0, 0)
+            assert rgb(settings.BACKGROUND_COLOR) == (1, 1, 1)
+            assert rgb(settings.DATA_COLOR) == (0.35, 0.35, 0.35)
+            assert settings.DATA_ALPHA == 0.8
+            assert settings.FONT_SIZE == 8.0
+            assert settings.APP_THEME == 'System default'
 
     def test_custom_changes(self):
 
@@ -123,6 +194,7 @@ class TestPreferences():
             settings.DATA_COLOR = (1, 0.5, 0.25)
             settings.DATA_ALPHA = 0.3
             settings.FONT_SIZE = 8.0
+            settings.APP_THEME = 'System default'
 
             dialog = PreferencesDialog(self.app)
             dialog.show()
@@ -133,7 +205,8 @@ class TestPreferences():
             assert rgb(settings.BACKGROUND_COLOR) == (0, 0.5, 1)
             assert rgb(settings.DATA_COLOR) == (1, 0.5, 0.25)
             assert settings.DATA_ALPHA == 0.3
-            settings.FONT_SIZE = 8.0
+            assert settings.FONT_SIZE == 8.0
+            assert settings.APP_THEME == 'System default'
 
             dialog = PreferencesDialog(self.app)
             dialog.show()
@@ -144,7 +217,8 @@ class TestPreferences():
             assert rgb(settings.BACKGROUND_COLOR) == (1, 0, 1)
             assert rgb(settings.DATA_COLOR) == (1, 0.5, 0.25)
             assert settings.DATA_ALPHA == 0.3
-            settings.FONT_SIZE = 8.0
+            assert settings.FONT_SIZE == 8.0
+            assert settings.APP_THEME == 'System default'
 
             dialog = PreferencesDialog(self.app)
             dialog.show()
@@ -155,7 +229,8 @@ class TestPreferences():
             assert rgb(settings.BACKGROUND_COLOR) == (1, 0, 1)
             assert rgb(settings.DATA_COLOR) == (1, 1, 0.5)
             assert settings.DATA_ALPHA == 0.3
-            settings.FONT_SIZE = 8.0
+            assert settings.FONT_SIZE == 8.0
+            assert settings.APP_THEME == 'System default'
 
             dialog = PreferencesDialog(self.app)
             dialog.show()
@@ -166,6 +241,7 @@ class TestPreferences():
             assert rgb(settings.BACKGROUND_COLOR) == (1, 0, 1)
             assert rgb(settings.DATA_COLOR) == (1, 1, 0.5)
             assert settings.DATA_ALPHA == 0.4
+            assert settings.APP_THEME == 'System default'
             settings.FONT_SIZE = 8.0
 
             dialog = PreferencesDialog(self.app)
@@ -177,7 +253,20 @@ class TestPreferences():
             assert rgb(settings.BACKGROUND_COLOR) == (1, 0, 1)
             assert rgb(settings.DATA_COLOR) == (1, 1, 0.5)
             assert settings.DATA_ALPHA == 0.4
-            settings.FONT_SIZE = 16.0
+            assert settings.FONT_SIZE == 16.0
+            assert settings.APP_THEME == 'System default'
+
+            dialog = PreferencesDialog(self.app)
+            dialog.show()
+            dialog.app_theme = 'Light'
+            dialog.accept()
+
+            assert rgb(settings.FOREGROUND_COLOR) == (0, 1, 1)
+            assert rgb(settings.BACKGROUND_COLOR) == (1, 0, 1)
+            assert rgb(settings.DATA_COLOR) == (1, 1, 0.5)
+            assert settings.DATA_ALPHA == 0.4
+            assert settings.FONT_SIZE == 16.0
+            assert settings.APP_THEME == 'Light'
 
     def test_custom_pane(self):
 
@@ -238,6 +327,7 @@ class TestPreferences():
             settings.DATA_COLOR = (1, 0.5, 0.25)
             settings.DATA_ALPHA = 0.3
             settings.FONT_SIZE = 8.0
+            settings.APP_THEME = 'System default'
 
             dialog = PreferencesDialog(self.app)
             dialog.show()
@@ -245,7 +335,7 @@ class TestPreferences():
             dialog.accept()
 
         assert len(listener.received) == 1
-        assert listener.received[0].settings == ('FOREGROUND_COLOR', 'BACKGROUND_COLOR', 'FONT_SIZE')
+        assert listener.received[0].settings == ('FOREGROUND_COLOR', 'BACKGROUND_COLOR', 'FONT_SIZE', 'APP_THEME')
 
     def test_save_to_disk(self, tmpdir):
 
@@ -257,6 +347,7 @@ class TestPreferences():
                 settings.DATA_COLOR = (1, 0.5, 0.25)
                 settings.DATA_ALPHA = 0.3
                 settings.FONT_SIZE = 8.0
+                settings.APP_THEME = 'System default'
 
                 dialog = PreferencesDialog(self.app)
                 dialog.show()
@@ -362,6 +453,7 @@ def test_foreground_background_settings():
         settings.DATA_COLOR = '0.5'
         settings.DATA_ALPHA = 0.5
         settings.FONT_SIZE = 8.0
+        settings.APP_THEME = 'System default'
 
         dialog = PreferencesDialog(app)
         dialog.show()

--- a/glue/config.py
+++ b/glue/config.py
@@ -1092,6 +1092,7 @@ settings.add('FONT_SIZE', -1.0, validator=float)
 settings.add('AUTOLINK', {}, validator=dict)
 settings.add('APP_THEME', 'System default', validator=str)
 
+
 def check_unit_converter(value):
     if value != 'default' and value not in unit_converter.members:
         raise KeyError(f'Unit converter {value} is not defined')

--- a/glue/config.py
+++ b/glue/config.py
@@ -1090,6 +1090,7 @@ settings.add('SHOW_INFO_PROFILE_OPEN', True, validator=bool)
 settings.add('SHOW_WARN_PROFILE_DUPLICATE', True, validator=bool)
 settings.add('FONT_SIZE', -1.0, validator=float)
 settings.add('AUTOLINK', {}, validator=dict)
+settings.add('DARK_MODE', False, validator=bool)
 
 
 def check_unit_converter(value):

--- a/glue/config.py
+++ b/glue/config.py
@@ -1090,8 +1090,7 @@ settings.add('SHOW_INFO_PROFILE_OPEN', True, validator=bool)
 settings.add('SHOW_WARN_PROFILE_DUPLICATE', True, validator=bool)
 settings.add('FONT_SIZE', -1.0, validator=float)
 settings.add('AUTOLINK', {}, validator=dict)
-settings.add('DARK_MODE', False, validator=bool)
-
+settings.add('APP_THEME', 'Light', validator=str)
 
 def check_unit_converter(value):
     if value != 'default' and value not in unit_converter.members:

--- a/glue/config.py
+++ b/glue/config.py
@@ -1090,7 +1090,7 @@ settings.add('SHOW_INFO_PROFILE_OPEN', True, validator=bool)
 settings.add('SHOW_WARN_PROFILE_DUPLICATE', True, validator=bool)
 settings.add('FONT_SIZE', -1.0, validator=float)
 settings.add('AUTOLINK', {}, validator=dict)
-settings.add('APP_THEME', 'Light', validator=str)
+settings.add('APP_THEME', 'System default', validator=str)
 
 def check_unit_converter(value):
     if value != 'default' and value not in unit_converter.members:

--- a/glue/viewers/common/qt/data_viewer.py
+++ b/glue/viewers/common/qt/data_viewer.py
@@ -206,6 +206,11 @@ class DataViewer(Viewer, BaseQtViewerWidget,
         else:
             self.hide_toolbars()
 
+    def _update_appearance_from_settings(self, message=None):
+        if message and 'APP_THEME' in message.settings:
+            self.remove_all_toolbars()
+            self.initialize_toolbar()
+
     def __gluestate__(self, context):
         state = Viewer.__gluestate__(self, context)
         state['size'] = self.viewer_size

--- a/glue/viewers/matplotlib/viewer.py
+++ b/glue/viewers/matplotlib/viewer.py
@@ -303,6 +303,7 @@ class MatplotlibViewerMixin(object):
         self.state._set_axes_aspect_ratio(self.axes_ratio)
 
     def _update_appearance_from_settings(self, message=None):
+        super(MatplotlibViewerMixin, self)._update_appearance_from_settings(message)
         update_appearance_from_settings(self.axes)
         self.redraw()
 


### PR DESCRIPTION
This PR contains an implementation of dark mode for the Qt app, suggested in #2332 and endorsed by @aagoodman. This primarily consists of adding the ability to change the application's `QPalette`, but there are a few elements that require some specific handling. In the UI, changing the application theme is done via the Preferences dialog. Some things to note:

* The two elements that required some custom styling are the data canvases that serve as tab backgrounds (whose colors are explicitly set in the code) and the IPython terminal.
    - The terminal uses the `pygments` library for syntax highlighting. There are only 3 dark [`pygment` styles](https://pygments.org/styles/) that meet the WCAG contrast minimum - of these, I decided to go with `rrt`.
    - If the user is in "System default" mode, we make a rough attempt to determine whether the mode is closer to light or dark by comparing the window base and text colors, and select the terminal theme accordingly.
* I added three options for the application palette: light, dark, and system default, with the last being the default option in glue. For most people I suspect light and system default will be essentially the same, but one can modify the default system palette so I think having an explicit light mode palette is useful.

There are still a couple of minor issues:
* The icons for the "window" tools (moving between tabs and changing the title) are difficult to see in dark mode. I'm thinking the solution is to change the icons to be a gray color that has decent contrast in both light and dark modes, but I'm open to other suggestions.
* The terminal colors are set via a CSS stylesheet, but the text styling doesn't seem to propagate back to old terminal items, which can make them a bit difficult to read if you change theme. Personally I don't think this is a big deal - I doubt users will be changing their theme that often - but it's worth nothing.

Any thoughts on either the implementation or the dark mode styling are welcome!