### PR TITLE
Render nans as 'bad' in mpl cmaps when mode='colormap'

### DIFF
--- a/glue/viewers/image/composite_array.py
+++ b/glue/viewers/image/composite_array.py
@@ -29,7 +29,6 @@ class CompositeArray(object):
 
         self._first = True
         self._mode = 'color'
-        self._set_nans_to_zero = True
 
     @property
     def mode(self):
@@ -138,22 +137,29 @@ class CompositeArray(object):
             data = interval(array)
             data = contrast_bias(data, out=data)
             data = stretch(data, out=data)
-            if self._set_nans_to_zero:
-                data[np.isnan(data)] = 0
 
             if self.mode == 'colormap':
+
+                # ensure "bad" values have the same alpha as the
+                # rest of the layer:
+                if hasattr(layer['cmap'], 'get_bad'):
+                    bad_color = layer['cmap'].get_bad().tolist()[:3]
+                    layer_cmap = layer['cmap'].with_extremes(
+                        bad=bad_color + [layer['alpha']]
+                    )
+                else:
+                    layer_cmap = layer['cmap']
 
                 if img is None:
                     img = np.ones(data.shape + (4,))
 
                 # Compute colormapped image
-                plane = layer['cmap'](data)
+                plane = layer_cmap(data)
 
                 # Check what the smallest colormap alpha value for this layer is
                 # - if it is 1 then this colormap does not change transparency,
                 # and this allows us to speed things up a little.
-
-                if layer['cmap'](CMAP_SAMPLING)[:, 3].min() == 1:
+                if layer_cmap(CMAP_SAMPLING)[:, 3].min() == 1:
 
                     if layer['alpha'] == 1:
                         img[...] = 0
@@ -164,7 +170,6 @@ class CompositeArray(object):
                 else:
 
                     # Use traditional alpha compositing
-
                     alpha_plane = layer['alpha'] * plane[:, :, 3]
 
                     plane[:, :, 0] = plane[:, :, 0] * alpha_plane
@@ -178,7 +183,6 @@ class CompositeArray(object):
                 img[:, :, 3] = 1
 
             else:
-
                 if img is None:
                     img = np.zeros(data.shape + (4,))
 

--- a/glue/viewers/image/composite_array.py
+++ b/glue/viewers/image/composite_array.py
@@ -29,6 +29,7 @@ class CompositeArray(object):
 
         self._first = True
         self._mode = 'color'
+        self._set_nans_to_zero = True
 
     @property
     def mode(self):
@@ -137,7 +138,8 @@ class CompositeArray(object):
             data = interval(array)
             data = contrast_bias(data, out=data)
             data = stretch(data, out=data)
-            data[np.isnan(data)] = 0
+            if self._set_nans_to_zero:
+                data[np.isnan(data)] = 0
 
             if self.mode == 'colormap':
 


### PR DESCRIPTION
## Description

By default, image viewers cast NaNs to zero before applying a colormap. This prevents the use of the matplotlib "bad" feature. For each colormap, values above or below the colormap vmin/vmax are rendered with an optionally specified value, and "bad" values (usually nans) are rendered by a third value:
```python
import matplotlib.pyplot as plt

plt.cm.viridis
```
<img width="541" alt="Screen Shot 2023-08-07 at 12 39 22" src="https://github.com/glue-viz/glue/assets/3497584/210f5cf8-fbf6-4bdf-b435-2c353e3f4d9a">

By default, `bad` is `color='k', alpha=0`, but this can be changed with:
```python
plt.cm.viridis.set_bad(color='r')
```
which allows users to clearly visualize nans efficiently and without special handling.

Glue currently forces nans to zero before they are converted to colors by the colormap:
https://github.com/glue-viz/glue/blob/0f83a03c997b78476043485f4145f6e69cb8a8cf/glue/viewers/image/composite_array.py#L140
which prevents the user from ever making use of the `bad` functionality.

This PR allows the user to set a private attribute on the `CompositeArray` class called `_set_nans_to_zero`. When True, the behavior is unchanged. When set to False by a user, nans are not forced to zero, and the `bad` values are rendered as described by the mpl colormap. An example is shown below using Imviz from jdaviz:

<img width="1470" alt="Screen Shot 2023-08-07 at 12 43 43" src="https://github.com/glue-viz/glue/assets/3497584/2bd215e5-ce41-46c8-9e6d-fef02db4b72d">
