### PR TITLE
Skip `test_save_aggregate_slice` for Numpy 1.25.x and unpin numpy-dev

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -45,6 +45,7 @@ jobs:
         - linux: py310-test-pyqt63-all
         - linux: py310-test-pyqt64-all
         - linux: py311-test-pyqt514
+        - linux: py311-test-pyqt515-lts-all
 
         # Documentation build
         - linux: py38-docs-pyqt514

--- a/glue/viewers/image/qt/tests/test_data_viewer.py
+++ b/glue/viewers/image/qt/tests/test_data_viewer.py
@@ -3,6 +3,7 @@
 import os
 import gc
 from collections import Counter
+from packaging.version import Version
 
 import pytest
 
@@ -29,6 +30,8 @@ from glue.core.fixed_resolution_buffer import ARRAY_CACHE, PIXEL_CACHE
 from glue.core.data_derived import IndexedData
 
 from ..data_viewer import ImageViewer
+
+NPY_GE_1_25 = Version(np.__version__) >= Version('1.25')
 
 DATA = os.path.join(os.path.dirname(__file__), 'data')
 
@@ -663,6 +666,7 @@ class TestImageViewer(object):
         assert not self.viewer.layers[2].enabled  # image subset
         assert self.viewer.layers[3].enabled  # scatter subset
 
+    @pytest.mark.skipif(NPY_GE_1_25, reason='`np.sum` can not be serialized after numpy/numpy#23020')
     def test_save_aggregate_slice(self, tmpdir):
 
         # Regression test to make sure that image viewers that include

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,8 @@ changedir =
     test: .tmp/{envname}
     docs: doc
 deps =
+    # Pin numpy until #2353/#2428 are resolved
+    numpy<1.25
     pyqt514: PyQt5==5.14.*
     pyqt515: PyQt5==5.15.*
     pyqt63: PyQt6==6.3.*
@@ -29,8 +31,8 @@ deps =
     pyside515: PySide2==5.15.*
     pyside63: PySide6==6.3.*
     pyside64: PySide6==6.4.*
-    # Pin numpy-dev until #2353 is resolved
-    dev: git+https://github.com/numpy/numpy@9b6a7b4f8
+    # Pin numpy-dev until #2353/#2428 are resolved
+    dev: git+https://github.com/numpy/numpy@maintenance/1.24.x
     dev: git+https://github.com/astropy/astropy
     lts: astropy==5.0.*
     lts: matplotlib==3.5.*

--- a/tox.ini
+++ b/tox.ini
@@ -21,8 +21,6 @@ changedir =
     test: .tmp/{envname}
     docs: doc
 deps =
-    # Pin numpy until #2353/#2428 are resolved
-    numpy<1.25
     pyqt514: PyQt5==5.14.*
     pyqt515: PyQt5==5.15.*
     pyqt63: PyQt6==6.3.*
@@ -31,11 +29,12 @@ deps =
     pyside515: PySide2==5.15.*
     pyside63: PySide6==6.3.*
     pyside64: PySide6==6.4.*
-    # Pin numpy-dev until #2353/#2428 are resolved
-    dev: git+https://github.com/numpy/numpy@maintenance/1.24.x
+    dev: git+https://github.com/numpy/numpy
     dev: git+https://github.com/astropy/astropy
     lts: astropy==5.0.*
     lts: matplotlib==3.5.*
+    # Pin numpy-lts until permanent solution for #2353/#2428
+    lts: numpy==1.24.*
     legacy: numpy==1.17.*
     legacy: matplotlib==3.2.*
     legacy: scipy==1.1.*


### PR DESCRIPTION
## Description
The `GlueSerializer` failure/hang first reported in #2353 has now made it into Numpy 1.25, so to keep jobs from just timing out (and burning CI hours), this pins all tests to 1.24.x as a temporary workaround.
Alternatively one could skip `test_save_aggregate_slice` conditionally on Numpy >= 1.25, but that would leave that test to be run in only one or two tests – but perhaps better, than lagging by an entire Numpy release with everything else?
Might reactivate an `lts` job with `numpy==1.24.*`...

Workaround for #2428