### PR TITLE
Move frontend-independent data/link parsing code from glue.qglue to glue.core

### DIFF
--- a/glue/config.py
+++ b/glue/config.py
@@ -202,7 +202,7 @@ class SettingRegistry(DictRegistry):
         return setting in self._defaults and setting not in self._members
 
 
-class QGlueParserRegistry(Registry):
+class CLIParserRegistry(Registry):
     """
     Registry for parsers that can be used to interpret arguments to the
     :func:`~glue.qglue` function.
@@ -1007,7 +1007,7 @@ fit_plugin = ProfileFitterRegistry()
 layer_action = LayerActionRegistry()
 menubar_plugin = MenubarPluginRegistry()
 preference_panes = PreferencePanesRegistry()
-qglue_parser = QGlueParserRegistry()
+cli_parser = CLIParserRegistry()
 startup_action = StartupActionRegistry()
 keyboard_shortcut = KeyboardShortcut()
 autolinker = AutoLinkerRegistry()
@@ -1039,6 +1039,7 @@ stretches.add('log', LogStretch(), display='Logarithmic')
 
 # Backward-compatibility
 single_subset_action = layer_action
+qglue_parser = cli_parser
 
 
 def load_configuration(search_path=None):

--- a/glue/core/__init__.py
+++ b/glue/core/__init__.py
@@ -13,4 +13,5 @@ from .subset_group import SubsetGroup  # noqa
 from .visual import VisualAttributes  # noqa
 
 # We import this last to avoid circular imports
+from . import parsers  # noqa
 from .application_base import Application  # noqa

--- a/glue/core/application_base.py
+++ b/glue/core/application_base.py
@@ -231,7 +231,7 @@ class Application(HubListener):
 
         links = kwargs.pop('links', None)
 
-        from glue.qglue import parse_data, parse_links
+        from glue.core.parsers import parse_data, parse_links
 
         for label, data in kwargs.items():
             datasets.extend(parse_data(data, label))

--- a/glue/core/data_factories/astropy_table.py
+++ b/glue/core/data_factories/astropy_table.py
@@ -3,7 +3,7 @@ import numpy as np
 
 from glue.core.data_factories.helpers import has_extension
 from glue.core.data import Component, Data
-from glue.config import data_factory, qglue_parser
+from glue.config import data_factory, cli_parser
 
 
 __all__ = ['astropy_tabular_data', 'sextractor_factory', 'cds_factory',
@@ -134,7 +134,7 @@ try:
 except ImportError:
     pass
 else:
-    @qglue_parser(Table)
+    @cli_parser(Table)
     def _parse_data_astropy_table(data, label):
         kwargs = dict((c, data[c]) for c in data.columns)
         return [Data(label=label, **kwargs)]

--- a/glue/core/data_factories/fits.py
+++ b/glue/core/data_factories/fits.py
@@ -5,7 +5,7 @@ from collections import OrderedDict
 
 from glue.core.coordinates import coordinates_from_header, WCSCoordinates
 from glue.core.data import Component, Data
-from glue.config import data_factory, qglue_parser
+from glue.config import data_factory, cli_parser
 
 __all__ = ['is_fits', 'fits_reader', 'is_casalike', 'casalike_cube']
 
@@ -234,7 +234,7 @@ except ImportError:
     pass
 else:
     # Put HDUList parser before list parser
-    @qglue_parser(HDUList, priority=100)
+    @cli_parser(HDUList, priority=100)
     def _parse_data_hdulist(data, label):
         from glue.core.data_factories.fits import fits_reader
         return fits_reader(data, label=label)

--- a/glue/core/data_factories/helpers.py
+++ b/glue/core/data_factories/helpers.py
@@ -254,7 +254,8 @@ def load_data(path, factory=None, **kwargs):
 
         Extra keywords are passed through to factory functions.
     """
-    from glue.qglue import parse_data
+
+    from glue.core.parsers import parse_data
 
     coord_first = kwargs.pop('coord_first', True)
     force_coords = kwargs.pop('force_coords', False)

--- a/glue/core/parsers/__init__.py
+++ b/glue/core/parsers/__init__.py
@@ -1,0 +1,1 @@
+from .parsers import parse_data, parse_links  # noqa

--- a/glue/core/parsers/parsers.py
+++ b/glue/core/parsers/parsers.py
@@ -1,0 +1,120 @@
+# Functions used to parse data and links from Python command-line
+
+import numpy as np
+
+from glue.config import cli_parser
+from glue.core import BaseData, Data
+
+__all__ = []
+
+
+@cli_parser(dict)
+def _parse_data_dict(data, label):
+    result = Data(label=label)
+    for label, component in data.items():
+        result.add_component(component, label)
+    return [result]
+
+
+@cli_parser(np.recarray)
+def _parse_data_recarray(data, label):
+    kwargs = dict((n, data[n]) for n in data.dtype.names)
+    return [Data(label=label, **kwargs)]
+
+
+@cli_parser(BaseData)
+def _parse_data_glue_data(data, label):
+    if isinstance(data, Data):
+        data.label = label
+    return [data]
+
+
+@cli_parser(np.ndarray)
+def _parse_data_numpy(data, label):
+    return [Data(**{label: data, 'label': label})]
+
+
+@cli_parser(list)
+def _parse_data_list(data, label):
+    return [Data(**{label: data, 'label': label})]
+
+
+@cli_parser(str)
+def _parse_data_path(path, label):
+    from glue.core.data_factories import load_data, as_list
+
+    data = load_data(path)
+    for d in as_list(data):
+        d.label = label
+    return as_list(data)
+
+
+def parse_data(data, label):
+
+    # First try new data translation layer
+
+    from glue.config import data_translator
+
+    try:
+        handler, preferred = data_translator.get_handler_for(data)
+    except TypeError:
+        pass
+    else:
+        data = handler.to_data(data)
+        data.label = label
+        data._preferred_translation = preferred
+        return [data]
+
+    # Then try legacy 'cli_parser' infrastructure
+
+    for item in cli_parser:
+
+        data_class = item.data_class
+        parser = item.parser
+        if isinstance(data, data_class):
+            try:
+                return parser(data, label)
+            except Exception as e:
+                raise ValueError("Invalid format for data '%s'\n\n%s" %
+                                 (label, e))
+
+    raise TypeError("Invalid data description: %s" % data)
+
+
+def parse_links(dc, links):
+    from glue.core.link_helpers import MultiLink
+    from glue.core import ComponentLink
+
+    data = dict((d.label, d) for d in dc)
+    result = []
+
+    def find_cid(s):
+        dlabel, clabel = s.split('.')
+        d = data[dlabel]
+        c = d.find_component_id(clabel)
+        if c is None:
+            raise ValueError("Invalid link (no component named %s)" % s)
+        return c
+
+    for link in links:
+        f, t = link[0:2]  # from and to component names
+        u = u2 = None
+        if len(link) >= 3:  # forward translation function
+            u = link[2]
+        if len(link) == 4:  # reverse translation function
+            u2 = link[3]
+
+        # component names -> component IDs
+        if isinstance(f, str):
+            f = [find_cid(f)]
+        else:
+            f = [find_cid(item) for item in f]
+
+        if isinstance(t, str):
+            t = find_cid(t)
+            result.append(ComponentLink(f, t, u))
+        else:
+            t = [find_cid(item) for item in t]
+            result += MultiLink(f, t, u, u2)
+
+    return result

--- a/glue/qglue.py
+++ b/glue/qglue.py
@@ -9,12 +9,9 @@ Utility function to load a variety of python objects into glue
 import sys
 from contextlib import contextmanager
 
-import numpy as np
-
-from glue.config import qglue_parser
-
 try:
     from glue.core import BaseData, Data
+    from glue.core.parsers import parse_data, parse_links
 except ImportError:
     # let qglue import, even though this won't work
     # qglue will throw an ImportError
@@ -41,118 +38,6 @@ def restore_io():
         sys.__stdin__ = _in
         sys.__stdout__ = _out
         sys.__stderr__ = _err
-
-
-@qglue_parser(dict)
-def _parse_data_dict(data, label):
-    result = Data(label=label)
-    for label, component in data.items():
-        result.add_component(component, label)
-    return [result]
-
-
-@qglue_parser(np.recarray)
-def _parse_data_recarray(data, label):
-    kwargs = dict((n, data[n]) for n in data.dtype.names)
-    return [Data(label=label, **kwargs)]
-
-
-@qglue_parser(BaseData)
-def _parse_data_glue_data(data, label):
-    if isinstance(data, Data):
-        data.label = label
-    return [data]
-
-
-@qglue_parser(np.ndarray)
-def _parse_data_numpy(data, label):
-    return [Data(**{label: data, 'label': label})]
-
-
-@qglue_parser(list)
-def _parse_data_list(data, label):
-    return [Data(**{label: data, 'label': label})]
-
-
-@qglue_parser(str)
-def _parse_data_path(path, label):
-    from glue.core.data_factories import load_data, as_list
-
-    data = load_data(path)
-    for d in as_list(data):
-        d.label = label
-    return as_list(data)
-
-
-def parse_data(data, label):
-
-    # First try new data translation layer
-
-    from glue.config import data_translator
-
-    try:
-        handler, preferred = data_translator.get_handler_for(data)
-    except TypeError:
-        pass
-    else:
-        data = handler.to_data(data)
-        data.label = label
-        data._preferred_translation = preferred
-        return [data]
-
-    # Then try legacy 'qglue_parser' infrastructure
-
-    for item in qglue_parser:
-
-        data_class = item.data_class
-        parser = item.parser
-        if isinstance(data, data_class):
-            try:
-                return parser(data, label)
-            except Exception as e:
-                raise ValueError("Invalid format for data '%s'\n\n%s" %
-                                 (label, e))
-
-    raise TypeError("Invalid data description: %s" % data)
-
-
-def parse_links(dc, links):
-    from glue.core.link_helpers import MultiLink
-    from glue.core import ComponentLink
-
-    data = dict((d.label, d) for d in dc)
-    result = []
-
-    def find_cid(s):
-        dlabel, clabel = s.split('.')
-        d = data[dlabel]
-        c = d.find_component_id(clabel)
-        if c is None:
-            raise ValueError("Invalid link (no component named %s)" % s)
-        return c
-
-    for link in links:
-        f, t = link[0:2]  # from and to component names
-        u = u2 = None
-        if len(link) >= 3:  # forward translation function
-            u = link[2]
-        if len(link) == 4:  # reverse translation function
-            u2 = link[3]
-
-        # component names -> component IDs
-        if isinstance(f, str):
-            f = [find_cid(f)]
-        else:
-            f = [find_cid(item) for item in f]
-
-        if isinstance(t, str):
-            t = find_cid(t)
-            result.append(ComponentLink(f, t, u))
-        else:
-            t = [find_cid(item) for item in t]
-            result += MultiLink(f, t, u, u2)
-
-    return result
 
 
 def qglue(**kwargs):

--- a/glue/tests/helpers.py
+++ b/glue/tests/helpers.py
@@ -15,6 +15,9 @@ def make_marker(mark_creator, module, label=None, version=None, mark_if='lt'):
         if label == 'PyQt5':  # PyQt5 does not use __version__
             from PyQt5 import QtCore
             version_installed = QtCore.PYQT_VERSION_STR
+        elif label == 'PyQt6':  # PyQt6 does not use __version__
+            from PyQt6 import QtCore
+            version_installed = QtCore.PYQT_VERSION_STR
         else:
             mod = __import__(module)
             version_installed = mod.__version__
@@ -73,11 +76,13 @@ PLOTLY_INSTALLED, requires_plotly = make_skipper('plotly')
 H5PY_INSTALLED, requires_h5py = make_skipper('h5py')
 
 PYQT5_INSTALLED, requires_pyqt5 = make_skipper('PyQt5')
+PYQT6_INSTALLED, requires_pyqt6 = make_skipper('PyQt6')
 PYSIDE2_INSTALLED, requires_pyside2 = make_skipper('PySide2')
+PYSIDE6_INSTALLED, requires_pyside6 = make_skipper('PySide6')
 
 HYPOTHESIS_INSTALLED, requires_hypothesis = make_skipper('hypothesis')
 
-QT_INSTALLED = PYQT5_INSTALLED or PYSIDE2_INSTALLED
+QT_INSTALLED = PYQT5_INSTALLED or PYQT6_INSTALLED or PYSIDE2_INSTALLED or PYSIDE6_INSTALLED
 
 SPECTRAL_CUBE_INSTALLED, requires_spectral_cube = make_skipper('spectral_cube',
                                                                label='spectral-cube')


### PR DESCRIPTION
glue.qglue contains some functions that don't depend on Qt and which are used by glue-jupyter. This splits them out into ``glue.core``. I have also fixed a bug that meant that some Qt tests were being skipped on PyQt6/PySide6.