### PR TITLE
Add back parsing functions to qglue temporarily

### DIFF
--- a/glue/app/qt/__init__.py
+++ b/glue/app/qt/__init__.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.app.qt is deprecated, use glue_qt.app) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.app.qt is deprecated, use glue_qt.app instead', GlueDeprecationWarning)
 from glue_qt.app import *  # noqa

--- a/glue/app/qt/actions.py
+++ b/glue/app/qt/actions.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.app.qt.actions is deprecated, use glue_qt.app.actions) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.app.qt.actions is deprecated, use glue_qt.app.actions instead', GlueDeprecationWarning)
 from glue_qt.app.actions import *  # noqa

--- a/glue/app/qt/application.py
+++ b/glue/app/qt/application.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.app.qt.application is deprecated, use glue_qt.app.application) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.app.qt.application is deprecated, use glue_qt.app.application instead', GlueDeprecationWarning)
 from glue_qt.app.application import *  # noqa

--- a/glue/app/qt/edit_subset_mode_toolbar.py
+++ b/glue/app/qt/edit_subset_mode_toolbar.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.app.qt.edit_subset_mode_toolbar is deprecated, use glue_qt.app.edit_subset_mode_toolbar) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.app.qt.edit_subset_mode_toolbar is deprecated, use glue_qt.app.edit_subset_mode_toolbar instead', GlueDeprecationWarning)
 from glue_qt.app.edit_subset_mode_toolbar import *  # noqa

--- a/glue/app/qt/feedback.py
+++ b/glue/app/qt/feedback.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.app.qt.feedback is deprecated, use glue_qt.app.feedback) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.app.qt.feedback is deprecated, use glue_qt.app.feedback instead', GlueDeprecationWarning)
 from glue_qt.app.feedback import *  # noqa

--- a/glue/app/qt/keyboard_shortcuts.py
+++ b/glue/app/qt/keyboard_shortcuts.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.app.qt.keyboard_shortcuts is deprecated, use glue_qt.app.keyboard_shortcuts) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.app.qt.keyboard_shortcuts is deprecated, use glue_qt.app.keyboard_shortcuts instead', GlueDeprecationWarning)
 from glue_qt.app.keyboard_shortcuts import *  # noqa

--- a/glue/app/qt/layer_tree_widget.py
+++ b/glue/app/qt/layer_tree_widget.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.app.qt.layer_tree_widget is deprecated, use glue_qt.app.layer_tree_widget) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.app.qt.layer_tree_widget is deprecated, use glue_qt.app.layer_tree_widget instead', GlueDeprecationWarning)
 from glue_qt.app.layer_tree_widget import *  # noqa

--- a/glue/app/qt/mdi_area.py
+++ b/glue/app/qt/mdi_area.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.app.qt.mdi_area is deprecated, use glue_qt.app.mdi_area) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.app.qt.mdi_area is deprecated, use glue_qt.app.mdi_area instead', GlueDeprecationWarning)
 from glue_qt.app.mdi_area import *  # noqa

--- a/glue/app/qt/metadata.py
+++ b/glue/app/qt/metadata.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.app.qt.metadata is deprecated, use glue_qt.app.metadata) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.app.qt.metadata is deprecated, use glue_qt.app.metadata instead', GlueDeprecationWarning)
 from glue_qt.app.metadata import *  # noqa

--- a/glue/app/qt/plugin_manager.py
+++ b/glue/app/qt/plugin_manager.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.app.qt.plugin_manager is deprecated, use glue_qt.app.plugin_manager) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.app.qt.plugin_manager is deprecated, use glue_qt.app.plugin_manager instead', GlueDeprecationWarning)
 from glue_qt.app.plugin_manager import *  # noqa

--- a/glue/app/qt/preferences.py
+++ b/glue/app/qt/preferences.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.app.qt.preferences is deprecated, use glue_qt.app.preferences) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.app.qt.preferences is deprecated, use glue_qt.app.preferences instead', GlueDeprecationWarning)
 from glue_qt.app.preferences import *  # noqa

--- a/glue/app/qt/save_data.py
+++ b/glue/app/qt/save_data.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.app.qt.save_data is deprecated, use glue_qt.app.save_data) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.app.qt.save_data is deprecated, use glue_qt.app.save_data instead', GlueDeprecationWarning)
 from glue_qt.app.save_data import *  # noqa

--- a/glue/app/qt/splash_screen.py
+++ b/glue/app/qt/splash_screen.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.app.qt.splash_screen is deprecated, use glue_qt.app.splash_screen) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.app.qt.splash_screen is deprecated, use glue_qt.app.splash_screen instead', GlueDeprecationWarning)
 from glue_qt.app.splash_screen import *  # noqa

--- a/glue/app/qt/terminal.py
+++ b/glue/app/qt/terminal.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.app.qt.terminal is deprecated, use glue_qt.app.terminal) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.app.qt.terminal is deprecated, use glue_qt.app.terminal instead', GlueDeprecationWarning)
 from glue_qt.app.terminal import *  # noqa

--- a/glue/app/qt/versions.py
+++ b/glue/app/qt/versions.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.app.qt.versions is deprecated, use glue_qt.app.versions) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.app.qt.versions is deprecated, use glue_qt.app.versions instead', GlueDeprecationWarning)
 from glue_qt.app.versions import *  # noqa

--- a/glue/core/data_exporters/qt/__init__.py
+++ b/glue/core/data_exporters/qt/__init__.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.core.data_exporters.qt is deprecated, use glue_qt.core.data_exporters) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.core.data_exporters.qt is deprecated, use glue_qt.core.data_exporters instead', GlueDeprecationWarning)
 from glue_qt.core.data_exporters import *  # noqa

--- a/glue/core/data_exporters/qt/dialog.py
+++ b/glue/core/data_exporters/qt/dialog.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.core.data_exporters.qt.dialog is deprecated, use glue_qt.core.data_exporters.dialog) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.core.data_exporters.qt.dialog is deprecated, use glue_qt.core.data_exporters.dialog instead', GlueDeprecationWarning)
 from glue_qt.core.data_exporters.dialog import *  # noqa

--- a/glue/core/qt/__init__.py
+++ b/glue/core/qt/__init__.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.core.qt is deprecated, use glue_qt.core) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.core.qt is deprecated, use glue_qt.core instead', GlueDeprecationWarning)
 from glue_qt.core import *  # noqa

--- a/glue/core/qt/data_collection_model.py
+++ b/glue/core/qt/data_collection_model.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.core.qt.data_collection_model is deprecated, use glue_qt.core.data_collection_model) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.core.qt.data_collection_model is deprecated, use glue_qt.core.data_collection_model instead', GlueDeprecationWarning)
 from glue_qt.core.data_collection_model import *  # noqa

--- a/glue/core/qt/dialogs.py
+++ b/glue/core/qt/dialogs.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.core.qt.dialogs is deprecated, use glue_qt.core.dialogs) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.core.qt.dialogs is deprecated, use glue_qt.core.dialogs instead', GlueDeprecationWarning)
 from glue_qt.core.dialogs import *  # noqa

--- a/glue/core/qt/fitters.py
+++ b/glue/core/qt/fitters.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.core.qt.fitters is deprecated, use glue_qt.core.fitters) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.core.qt.fitters is deprecated, use glue_qt.core.fitters instead', GlueDeprecationWarning)
 from glue_qt.core.fitters import *  # noqa

--- a/glue/core/qt/layer_artist_model.py
+++ b/glue/core/qt/layer_artist_model.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.core.qt.layer_artist_model is deprecated, use glue_qt.core.layer_artist_model) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.core.qt.layer_artist_model is deprecated, use glue_qt.core.layer_artist_model instead', GlueDeprecationWarning)
 from glue_qt.core.layer_artist_model import *  # noqa

--- a/glue/core/qt/message_widget.py
+++ b/glue/core/qt/message_widget.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.core.qt.message_widget is deprecated, use glue_qt.core.message_widget) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.core.qt.message_widget is deprecated, use glue_qt.core.message_widget instead', GlueDeprecationWarning)
 from glue_qt.core.message_widget import *  # noqa

--- a/glue/core/qt/mime.py
+++ b/glue/core/qt/mime.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.core.qt.mime is deprecated, use glue_qt.core.mime) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.core.qt.mime is deprecated, use glue_qt.core.mime instead', GlueDeprecationWarning)
 from glue_qt.core.mime import *  # noqa

--- a/glue/core/qt/simpleforms.py
+++ b/glue/core/qt/simpleforms.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.core.qt.simpleforms is deprecated, use glue_qt.core.simpleforms) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.core.qt.simpleforms is deprecated, use glue_qt.core.simpleforms instead', GlueDeprecationWarning)
 from glue_qt.core.simpleforms import *  # noqa

--- a/glue/core/qt/style_dialog.py
+++ b/glue/core/qt/style_dialog.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.core.qt.style_dialog is deprecated, use glue_qt.core.style_dialog) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.core.qt.style_dialog is deprecated, use glue_qt.core.style_dialog instead', GlueDeprecationWarning)
 from glue_qt.core.style_dialog import *  # noqa

--- a/glue/dialogs/autolinker/qt/__init__.py
+++ b/glue/dialogs/autolinker/qt/__init__.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.dialogs.autolinker.qt is deprecated, use glue_qt.dialogs.autolinker) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.dialogs.autolinker.qt is deprecated, use glue_qt.dialogs.autolinker instead', GlueDeprecationWarning)
 from glue_qt.dialogs.autolinker import *  # noqa

--- a/glue/dialogs/autolinker/qt/autolinker.py
+++ b/glue/dialogs/autolinker/qt/autolinker.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.dialogs.autolinker.qt.autolinker is deprecated, use glue_qt.dialogs.autolinker.autolinker) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.dialogs.autolinker.qt.autolinker is deprecated, use glue_qt.dialogs.autolinker.autolinker instead', GlueDeprecationWarning)
 from glue_qt.dialogs.autolinker.autolinker import *  # noqa

--- a/glue/dialogs/common/qt/__init__.py
+++ b/glue/dialogs/common/qt/__init__.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.dialogs.common.qt is deprecated, use glue_qt.dialogs.common) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.dialogs.common.qt is deprecated, use glue_qt.dialogs.common instead', GlueDeprecationWarning)
 from glue_qt.dialogs.common import *  # noqa

--- a/glue/dialogs/common/qt/component_tree_widget.py
+++ b/glue/dialogs/common/qt/component_tree_widget.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.dialogs.common.qt.component_tree_widget is deprecated, use glue_qt.dialogs.common.component_tree_widget) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.dialogs.common.qt.component_tree_widget is deprecated, use glue_qt.dialogs.common.component_tree_widget instead', GlueDeprecationWarning)
 from glue_qt.dialogs.common.component_tree_widget import *  # noqa

--- a/glue/dialogs/component_arithmetic/qt/__init__.py
+++ b/glue/dialogs/component_arithmetic/qt/__init__.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.dialogs.component_arithmetic.qt is deprecated, use glue_qt.dialogs.component_arithmetic) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.dialogs.component_arithmetic.qt is deprecated, use glue_qt.dialogs.component_arithmetic instead', GlueDeprecationWarning)
 from glue_qt.dialogs.component_arithmetic import *  # noqa

--- a/glue/dialogs/component_arithmetic/qt/component_arithmetic.py
+++ b/glue/dialogs/component_arithmetic/qt/component_arithmetic.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.dialogs.component_arithmetic.qt.component_arithmetic is deprecated, use glue_qt.dialogs.component_arithmetic.component_arithmetic) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.dialogs.component_arithmetic.qt.component_arithmetic is deprecated, use glue_qt.dialogs.component_arithmetic.component_arithmetic instead', GlueDeprecationWarning)
 from glue_qt.dialogs.component_arithmetic.component_arithmetic import *  # noqa

--- a/glue/dialogs/component_arithmetic/qt/equation_editor.py
+++ b/glue/dialogs/component_arithmetic/qt/equation_editor.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.dialogs.component_arithmetic.qt.equation_editor is deprecated, use glue_qt.dialogs.component_arithmetic.equation_editor) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.dialogs.component_arithmetic.qt.equation_editor is deprecated, use glue_qt.dialogs.component_arithmetic.equation_editor instead', GlueDeprecationWarning)
 from glue_qt.dialogs.component_arithmetic.equation_editor import *  # noqa

--- a/glue/dialogs/component_manager/qt/__init__.py
+++ b/glue/dialogs/component_manager/qt/__init__.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.dialogs.component_manager.qt is deprecated, use glue_qt.dialogs.component_manager) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.dialogs.component_manager.qt is deprecated, use glue_qt.dialogs.component_manager instead', GlueDeprecationWarning)
 from glue_qt.dialogs.component_manager import *  # noqa

--- a/glue/dialogs/component_manager/qt/component_manager.py
+++ b/glue/dialogs/component_manager/qt/component_manager.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.dialogs.component_manager.qt.component_manager is deprecated, use glue_qt.dialogs.component_manager.component_manager) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.dialogs.component_manager.qt.component_manager is deprecated, use glue_qt.dialogs.component_manager.component_manager instead', GlueDeprecationWarning)
 from glue_qt.dialogs.component_manager.component_manager import *  # noqa

--- a/glue/dialogs/data_wizard/qt/__init__.py
+++ b/glue/dialogs/data_wizard/qt/__init__.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.dialogs.data_wizard.qt is deprecated, use glue_qt.dialogs.data_wizard) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.dialogs.data_wizard.qt is deprecated, use glue_qt.dialogs.data_wizard instead', GlueDeprecationWarning)
 from glue_qt.dialogs.data_wizard import *  # noqa

--- a/glue/dialogs/data_wizard/qt/data_wizard_dialog.py
+++ b/glue/dialogs/data_wizard/qt/data_wizard_dialog.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.dialogs.data_wizard.qt.data_wizard_dialog is deprecated, use glue_qt.dialogs.data_wizard.data_wizard_dialog) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.dialogs.data_wizard.qt.data_wizard_dialog is deprecated, use glue_qt.dialogs.data_wizard.data_wizard_dialog instead', GlueDeprecationWarning)
 from glue_qt.dialogs.data_wizard.data_wizard_dialog import *  # noqa

--- a/glue/dialogs/link_editor/qt/__init__.py
+++ b/glue/dialogs/link_editor/qt/__init__.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.dialogs.link_editor.qt is deprecated, use glue_qt.dialogs.link_editor) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.dialogs.link_editor.qt is deprecated, use glue_qt.dialogs.link_editor instead', GlueDeprecationWarning)
 from glue_qt.dialogs.link_editor import *  # noqa

--- a/glue/dialogs/link_editor/qt/data_graph.py
+++ b/glue/dialogs/link_editor/qt/data_graph.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.dialogs.link_editor.qt.data_graph is deprecated, use glue_qt.dialogs.link_editor.data_graph) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.dialogs.link_editor.qt.data_graph is deprecated, use glue_qt.dialogs.link_editor.data_graph instead', GlueDeprecationWarning)
 from glue_qt.dialogs.link_editor.data_graph import *  # noqa

--- a/glue/dialogs/link_editor/qt/link_editor.py
+++ b/glue/dialogs/link_editor/qt/link_editor.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.dialogs.link_editor.qt.link_editor is deprecated, use glue_qt.dialogs.link_editor.link_editor) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.dialogs.link_editor.qt.link_editor is deprecated, use glue_qt.dialogs.link_editor.link_editor instead', GlueDeprecationWarning)
 from glue_qt.dialogs.link_editor.link_editor import *  # noqa

--- a/glue/dialogs/subset_facet/qt/__init__.py
+++ b/glue/dialogs/subset_facet/qt/__init__.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.dialogs.subset_facet.qt is deprecated, use glue_qt.dialogs.subset_facet) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.dialogs.subset_facet.qt is deprecated, use glue_qt.dialogs.subset_facet instead', GlueDeprecationWarning)
 from glue_qt.dialogs.subset_facet import *  # noqa

--- a/glue/dialogs/subset_facet/qt/subset_facet.py
+++ b/glue/dialogs/subset_facet/qt/subset_facet.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.dialogs.subset_facet.qt.subset_facet is deprecated, use glue_qt.dialogs.subset_facet.subset_facet) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.dialogs.subset_facet.qt.subset_facet is deprecated, use glue_qt.dialogs.subset_facet.subset_facet instead', GlueDeprecationWarning)
 from glue_qt.dialogs.subset_facet.subset_facet import *  # noqa

--- a/glue/icons/qt/__init__.py
+++ b/glue/icons/qt/__init__.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.icons.qt is deprecated, use glue_qt.icons) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.icons.qt is deprecated, use glue_qt.icons instead', GlueDeprecationWarning)
 from glue_qt.icons import *  # noqa

--- a/glue/icons/qt/helpers.py
+++ b/glue/icons/qt/helpers.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.icons.qt.helpers is deprecated, use glue_qt.icons.helpers) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.icons.qt.helpers is deprecated, use glue_qt.icons.helpers instead', GlueDeprecationWarning)
 from glue_qt.icons.helpers import *  # noqa

--- a/glue/io/qt/__init__.py
+++ b/glue/io/qt/__init__.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.io.qt is deprecated, use glue_qt.io) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.io.qt is deprecated, use glue_qt.io instead', GlueDeprecationWarning)
 from glue_qt.io import *  # noqa

--- a/glue/io/qt/directory_importer/__init__.py
+++ b/glue/io/qt/directory_importer/__init__.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.io.qt.directory_importer is deprecated, use glue_qt.io.directory_importer) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.io.qt.directory_importer is deprecated, use glue_qt.io.directory_importer instead', GlueDeprecationWarning)
 from glue_qt.io.directory_importer import *  # noqa

--- a/glue/io/qt/directory_importer/directory_importer.py
+++ b/glue/io/qt/directory_importer/directory_importer.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.io.qt.directory_importer.directory_importer is deprecated, use glue_qt.io.directory_importer.directory_importer) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.io.qt.directory_importer.directory_importer is deprecated, use glue_qt.io.directory_importer.directory_importer instead', GlueDeprecationWarning)
 from glue_qt.io.directory_importer.directory_importer import *  # noqa

--- a/glue/io/qt/subset_mask.py
+++ b/glue/io/qt/subset_mask.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.io.qt.subset_mask is deprecated, use glue_qt.io.subset_mask) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.io.qt.subset_mask is deprecated, use glue_qt.io.subset_mask instead', GlueDeprecationWarning)
 from glue_qt.io.subset_mask import *  # noqa

--- a/glue/plugins/dendro_viewer/qt/__init__.py
+++ b/glue/plugins/dendro_viewer/qt/__init__.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.plugins.dendro_viewer.qt is deprecated, use glue_qt.plugins.dendro_viewer) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.plugins.dendro_viewer.qt is deprecated, use glue_qt.plugins.dendro_viewer instead', GlueDeprecationWarning)
 from glue_qt.plugins.dendro_viewer import *  # noqa

--- a/glue/plugins/dendro_viewer/qt/data_viewer.py
+++ b/glue/plugins/dendro_viewer/qt/data_viewer.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.plugins.dendro_viewer.qt.data_viewer is deprecated, use glue_qt.plugins.dendro_viewer.data_viewer) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.plugins.dendro_viewer.qt.data_viewer is deprecated, use glue_qt.plugins.dendro_viewer.data_viewer instead', GlueDeprecationWarning)
 from glue_qt.plugins.dendro_viewer.data_viewer import *  # noqa

--- a/glue/plugins/dendro_viewer/qt/layer_style_editor.py
+++ b/glue/plugins/dendro_viewer/qt/layer_style_editor.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.plugins.dendro_viewer.qt.layer_style_editor is deprecated, use glue_qt.plugins.dendro_viewer.layer_style_editor) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.plugins.dendro_viewer.qt.layer_style_editor is deprecated, use glue_qt.plugins.dendro_viewer.layer_style_editor instead', GlueDeprecationWarning)
 from glue_qt.plugins.dendro_viewer.layer_style_editor import *  # noqa

--- a/glue/plugins/dendro_viewer/qt/options_widget.py
+++ b/glue/plugins/dendro_viewer/qt/options_widget.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.plugins.dendro_viewer.qt.options_widget is deprecated, use glue_qt.plugins.dendro_viewer.options_widget) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.plugins.dendro_viewer.qt.options_widget is deprecated, use glue_qt.plugins.dendro_viewer.options_widget instead', GlueDeprecationWarning)
 from glue_qt.plugins.dendro_viewer.options_widget import *  # noqa

--- a/glue/plugins/tools/pv_slicer/qt/__init__.py
+++ b/glue/plugins/tools/pv_slicer/qt/__init__.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.plugins.tools.pv_slicer.qt is deprecated, use glue_qt.plugins.tools.pv_slicer) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.plugins.tools.pv_slicer.qt is deprecated, use glue_qt.plugins.tools.pv_slicer instead', GlueDeprecationWarning)
 from glue_qt.plugins.tools.pv_slicer import *  # noqa

--- a/glue/plugins/tools/pv_slicer/qt/pv_slicer.py
+++ b/glue/plugins/tools/pv_slicer/qt/pv_slicer.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.plugins.tools.pv_slicer.qt.pv_slicer is deprecated, use glue_qt.plugins.tools.pv_slicer.pv_slicer) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.plugins.tools.pv_slicer.qt.pv_slicer is deprecated, use glue_qt.plugins.tools.pv_slicer.pv_slicer instead', GlueDeprecationWarning)
 from glue_qt.plugins.tools.pv_slicer.pv_slicer import *  # noqa

--- a/glue/qglue.py
+++ b/glue/qglue.py
@@ -1,4 +1,18 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.qglue is deprecated, use glue_qt.qglue) instead', GlueDeprecationWarning)
+
+warnings.warn('Importing from glue.qglue is deprecated, use glue_qt.qglue instead', GlueDeprecationWarning)
+
 from glue_qt.qglue import *  # noqa
+
+
+def parse_data(*args, **kwargs):
+    warnings.warn('glue.qglue.parse_data is deprecated, use glue.core.parsers.parse_data instead', GlueDeprecationWarning)
+    from glue.core.parsers import parse_data
+    return parse_data(*args, **kwargs)
+
+
+def parse_links(*args, **kwargs):
+    warnings.warn('glue.qglue.parse_links is deprecated, use glue.core.parsers.parse_links instead', GlueDeprecationWarning)
+    from glue.core.parsers import parse_links
+    return parse_links(*args, **kwargs)

--- a/glue/utils/qt/__init__.py
+++ b/glue/utils/qt/__init__.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.utils.qt is deprecated, use glue_qt.utils) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.utils.qt is deprecated, use glue_qt.utils instead', GlueDeprecationWarning)
 from glue_qt.utils import *  # noqa

--- a/glue/utils/qt/app.py
+++ b/glue/utils/qt/app.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.utils.qt.app is deprecated, use glue_qt.utils.app) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.utils.qt.app is deprecated, use glue_qt.utils.app instead', GlueDeprecationWarning)
 from glue_qt.utils.app import *  # noqa

--- a/glue/utils/qt/autocomplete_widget.py
+++ b/glue/utils/qt/autocomplete_widget.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.utils.qt.autocomplete_widget is deprecated, use glue_qt.utils.autocomplete_widget) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.utils.qt.autocomplete_widget is deprecated, use glue_qt.utils.autocomplete_widget instead', GlueDeprecationWarning)
 from glue_qt.utils.autocomplete_widget import *  # noqa

--- a/glue/utils/qt/colors.py
+++ b/glue/utils/qt/colors.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.utils.qt.colors is deprecated, use glue_qt.utils.colors) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.utils.qt.colors is deprecated, use glue_qt.utils.colors instead', GlueDeprecationWarning)
 from glue_qt.utils.colors import *  # noqa

--- a/glue/utils/qt/decorators.py
+++ b/glue/utils/qt/decorators.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.utils.qt.decorators is deprecated, use glue_qt.utils.decorators) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.utils.qt.decorators is deprecated, use glue_qt.utils.decorators instead', GlueDeprecationWarning)
 from glue_qt.utils.decorators import *  # noqa

--- a/glue/utils/qt/delegates.py
+++ b/glue/utils/qt/delegates.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.utils.qt.delegates is deprecated, use glue_qt.utils.delegates) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.utils.qt.delegates is deprecated, use glue_qt.utils.delegates instead', GlueDeprecationWarning)
 from glue_qt.utils.delegates import *  # noqa

--- a/glue/utils/qt/dialogs.py
+++ b/glue/utils/qt/dialogs.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.utils.qt.dialogs is deprecated, use glue_qt.utils.dialogs) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.utils.qt.dialogs is deprecated, use glue_qt.utils.dialogs instead', GlueDeprecationWarning)
 from glue_qt.utils.dialogs import *  # noqa

--- a/glue/utils/qt/helpers.py
+++ b/glue/utils/qt/helpers.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.utils.qt.helpers is deprecated, use glue_qt.utils.helpers) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.utils.qt.helpers is deprecated, use glue_qt.utils.helpers instead', GlueDeprecationWarning)
 from glue_qt.utils.helpers import *  # noqa

--- a/glue/utils/qt/mime.py
+++ b/glue/utils/qt/mime.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.utils.qt.mime is deprecated, use glue_qt.utils.mime) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.utils.qt.mime is deprecated, use glue_qt.utils.mime instead', GlueDeprecationWarning)
 from glue_qt.utils.mime import *  # noqa

--- a/glue/utils/qt/mixins.py
+++ b/glue/utils/qt/mixins.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.utils.qt.mixins is deprecated, use glue_qt.utils.mixins) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.utils.qt.mixins is deprecated, use glue_qt.utils.mixins instead', GlueDeprecationWarning)
 from glue_qt.utils.mixins import *  # noqa

--- a/glue/utils/qt/python_list_model.py
+++ b/glue/utils/qt/python_list_model.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.utils.qt.python_list_model is deprecated, use glue_qt.utils.python_list_model) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.utils.qt.python_list_model is deprecated, use glue_qt.utils.python_list_model instead', GlueDeprecationWarning)
 from glue_qt.utils.python_list_model import *  # noqa

--- a/glue/utils/qt/threading.py
+++ b/glue/utils/qt/threading.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.utils.qt.threading is deprecated, use glue_qt.utils.threading) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.utils.qt.threading is deprecated, use glue_qt.utils.threading instead', GlueDeprecationWarning)
 from glue_qt.utils.threading import *  # noqa

--- a/glue/utils/qt/widget_properties.py
+++ b/glue/utils/qt/widget_properties.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.utils.qt.widget_properties is deprecated, use glue_qt.utils.widget_properties) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.utils.qt.widget_properties is deprecated, use glue_qt.utils.widget_properties instead', GlueDeprecationWarning)
 from glue_qt.utils.widget_properties import *  # noqa

--- a/glue/viewers/common/qt/__init__.py
+++ b/glue/viewers/common/qt/__init__.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.viewers.common.qt is deprecated, use glue_qt.viewers.common) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.viewers.common.qt is deprecated, use glue_qt.viewers.common instead', GlueDeprecationWarning)
 from glue_qt.viewers.common import *  # noqa

--- a/glue/viewers/common/qt/base_widget.py
+++ b/glue/viewers/common/qt/base_widget.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.viewers.common.qt.base_widget is deprecated, use glue_qt.viewers.common.base_widget) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.viewers.common.qt.base_widget is deprecated, use glue_qt.viewers.common.base_widget instead', GlueDeprecationWarning)
 from glue_qt.viewers.common.base_widget import *  # noqa

--- a/glue/viewers/common/qt/data_slice_widget.py
+++ b/glue/viewers/common/qt/data_slice_widget.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.viewers.common.qt.data_slice_widget is deprecated, use glue_qt.viewers.common.data_slice_widget) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.viewers.common.qt.data_slice_widget is deprecated, use glue_qt.viewers.common.data_slice_widget instead', GlueDeprecationWarning)
 from glue_qt.viewers.common.data_slice_widget import *  # noqa

--- a/glue/viewers/common/qt/data_viewer.py
+++ b/glue/viewers/common/qt/data_viewer.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.viewers.common.qt.data_viewer is deprecated, use glue_qt.viewers.common.data_viewer) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.viewers.common.qt.data_viewer is deprecated, use glue_qt.viewers.common.data_viewer instead', GlueDeprecationWarning)
 from glue_qt.viewers.common.data_viewer import *  # noqa

--- a/glue/viewers/common/qt/data_viewer_with_state.py
+++ b/glue/viewers/common/qt/data_viewer_with_state.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.viewers.common.qt.data_viewer_with_state is deprecated, use glue_qt.viewers.common.data_viewer_with_state) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.viewers.common.qt.data_viewer_with_state is deprecated, use glue_qt.viewers.common.data_viewer_with_state instead', GlueDeprecationWarning)
 from glue_qt.viewers.common.data_viewer_with_state import *  # noqa

--- a/glue/viewers/common/qt/tool.py
+++ b/glue/viewers/common/qt/tool.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.viewers.common.qt.tool is deprecated, use glue_qt.viewers.common.tool) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.viewers.common.qt.tool is deprecated, use glue_qt.viewers.common.tool instead', GlueDeprecationWarning)
 from glue_qt.viewers.common.tool import *  # noqa

--- a/glue/viewers/common/qt/toolbar.py
+++ b/glue/viewers/common/qt/toolbar.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.viewers.common.qt.toolbar is deprecated, use glue_qt.viewers.common.toolbar) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.viewers.common.qt.toolbar is deprecated, use glue_qt.viewers.common.toolbar instead', GlueDeprecationWarning)
 from glue_qt.viewers.common.toolbar import *  # noqa

--- a/glue/viewers/common/qt/tools.py
+++ b/glue/viewers/common/qt/tools.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.viewers.common.qt.tools is deprecated, use glue_qt.viewers.common.tools) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.viewers.common.qt.tools is deprecated, use glue_qt.viewers.common.tools instead', GlueDeprecationWarning)
 from glue_qt.viewers.common.tools import *  # noqa

--- a/glue/viewers/custom/qt/__init__.py
+++ b/glue/viewers/custom/qt/__init__.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.viewers.custom.qt is deprecated, use glue_qt.viewers.custom) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.viewers.custom.qt is deprecated, use glue_qt.viewers.custom instead', GlueDeprecationWarning)
 from glue_qt.viewers.custom import *  # noqa

--- a/glue/viewers/custom/qt/custom_viewer.py
+++ b/glue/viewers/custom/qt/custom_viewer.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.viewers.custom.qt.custom_viewer is deprecated, use glue_qt.viewers.custom.custom_viewer) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.viewers.custom.qt.custom_viewer is deprecated, use glue_qt.viewers.custom.custom_viewer instead', GlueDeprecationWarning)
 from glue_qt.viewers.custom.custom_viewer import *  # noqa

--- a/glue/viewers/custom/qt/elements.py
+++ b/glue/viewers/custom/qt/elements.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.viewers.custom.qt.elements is deprecated, use glue_qt.viewers.custom.elements) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.viewers.custom.qt.elements is deprecated, use glue_qt.viewers.custom.elements instead', GlueDeprecationWarning)
 from glue_qt.viewers.custom.elements import *  # noqa

--- a/glue/viewers/histogram/qt/__init__.py
+++ b/glue/viewers/histogram/qt/__init__.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.viewers.histogram.qt is deprecated, use glue_qt.viewers.histogram) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.viewers.histogram.qt is deprecated, use glue_qt.viewers.histogram instead', GlueDeprecationWarning)
 from glue_qt.viewers.histogram import *  # noqa

--- a/glue/viewers/histogram/qt/data_viewer.py
+++ b/glue/viewers/histogram/qt/data_viewer.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.viewers.histogram.qt.data_viewer is deprecated, use glue_qt.viewers.histogram.data_viewer) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.viewers.histogram.qt.data_viewer is deprecated, use glue_qt.viewers.histogram.data_viewer instead', GlueDeprecationWarning)
 from glue_qt.viewers.histogram.data_viewer import *  # noqa

--- a/glue/viewers/histogram/qt/layer_artist.py
+++ b/glue/viewers/histogram/qt/layer_artist.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.viewers.histogram.qt.layer_artist is deprecated, use glue_qt.viewers.histogram.layer_artist) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.viewers.histogram.qt.layer_artist is deprecated, use glue_qt.viewers.histogram.layer_artist instead', GlueDeprecationWarning)
 from glue_qt.viewers.histogram.layer_artist import *  # noqa

--- a/glue/viewers/histogram/qt/layer_style_editor.py
+++ b/glue/viewers/histogram/qt/layer_style_editor.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.viewers.histogram.qt.layer_style_editor is deprecated, use glue_qt.viewers.histogram.layer_style_editor) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.viewers.histogram.qt.layer_style_editor is deprecated, use glue_qt.viewers.histogram.layer_style_editor instead', GlueDeprecationWarning)
 from glue_qt.viewers.histogram.layer_style_editor import *  # noqa

--- a/glue/viewers/histogram/qt/options_widget.py
+++ b/glue/viewers/histogram/qt/options_widget.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.viewers.histogram.qt.options_widget is deprecated, use glue_qt.viewers.histogram.options_widget) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.viewers.histogram.qt.options_widget is deprecated, use glue_qt.viewers.histogram.options_widget instead', GlueDeprecationWarning)
 from glue_qt.viewers.histogram.options_widget import *  # noqa

--- a/glue/viewers/image/qt/__init__.py
+++ b/glue/viewers/image/qt/__init__.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.viewers.image.qt is deprecated, use glue_qt.viewers.image) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.viewers.image.qt is deprecated, use glue_qt.viewers.image instead', GlueDeprecationWarning)
 from glue_qt.viewers.image import *  # noqa

--- a/glue/viewers/image/qt/contrast_mouse_mode.py
+++ b/glue/viewers/image/qt/contrast_mouse_mode.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.viewers.image.qt.contrast_mouse_mode is deprecated, use glue_qt.viewers.image.contrast_mouse_mode) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.viewers.image.qt.contrast_mouse_mode is deprecated, use glue_qt.viewers.image.contrast_mouse_mode instead', GlueDeprecationWarning)
 from glue_qt.viewers.image.contrast_mouse_mode import *  # noqa

--- a/glue/viewers/image/qt/data_viewer.py
+++ b/glue/viewers/image/qt/data_viewer.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.viewers.image.qt.data_viewer is deprecated, use glue_qt.viewers.image.data_viewer) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.viewers.image.qt.data_viewer is deprecated, use glue_qt.viewers.image.data_viewer instead', GlueDeprecationWarning)
 from glue_qt.viewers.image.data_viewer import *  # noqa

--- a/glue/viewers/image/qt/layer_style_editor.py
+++ b/glue/viewers/image/qt/layer_style_editor.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.viewers.image.qt.layer_style_editor is deprecated, use glue_qt.viewers.image.layer_style_editor) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.viewers.image.qt.layer_style_editor is deprecated, use glue_qt.viewers.image.layer_style_editor instead', GlueDeprecationWarning)
 from glue_qt.viewers.image.layer_style_editor import *  # noqa

--- a/glue/viewers/image/qt/layer_style_editor_subset.py
+++ b/glue/viewers/image/qt/layer_style_editor_subset.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.viewers.image.qt.layer_style_editor_subset is deprecated, use glue_qt.viewers.image.layer_style_editor_subset) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.viewers.image.qt.layer_style_editor_subset is deprecated, use glue_qt.viewers.image.layer_style_editor_subset instead', GlueDeprecationWarning)
 from glue_qt.viewers.image.layer_style_editor_subset import *  # noqa

--- a/glue/viewers/image/qt/mouse_mode.py
+++ b/glue/viewers/image/qt/mouse_mode.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.viewers.image.qt.mouse_mode is deprecated, use glue_qt.viewers.image.mouse_mode) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.viewers.image.qt.mouse_mode is deprecated, use glue_qt.viewers.image.mouse_mode instead', GlueDeprecationWarning)
 from glue_qt.viewers.image.mouse_mode import *  # noqa

--- a/glue/viewers/image/qt/options_widget.py
+++ b/glue/viewers/image/qt/options_widget.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.viewers.image.qt.options_widget is deprecated, use glue_qt.viewers.image.options_widget) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.viewers.image.qt.options_widget is deprecated, use glue_qt.viewers.image.options_widget instead', GlueDeprecationWarning)
 from glue_qt.viewers.image.options_widget import *  # noqa

--- a/glue/viewers/image/qt/pixel_selection_mode.py
+++ b/glue/viewers/image/qt/pixel_selection_mode.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.viewers.image.qt.pixel_selection_mode is deprecated, use glue_qt.viewers.image.pixel_selection_mode) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.viewers.image.qt.pixel_selection_mode is deprecated, use glue_qt.viewers.image.pixel_selection_mode instead', GlueDeprecationWarning)
 from glue_qt.viewers.image.pixel_selection_mode import *  # noqa

--- a/glue/viewers/image/qt/profile_viewer_tool.py
+++ b/glue/viewers/image/qt/profile_viewer_tool.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.viewers.image.qt.profile_viewer_tool is deprecated, use glue_qt.viewers.image.profile_viewer_tool) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.viewers.image.qt.profile_viewer_tool is deprecated, use glue_qt.viewers.image.profile_viewer_tool instead', GlueDeprecationWarning)
 from glue_qt.viewers.image.profile_viewer_tool import *  # noqa

--- a/glue/viewers/image/qt/slice_widget.py
+++ b/glue/viewers/image/qt/slice_widget.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.viewers.image.qt.slice_widget is deprecated, use glue_qt.viewers.image.slice_widget) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.viewers.image.qt.slice_widget is deprecated, use glue_qt.viewers.image.slice_widget instead', GlueDeprecationWarning)
 from glue_qt.viewers.image.slice_widget import *  # noqa

--- a/glue/viewers/image/qt/standalone_image_viewer.py
+++ b/glue/viewers/image/qt/standalone_image_viewer.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.viewers.image.qt.standalone_image_viewer is deprecated, use glue_qt.viewers.image.standalone_image_viewer) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.viewers.image.qt.standalone_image_viewer is deprecated, use glue_qt.viewers.image.standalone_image_viewer instead', GlueDeprecationWarning)
 from glue_qt.viewers.image.standalone_image_viewer import *  # noqa

--- a/glue/viewers/matplotlib/qt/__init__.py
+++ b/glue/viewers/matplotlib/qt/__init__.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.viewers.matplotlib.qt is deprecated, use glue_qt.viewers.matplotlib) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.viewers.matplotlib.qt is deprecated, use glue_qt.viewers.matplotlib instead', GlueDeprecationWarning)
 from glue_qt.viewers.matplotlib import *  # noqa

--- a/glue/viewers/matplotlib/qt/axes_editor.py
+++ b/glue/viewers/matplotlib/qt/axes_editor.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.viewers.matplotlib.qt.axes_editor is deprecated, use glue_qt.viewers.matplotlib.axes_editor) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.viewers.matplotlib.qt.axes_editor is deprecated, use glue_qt.viewers.matplotlib.axes_editor instead', GlueDeprecationWarning)
 from glue_qt.viewers.matplotlib.axes_editor import *  # noqa

--- a/glue/viewers/matplotlib/qt/compute_worker.py
+++ b/glue/viewers/matplotlib/qt/compute_worker.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.viewers.matplotlib.qt.compute_worker is deprecated, use glue_qt.viewers.matplotlib.compute_worker) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.viewers.matplotlib.qt.compute_worker is deprecated, use glue_qt.viewers.matplotlib.compute_worker instead', GlueDeprecationWarning)
 from glue_qt.viewers.matplotlib.compute_worker import *  # noqa

--- a/glue/viewers/matplotlib/qt/data_viewer.py
+++ b/glue/viewers/matplotlib/qt/data_viewer.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.viewers.matplotlib.qt.data_viewer is deprecated, use glue_qt.viewers.matplotlib.data_viewer) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.viewers.matplotlib.qt.data_viewer is deprecated, use glue_qt.viewers.matplotlib.data_viewer instead', GlueDeprecationWarning)
 from glue_qt.viewers.matplotlib.data_viewer import *  # noqa

--- a/glue/viewers/matplotlib/qt/legend_editor.py
+++ b/glue/viewers/matplotlib/qt/legend_editor.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.viewers.matplotlib.qt.legend_editor is deprecated, use glue_qt.viewers.matplotlib.legend_editor) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.viewers.matplotlib.qt.legend_editor is deprecated, use glue_qt.viewers.matplotlib.legend_editor instead', GlueDeprecationWarning)
 from glue_qt.viewers.matplotlib.legend_editor import *  # noqa

--- a/glue/viewers/matplotlib/qt/toolbar.py
+++ b/glue/viewers/matplotlib/qt/toolbar.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.viewers.matplotlib.qt.toolbar is deprecated, use glue_qt.viewers.matplotlib.toolbar) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.viewers.matplotlib.qt.toolbar is deprecated, use glue_qt.viewers.matplotlib.toolbar instead', GlueDeprecationWarning)
 from glue_qt.viewers.matplotlib.toolbar import *  # noqa

--- a/glue/viewers/matplotlib/qt/toolbar_mode.py
+++ b/glue/viewers/matplotlib/qt/toolbar_mode.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.viewers.matplotlib.qt.toolbar_mode is deprecated, use glue_qt.viewers.matplotlib.toolbar_mode) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.viewers.matplotlib.qt.toolbar_mode is deprecated, use glue_qt.viewers.matplotlib.toolbar_mode instead', GlueDeprecationWarning)
 from glue_qt.viewers.matplotlib.toolbar_mode import *  # noqa

--- a/glue/viewers/matplotlib/qt/widget.py
+++ b/glue/viewers/matplotlib/qt/widget.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.viewers.matplotlib.qt.widget is deprecated, use glue_qt.viewers.matplotlib.widget) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.viewers.matplotlib.qt.widget is deprecated, use glue_qt.viewers.matplotlib.widget instead', GlueDeprecationWarning)
 from glue_qt.viewers.matplotlib.widget import *  # noqa

--- a/glue/viewers/profile/qt/__init__.py
+++ b/glue/viewers/profile/qt/__init__.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.viewers.profile.qt is deprecated, use glue_qt.viewers.profile) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.viewers.profile.qt is deprecated, use glue_qt.viewers.profile instead', GlueDeprecationWarning)
 from glue_qt.viewers.profile import *  # noqa

--- a/glue/viewers/profile/qt/data_viewer.py
+++ b/glue/viewers/profile/qt/data_viewer.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.viewers.profile.qt.data_viewer is deprecated, use glue_qt.viewers.profile.data_viewer) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.viewers.profile.qt.data_viewer is deprecated, use glue_qt.viewers.profile.data_viewer instead', GlueDeprecationWarning)
 from glue_qt.viewers.profile.data_viewer import *  # noqa

--- a/glue/viewers/profile/qt/layer_artist.py
+++ b/glue/viewers/profile/qt/layer_artist.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.viewers.profile.qt.layer_artist is deprecated, use glue_qt.viewers.profile.layer_artist) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.viewers.profile.qt.layer_artist is deprecated, use glue_qt.viewers.profile.layer_artist instead', GlueDeprecationWarning)
 from glue_qt.viewers.profile.layer_artist import *  # noqa

--- a/glue/viewers/profile/qt/layer_style_editor.py
+++ b/glue/viewers/profile/qt/layer_style_editor.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.viewers.profile.qt.layer_style_editor is deprecated, use glue_qt.viewers.profile.layer_style_editor) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.viewers.profile.qt.layer_style_editor is deprecated, use glue_qt.viewers.profile.layer_style_editor instead', GlueDeprecationWarning)
 from glue_qt.viewers.profile.layer_style_editor import *  # noqa

--- a/glue/viewers/profile/qt/mouse_mode.py
+++ b/glue/viewers/profile/qt/mouse_mode.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.viewers.profile.qt.mouse_mode is deprecated, use glue_qt.viewers.profile.mouse_mode) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.viewers.profile.qt.mouse_mode is deprecated, use glue_qt.viewers.profile.mouse_mode instead', GlueDeprecationWarning)
 from glue_qt.viewers.profile.mouse_mode import *  # noqa

--- a/glue/viewers/profile/qt/options_widget.py
+++ b/glue/viewers/profile/qt/options_widget.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.viewers.profile.qt.options_widget is deprecated, use glue_qt.viewers.profile.options_widget) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.viewers.profile.qt.options_widget is deprecated, use glue_qt.viewers.profile.options_widget instead', GlueDeprecationWarning)
 from glue_qt.viewers.profile.options_widget import *  # noqa

--- a/glue/viewers/profile/qt/profile_tools.py
+++ b/glue/viewers/profile/qt/profile_tools.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.viewers.profile.qt.profile_tools is deprecated, use glue_qt.viewers.profile.profile_tools) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.viewers.profile.qt.profile_tools is deprecated, use glue_qt.viewers.profile.profile_tools instead', GlueDeprecationWarning)
 from glue_qt.viewers.profile.profile_tools import *  # noqa

--- a/glue/viewers/scatter/qt/__init__.py
+++ b/glue/viewers/scatter/qt/__init__.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.viewers.scatter.qt is deprecated, use glue_qt.viewers.scatter) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.viewers.scatter.qt is deprecated, use glue_qt.viewers.scatter instead', GlueDeprecationWarning)
 from glue_qt.viewers.scatter import *  # noqa

--- a/glue/viewers/scatter/qt/data_viewer.py
+++ b/glue/viewers/scatter/qt/data_viewer.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.viewers.scatter.qt.data_viewer is deprecated, use glue_qt.viewers.scatter.data_viewer) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.viewers.scatter.qt.data_viewer is deprecated, use glue_qt.viewers.scatter.data_viewer instead', GlueDeprecationWarning)
 from glue_qt.viewers.scatter.data_viewer import *  # noqa

--- a/glue/viewers/scatter/qt/layer_style_editor.py
+++ b/glue/viewers/scatter/qt/layer_style_editor.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.viewers.scatter.qt.layer_style_editor is deprecated, use glue_qt.viewers.scatter.layer_style_editor) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.viewers.scatter.qt.layer_style_editor is deprecated, use glue_qt.viewers.scatter.layer_style_editor instead', GlueDeprecationWarning)
 from glue_qt.viewers.scatter.layer_style_editor import *  # noqa

--- a/glue/viewers/scatter/qt/options_widget.py
+++ b/glue/viewers/scatter/qt/options_widget.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.viewers.scatter.qt.options_widget is deprecated, use glue_qt.viewers.scatter.options_widget) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.viewers.scatter.qt.options_widget is deprecated, use glue_qt.viewers.scatter.options_widget instead', GlueDeprecationWarning)
 from glue_qt.viewers.scatter.options_widget import *  # noqa

--- a/glue/viewers/table/qt/__init__.py
+++ b/glue/viewers/table/qt/__init__.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.viewers.table.qt is deprecated, use glue_qt.viewers.table) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.viewers.table.qt is deprecated, use glue_qt.viewers.table instead', GlueDeprecationWarning)
 from glue_qt.viewers.table import *  # noqa

--- a/glue/viewers/table/qt/data_viewer.py
+++ b/glue/viewers/table/qt/data_viewer.py
@@ -1,4 +1,4 @@
 import warnings
 from glue.utils.error import GlueDeprecationWarning
-warnings.warn('Importing from glue.viewers.table.qt.data_viewer is deprecated, use glue_qt.viewers.table.data_viewer) instead', GlueDeprecationWarning)
+warnings.warn('Importing from glue.viewers.table.qt.data_viewer is deprecated, use glue_qt.viewers.table.data_viewer instead', GlueDeprecationWarning)
 from glue_qt.viewers.table.data_viewer import *  # noqa


### PR DESCRIPTION
Adding back functions that should have been deprecated before they were removed/moved to a different module. Also fixed a typo in the warnings.