### PR TITLE
Fix compatibility with latest developer version of astropy

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,9 @@
 version: 2
 
 build:
-  image: latest
+  os: "ubuntu-22.04"
+  tools:
+    python: "3"
 
 sphinx:
   builder: html
@@ -9,7 +11,6 @@ sphinx:
   fail_on_warning: true
 
 python:
-  version: 3.8
   install:
     - method: pip
       path: .

--- a/glue/plugins/coordinate_helpers/link_helpers.py
+++ b/glue/plugins/coordinate_helpers/link_helpers.py
@@ -21,12 +21,12 @@ class BaseCelestialMultiLink(BaseMultiLink):
 
     def forwards(self, in_lon, in_lat):
         cin = self.frame_in(in_lon * u.deg, in_lat * u.deg)
-        cout = cin.transform_to(self.frame_out)
+        cout = cin.transform_to(self.frame_out())
         return cout.spherical.lon.degree, cout.spherical.lat.degree
 
     def backwards(self, out_lon, out_lat):
         cout = self.frame_out(out_lon * u.deg, out_lat * u.deg)
-        cin = cout.transform_to(self.frame_in)
+        cin = cout.transform_to(self.frame_in())
         return cin.spherical.lon.degree, cin.spherical.lat.degree
 
     # Backward-compatibility with glue-core <0.15


### PR DESCRIPTION
Looks like a bunch of deprecated code has been removed - frame classes have to now be instantiated when passing to ``transform_to``