### PR TITLE
Fix bug when changing the number of bins on a histogram with modified/deleted data

### DIFF
--- a/glue/core/application_base.py
+++ b/glue/core/application_base.py
@@ -93,6 +93,9 @@ class Application(HubListener):
         self.add_widget(c)
         return c
 
+    def add_widget(self, viewer):
+        pass
+
     @catch_error("Failed to save session")
     def save_session(self, path, include_data=False, absolute_paths=True):
         """

--- a/glue/core/state_objects.py
+++ b/glue/core/state_objects.py
@@ -11,7 +11,7 @@ from glue.core.state import saver, loader
 from glue.core.component_id import PixelComponentID
 
 __all__ = ['State', 'StateAttributeCacheHelper',
-           'StateAttributeLimitsHelper', 'StateAttributeSingleValueHelper']
+           'StateAttributeLimitsHelper', 'StateAttributeSingleValueHelper', 'StateAttributeHistogramHelper']
 
 
 @saver(CallbackList)
@@ -192,7 +192,6 @@ class StateAttributeCacheHelper(object):
             self.update_values(attribute=self.component_id, use_default_modifiers=True)
 
     def _update_values(self, **properties):
-
         if hasattr(self, '_in_set'):
             if self._in_set:
                 return
@@ -428,7 +427,9 @@ class StateAttributeHistogramHelper(StateAttributeCacheHelper):
             self._common_n_bin = None
 
     def _apply_common_n_bin(self):
+        print('_apply_common_n_bin')
         for att in self._cache:
+            print('att', att.label, att.parent.label)
             if not self.data.get_kind(att) == 'categorical':
                 self._cache[att]['n_bin'] = self._common_n_bin
 
@@ -443,6 +444,8 @@ class StateAttributeHistogramHelper(StateAttributeCacheHelper):
             self._common_n_bin = None
 
     def update_values(self, force=False, use_default_modifiers=False, **properties):
+
+        print('main update_values', properties)
 
         if not force and not any(prop in properties for prop in ('attribute', 'n_bin')) or self.data is None:
             self.set()

--- a/glue/viewers/histogram/tests/test_state.py
+++ b/glue/viewers/histogram/tests/test_state.py
@@ -1,0 +1,33 @@
+from glue.viewers.common.viewer import Viewer
+from glue.viewers.histogram.state import HistogramViewerState
+from glue.core.application_base import Application
+from glue.core.data import Data
+
+
+class TestHistogramViewer(Viewer):
+    _state_cls = HistogramViewerState
+
+
+def test_remove_data_collection():
+
+    # Regression test for a bug that caused an IncompatibleAttribute
+    # error when updating the number of bins in a histogram after
+    # removing a dataset from the DataCollection (this was due to
+    # a caching issue)
+
+    data1 = Data(x=[1, 2, 3], label='data1')
+    data2 = Data(y=[1, 2, 3], label='data2')
+
+    app = Application()
+    app.data_collection.append(data1)
+    app.data_collection.append(data2)
+
+    viewer = app.new_data_viewer(TestHistogramViewer)
+    viewer.add_data(data1)
+    viewer.add_data(data2)
+
+    viewer.state.hist_n_bin = 30
+
+    app.data_collection.remove(data1)
+
+    viewer.state.hist_n_bin = 20

--- a/glue/viewers/histogram/tests/test_state.py
+++ b/glue/viewers/histogram/tests/test_state.py
@@ -31,3 +31,29 @@ def test_remove_data_collection():
     app.data_collection.remove(data1)
 
     viewer.state.hist_n_bin = 20
+
+
+def test_incompatible_datasets():
+
+    # Regression test for a bug that caused an IncompatibleAttribute
+    # error when changing the dataset used in the histogram viewer to one that
+    # is not linked to the first dataset.
+
+    data1 = Data(x=[1, 2, 3], label='data1')
+    data2 = Data(y=[1, 2, 3], label='data2')
+
+    app = Application()
+    app.data_collection.append(data1)
+    app.data_collection.append(data2)
+
+    viewer = app.new_data_viewer(TestHistogramViewer)
+    viewer.add_data(data1)
+    viewer.add_data(data2)
+
+    viewer.state.x_att = data1.id['x']
+
+    viewer.state.hist_n_bin = 30
+
+    viewer.state.x_att = data2.id['y']
+
+    viewer.state.hist_n_bin = 20


### PR DESCRIPTION
This fixes an issue that was seen in https://github.com/spacetelescope/jdaviz/pull/2529 which is that if we change the dataset used for the x attribute for the histogram, this failed if the original dataset was removed from the data collection or if the new dataset was not linked to the original one.