### PR TITLE
Fix docs failure related to theme warning

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -62,3 +62,4 @@ intersphinx_mapping = {
 html_theme = "sphinx_book_theme"
 html_static_path = ["_static"]
 html_logo = "_static/logo.png"
+html_theme_options = {'navigation_with_keys': False}


### PR DESCRIPTION
Just need to explicitly set ``navigation_with_keys`` to ``False``