### PR TITLE
Ignore all test files in coverage calculation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -110,13 +110,15 @@ filterwarnings =
 
 [coverage:run]
 omit =
-    glue/*tests/*
-    glue/core/odict.py,
-    glue/core/glue_pickle.py
+    glue/tests/*
+    glue/*/tests/*
+    glue/*/*/tests/*
+    glue/*/*/*/tests/*
     glue/external/*
-    */glue/*tests/*
-    */glue/core/odict.py,
-    */glue/core/glue_pickle.py
+    */glue/tests/*
+    */glue/*/tests/*
+    */glue/*/*/tests/*
+    */glue/*/*/*/tests/*
     */glue/external/*
 
 [coverage:paths]


### PR DESCRIPTION
Some of the test files were still included in the coverage calculation