### PR TITLE
Provide stronger checking for region display. Fix x/y flip.

### DIFF
--- a/glue/tests/visual/py311-test-visual.json
+++ b/glue/tests/visual/py311-test-visual.json
@@ -1,7 +1,8 @@
 {
   "glue.viewers.histogram.tests.test_viewer.test_simple_viewer": "cb08123fbad135ab614bb7ec13475fcc83321057d884fe80c3a32970b2d14762",
   "glue.viewers.image.tests.test_viewer.test_simple_viewer": "72abd60b484d14f721254f027bb0ab9b36245d5db77eb87693f4dd9998fd28be",
-  "glue.viewers.image.tests.test_viewer.test_region_layer": "b54088d1f31562d309d35c5e90c0a382c7ba4c16cc0db8134e9532f71f047076",
+  "glue.viewers.image.tests.test_viewer.test_region_layer": "0114922ab0a3980f56252656c69545927841aea0e6950250cdc2b1bafcd19d50",
+  "glue.viewers.image.tests.test_viewer.test_region_layer_flip": "a142142f34961aba7e98188ad43abafe0e6e5b82e13e8cdab5131d297ed5832c",
   "glue.viewers.profile.tests.test_viewer.test_simple_viewer": "f68a21be5080fec513388b2d2b220512e7b0df5498e2489da54e58708de435b3",
   "glue.viewers.scatter.tests.test_viewer.test_simple_viewer": "1020a7bd3abe40510b9e03047c3b423b75c3c64ac18e6dcd6257173cec1ed53f",
   "glue.viewers.scatter.tests.test_viewer.test_scatter_density_map": "3379d655262769a6ccbdbaf1970bffa9237adbec23a93d3ab75da51b9a3e7f8b"

--- a/glue/viewers/image/tests/test_viewer.py
+++ b/glue/viewers/image/tests/test_viewer.py
@@ -1,5 +1,5 @@
 import numpy as np
-
+from echo import delay_callback
 from glue.tests.visual.helpers import visual_test
 from glue.viewers.image.viewer import SimpleImageViewer
 from glue.core.application_base import Application
@@ -58,6 +58,42 @@ def test_region_layer():
     viewer.add_data(image_data)
     viewer.add_data(region_data)
 
-    app.data_collection.new_subset_group(label='subset1', subset_state=region_data.id['values'] > 2)
+    return viewer.figure
+
+
+@visual_test
+def test_region_layer_flip():
+    poly_1 = Polygon([(20, 20), (60, 20), (60, 40), (20, 40)])
+    poly_2 = Polygon([(60, 50), (60, 70), (80, 70), (80, 50)])
+    poly_3 = Polygon([(10, 10), (15, 10), (15, 15), (10, 15)])
+    poly_4 = Polygon([(10, 20), (15, 20), (15, 30), (10, 30), (12, 25)])
+
+    polygons = MultiPolygon([poly_3, poly_4])
+
+    geoms = np.array([poly_1, poly_2, polygons])
+    values = np.array([1, 2, 3])
+    region_data = RegionData(regions=geoms, values=values)
+
+    image_data = Data(x=np.arange(10000).reshape((100, 100)), label='data1')
+    app = Application()
+    app.data_collection.append(image_data)
+    app.data_collection.append(region_data)
+
+    link1 = LinkSame(region_data.center_x_id, image_data.pixel_component_ids[0])
+    link2 = LinkSame(region_data.center_y_id, image_data.pixel_component_ids[1])
+    app.data_collection.add_link(link1)
+    app.data_collection.add_link(link2)
+
+    viewer = app.new_data_viewer(SimpleImageViewer)
+    viewer.add_data(image_data)
+    viewer.add_data(region_data)
+
+    # We need this delay callback here because, while this works in the QT GUI,
+    # we need to make sure not to try and redraw the regions while we are flipping
+    # the coordinates displayed.
+
+    with delay_callback(viewer.state, 'x_att', 'y_att'):
+        viewer.state.x_att = image_data.pixel_component_ids[0]
+        viewer.state.y_att = image_data.pixel_component_ids[1]
 
     return viewer.figure


### PR DESCRIPTION
# Pull Request Template

## Description

Fixes #2464 

We now directly check that the x/y-axis in the region specifications is the same as a the x/y-axis displayed in the image viewer. This allows us to correctly display the regions when the image axes are flipped and prevents erroneous display of the regions if the linking was incorrectly set up.