### PR TITLE
Compatibility and tests against Numpy 2.0.0rc1

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -47,14 +47,17 @@ jobs:
 
         # Test some configurations on Windows
         - windows: py38-test
-        - windows: py310-test
-        - windows: py311-test
-        - windows: py312-test
+        - windows: py39-test
 
         # Test against latest developer versions of some packages
         - linux: py310-test-dev-all
         - linux: py311-test-dev
         - linux: py312-test-dev-all
+
+        - macos: py311-test-dev-all
+        - macos: py312-test-dev
+
+        - windows: py310-test-dev
 
   publish:
     needs: tests

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -30,7 +30,7 @@ jobs:
         - linux: py39-test
         - linux: py310-test-all
         - linux: py311-test
-        - linux: py311-test-all
+        - linux: py312-test-all
 
         # Documentation build
         - linux: py38-docs
@@ -43,14 +43,18 @@ jobs:
         - macos: py39-test
         - macos: py310-test-all
         - macos: py311-test
+        - macos: py312-test-all
 
         # Test some configurations on Windows
         - windows: py38-test
         - windows: py310-test
+        - windows: py311-test
+        - windows: py312-test
 
         # Test against latest developer versions of some packages
         - linux: py310-test-dev-all
         - linux: py311-test-dev
+        - linux: py312-test-dev-all
 
   publish:
     needs: tests

--- a/glue/utils/array.py
+++ b/glue/utils/array.py
@@ -504,6 +504,8 @@ class categorical_ndarray(np.ndarray):
 
     def __new__(cls, value, dtype=None, copy=True, order=None, subok=False,
                 ndmin=0, categories=None):
+        if not copy and np.lib.NumpyVersion(np.__version__) >= "2.0.0rc1":
+            copy = None
         result = np.array(value, dtype=dtype, copy=copy, order=order,
                           subok=True, ndmin=ndmin).view(categorical_ndarray)
         if categories is not None:

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ install_requires =
     pandas>=1.2
     echo>=0.6
     astropy>=4.0
+    fast_histogram>=0.12
     setuptools>=30.3.0
     ipython>=4.0
     dill>=0.2

--- a/tox.ini
+++ b/tox.ini
@@ -21,11 +21,9 @@ changedir =
     test: .tmp/{envname}
     docs: doc
 deps =
-    dev: numpy==2.0.0rc1
-    dev: scipy==1.13.0
-    dev: astropy==6.1.0rc1
-    dev: shapely>=0.0.dev0
-    dev: git+https://github.com/radio-astro-tools/casa-formats-io.git
+    dev: numpy>=0.0.dev0
+    dev: scipy>=0.0.dev0
+    dev: astropy>=0.0.dev0
     # LTS
     lts: astropy==5.0.*
     lts: matplotlib==3.5.*
@@ -55,7 +53,7 @@ extras =
 # for as long all test deps need to be manually pulled in above as well!
 install_command =
     !dev: python -I -m pip install
-    dev: python -I -m pip install -v --pre
+    dev: python -I -m pip install -v
 commands =
     test: pip freeze
     test: pytest --pyargs glue --cov glue --cov-config={toxinidir}/setup.cfg {env:MPLFLAGS} {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,39,310,311}-{codestyle,test,docs}-all-{dev,legacy}{,-visual}
+    py{38,39,310,311,312}-{codestyle,test,docs}-all-{dev,legacy}{,-visual}
 requires = pip >= 18.0
            setuptools >= 30.3.0
 
@@ -10,7 +10,7 @@ passenv =
     DISPLAY
     HOME
 setenv =
-    dev: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+    dev: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/liberfa/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
     visual: MPLFLAGS = -m "mpl_image_compare" --mpl --mpl-generate-summary=html --mpl-results-path={toxinidir}/results --mpl-hash-library={toxinidir}/glue/tests/visual/{envname}.json --mpl-baseline-path=https://raw.githubusercontent.com/glue-viz/glue-core-visual-tests/images/{envname}/
 whitelist_externals =
     find
@@ -22,7 +22,12 @@ changedir =
     docs: doc
 deps =
     dev: numpy>=0.0.dev0
+    dev: scipy>=0.0.dev0
     dev: astropy>=0.0.dev0
+    dev: pyerfa>=0.0.dev0
+    dev: matplotlib>=0.0.dev0
+    dev: git+https://github.com/contourpy/contourpy.git
+    dev: git+https://github.com/pandas-dev/pandas.git
     lts: astropy==5.0.*
     lts: matplotlib==3.5.*
     # Pin numpy-lts until permanent solution for #2353/#2428
@@ -46,6 +51,10 @@ extras =
     all: all
     docs: docs
     visual: visualtest
+# Need `--no-deps` as long as pandas and contours have no branch for numpy>=2.0
+install_command =
+    !dev: python -I -m pip install
+    dev: python -I -m pip install -v --pre --no-deps
 commands =
     test: pip freeze
     test: pytest --pyargs glue --cov glue --cov-config={toxinidir}/setup.cfg {env:MPLFLAGS} {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -21,56 +21,11 @@ changedir =
     test: .tmp/{envname}
     docs: doc
 deps =
-    dev: numpy>=0.0.dev0
-    dev: scipy>=0.0.dev0
-    dev: astropy>=0.0.dev0
-    dev: pyerfa>=0.0.dev0
-    dev: matplotlib>=0.0.dev0
+    dev: numpy==2.0.0rc1
+    dev: scipy==1.13.0
+    dev: astropy==6.1.0rc1
     dev: shapely>=0.0.dev0
-    dev: contourpy>=0.0.dev0
-    dev: pandas>=0.0.dev0
     dev: git+https://github.com/radio-astro-tools/casa-formats-io.git
-    dev: git+https://github.com/astrofrog/fast-histogram.git
-    # pytest*
-    dev: coverage
-    dev: exceptiongroup
-    dev: flake8
-    dev: iniconfig
-    dev: mccabe
-    dev: packaging
-    dev: pluggy
-    dev: pycodestyle
-    dev: pyflakes
-    dev: tomli
-    # astropy
-    dev: astropy-iers-data
-    dev: pyyaml
-    # matplotlib
-    dev: cycler
-    dev: fonttools
-    dev: kiwisolver
-    dev: pillow
-    dev: pyparsing
-    # pandas
-    dev: python-dateutil
-    dev: pytz
-    dev: six
-    dev: tzdata
-    # ipython
-    dev: asttokens
-    dev: decorator
-    dev: executing
-    dev: jedi>=0.16
-    dev: matplotlib-inline
-    dev: parso
-    dev: pexpect
-    dev: prompt_toolkit>=3.0.41,<3.1.0
-    dev: ptyprocess
-    dev: pure-eval
-    dev: pygments>=2.4.0
-    dev: stack_data
-    dev: traitlets
-    dev: wcwidth
     # LTS
     lts: astropy==5.0.*
     lts: matplotlib==3.5.*
@@ -100,7 +55,7 @@ extras =
 # for as long all test deps need to be manually pulled in above as well!
 install_command =
     !dev: python -I -m pip install
-    dev: python -I -m pip install -v --pre --no-deps
+    dev: python -I -m pip install -v --pre
 commands =
     test: pip freeze
     test: pytest --pyargs glue --cov glue --cov-config={toxinidir}/setup.cfg {env:MPLFLAGS} {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,31 @@ deps =
     dev: matplotlib>=0.0.dev0
     dev: git+https://github.com/contourpy/contourpy.git
     dev: git+https://github.com/pandas-dev/pandas.git
+    # pytest*
+    dev: coverage
+    dev: exceptiongroup
+    dev: flake8
+    dev: iniconfig
+    dev: mccabe
+    dev: packaging
+    dev: pluggy
+    dev: pycodestyle
+    dev: pyflakes
+    dev: tomli
+    # astropy
+    dev: astropy-iers-data
+    dev: pyyaml
+    # matplotlib
+    dev: cycler
+    dev: fonttools
+    dev: kiwisolver
+    dev: pillow
+    dev: pyparsing
+    # pandas
+    dev: python-dateutil
+    dev: pytz
+    dev: six
+    dev: tzdata
     lts: astropy==5.0.*
     lts: matplotlib==3.5.*
     # Pin numpy-lts until permanent solution for #2353/#2428
@@ -51,7 +76,8 @@ extras =
     all: all
     docs: docs
     visual: visualtest
-# Need `--no-deps` as long as pandas and contours have no branch for numpy>=2.0
+# Need `--no-deps` as long as pandas and contours have no branch for numpy>=2.0 -
+# for as long all test deps need to be manually pulled in above as well!
 install_command =
     !dev: python -I -m pip install
     dev: python -I -m pip install -v --pre --no-deps

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,7 @@ deps =
     dev: astropy>=0.0.dev0
     dev: pyerfa>=0.0.dev0
     dev: matplotlib>=0.0.dev0
+    dev: shapely==2.0.1+78.gba0924e
     dev: git+https://github.com/contourpy/contourpy.git
     dev: git+https://github.com/pandas-dev/pandas.git
     # pytest*

--- a/tox.ini
+++ b/tox.ini
@@ -26,9 +26,11 @@ deps =
     dev: astropy>=0.0.dev0
     dev: pyerfa>=0.0.dev0
     dev: matplotlib>=0.0.dev0
-    dev: shapely==2.0.1+78.gba0924e
-    dev: git+https://github.com/contourpy/contourpy.git
-    dev: git+https://github.com/pandas-dev/pandas.git
+    dev: shapely>=0.0.dev0
+    dev: contourpy>=0.0.dev0
+    dev: pandas>=0.0.dev0
+    dev: git+https://github.com/radio-astro-tools/casa-formats-io.git
+    dev: git+https://github.com/astrofrog/fast-histogram.git
     # pytest*
     dev: coverage
     dev: exceptiongroup
@@ -54,6 +56,22 @@ deps =
     dev: pytz
     dev: six
     dev: tzdata
+    # ipython
+    dev: asttokens
+    dev: decorator
+    dev: executing
+    dev: jedi>=0.16
+    dev: matplotlib-inline
+    dev: parso
+    dev: pexpect
+    dev: prompt_toolkit>=3.0.41,<3.1.0
+    dev: ptyprocess
+    dev: pure-eval
+    dev: pygments>=2.4.0
+    dev: stack_data
+    dev: traitlets
+    dev: wcwidth
+    # LTS
     lts: astropy==5.0.*
     lts: matplotlib==3.5.*
     # Pin numpy-lts until permanent solution for #2353/#2428
@@ -77,7 +95,8 @@ extras =
     all: all
     docs: docs
     visual: visualtest
-# Need `--no-deps` as long as pandas and contours have no branch for numpy>=2.0 -
+# Need `--pre` for packages like pandas having no released version supporting numpy>=2.0 yet,
+# + `--no-deps` for casa-formats-io having no branch for numpy>=2.0 -
 # for as long all test deps need to be manually pulled in above as well!
 install_command =
     !dev: python -I -m pip install


### PR DESCRIPTION
## Description
Installing numpy dev in CI is currently blocked by various upstream packages pinned to `numpy < 2.0`; adding those to the developer versions.
This would update both `dev` jobs to `numpy>=0.0.dev0`; restrict to a new env `npdev` instead?

- [x] ~~pandas has no compatible wheel and a hard dependency on `numpy < 2.0`~~.
- [x] ~~contourpy has no compatible wheel and a hard dependency on `numpy < 2.0`~~.
- [x] ~~shapely has no compatible wheel for `numpy < 2.0`~~ (shapely/shapely#1949), build depends on libgeos.
- [x] ~~fast-histogram has no compatible wheel~~.
- [x] casa-formats-io has no compatible wheel ~~and a pinned dependency on `numpy < 2.0`~~.

Only workaround for the pins seems to be to install with `--no-deps` (pandas-dev/pandas#55488) which in turn requires every single test dependency to be pulled in explicitly; if anyone has an idea how to run a first pass without `--no-deps` an then a second `pip install` to override the numpy pin, that could be simplified a bit.

Building shapely seems to require compiling its own `libgeos` installation per its
[install script](https://github.com/shapely/shapely/blob/main/ci/install_geos.sh); unless I find a way to get an apt install for that, this is a showstopper for now.
(It seems to be available, but would require pointing the CI to fetch from an [alternative repo](https://libgeos.org/usage/install/#ubuntu)).