### PR TITLE
Allow serializing and deserializing named astropy units

### DIFF
--- a/glue/core/state.py
+++ b/glue/core/state.py
@@ -65,6 +65,7 @@ from inspect import isgeneratorfunction
 import numpy as np
 from matplotlib.colors import Colormap
 from matplotlib import cm
+import astropy.units as u
 from astropy.units import UnitBase, Unit
 from astropy.wcs import WCS
 import shapely
@@ -624,7 +625,14 @@ def _load_slice(rec, context):
 
 @saver(UnitBase)
 def _save_unit_base(unit, context):
-    return dict(unit_base=unit.to_string())
+    unit_str = unit.to_string()
+    # Check that unit can be parsed back with default enabled systems
+    try:
+        with u.set_enabled_units([u.si, u.cgs, u.astrophys]):
+            _ = u.Unit(unit_str)
+    except ValueError:
+        raise GlueSerializeError(f"Serializing units of '{unit}' is not yet supported")
+    return dict(unit_base=unit_str)
 
 
 @loader(UnitBase)

--- a/glue/core/state.py
+++ b/glue/core/state.py
@@ -65,6 +65,7 @@ from inspect import isgeneratorfunction
 import numpy as np
 from matplotlib.colors import Colormap
 from matplotlib import cm
+from astropy.units import NamedUnit, Unit
 from astropy.wcs import WCS
 import shapely
 
@@ -619,6 +620,16 @@ def _save_slice(slc, context):
 @loader(slice)
 def _load_slice(rec, context):
     return slice(rec['start'], rec['stop'], rec['step'])
+
+
+@saver(NamedUnit)
+def _save_named_unit(unit, context):
+    return dict(named_unit=unit.to_string())
+
+
+@loader(NamedUnit)
+def _load_named_unit(rec, context):
+    return Unit(rec["named_unit"])
 
 
 @saver(WCS)

--- a/glue/core/state.py
+++ b/glue/core/state.py
@@ -65,7 +65,7 @@ from inspect import isgeneratorfunction
 import numpy as np
 from matplotlib.colors import Colormap
 from matplotlib import cm
-from astropy.units import NamedUnit, Unit
+from astropy.units import UnitBase, Unit
 from astropy.wcs import WCS
 import shapely
 
@@ -622,14 +622,14 @@ def _load_slice(rec, context):
     return slice(rec['start'], rec['stop'], rec['step'])
 
 
-@saver(NamedUnit)
-def _save_named_unit(unit, context):
-    return dict(named_unit=unit.to_string())
+@saver(UnitBase)
+def _save_unit_base(unit, context):
+    return dict(unit_base=unit.to_string())
 
 
-@loader(NamedUnit)
-def _load_named_unit(rec, context):
-    return Unit(rec["named_unit"])
+@loader(UnitBase)
+def _load_unit_base(rec, context):
+    return Unit(rec["unit_base"])
 
 
 @saver(WCS)

--- a/glue/core/tests/test_state.py
+++ b/glue/core/tests/test_state.py
@@ -305,6 +305,14 @@ def test_datetime_component():
     assert isinstance(c2.data[0], np.datetime64)
 
 
+@requires_astropy
+def test_astropy_units():
+    import astropy.units as u
+    unit = u.m
+    unit2 = clone(unit)
+    assert unit2 is unit
+
+
 class DummyClass(object):
     pass
 

--- a/glue/core/tests/test_state.py
+++ b/glue/core/tests/test_state.py
@@ -312,6 +312,21 @@ def test_astropy_units():
     unit2 = clone(unit)
     assert unit2 is unit
 
+    unit = u.km
+    unit2 = clone(unit)
+    assert unit2 is unit
+
+
+@requires_astropy
+def test_astropy_compound_units():
+    import astropy.units as u
+    unit = u.m / u.s
+    unit2 = clone(unit)
+    assert unit2 == unit
+    unit = u.W / u.m**2 / u.nm
+    unit2 = clone(unit)
+    assert unit2 == unit
+
 
 class DummyClass(object):
     pass

--- a/glue/core/tests/test_state.py
+++ b/glue/core/tests/test_state.py
@@ -323,6 +323,22 @@ def test_astropy_compound_units():
     unit = u.m / u.s
     unit2 = clone(unit)
     assert unit2 == unit
+
+    unit = u.W / u.m**2 / u.nm
+    unit2 = clone(unit)
+    assert unit2 == unit
+
+    unit = u.km
+    unit2 = clone(unit)
+    assert unit2 is unit
+
+
+@requires_astropy
+def test_astropy_compound_units():
+    import astropy.units as u
+    unit = u.m / u.s
+    unit2 = clone(unit)
+    assert unit2 == unit
     unit = u.W / u.m**2 / u.nm
     unit2 = clone(unit)
     assert unit2 == unit

--- a/glue/core/tests/test_state.py
+++ b/glue/core/tests/test_state.py
@@ -333,17 +333,6 @@ def test_astropy_compound_units():
     assert unit2 is unit
 
 
-@requires_astropy
-def test_astropy_compound_units():
-    import astropy.units as u
-    unit = u.m / u.s
-    unit2 = clone(unit)
-    assert unit2 == unit
-    unit = u.W / u.m**2 / u.nm
-    unit2 = clone(unit)
-    assert unit2 == unit
-
-
 class DummyClass(object):
     pass
 


### PR DESCRIPTION
This PR adds serialization support for astropy `NamedUnit`s. The immediate use case for this is storing the decay unit in https://github.com/glue-viz/glue-wwt/pull/103. This seems to work well for me, and it looks like astropy will give the builtin instance after deserialization, e.g.

```
import astropy.units as u
assert u.Unit("m") is u.m  # Passes
```

However, if someone more astropy-savvy than myself knows of a better way that we should do this, please let me know!