### PR TITLE
Allow setting slices or `subset_state` for determining min/max levels in `StateAttributeLimitsHelper`

### DIFF
--- a/glue/core/state_objects.py
+++ b/glue/core/state_objects.py
@@ -356,7 +356,7 @@ class StateAttributeLimitsHelper(StateAttributeCacheHelper):
             self.set(lower=lower, upper=upper)
             return
 
-        if not force and (percentile == 'Custom' or not hasattr(self, 'data') or self.data is None):
+        if percentile == 'Custom' or (not force and getattr(self, 'data', None) is None):
             self.set(percentile=percentile, log=log)
         else:
             # Shortcut if the component ID is a pixel component ID
@@ -416,8 +416,12 @@ class StateAttributeLimitsHelper(StateAttributeCacheHelper):
         self.set(lower=self.upper, upper=self.lower)
 
     def set_slice(self, slices):
+        """Set subset for compute_statistic to current slice or global"""
+
         self.set(subset_state=None if slices is None else SliceSubsetState(self.data, slices))
-        self.update_values(force=True)
+        # Force update if percentile not set to 'Custom'.
+        if isinstance(self.percentile, (int, float)):
+            self.update_values(force=True)
 
 
 class StateAttributeSingleValueHelper(StateAttributeCacheHelper):

--- a/glue/core/state_objects.py
+++ b/glue/core/state_objects.py
@@ -303,7 +303,6 @@ class StateAttributeLimitsHelper(StateAttributeCacheHelper):
         self.subset_state = None
 
         if self.attribute is not None:
-
             if (self.lower is not None and self.upper is not None and getattr(self, 'percentile', None) is None):
                 # If the lower and upper limits are already set, we need to make
                 # sure we don't override them, so we set the percentile mode to
@@ -316,7 +315,7 @@ class StateAttributeLimitsHelper(StateAttributeCacheHelper):
 
     def update_values(self, force=False, use_default_modifiers=False, **properties):
 
-        if not force and not any(prop in properties for prop in ('attribute', 'percentile', 'log', 'display_units')):
+        if not force and not any(prop in properties for prop in ('attribute', ) + self.modifiers_names):
             self.set(percentile='Custom')
             return
 
@@ -358,11 +357,8 @@ class StateAttributeLimitsHelper(StateAttributeCacheHelper):
             return
 
         if not force and (percentile == 'Custom' or not hasattr(self, 'data') or self.data is None):
-
             self.set(percentile=percentile, log=log)
-
         else:
-
             # Shortcut if the component ID is a pixel component ID
             if isinstance(self.component_id, PixelComponentID) and percentile == 100 and not log:
                 lower = -0.5
@@ -394,7 +390,6 @@ class StateAttributeLimitsHelper(StateAttributeCacheHelper):
             if not isinstance(lower, np.datetime64) and np.isnan(lower):
                 lower, upper = 0, 1
             else:
-
                 if self.data.get_kind(self.component_id) == 'categorical':
                     lower = np.floor(lower - 0.5) + 0.5
                     upper = np.ceil(upper + 0.5) - 0.5
@@ -422,6 +417,7 @@ class StateAttributeLimitsHelper(StateAttributeCacheHelper):
 
     def set_slice(self, slices):
         self.set(subset_state=None if slices is None else SliceSubsetState(self.data, slices))
+        self.update_values(force=True)
 
 
 class StateAttributeSingleValueHelper(StateAttributeCacheHelper):

--- a/glue/core/state_objects.py
+++ b/glue/core/state_objects.py
@@ -292,7 +292,7 @@ class StateAttributeLimitsHelper(StateAttributeCacheHelper):
     """
 
     values_names = ('lower', 'upper')
-    modifiers_names = ('log', 'percentile', 'display_units', 'subset_state')
+    modifiers_names = ('log', 'percentile', 'display_units')
 
     def __init__(self, state, attribute, random_subset=10000, margin=0, **kwargs):
 
@@ -300,7 +300,7 @@ class StateAttributeLimitsHelper(StateAttributeCacheHelper):
 
         self.margin = margin
         self.random_subset = random_subset
-        self.subset_state = None
+        self._subset_state = None
 
         if self.attribute is not None:
             if (self.lower is not None and self.upper is not None and getattr(self, 'percentile', None) is None):
@@ -371,20 +371,20 @@ class StateAttributeLimitsHelper(StateAttributeCacheHelper):
             if percentile == 100:
                 lower = self.data.compute_statistic('minimum', cid=self.component_id,
                                                     finite=True, positive=log,
-                                                    subset_state=self.subset_state,
+                                                    subset_state=self._subset_state,
                                                     random_subset=self.random_subset)
                 upper = self.data.compute_statistic('maximum', cid=self.component_id,
                                                     finite=True, positive=log,
-                                                    subset_state=self.subset_state,
+                                                    subset_state=self._subset_state,
                                                     random_subset=self.random_subset)
             else:
                 lower = self.data.compute_statistic('percentile', cid=self.component_id,
                                                     percentile=exclude, positive=log,
-                                                    subset_state=self.subset_state,
+                                                    subset_state=self._subset_state,
                                                     random_subset=self.random_subset)
                 upper = self.data.compute_statistic('percentile', cid=self.component_id,
                                                     percentile=100 - exclude, positive=log,
-                                                    subset_state=self.subset_state,
+                                                    subset_state=self._subset_state,
                                                     random_subset=self.random_subset)
 
             if not isinstance(lower, np.datetime64) and np.isnan(lower):
@@ -418,7 +418,8 @@ class StateAttributeLimitsHelper(StateAttributeCacheHelper):
     def set_slice(self, slices):
         """Set subset for compute_statistic to current slice or global"""
 
-        self.set(subset_state=None if slices is None else SliceSubsetState(self.data, slices))
+        self._subset_state = None if slices is None else SliceSubsetState(self.data, slices)
+
         # Force update if percentile not set to 'Custom'.
         if isinstance(self.percentile, (int, float)):
             self.update_values(force=True)

--- a/glue/core/tests/test_state_objects.py
+++ b/glue/core/tests/test_state_objects.py
@@ -4,7 +4,6 @@ from numpy.testing import assert_allclose
 
 from echo import CallbackProperty, ListCallbackProperty
 from glue.core import Data, DataCollection
-from glue.core.subset import SliceSubsetState
 
 from .test_state import clone
 from ..state_objects import (State, StateAttributeLimitsHelper,
@@ -95,13 +94,11 @@ class TestStateAttributeLimitsHelper():
             upper = CallbackProperty()
             log = CallbackProperty(False)
             scale = CallbackProperty(100)
-            subset_state = CallbackProperty()
 
         self.state = SimpleState()
 
         self.helper = StateAttributeLimitsHelper(self.state, attribute='comp',
                                                  lower='lower', upper='upper',
-                                                 subset_state='subset_state',
                                                  percentile='scale', log='log')
         self.state.data = self.data
         self.state.comp = self.data.id['x']
@@ -185,31 +182,25 @@ class TestStateAttributeLimitsHelper():
         assert self.helper.upper == 234
         assert self.helper.log
 
-    def test_subset(self):
-
-        # Directly set subset to compute limits from
-        assert self.helper.percentile == 100
-        self.helper.subset_state = SliceSubsetState(self.helper.data, [slice(6000)])
-        assert_allclose(self.helper.lower, -100)
-        assert_allclose(self.helper.upper, 19.992)
-        self.helper.percentile = 90
-        assert_allclose(self.helper.lower, -94.0004)
-        assert_allclose(self.helper.upper, 13.9924)
-
-    def test_slice(self):
+    def test_set_slice(self):
 
         # Set subset to compute limits from slice
         self.helper.set_slice([slice(2000, 8000)])
+
         assert self.helper.percentile == 100
-        assert self.helper.subset_state.slices == [slice(2000, 8000)]
+
         assert_allclose(self.helper.lower, -59.996)
         assert_allclose(self.helper.upper, 59.996)
+
         self.helper.percentile = 90
+
         assert_allclose(self.helper.lower, -53.9964)
         assert_allclose(self.helper.upper, 53.9964)
 
         self.helper.set_slice(None)
+
         self.helper.percentile = 95
+
         assert_allclose(self.helper.lower, -95)
         assert_allclose(self.helper.upper, 95)
 

--- a/glue/core/tests/test_state_objects.py
+++ b/glue/core/tests/test_state_objects.py
@@ -4,6 +4,7 @@ from numpy.testing import assert_allclose
 
 from echo import CallbackProperty, ListCallbackProperty
 from glue.core import Data, DataCollection
+from glue.core.subset import SliceSubsetState
 
 from .test_state import clone
 from ..state_objects import (State, StateAttributeLimitsHelper,
@@ -181,6 +182,35 @@ class TestStateAttributeLimitsHelper():
         assert self.helper.lower == -122
         assert self.helper.upper == 234
         assert self.helper.log
+
+    def test_subset(self):
+
+        # Set subset to compute limits from
+        self.helper.subset_state = SliceSubsetState(self.helper.data, [slice(6000)])
+        self.helper.percentile = 100
+        # self.helper.update_values()
+        assert_allclose(self.helper.lower, -100)
+        assert_allclose(self.helper.upper, 19.992)
+        self.helper.percentile = 90
+        assert_allclose(self.helper.lower, -94.0004)
+        assert_allclose(self.helper.upper, 13.9924)
+
+    def test_slice(self):
+
+        # Set subset to compute limits from slice
+        self.helper.set_slice([slice(2000, 8000)])
+        self.helper.percentile = 100
+        # self.helper.update_values()
+        assert_allclose(self.helper.lower, -59.996)
+        assert_allclose(self.helper.upper, 59.996)
+        self.helper.percentile = 90
+        assert_allclose(self.helper.lower, -53.9964)
+        assert_allclose(self.helper.upper, 53.9964)
+
+        self.helper.set_slice(None)
+        self.helper.percentile = 95
+        assert_allclose(self.helper.lower, -95)
+        assert_allclose(self.helper.upper, 95)
 
 
 class TestStateAttributeSingleValueHelper():

--- a/glue/core/tests/test_state_objects.py
+++ b/glue/core/tests/test_state_objects.py
@@ -95,11 +95,13 @@ class TestStateAttributeLimitsHelper():
             upper = CallbackProperty()
             log = CallbackProperty(False)
             scale = CallbackProperty(100)
+            subset_state = CallbackProperty()
 
         self.state = SimpleState()
 
         self.helper = StateAttributeLimitsHelper(self.state, attribute='comp',
                                                  lower='lower', upper='upper',
+                                                 subset_state='subset_state',
                                                  percentile='scale', log='log')
         self.state.data = self.data
         self.state.comp = self.data.id['x']
@@ -185,10 +187,9 @@ class TestStateAttributeLimitsHelper():
 
     def test_subset(self):
 
-        # Set subset to compute limits from
+        # Directly set subset to compute limits from
+        assert self.helper.percentile == 100
         self.helper.subset_state = SliceSubsetState(self.helper.data, [slice(6000)])
-        self.helper.percentile = 100
-        # self.helper.update_values()
         assert_allclose(self.helper.lower, -100)
         assert_allclose(self.helper.upper, 19.992)
         self.helper.percentile = 90
@@ -199,8 +200,8 @@ class TestStateAttributeLimitsHelper():
 
         # Set subset to compute limits from slice
         self.helper.set_slice([slice(2000, 8000)])
-        self.helper.percentile = 100
-        # self.helper.update_values()
+        assert self.helper.percentile == 100
+        assert self.helper.subset_state.slices == [slice(2000, 8000)]
         assert_allclose(self.helper.lower, -59.996)
         assert_allclose(self.helper.upper, 59.996)
         self.helper.percentile = 90

--- a/glue/viewers/image/state.py
+++ b/glue/viewers/image/state.py
@@ -587,6 +587,19 @@ class ImageLayerState(BaseImageLayerState, StretchStateMixin):
         """
         self.attribute_lim_helper.flip_limits()
 
+    def set_slice(self, slices):
+        """
+        Select a subset slice for determining image levels.
+
+        Parameters
+        ----------
+        slices : iterable of :class:`slice` or `None`
+            An iterable containing :class:`slice` objects that can instantiate
+            a :class:`~glue.core.subset.SliceSubsetState` and has to be consistent
+            with the shape of `self.data`; `None` to unslice.
+        """
+        self.attribute_lim_helper.set_slice(slices)
+
     def reset_contrast_bias(self):
         with delay_callback(self, 'contrast', 'bias'):
             self.contrast = 1

--- a/glue/viewers/image/state.py
+++ b/glue/viewers/image/state.py
@@ -492,8 +492,8 @@ class ImageLayerState(BaseImageLayerState, StretchStateMixin):
     v_min = DDCProperty(docstring='The lower level shown')
     v_max = DDCProperty(docstring='The upper level shown')
     attribute_display_unit = DDSCProperty(docstring='The units to use to define the levels')
-    percentile = DDSCProperty(docstring='The percentile value used to '
-                                        'automatically calculate levels')
+    percentile = DDSCProperty(docstring='The percentile value used to automatically '
+                                        'calculate levels; "Custom" for manually set levels')
     contrast = DDCProperty(1, docstring='The contrast of the layer')
     bias = DDCProperty(0.5, docstring='A constant value that is added to the '
                                       'layer before rendering')
@@ -501,9 +501,9 @@ class ImageLayerState(BaseImageLayerState, StretchStateMixin):
     global_sync = DDCProperty(False, docstring='Whether the color and transparency '
                                                'should be synced with the global '
                                                'color and transparency for the data')
-    global_limits = DDCProperty(True, docstring='Calculate automatic levels on statistics '
-                                                'over the entire data cube or only the '
-                                                'current layer (slice)')
+    stretch_global = DDCProperty(True, docstring='Calculate automatic levels for rendering '
+                                                 'stretch from the full data cube or only the '
+                                                 'current layer (slice)')
 
     def __init__(self, layer=None, viewer_state=None, **kwargs):
 
@@ -545,7 +545,7 @@ class ImageLayerState(BaseImageLayerState, StretchStateMixin):
 
         self.add_callback('global_sync', self._update_syncing)
         self.add_callback('layer', self._update_attribute)
-        self.add_callback('global_limits', self._set_global_limits, priority=0)
+        self.add_callback('stretch_global', self._set_global_stretch, priority=0)
 
         self._update_syncing()
 
@@ -585,8 +585,8 @@ class ImageLayerState(BaseImageLayerState, StretchStateMixin):
     def _get_image(self, view=None):
         return self.layer[self.attribute, view]
 
-    def _set_global_limits(self, global_limits=True):
-        if global_limits:
+    def _set_global_stretch(self, stretch_global=True):
+        if stretch_global:
             self.viewer_state.remove_callback('slices', self._update_slice_subset)
             self.attribute_lim_helper.set_slice(None)
         else:

--- a/glue/viewers/image/tests/test_state.py
+++ b/glue/viewers/image/tests/test_state.py
@@ -418,3 +418,43 @@ def test_attribute_units():
 
     assert_allclose(layer_state1.v_min, 2.475)
     assert_allclose(layer_state1.v_max, 50)
+
+
+def test_stretch_global():
+
+    # Test the option of using global vs per-slice stretch
+
+    viewer_state = ImageViewerState()
+
+    data1 = Data(x=np.arange(1000).reshape((10, 10, 10)))
+
+    layer_state = ImageLayerState(layer=data1, viewer_state=viewer_state)
+    viewer_state.layers.append(layer_state)
+
+    assert layer_state.stretch_global is True
+
+    assert layer_state.percentile == 100
+    assert layer_state.v_min == 0
+    assert layer_state.v_max == 999
+
+    assert viewer_state.slices == (0, 0, 0)
+
+    layer_state.stretch_global = False
+
+    assert layer_state.v_min == 0
+    assert layer_state.v_max == 99
+
+    viewer_state.slices = (9, 0, 0)
+
+    assert layer_state.v_min == 900
+    assert layer_state.v_max == 999
+
+    layer_state.percentile = 90
+
+    assert layer_state.v_min == 904.95
+    assert layer_state.v_max == 994.05
+
+    layer_state.stretch_global = True
+
+    assert layer_state.v_min == 49.95
+    assert layer_state.v_max == 949.05


### PR DESCRIPTION
## Description
This enables passing a `subset_state` to the `compute_statistic` calls in `StateAttributeLimitsHelper` to derive limits based on that subset only and adds a `set_slice` convenience method to create a `SliceSubsetState` for that purpose.
That function is also exposed through `ImageLayerState`.

TBD: ~~`StateAttributeLimitsHelper` should automatically update (re-run statistics) on changes to `subset_state`; currently have to trigger this via setting `percentile` or other attributes (see tests)~~.
Adding this to Callbacks looks a bit hackish, but update seems to work so far.

Perhaps should test multi-dimensional case as well and explore other types of subsets (`SliceSubsetState` has special handling in `compute_statistic`).