### PR TITLE
Fix the logic for region display when exchanging x/y world coordinates

### DIFF
--- a/glue/tests/visual/py311-test-visual.json
+++ b/glue/tests/visual/py311-test-visual.json
@@ -5,5 +5,7 @@
   "glue.viewers.image.tests.test_viewer.test_region_layer_flip": "a142142f34961aba7e98188ad43abafe0e6e5b82e13e8cdab5131d297ed5832c",
   "glue.viewers.profile.tests.test_viewer.test_simple_viewer": "f68a21be5080fec513388b2d2b220512e7b0df5498e2489da54e58708de435b3",
   "glue.viewers.scatter.tests.test_viewer.test_simple_viewer": "1020a7bd3abe40510b9e03047c3b423b75c3c64ac18e6dcd6257173cec1ed53f",
-  "glue.viewers.scatter.tests.test_viewer.test_scatter_density_map": "3379d655262769a6ccbdbaf1970bffa9237adbec23a93d3ab75da51b9a3e7f8b"
+  "glue.viewers.scatter.tests.test_viewer.test_scatter_density_map": "3379d655262769a6ccbdbaf1970bffa9237adbec23a93d3ab75da51b9a3e7f8b",
+  "glue.viewers.image.tests.test_viewer.TestWCSRegionDisplay.test_wcs_viewer": "651e0d954c6b77becb7064de24f5101b9f2882adabc1d5aedbc183b9762c59b1",
+  "glue.viewers.image.tests.test_viewer.TestWCSRegionDisplay.test_flipped_wcs_viewer": "fcc18a1398d1f3f61b6989a722402cde9365a34483eedf8eac222647e20eb8ab"
 }

--- a/glue/viewers/image/tests/test_viewer.py
+++ b/glue/viewers/image/tests/test_viewer.py
@@ -125,7 +125,6 @@ class TestWCSRegionDisplay(object):
 
         self.viewer = self.application.new_data_viewer(SimpleImageViewer)
 
-    @visual_test
     def test_flipped_viewer(self):
         self.viewer.add_data(self.image1)
 
@@ -153,5 +152,3 @@ class TestWCSRegionDisplay(object):
 
         # Because we have flipped the viewer, the patches should have changed
         assert np.array_equal(original_path_patch, np.flip(new_path_patch, axis=1))
-
-        return self.viewer.figure

--- a/glue/viewers/image/tests/test_viewer.py
+++ b/glue/viewers/image/tests/test_viewer.py
@@ -216,7 +216,6 @@ class TestWCSRegionDisplay(object):
         assert self.viewer.layers[0].enabled
         assert self.viewer.layers[1].enabled
 
-
     @visual_test
     def test_wcs_viewer(self):
         self.viewer.add_data(self.image1)

--- a/glue/viewers/image/tests/test_viewer.py
+++ b/glue/viewers/image/tests/test_viewer.py
@@ -184,6 +184,39 @@ class TestWCSRegionDisplay(object):
 
         self.viewer = self.application.new_data_viewer(SimpleImageViewer)
 
+    def test_wcs_viewer_bad_link(self):
+        self.viewer.add_data(self.image1)
+
+        link1 = LinkSame(self.region_data.id['color'], self.image1.world_component_ids[1])
+        link2 = LinkSame(self.region_data.id['area'], self.image1.world_component_ids[0])
+
+        self.application.data_collection.add_link(link1)
+        self.application.data_collection.add_link(link2)
+
+        self.viewer.add_data(self.region_data)
+
+        assert self.viewer.state._display_world is True
+        assert len(self.viewer.state.layers) == 2
+        assert self.viewer.layers[0].enabled
+        assert not self.viewer.layers[1].enabled
+
+    def test_wcs_viewer_good_link(self):
+        self.viewer.add_data(self.image1)
+
+        link1 = LinkSame(self.region_data.center_x_id, self.image1.world_component_ids[1])
+        link2 = LinkSame(self.region_data.center_y_id, self.image1.world_component_ids[0])
+
+        self.application.data_collection.add_link(link1)
+        self.application.data_collection.add_link(link2)
+
+        self.viewer.add_data(self.region_data)
+
+        assert self.viewer.state._display_world is True
+        assert len(self.viewer.state.layers) == 2
+        assert self.viewer.layers[0].enabled
+        assert self.viewer.layers[1].enabled
+
+
     @visual_test
     def test_wcs_viewer(self):
         self.viewer.add_data(self.image1)

--- a/glue/viewers/image/tests/test_viewer.py
+++ b/glue/viewers/image/tests/test_viewer.py
@@ -6,8 +6,10 @@ from glue.core.application_base import Application
 from glue.core.data import Data
 from glue.core.link_helpers import LinkSame
 from glue.core.data_region import RegionData
+from astropy.wcs import WCS
 
-from shapely.geometry import Polygon, MultiPolygon
+from shapely.geometry import Polygon, MultiPolygon, Point
+import shapely
 
 
 @visual_test
@@ -97,3 +99,59 @@ def test_region_layer_flip():
         viewer.state.y_att = image_data.pixel_component_ids[1]
 
     return viewer.figure
+
+
+class TestWCSRegionDisplay(object):
+    def setup_method(self, method):
+
+        wcs1 = WCS(naxis=2)
+        wcs1.wcs.ctype = 'RA---TAN', 'DEC--TAN'
+        wcs1.wcs.crpix = -3, 5
+        wcs1.wcs.cd = [[2, -1], [1, 2]]
+
+        wcs1.wcs.set()
+
+        self.image1 = Data(label='image1', a=[[3, 3], [2, 2]], b=[[4, 4], [3, 2]],
+                            coords=wcs1)
+        SHAPELY_CIRCLE_ARRAY = np.array([Point(1.5, 2.5).buffer(1), Polygon([(1, 1), (2, 2), (2, 3), (1, 3)])])
+        self.region_data = RegionData(label='My Regions',
+                                      color=np.array(['red', 'blue']),
+                                      area=shapely.area(SHAPELY_CIRCLE_ARRAY),
+                                      boundary=SHAPELY_CIRCLE_ARRAY)
+        self.application = Application()
+
+        self.application.data_collection.append(self.image1)
+        self.application.data_collection.append(self.region_data)
+
+        self.viewer = self.application.new_data_viewer(SimpleImageViewer)
+
+    @visual_test
+    def test_flipped_viewer(self):
+        self.viewer.add_data(self.image1)
+
+        link1 = LinkSame(self.region_data.center_x_id, self.image1.world_component_ids[1])
+        link2 = LinkSame(self.region_data.center_y_id, self.image1.world_component_ids[0])
+
+        self.application.data_collection.add_link(link1)
+        self.application.data_collection.add_link(link2)
+
+        self.viewer.add_data(self.region_data)
+        original_path_patch = self.viewer.layers[1].region_collection.patches[1].get_path().vertices
+
+        # Flip x,y in the viewer
+        with delay_callback(self.viewer.state, 'x_att_world', 'y_att_world', 'x_att', 'y_att'):
+            self.viewer.state.x_att_world = self.image1.world_component_ids[0]
+            self.viewer.state.y_att_world = self.image1.world_component_ids[1]
+            self.viewer.state.x_att = self.image1.pixel_component_ids[0]
+            self.viewer.state.y_att = self.image1.pixel_component_ids[1]
+
+        assert self.viewer.state._display_world is True
+        assert len(self.viewer.state.layers) == 2
+        assert self.viewer.layers[0].enabled
+        assert self.viewer.layers[1].enabled
+        new_path_patch = self.viewer.layers[1].region_collection.patches[1].get_path().vertices
+
+        # Because we have flipped the viewer, the patches should have changed
+        assert np.array_equal(original_path_patch, np.flip(new_path_patch, axis=1))
+
+        return self.viewer.figure


### PR DESCRIPTION
# Pull Request Template

## Description

This is a fix and test for https://github.com/glue-viz/glue-qt/issues/16, where regions defined in world coordinates were not rotating properly when the x and y coordinates are exchanged.