### PR TITLE
Allow transparent regions in composite images when out of bounds

### DIFF
--- a/glue/core/fixed_resolution_buffer.py
+++ b/glue/core/fixed_resolution_buffer.py
@@ -261,7 +261,7 @@ def compute_fixed_resolution_buffer(data, bounds, target_data=None, target_cid=N
         # Take subset_state into account, if present
         if subset_state is None:
             array = data.get_data(target_cid, view=subregion).astype(float)
-            invalid_value = -np.inf
+            invalid_value = np.nan
         else:
             array = data.get_mask(subset_state, view=subregion)
             invalid_value = False
@@ -275,7 +275,7 @@ def compute_fixed_resolution_buffer(data, bounds, target_data=None, target_cid=N
         # Take subset_state into account, if present
         if subset_state is None:
             array = data.get_data(target_cid, view=translated_coords).astype(float)
-            invalid_value = -np.inf
+            invalid_value = np.nan
         else:
             array = data.get_mask(subset_state, view=translated_coords)
             invalid_value = False

--- a/glue/core/tests/test_fixed_resolution_buffer.py
+++ b/glue/core/tests/test_fixed_resolution_buffer.py
@@ -89,11 +89,11 @@ class TestFixedResolutionBuffer():
         # Bounds are outside data along some dimensions
         ([(-5, 9, 15), (3, 5, 3), (0, 9, 10), (5, 6, 2)],
             np.pad(ARRAY[:, 3:6, :, 5:7], [(5, 4), (0, 0), (0, 2), (0, 0)],
-                   mode='constant', constant_values=-np.inf)),
+                   mode='constant', constant_values=np.nan)),
 
         # No overlap
         ([(2, 3, 2), (3, 3, 1), (-5, -4, 2), (0, 7, 8)],
-            -np.inf * np.ones((2, 1, 2, 8)))
+            np.nan * np.ones((2, 1, 2, 8)))
 
     ]
 
@@ -137,22 +137,22 @@ def test_base_cartesian_data():
                                                  target_data=data1,
                                                  bounds=[(-1, 1, 3), (0, 3, 4), 1],
                                                  target_cid=data1.main_components[0]),
-                 np.array([[-np.inf, -np.inf, -np.inf, -np.inf],
+                 np.array([[np.nan, np.nan, np.nan, np.nan],
                            [1, 4, 7, 10],
-                           [-np.inf, -np.inf, -np.inf, -np.inf]]))
+                           [np.nan, np.nan, np.nan, np.nan]]))
 
     assert_equal(compute_fixed_resolution_buffer(data2,
                                                  target_data=data2,
                                                  bounds=[(-1, 1, 3), (0, 3, 4), 1],
                                                  target_cid=data2.main_components[0]),
-                 np.array([[-np.inf, -np.inf, -np.inf, -np.inf],
+                 np.array([[np.nan, np.nan, np.nan, np.nan],
                            [1, 4, 7, 10],
-                           [-np.inf, -np.inf, -np.inf, -np.inf]]))
+                           [np.nan, np.nan, np.nan, np.nan]]))
 
     assert_equal(compute_fixed_resolution_buffer(data1,
                                                  target_data=data2,
                                                  bounds=[(-1, 1, 3), (0, 3, 4), 1],
                                                  target_cid=data1.main_components[0]),
-                 np.array([[-np.inf, -np.inf, -np.inf, -np.inf],
-                           [-np.inf, 2, 5, 8],
-                           [-np.inf, -np.inf, -np.inf, -np.inf]]))
+                 np.array([[np.nan, np.nan, np.nan, np.nan],
+                           [np.nan, 2, 5, 8],
+                           [np.nan, np.nan, np.nan, np.nan]]))


### PR DESCRIPTION
## Description

When multiple images are loaded in image viewers in glue, the fixed resolution buffer logic chooses the data layer color and alpha for out-of-bounds regions. The logic passes in a "data value" of negative infinity, and sends that through the colormap. By default, this can give black out-of-bounds regions, which darkens the appearance of lower layers. In a simple example with two layers below, both layers have `alpha=0.5`, but the larger and lower layer is darker because the upper layer is rendered on top with black pixels at alpha=0.5.

<img width="831" alt="Screen Shot 2024-04-16 at 11 29 52" src="https://github.com/glue-viz/glue/assets/3497584/7f0b5ee8-7f4f-4182-91e4-f15fb94b1af3">

This PR replaces `-np.inf` with `np.nan` as the default out-of-bounds value to pass into the colormap. Because of the default nan/clipping in `composite_array`, users shouldn't see a difference in the viewer unless they opt-in, in which case they will see:

<img width="831" alt="Screen Shot 2024-04-16 at 11 36 52" src="https://github.com/glue-viz/glue/assets/3497584/6a19cc7c-6510-44c3-8471-e07ae4666b6e">

To opt in (after this PR), select a colormap with a transparent bad pixel:
```
import matplotlib.pyplot as plt
cmap = plt.cm.gray.with_extremes(bad=(0, 0, 0, 0))
```
and allow the `bad` alpha to be shown (since https://github.com/glue-viz/glue/pull/2468):
```
layer.composite._allow_bad_alpha = True
```