### PR TITLE
Remove pvextractor from dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,6 @@ install_requires =
     xlrd>=1.2
     openpyxl>=3.0
     mpl-scatter-density>=0.7
-    pvextractor>=0.2
     importlib_resources>=1.3; python_version<'3.9'
     importlib_metadata>=3.6; python_version<'3.10'
     shapely>=2.0


### PR DESCRIPTION
This PR removes `pvextractor` from the dependencies, as it's not used anywhere within the `glue-core` codebase. The functionality that uses `pvextractor` all now lives in `glue-qt` (where it's already a dependency).

The motivation for this is https://github.com/glue-viz/glue-wwt/issues/111. The dependency on `pvextractor` here means that `qtpy` is an upstream dependency for `glue-wwt`, and more generally anything that depends on `glue-core`.