### PR TITLE
Fix compatibility with Numpy 2.0 and fix compatibility of viewers with generic BaseData subclasses

### DIFF
--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -71,6 +71,8 @@ class BaseData(object, metaclass=abc.ABCMeta):
 
         self.style = VisualAttributes(parent=self)
 
+        self.uuid = str(uuid.uuid4())
+
     @property
     def label(self):
         """
@@ -772,11 +774,6 @@ class Data(BaseCartesianData):
             self.add_component(data, lbl)
 
         self._key_joins = {}
-
-        # To avoid circular references when saving objects with references to
-        # the data, we make sure that all Data objects have a UUID that can
-        # uniquely identify them.
-        self.uuid = str(uuid.uuid4())
 
     @property
     def coords(self):

--- a/glue/viewers/common/tests/test_stretch_state_mixin.py
+++ b/glue/viewers/common/tests/test_stretch_state_mixin.py
@@ -39,13 +39,16 @@ class TestStretchStateMixin:
             self.state.stretch_parameters["foo"] = 1
 
     def test_set_parameter(self):
+
+        pytest.importorskip('astropy', minversion='6.0')
+
         self.state.stretch = "log"
 
-        assert self.state.stretch_object.exp == 1000
+        assert self.state.stretch_object.a == 1000
 
         # Setting the stretch parameter 'exp' is synced with the stretch object attribute
-        self.state.stretch_parameters["exp"] = 200
-        assert self.state.stretch_object.exp == 200
+        self.state.stretch_parameters["a"] = 200
+        assert self.state.stretch_object.a == 200
 
         # Changing stretch resets the stretch parameter dictionary
         self.state.stretch = "linear"
@@ -53,4 +56,4 @@ class TestStretchStateMixin:
 
         # And there is no memory of previous parameters
         self.state.stretch = "log"
-        assert self.state.stretch_object.exp == 1000
+        assert self.state.stretch_object.a == 1000

--- a/glue/viewers/common/viewer.py
+++ b/glue/viewers/common/viewer.py
@@ -457,6 +457,10 @@ class Viewer(BaseViewer):
 
         imports = ['from glue.core.state import load']
 
+        # Always include Numpy because as of Numpy 2.0, scalars are sometimes
+        # represented in string form as e.g. np.float64(...)
+        imports += ['import numpy as np']
+
         imports_header, header = self._script_header()
         imports.extend(imports_header)
 

--- a/glue/viewers/histogram/tests/test_viewer.py
+++ b/glue/viewers/histogram/tests/test_viewer.py
@@ -7,6 +7,7 @@ from glue.tests.visual.helpers import visual_test
 from glue.viewers.histogram.viewer import SimpleHistogramViewer
 from glue.core.application_base import Application
 from glue.core.data import Data
+from glue.core.data_derived import IndexedData
 
 
 @visual_test
@@ -119,3 +120,29 @@ def test_reset_limits():
 
     assert_allclose(viewer.state.hist_x_min, 49.95)
     assert_allclose(viewer.state.hist_x_max, 949.05)
+
+
+def test_indexed_data():
+
+    # Make sure that the scatter viewer works properly with IndexedData objects
+
+    data_4d = Data(label='hypercube',
+                   x=np.random.random((3, 5, 4, 3)),
+                   y=np.random.random((3, 5, 4, 3)))
+
+    data_2d = IndexedData(data_4d, (2, None, 3, None))
+
+    application = Application()
+
+    session = application.session
+
+    hub = session.hub
+
+    data_collection = session.data_collection
+    data_collection.append(data_4d)
+    data_collection.append(data_2d)
+
+    viewer = application.new_data_viewer(SimpleHistogramViewer)
+    viewer.add_data(data_2d)
+
+    assert viewer.state.x_att is data_2d.main_components[0]

--- a/glue/viewers/image/state.py
+++ b/glue/viewers/image/state.py
@@ -620,6 +620,7 @@ class ImageLayerState(BaseImageLayerState, StretchStateMixin):
 
     def _update_attribute_display_unit_choices(self, *args):
 
+        # NOTE: only Data and its subclasses support specifying units
         if self.layer is None or self.attribute is None or not isinstance(self.layer, Data):
             ImageLayerState.attribute_display_unit.set_choices(self, [])
             return

--- a/glue/viewers/image/state.py
+++ b/glue/viewers/image/state.py
@@ -1,7 +1,7 @@
 import uuid
 from collections import defaultdict
 
-from glue.core import BaseData
+from glue.core import BaseData, Data
 from glue.config import colormaps
 from glue.viewers.matplotlib.state import (MatplotlibDataViewerState,
                                            MatplotlibLayerState,
@@ -620,7 +620,7 @@ class ImageLayerState(BaseImageLayerState, StretchStateMixin):
 
     def _update_attribute_display_unit_choices(self, *args):
 
-        if self.layer is None or self.attribute is None:
+        if self.layer is None or self.attribute is None or not isinstance(self.layer, Data):
             ImageLayerState.attribute_display_unit.set_choices(self, [])
             return
 

--- a/glue/viewers/image/tests/test_viewer.py
+++ b/glue/viewers/image/tests/test_viewer.py
@@ -6,6 +6,7 @@ from glue.core.application_base import Application
 from glue.core.data import Data
 from glue.core.link_helpers import LinkSame
 from glue.core.data_region import RegionData
+from glue.core.data_derived import IndexedData
 from astropy.wcs import WCS
 
 from shapely.geometry import Polygon, MultiPolygon, Point
@@ -265,3 +266,32 @@ class TestWCSRegionDisplay(object):
         assert np.array_equal(original_path_patch, np.flip(new_path_patch, axis=1))
 
         return self.viewer.figure
+
+
+def test_indexed_data():
+
+    # Make sure that the image viewer works properly with IndexedData objects
+
+    data_4d = Data(label='hypercube_wcs',
+                   x=np.random.random((3, 5, 4, 3)),
+                   coords=WCS(naxis=4))
+
+    data_2d = IndexedData(data_4d, (2, None, 3, None))
+
+    application = Application()
+
+    session = application.session
+
+    hub = session.hub
+
+    data_collection = session.data_collection
+    data_collection.append(data_4d)
+    data_collection.append(data_2d)
+
+    viewer = application.new_data_viewer(SimpleImageViewer)
+    viewer.add_data(data_2d)
+
+    assert viewer.state.x_att is data_2d.pixel_component_ids[1]
+    assert viewer.state.y_att is data_2d.pixel_component_ids[0]
+    assert viewer.state.x_att_world is data_2d.world_component_ids[1]
+    assert viewer.state.y_att_world is data_2d.world_component_ids[0]

--- a/glue/viewers/profile/state.py
+++ b/glue/viewers/profile/state.py
@@ -3,7 +3,7 @@ from glue.core.hub import HubListener
 
 import numpy as np
 
-from glue.core import Subset
+from glue.core import Subset, Data
 from echo import delay_callback
 from glue.viewers.matplotlib.state import (MatplotlibDataViewerState,
                                            MatplotlibLayerState,
@@ -11,7 +11,6 @@ from glue.viewers.matplotlib.state import (MatplotlibDataViewerState,
                                            DeferredDrawSelectionCallbackProperty as DDSCProperty)
 from glue.core.data_combo_helper import ManualDataComboHelper, ComponentIDComboHelper
 from glue.utils import defer_draw, avoid_circular
-from glue.core.data import BaseData
 from glue.core.link_manager import is_convertible_to_single_pixel_cid
 from glue.core.exceptions import IncompatibleDataException
 from glue.core.message import SubsetUpdateMessage
@@ -264,7 +263,8 @@ class ProfileViewerState(MatplotlibDataViewerState):
 
     def _update_x_display_unit_choices(self):
 
-        if self.reference_data is None:
+        # NOTE: only Data and its subclasses support specifying units
+        if self.reference_data is None or not isinstance(self.reference_data, Data):
             ProfileViewerState.x_display_unit.set_choices(self, [])
             return
 
@@ -280,7 +280,8 @@ class ProfileViewerState(MatplotlibDataViewerState):
 
         component_units = set()
         for layer_state in self.layers:
-            if isinstance(layer_state.layer, BaseData):
+            # NOTE: only Data and its subclasses support specifying units
+            if isinstance(layer_state.layer, Data):
                 component = layer_state.layer.get_component(layer_state.attribute)
                 if component.units:
                     component_units.add((layer_state.layer, layer_state.attribute, component.units))

--- a/glue/viewers/profile/tests/test_viewer.py
+++ b/glue/viewers/profile/tests/test_viewer.py
@@ -11,6 +11,7 @@ from glue.core.data import Data
 from glue.config import settings, unit_converter
 from glue.plugins.wcs_autolinking.wcs_autolinking import WCSLink
 from glue.core.roi import XRangeROI
+from glue.core.data_derived import IndexedData
 
 
 @visual_test
@@ -171,3 +172,29 @@ def test_unit_conversion():
 
     viewer.state.reference_data = d2
     viewer.state.y_display_unit = 'mJy'
+
+
+def test_indexed_data():
+
+    # Make sure that the profile viewer works properly with IndexedData objects
+
+    data_4d = Data(label='hypercube_wcs',
+                   x=np.random.random((3, 5, 4, 3)),
+                   coords=WCS(naxis=4))
+
+    data_2d = IndexedData(data_4d, (2, None, 3, None))
+
+    application = Application()
+
+    session = application.session
+
+    hub = session.hub
+
+    data_collection = session.data_collection
+    data_collection.append(data_4d)
+    data_collection.append(data_2d)
+
+    viewer = application.new_data_viewer(SimpleProfileViewer)
+    viewer.add_data(data_2d)
+
+    assert viewer.state.x_att is data_2d.world_component_ids[0]

--- a/glue/viewers/scatter/tests/test_viewer.py
+++ b/glue/viewers/scatter/tests/test_viewer.py
@@ -9,6 +9,7 @@ from glue.viewers.scatter.viewer import SimpleScatterViewer
 from glue.core.application_base import Application
 from glue.core.data import Data
 from glue.core.link_helpers import LinkSame
+from glue.core.data_derived import IndexedData
 
 
 @visual_test
@@ -103,3 +104,30 @@ def test_reset_limits():
 
     assert_allclose(viewer.state.y_min, 1000 + 67.932)
     assert_allclose(viewer.state.y_max, 1000 + 931.068)
+
+
+def test_indexed_data():
+
+    # Make sure that the scatter viewer works properly with IndexedData objects
+
+    data_4d = Data(label='hypercube',
+                   x=np.random.random((3, 5, 4, 3)),
+                   y=np.random.random((3, 5, 4, 3)))
+
+    data_2d = IndexedData(data_4d, (2, None, 3, None))
+
+    application = Application()
+
+    session = application.session
+
+    hub = session.hub
+
+    data_collection = session.data_collection
+    data_collection.append(data_4d)
+    data_collection.append(data_2d)
+
+    viewer = application.new_data_viewer(SimpleScatterViewer)
+    viewer.add_data(data_2d)
+
+    assert viewer.state.x_att is data_2d.main_components[0]
+    assert viewer.state.y_att is data_2d.main_components[1]


### PR DESCRIPTION
Found these while trying to get the glue-qt test suite to pass again.