### PR TITLE
Remove __gluestate__ and __setgluestate__ from base Application class

### DIFF
--- a/glue/config.py
+++ b/glue/config.py
@@ -390,7 +390,7 @@ class ColormapRegistry(Registry):
 
     def name_from_cmap(self, cmap_desired):
         for name, cmap in self.members:
-            if cmap is cmap_desired:
+            if cmap is cmap_desired or cmap.name == cmap_desired.name:
                 return name
         raise ValueError("Could not find name for colormap")
 

--- a/glue/core/application_base.py
+++ b/glue/core/application_base.py
@@ -364,10 +364,4 @@ class Application(HubListener):
         # manually register the newly-created session, which
         # the viewers need
         context.register_object(rec['session'], self.session)
-        for i, tab in enumerate(rec['viewers']):
-            if self.tab(i) is None:
-                self.new_tab()
-            for v in tab:
-                viewer = context.object(v)
-                self.add_widget(viewer, tab=i, hold_position=True)
         return self

--- a/glue/core/application_base.py
+++ b/glue/core/application_base.py
@@ -350,18 +350,3 @@ class Application(HubListener):
         for data in self.data_collection:
             data.style.color = color
             data.style.alpha = alpha
-
-    def __gluestate__(self, context):
-        viewers = [list(map(context.id, tab)) for tab in self.viewers]
-        data = self.session.data_collection
-        from glue.main import _loaded_plugins
-        return dict(session=context.id(self.session), viewers=viewers,
-                    data=context.id(data), plugins=_loaded_plugins)
-
-    @classmethod
-    def __setgluestate__(cls, rec, context):
-        self = cls(data_collection=context.object(rec['data']))
-        # manually register the newly-created session, which
-        # the viewers need
-        context.register_object(rec['session'], self.session)
-        return self


### PR DESCRIPTION
It is easier to just code these specifically for Jupyter and Qt since how the viewers are stored is quite different (Qt uses tabs)

This also fixes an issue with restoring colormaps from session files under certain circumstances