### PR TITLE
DEP: drop runtime dependency on `setuptools`

### DIFF
--- a/glue/main.py
+++ b/glue/main.py
@@ -41,9 +41,7 @@ def load_plugins(splash=None, require_qt_plugins=False, plugins_to_load=None):
     # where ``setup`` is a function that does whatever is needed to set up the
     # plugin, such as add items to various registries.
 
-    import setuptools
-    logger.info("Loading external plugins using "
-                "setuptools=={0}".format(setuptools.__version__))
+    logger.info("Loading external plugins")
 
     from glue._plugin_helpers import iter_plugin_entry_points, PluginConfig
     config = PluginConfig.load()

--- a/glue/main.py
+++ b/glue/main.py
@@ -70,21 +70,9 @@ def load_plugins(splash=None, require_qt_plugins=False, plugins_to_load=None):
             if not config.plugins[item.name]:
                 continue
 
-        # We don't use item.load() because that then checks requirements of all
-        # the imported packages, which can lead to errors like this one that
-        # don't really matter:
-        #
-        # Exception: (pytest 2.6.0 (/Users/tom/miniconda3/envs/py27/lib/python2.7/site-packages),
-        #             Requirement.parse('pytest>=2.8'), set(['astropy']))
-        #
-        # Just to be clear, this kind of error does indicate that there is an
-        # old version of a package in the environment, but this can confuse
-        # users as importing astropy directly would work (as setuptools then
-        # doesn't do a stringent test of dependency versions). Often this kind
-        # of error can occur if there is a conda version of a package and an
-        # older pip version.
-
         try:
+            # item.load() (importlib.metadata.EntryPoint.load) doesn't *always*
+            # return a module, so,  using import_module is safer here.
             module = import_module(item.module)
             function = getattr(module, item.attr)
             function()

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,6 @@ install_requires =
     echo>=0.6
     astropy>=4.0
     fast_histogram>=0.12
-    setuptools>=30.3.0
     ipython>=4.0
     dill>=0.2
     h5py>=2.10; python_version<'3.11'

--- a/tox.ini
+++ b/tox.ini
@@ -35,13 +35,12 @@ deps =
     legacy: pandas==1.2.*
     legacy: echo==0.5.*
     legacy: astropy==4.0.*
-    legacy: setuptools==30.3.*
     legacy: ipython==7.16.*
     legacy: ipykernel==5.3.*
     legacy: dill==0.2.*
     legacy: xlrd==1.2.*
     legacy: h5py==2.10.*
-    legacy: mpl-scatter-density==0.7.*
+    legacy: mpl-scatter-density==0.8.*
     legacy: openpyxl==3.0.*
 extras =
     test


### PR DESCRIPTION
## Description

This is a follow up to #2365
At the moment this breaks tests because `mpl-scatter-density` has an undeclared runtime dependency on `setuptools`
(addressed at https://github.com/astrofrog/mpl-scatter-density/pull/43)

I also note that the following comment
https://github.com/glue-viz/glue/blob/e9df453717b05a632737fbf7a1cefd760459af3c/glue/main.py#L75-L87

which was introduced in #1487, has been irrelevant since #2365 (at least in part) since it mentions behavior details that were specific to setuptools. Should this comment be removed entierely or just rephrased ?