### PR TITLE
Correct y limits in ProfileViewerState when min same as max

### DIFF
--- a/glue/viewers/profile/state.py
+++ b/glue/viewers/profile/state.py
@@ -231,9 +231,8 @@ class ProfileViewerState(MatplotlibDataViewerState):
                     self.y_min = y_min
                     self.y_max = y_max
                 elif np.allclose(y_min, y_max):
-                    dy = max(0.1, 0.1 * y_min)
-                    self.y_min = y_min - dy
-                    self.y_max = y_max + dy
+                    self.y_min = y_min * 0.9
+                    self.y_max = y_max * 1.1
                 else:
                     self.y_min = 0
                     self.y_max = 1

--- a/glue/viewers/profile/state.py
+++ b/glue/viewers/profile/state.py
@@ -230,6 +230,10 @@ class ProfileViewerState(MatplotlibDataViewerState):
                 if y_max > y_min:
                     self.y_min = y_min
                     self.y_max = y_max
+                elif np.allclose(y_min, y_max):
+                    dy = max(0.1, 0.1 * y_min)
+                    self.y_min = y_min - dy
+                    self.y_max = y_max + dy
                 else:
                     self.y_min = 0
                     self.y_max = 1

--- a/glue/viewers/profile/state.py
+++ b/glue/viewers/profile/state.py
@@ -231,8 +231,12 @@ class ProfileViewerState(MatplotlibDataViewerState):
                     self.y_min = y_min
                     self.y_max = y_max
                 elif np.allclose(y_min, y_max):
-                    self.y_min = y_min * 0.9
-                    self.y_max = y_max * 1.1
+                    if np.allclose(y_min, 0):
+                        self.y_min = -0.1
+                        self.y_max = 0.1
+                    else:
+                        self.y_min = y_min * 0.9
+                        self.y_max = y_max * 1.1
                 else:
                     self.y_min = 0
                     self.y_max = 1

--- a/glue/viewers/profile/state.py
+++ b/glue/viewers/profile/state.py
@@ -231,12 +231,12 @@ class ProfileViewerState(MatplotlibDataViewerState):
                     self.y_min = y_min
                     self.y_max = y_max
                 elif np.allclose(y_min, y_max):
-                    if np.allclose(y_min, 0):
-                        self.y_min = -0.1
-                        self.y_max = 0.1
+                    if y_min == 0.0:
+                        dy = np.finfo(y_min).resolution**2
                     else:
-                        self.y_min = y_min * 0.9
-                        self.y_max = y_max * 1.1
+                        dy = abs(0.1 * y_min)
+                    self.y_min = y_min - dy
+                    self.y_max = y_max + dy
                 else:
                     self.y_min = 0
                     self.y_max = 1

--- a/glue/viewers/profile/tests/test_state.py
+++ b/glue/viewers/profile/tests/test_state.py
@@ -149,7 +149,7 @@ class TestProfileViewerState:
 
         assert self.viewer_state.x_min == -0.5
         assert self.viewer_state.x_max == 2.5
-
+    
     def test_visible(self):
 
         self.layer_state.visible = False
@@ -161,3 +161,35 @@ class TestProfileViewerState:
         x, y = self.layer_state.profile
         assert_allclose(x, [0, 2, 4])
         assert_allclose(y, [3.5, 11.5, 19.5])
+
+
+def test_limits_profile_y_zero():
+    data = Data(label='d1')
+    data.coords = SimpleCoordinates()
+    data['x'] = np.zeros(24).reshape((3, 4, 2)).astype(float)
+
+    data_collection = DataCollection([data])
+
+    viewer_state = ProfileViewerState()
+    layer_state = ProfileLayerState(viewer_state=viewer_state, layer=data)
+    viewer_state.layers.append(layer_state)
+    viewer_state.function = 'mean'
+
+    assert viewer_state.y_min == -1e-30
+    assert viewer_state.y_max == 1e-30
+
+
+def test_limits_profile_y_one():
+    data = Data(label='d1')
+    data.coords = SimpleCoordinates()
+    data['x'] = np.ones(24).reshape((3, 4, 2)).astype(float)
+
+    data_collection = DataCollection([data])
+
+    viewer_state = ProfileViewerState()
+    layer_state = ProfileLayerState(viewer_state=viewer_state, layer=data)
+    viewer_state.layers.append(layer_state)
+    viewer_state.function = 'mean'
+
+    assert viewer_state.y_min == -0.1
+    assert viewer_state.y_max == 0.1

--- a/glue/viewers/profile/tests/test_state.py
+++ b/glue/viewers/profile/tests/test_state.py
@@ -191,5 +191,5 @@ def test_limits_profile_y_one():
     viewer_state.layers.append(layer_state)
     viewer_state.function = 'mean'
 
-    assert viewer_state.y_min == -0.1
-    assert viewer_state.y_max == 0.1
+    assert viewer_state.y_min == 0.9
+    assert viewer_state.y_max == 1.1

--- a/glue/viewers/profile/tests/test_state.py
+++ b/glue/viewers/profile/tests/test_state.py
@@ -149,7 +149,7 @@ class TestProfileViewerState:
 
         assert self.viewer_state.x_min == -0.5
         assert self.viewer_state.x_max == 2.5
-    
+
     def test_visible(self):
 
         self.layer_state.visible = False


### PR DESCRIPTION
This fixes a display limit problem we see over at Cubeviz when cube is all ones.

```python
import numpy as np
from astropy import units as u
from specutils import Spectrum1D

from jdaviz import Cubeviz

sp = Spectrum1D(flux=np.ones((7, 8, 9)) * u.nJy)

cubeviz_helper = Cubeviz()
cubeviz_helper.load_data(sp, data_label='test_cube')
cubeviz_helper.show()
```

Without this patch:

![Screenshot 2024-09-11 155700](https://github.com/user-attachments/assets/6730ed3f-fcd8-4d4e-85c1-c3de5e420773)

With this patch:

![Screenshot 2024-09-11 155442](https://github.com/user-attachments/assets/0a4376af-7d64-4211-9a38-38f91fae4bed)

[🐱](https://jira.stsci.edu/browse/JDAT-4767)