### PR TITLE
Add CI for Python 3.13 and update dev envs

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -43,17 +43,19 @@ jobs:
 
         # Test some configurations on Windows
         - windows: py310-test
-        - windows: py311-test-all
+        - windows: py312-test-all
 
         # Test against latest developer versions of some packages
-        - linux: py310-test-dev-all
-        - linux: py311-test-dev
-        - linux: py312-test-dev-all
+        - linux: py311-test-dev-all
+        - linux: py312-test-dev
+        - linux: py313-test-dev-all
 
-        - macos: py311-test-dev-all
-        - macos: py312-test-dev
+        - macos: py311-test-dev
+        - macos: py312-test-dev-all
+        - macos: py313-test-dev
 
-        - windows: py310-test-dev
+        - windows: py311-test-dev-all
+        - windows: py313-test-dev
 
   publish:
     needs: tests

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,39,310,311,312}-{codestyle,test,docs}-all-{dev,legacy}{,-visual}
+    py{38,39,310,311,312,313}-{codestyle,test,docs}-all-{dev,legacy}{,-visual}
 requires = pip >= 18.0
            setuptools >= 30.3.0
 


### PR DESCRIPTION
## Description

Introducing test jobs for currently 3.13rc2 and pushing the `py310-test-dev` envs, which are now stuck at Astropy 6.1.3, to higher Python versions.

Non-dev job for py313 is failing on missing libhdf5-dev when trying to build h5py from source; don't know how to install the apt for just a specific env.
~~I have _down-versioned_ the windows-dev job here so it runs with astropy 6.1.3~~; upgrading to py312 produced the same data_factory failures 
> E           AssertionError: assert <function astropy_tabular_data at 0x0000020F8CEE2C00> is <function img_data at 0x0000020F8CEE8FE0>

but the also occur with the non-dev Windows job, so it appears to be a Python 3.11+ issue on that platform.
As far as I can tell this is incorrectly identifying the .png file as readable as an `astropy_tabular_data` _"Catalog"_.
@pllim any ideas what could have happened there?

Addresses #2517