### PR TITLE
add placeholder close method to BaseViewer

### DIFF
--- a/glue/viewers/common/viewer.py
+++ b/glue/viewers/common/viewer.py
@@ -74,7 +74,7 @@ class BaseViewer(HubListener):
 
     def add_subset(self, subset):
         raise NotImplementedError()
-    
+
     def close(self):
         raise NotImplementedError()
 

--- a/glue/viewers/common/viewer.py
+++ b/glue/viewers/common/viewer.py
@@ -74,6 +74,9 @@ class BaseViewer(HubListener):
 
     def add_subset(self, subset):
         raise NotImplementedError()
+    
+    def close(self):
+        raise NotImplementedError()
 
     def __str__(self):
         return self.LABEL


### PR DESCRIPTION
## Description

Adds a placeholder `close` method to `BaseViewer`. This is needed in [widgetti/glue-solara](https://github.com/widgetti/glue-solara) to ensure that the associated widgets and listeners are cleaned up. We expect the method itself to be implemented in [glue-viz/glue-jupyter](https://github.com/glue-viz/glue-jupyter).