### PR TITLE
Provide a way to avoid creating world<->pixel links in datasets

### DIFF
--- a/glue/config.py
+++ b/glue/config.py
@@ -932,6 +932,7 @@ settings.add('FONT_SIZE', -1.0, validator=float)
 settings.add('AUTOLINK', {}, validator=dict)
 settings.add('AUTO_COMPUTE_COORDS_LINKS', True, validator=bool)
 
+
 def check_unit_converter(value):
     if value != 'default' and value not in unit_converter.members:
         raise KeyError(f'Unit converter {value} is not defined')

--- a/glue/config.py
+++ b/glue/config.py
@@ -930,7 +930,7 @@ settings.add('SHOW_INFO_PROFILE_OPEN', True, validator=bool)
 settings.add('SHOW_WARN_PROFILE_DUPLICATE', True, validator=bool)
 settings.add('FONT_SIZE', -1.0, validator=float)
 settings.add('AUTOLINK', {}, validator=dict)
-
+settings.add('AUTO_COMPUTE_COORDS_LINKS', True, validator=bool)
 
 def check_unit_converter(value):
     if value != 'default' and value not in unit_converter.members:

--- a/glue/core/data.py
+++ b/glue/core/data.py
@@ -1179,7 +1179,8 @@ class Data(BaseCartesianData):
                     label = axis_label(self.coords, i)
                     cid = self.add_component(comp, label)
                     self._world_component_ids.append(cid)
-                self._set_up_coordinate_component_links(ndim)
+                if settings.AUTO_COMPUTE_COORDS_LINKS:
+                    self._set_up_coordinate_component_links(ndim)
 
     def _set_up_coordinate_component_links(self, ndim):
 

--- a/glue/core/tests/test_data.py
+++ b/glue/core/tests/test_data.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 from astropy.utils import NumpyRNGContext
 
 from glue import core
+from glue.config import settings
 
 from ..component import Component, DerivedComponent, CategoricalComponent, DateTimeComponent
 from ..component_id import ComponentID
@@ -1185,3 +1186,20 @@ def test_compute_histogram_random_subset_dask():
 
     result = data.compute_histogram([data.id['x'], data.id['y']], range=[[-0.5, 10.5], [-0.5, 1.5]], bins=[5, 1], weights=data.id['y'], random_subset=100_000)
     assert_allclose(result[:, 0], [178535., 230694., 229997., 231215., 178135.], atol=20_000)
+
+
+def test_disable_auto_links():
+
+    settings.AUTO_COMPUTE_COORDS_LINKS = False
+
+    data1 = Data(a=[1, 2, 3], b=[2, 3, 4], label='data1',
+                 coords=IdentityCoordinates(n_dim=1))
+
+    assert len(data1.links) == 0
+
+    settings.AUTO_COMPUTE_COORDS_LINKS = True
+
+    data2 = Data(a=[1, 2, 3], b=[2, 3, 4], label='data1',
+                 coords=IdentityCoordinates(n_dim=1))
+
+    assert len(data2.links) == 2


### PR DESCRIPTION
This requires setting:

```python
from glue.config import settings
settings.AUTO_COMPUTE_COORDS_LINKS = False
```

The reason this is done via settings instead of via a kwarg to ``Data`` is because it is not always possible to pass in kwargs when e.g. loading datasets, so having a global setting makes more sense.

Fixes https://github.com/glue-viz/glue/issues/2525