### PR TITLE
Implement hub callback priorities

### DIFF
--- a/glue/core/hub.py
+++ b/glue/core/hub.py
@@ -91,8 +91,8 @@ class Hub(object):
 
         :param priority:
            An optional integer to set the priority of the handler. Handlers
-           are sorted such that lower integer priority handlers get called
-           first when broadcasting a message.
+           are sorted such that higher priority handlers get called first
+           when broadcasting a message.
 
 
         Raises:

--- a/glue/core/hub.py
+++ b/glue/core/hub.py
@@ -225,8 +225,6 @@ class Hub(object):
         else:
             logging.getLogger(__name__).info("Broadcasting %s", message)
             for subscriber, handler in self._find_handlers(message):
-                if isinstance(message, SubsetCreateMessage):
-                    print(f"Calling handler: {handler}")
                 handler(message)
 
     def __getstate__(self):

--- a/glue/core/hub.py
+++ b/glue/core/hub.py
@@ -186,8 +186,8 @@ class Hub(object):
             if test(message):
                 prioritized_handlers.append((subscriber, handler, priority))
 
-            for subscriber, handler, _ in sorted(prioritized_handlers, key=lambda x: x[2], reverse=True):
-                yield subscriber, handler
+        for subscriber, handler, _ in sorted(prioritized_handlers, key=lambda x: x[2], reverse=True):
+            yield subscriber, handler
 
     @contextmanager
     def ignore_callbacks(self, ignore_type):

--- a/glue/core/hub.py
+++ b/glue/core/hub.py
@@ -189,8 +189,8 @@ class Hub(object):
                 priorities.append(priority)
                 prioritized_handlers.append((subscriber, handler))
 
-            for i in np.argsort(priorities):
-                yield prioritized_handlers[i]
+            for subscriber, handler, _ in sorted(prioritized_handlers, key=lambda x: x[2], reverse=True):
+                yield subscriber, handler
 
     @contextmanager
     def ignore_callbacks(self, ignore_type):

--- a/glue/core/hub.py
+++ b/glue/core/hub.py
@@ -3,7 +3,6 @@ from contextlib import contextmanager
 from weakref import WeakKeyDictionary
 from inspect import getmro
 from collections import Counter
-import numpy as np
 
 from glue.core.exceptions import InvalidSubscriber, InvalidMessage
 from glue.core.message import Message
@@ -170,7 +169,6 @@ class Hub(object):
         # subscriber => { message type => (filter, handler, priority)}
 
         # loop over subscribed objects
-        priorities = []
         prioritized_handlers = []
         for subscriber, subscriptions in list(self._subscriptions.items()):
 
@@ -186,8 +184,7 @@ class Hub(object):
 
             handler, test, priority = subscriptions[candidate]
             if test(message):
-                priorities.append(priority)
-                prioritized_handlers.append((subscriber, handler))
+                prioritized_handlers.append((subscriber, handler, priority))
 
             for subscriber, handler, _ in sorted(prioritized_handlers, key=lambda x: x[2], reverse=True):
                 yield subscriber, handler

--- a/glue/core/hub.py
+++ b/glue/core/hub.py
@@ -6,7 +6,7 @@ from collections import Counter
 import numpy as np
 
 from glue.core.exceptions import InvalidSubscriber, InvalidMessage
-from glue.core.message import Message, SubsetCreateMessage
+from glue.core.message import Message
 from glue.core.hub_callback_container import HubCallbackContainer
 
 __all__ = ['Hub', 'HubListener']

--- a/glue/core/hub_callback_container.py
+++ b/glue/core/hub_callback_container.py
@@ -19,7 +19,7 @@ class HubCallbackContainer(object):
     def __init__(self):
         self.callbacks = {}
 
-    def _wrap(self, handler, filter):
+    def _wrap(self, handler, filter, priority):
         """
         Given a function/method, this will automatically wrap a method using
         weakref to avoid circular references.
@@ -57,6 +57,8 @@ class HubCallbackContainer(object):
 
             value += (filter, None)
 
+        value += (priority,)
+
         return value
 
     def _auto_remove(self, method_instance):
@@ -91,6 +93,9 @@ class HubCallbackContainer(object):
             inst = callback[3]()
             result += (partial(func, inst),)
 
+        # Add priority
+        result += (callback[4],)
+
         return result
 
     def __iter__(self):
@@ -108,8 +113,8 @@ class HubCallbackContainer(object):
         return hasattr(func, '__func__') and getattr(func, '__self__', None) is not None
 
     def __setitem__(self, message_class, value):
-        handler, filter = value
-        self.callbacks[message_class] = self._wrap(handler, filter)
+        handler, filter, priority = value
+        self.callbacks[message_class] = self._wrap(handler, filter, priority)
 
     def pop(self, message_class):
         return self.callbacks.pop(message_class)

--- a/glue/core/tests/test_hub.py
+++ b/glue/core/tests/test_hub.py
@@ -167,6 +167,10 @@ class TestHub(object):
 
     @pytest.mark.parametrize('priorities', (False, True))
     def test_handler_priorities(self, priorities):
+        """
+        Test that handlers are called in order of descending priority, if set,
+        in order subscribed to otherwise.
+        """
         msg, _, subscriber1 = self.get_subscription()
         _, _, subscriber2 = self.get_subscription()
         _, _, subscriber3 = self.get_subscription()

--- a/glue/core/tests/test_hub.py
+++ b/glue/core/tests/test_hub.py
@@ -167,41 +167,41 @@ class TestHub(object):
 
     @pytest.mark.parametrize('priorities', (False, True))
     def test_handler_priorities(self, priorities):
-            msg, _, subscriber1 = self.get_subscription()
-            _, _, subscriber2 = self.get_subscription()
-            _, _, subscriber3 = self.get_subscription()
+        msg, _, subscriber1 = self.get_subscription()
+        _, _, subscriber2 = self.get_subscription()
+        _, _, subscriber3 = self.get_subscription()
 
-            class Handlers:
+        class Handlers:
 
-                def __init__(self):
-                    self.priority_test_val = 0
+            def __init__(self):
+                self.priority_test_val = 0
 
-                def handler1(self, msg):
-                    self.priority_test_val += 10
+            def handler1(self, msg):
+                self.priority_test_val += 10
 
-                def handler2(self, msg):
-                    global priority_test_val
-                    self.priority_test_val *= 2
+            def handler2(self, msg):
+                global priority_test_val
+                self.priority_test_val *= 2
 
-                def handler3(self, msg):
-                    self.priority_test_val = 18
+            def handler3(self, msg):
+                self.priority_test_val = 18
 
-            handlers = Handlers()
+        handlers = Handlers()
 
-            if priorities:
-                self.hub.subscribe(subscriber1, msg, handlers.handler1, priority=100)
-                self.hub.subscribe(subscriber2, msg, handlers.handler2)
-                self.hub.subscribe(subscriber3, msg, handlers.handler3, priority=200)
-            else:
-                self.hub.subscribe(subscriber1, msg, handlers.handler1)
-                self.hub.subscribe(subscriber2, msg, handlers.handler2)
-                self.hub.subscribe(subscriber3, msg, handlers.handler3)
+        if priorities:
+            self.hub.subscribe(subscriber1, msg, handlers.handler1, priority=100)
+            self.hub.subscribe(subscriber2, msg, handlers.handler2)
+            self.hub.subscribe(subscriber3, msg, handlers.handler3, priority=200)
+        else:
+            self.hub.subscribe(subscriber1, msg, handlers.handler1)
+            self.hub.subscribe(subscriber2, msg, handlers.handler2)
+            self.hub.subscribe(subscriber3, msg, handlers.handler3)
 
-            msg_instance = msg("Test")
+        msg_instance = msg("Test")
 
-            self.hub.broadcast(msg_instance)
+        self.hub.broadcast(msg_instance)
 
-            assert handlers.priority_test_val == (56 if priorities else 18)
+        assert handlers.priority_test_val == (56 if priorities else 18)
 
 
 class TestHubListener(object):


### PR DESCRIPTION
This PR allows users to set a priority for the hub callback when subscribing to a hub message, e.g.:

```
self.hub.subscribe(self, SubsetCreateMessage,
                           handler=lambda _: self._on_subset_created(),
                           priority=100)
```

I implemented this with a default priority of 10, where lower integer values are higher priority. I confirmed that this PR (and the code snippet above in Jdaviz) fixes the bug with the Layer not being populated before our data menu processes the `SubsetCreateMessage`.

@astrofrog @dhomeier There are two failing tests, I haven't figured out yet why those are now failing, so if you have thoughts on that or the implementation in general let me know.