### PR TITLE
Add pre-commit and Ruff setup with flake8 and other codestyle checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,57 @@
+ci:
+  autofix_prs: false
+  autoupdate_schedule: 'monthly'
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: check-added-large-files
+        args: ["--enforce-all", "--maxkb=300"]
+        exclude: "^(\
+            CHANGES.md|\
+            glue/external/echoes|\
+        )$"
+        # Prevent giant files from being committed.
+      - id: check-case-conflict
+        # Check for files with names that would conflict on a case-insensitive
+        # filesystem like MacOS HFS+ or Windows FAT.
+      - id: check-json
+        # Attempts to load all json files to verify syntax.
+      - id: check-merge-conflict
+        # Check for files that contain merge conflict strings.
+      - id: check-symlinks
+        # Checks for symlinks which do not point to anything.
+      - id: check-toml
+        # Attempts to load all TOML files to verify syntax.
+      - id: check-xml
+        # Attempts to load all xml files to verify syntax.
+      - id: check-yaml
+        # Attempts to load all yaml files to verify syntax.
+        exclude: ".*(.github.*)$"
+      - id: detect-private-key
+        # Checks for the existence of private keys.
+      - id: end-of-file-fixer
+        # Makes sure files end in a newline and only a newline.
+        exclude: ".*(glue/dialogs/README.md|data.*|extern.*|icons.*|licenses.*|_static.*|_parsetab.py)$"
+      # - id: fix-encoding-pragma  # covered by pyupgrade
+      - id: trailing-whitespace
+        # Trims trailing whitespace.
+        exclude_types: [python]  # Covered by Ruff W291.
+        exclude: ".*(CHANGES.md|data.*|extern.*|licenses.*|_static.*)$"
+
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.10.0
+    hooks:
+      - id: rst-directive-colons
+        # Detect mistake of rst directive not ending with double colon.
+      - id: rst-inline-touching-normal
+        # Detect mistake of inline code touching normal text in rst.
+      - id: text-unicode-replacement-char
+        # Forbid files which have a UTF-8 Unicode replacement character.
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: "v0.9.9"
+    hooks:
+      - id: ruff
+        args: ["--fix", "--show-fixes"]

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,72 @@
+extend = "pyproject.toml"
+lint.ignore = [
+    # NOTE: to find a good code to fix, run:
+    # ruff --select="ALL" --statistics glue/<subpackage>
+
+    # flake8-bugbear (B)
+    "B006",  # MutableArgumentDefault
+    "B007",  # UnusedLoopControlVariable
+    "B018",  # Found useless expression
+    "B028",  # No-explicit-stacklevel
+    "B904",  # RaiseWithoutFromInsideExcept
+
+    # mccabe (C90) : code complexity
+    # TODO: configure maximum allowed complexity.
+    "C901",  # McCabeComplexity
+
+    # pycodestyle (E, W)
+    "E501",  # line-too-long
+    "E731",  # lambda-assignment
+
+    # Pyflakes (F)
+    "F841",  # unused-variable
+
+    # flake8-simplify (SIM)
+    "SIM102",  # NestedIfStatements
+    "SIM105",  # UseContextlibSuppress
+    "SIM108",  # UseTernaryOperator
+    "SIM114",  # if-with-same-arms
+    "SIM115",  # OpenFileWithContextHandler
+    "SIM117",  # MultipleWithStatements
+    "SIM118",  # KeyInDict
+    "SIM201",  # NegateEqualOp
+    "SIM300",  # yoda condition
+]
+lint.unfixable = [
+    "E711"  # NoneComparison. Hard to fix b/c numpy has it's own None.
+]
+
+[lint.extend-per-file-ignores]
+"__init__.py" = ["E402", "F401", "F403"]
+"glue/core/state.py" = [
+    "SIM401",  # Use `rec.get('pretransform', None)` instead of an `if` block
+    "B009",    # Do not call `getattr` with a constant attribute value.
+]
+"glue/core/subset.py" = [
+    "SIM401",  # Use `rec.get('pretransform', None)` instead of an `if` block
+    "SIM910",  # Use `kwargs.get("label")` instead of `kwargs.get("label", None)`
+]
+"glue/core/tests/test_data_region.py" = [
+    "B011",    # Do not `assert False` (`python -O` removes these calls), raise `AssertionError()`
+]
+
+"glue/core/contracts.py" = ["B004"]  # Using `hasattr(x, "__call__")` to test if x is callable is unreliable
+"glue/dialogs/link_editor/state.py" = ["B010"]    # Do not call `setattr` with a constant attribute value
+
+"glue/plugins/coordinate_helpers/tests/test_link_helpers.py" = ["E402"]  # Module level import not at top of file
+"glue/core/tests/test_link_manager.py" = ["E713"]  # Test for membership should be `not in`
+"glue/core/tests/test_roi.py" = ["E721"]  # Do not compare types, use `isinstance()`
+
+"glue/tests/test_main.py" = ["SIM222"]    # Use `'loaded'` instead of `'loaded' or ...`
+"glue/core/component_id.py" = ["SIM110"]  # Use `return any(cid in link for link in self)` instead of `for` loop
+"glue/core/link_helpers.py" = ["SIM110"]  # Use `return any(cid in link for link in self)` instead of `for` loop
+
+# TODO: fix these, on a per-subpackage basis.
+# When a general exclusion is being fixed, but it affects many subpackages, it
+# is better to fix for subpackages individually. The general exclusion should be
+# copied to these subpackage sections and fixed there.
+"glue/core/*" = ["SIM101"]  # Multiple `isinstance` calls for `value`, merge into a single call
+
+"glue/utils/*" = ["B015"]   # Pointless comparison at end of function scope
+
+"doc/*" = []

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -3,6 +3,13 @@ lint.ignore = [
     # NOTE: to find a good code to fix, run:
     # ruff --select="ALL" --statistics glue/<subpackage>
 
+    # flake8-unused-arguments (ARG)
+    "ARG001",  # unused-function-argument
+    "ARG002",  # unused-method-argument
+    "ARG003",  # unused-class-method-argument
+    "ARG004",  # unused-static-method-argument
+    "ARG005",  # unused-lambda-argument
+
     # flake8-bugbear (B)
     "B006",  # MutableArgumentDefault
     "B007",  # UnusedLoopControlVariable
@@ -10,56 +17,264 @@ lint.ignore = [
     "B028",  # No-explicit-stacklevel
     "B904",  # RaiseWithoutFromInsideExcept
 
+    # flake8-blind-except (BLE)
+    "BLE001",  # blind-except
+
+    # flake8-comprehensions (C4)
+    "C400",  # Unnecessary generator (rewrite as a list comprehension)
+    "C401",  # Unnecessary generator (rewrite as a set comprehension)
+    "C402",  # Unnecessary generator (rewrite as a dict comprehension)
+    "C403",  # Unnecessary list comprehension (rewrite as a set comprehension)
+    "C405",  # Unnecessary list literal (rewrite as a set literal)
+    "C406",  # Unnecessary list literal (rewrite as a dict literal)
+    "C408",  # Unnecessary `dict()` call (rewrite as a literal)
+    "C409",  # Unnecessary list literal passed to `tuple()` (rewrite as a set comprehension)
+    "C413",  # Unnecessary `list()` call around `sorted()`
+    "C416",  # Unnecessary list comprehension (rewrite using `list()`)
+    "C417",  # Unnecessary `map()` usage (rewrite using a list comprehension)
+    "C419",  # Unnecessary list comprehension
+
     # mccabe (C90) : code complexity
-    # TODO: configure maximum allowed complexity.
+    # TODO: configure maximum allowed complexity (default 10; 40 exceptions, 4 > 28).
     "C901",  # McCabeComplexity
+
+    # pydocstyle (D)
+    # Missing Docstrings
+    "D100",  # undocumented-public-module
+    "D101",  # undocumented-public-class
+    "D103",  # undocumented-public-function
+    "D104",  # undocumented-public-package
+    "D202",  # blank-line-after-function
+    "D204",  # incorrect-blank-line-after-class
+    "D205",  # blank-line-after-summary
+    "D209",  # new-line-after-last-paragraph
+    "D210",  # surrounding-whitespace
+    "D211",  # blank-line-before-class
+    "D214",  # overindented-section
+    # Docstring Content Issues
+    "D401",  # non-imperative-mood.
+    "D404",  # docstring-starts-with-this
+    "D406",  # missing-new-line-after-section-name
+    "D407",  # missing-dashed-underline-after-section
+    "D409",  # mismatched-section-underline-length
+    "D411",  # no-blank-line-before-section
+    "D412",  # blank-lines-between-header-and-content
+    "D414",  # empty-docstring-section
 
     # pycodestyle (E, W)
     "E501",  # line-too-long
     "E731",  # lambda-assignment
+    "W605",  # invalid-escape-sequence
+
+    # flake8-errmsg (EM)  : nicer error tracebacks
+    "EM101",   # raw-string-in-exception
+    "EM102",   # f-string-in-exception
+    "EM103",   # dot-format-in-exception
+
+    # eradicate (ERA)
+    # NOTE: be careful that developer notes are kept.
+    "ERA001",  # commented-out-code
 
     # Pyflakes (F)
     "F841",  # unused-variable
 
+    # flake8-boolean-trap (FBT)  : boolean flags should be kwargs, not args
+    # NOTE: a good thing to fix, but changes API.
+    "FBT002",  # boolean-default-value-in-function-definition
+    "FBT003",  # boolean-positional-value-in-function-call
+
+    # flake8-fixme (FIX)
+    "FIX001",  # Line contains FIXME. This should be fixed or at least FIXME replaced with TODO
+    "FIX003",  # Line contains XXX, consider resolving the issue
+    "FIX004",  # Line contains HACK, replace HACK with NOTE.
+
+    # isort (I)
+    "I001",  # unsorted imports
+
+    # pep8-naming (N)
+    # NOTE: some of these can/should be fixed, but this changes the API.
+    "N801",  # invalid-class-name
+    "N802",  # invalid-function-name
+    "N818",  # error-suffix-on-exception-name
+
+    # NumPy-specific rules (NPY)
+    "NPY002", # Replace legacy `np.random.rand` call with `np.random.Generator`  (2023-05-03)
+
+    # Perflint (PERF)
+    "PERF102",  # When using only the values of a dict use the `values()` method
+    "PERF203",  # `try`-`except` within a loop incurs performance overhead
+    "PERF401",  # Use a list comprehension to create a transformed list
+
+    # pygrep-hooks (PGH)
+    "PGH004",  # Use specific rule codes when using `noqa`
+
+    # flake8-pie (PIE)
+    "PIE790",  # Unnecessary `pass` statement
+    "PIE808",  # Unnecessary `start` argument in `range`
+
+    # Pylint (PLC, PLE, PLR, PLW)
+    "PLR0402",  # ConsiderUsingFromImport
+    "PLR0911",  # too-many-return-statements
+    "PLR0912",  # too-many-branches
+    "PLR0913",  # too-many-args
+    "PLR0915",  # too-many-statements
+    "PLR1704",  # Redefining argument with the local name `{name}`
+    "PLR1711",  # Useless `return` statement at end of function
+    "PLR1714",  # Consider merging multiple comparisons
+    "PLR2004",  # MagicValueComparison
+    "PLR5501",  # collapsible-else-if
+    "PLW0120",  # useless-else-on-loop
+    "PLW0602",  # global-variable-not-assigned
+    "PLW0603",  # global-statement
+    "PLW2901",  # redefined-loop-name
+
+    # flake8-pytest-style (PT)
+    "PT007",   # pytest-parametrize-values-wrong-type
+    "PT011",   # pytest-raises-too-broad
+    "PT012",   # pytest-raises-with-multiple-statements
+    "PT018",   # pytest-composite-assertion
+    "PT023",   # pytest-incorrect-mark-parentheses-style
+
+    # flake8-use-pathlib (PTH)
+    "PTH100",  # os-path-abspath
+    "PTH102",  # os-mkdir
+    "PTH103",  # os-makedirs
+    "PTH107",  # os-remove
+    "PTH108",  # os-unlink
+    "PTH109",  # os-getcwd
+    "PTH110",  # os-path-exists
+    "PTH111",  # os-path-expanduser
+    "PTH116",  # os-stat
+    "PTH117",  # os-path-isabs
+    "PTH118",  # os-path-join
+    "PTH119",  # os-path-basename
+    "PTH120",  # os-path-dirname
+    "PTH122",  # os-path-splitext
+    "PTH123",  # builtin-open
+
+    # flake8-pyi (PYI)
+    "PYI024",  # Use `typing.NamedTuple` instead of `collections.namedtuple`
+
+    # flake8-quotes (Q)
+    "Q000",    # Single quotes found but double quotes preferred
+
+
+    # flake8-return (RET)
+    "RET501",  # unnecessary-return-none
+    "RET502",  # implicit-return-value
+    "RET503",  # implicit-return
+    "RET504",  # unnecessary-assign
+    "RET505",  # unnecessary-else-after-return
+    "RET506",  # unnecessary-else-after-raise
+
+    # flake8-raise (RSE)
+    "RSE102",  # unnecessary-paren-on-raise-exception
+
+    # flake8-bandit (S)
+    "S101",  # Use of `assert` detected
+    "S110",  # try-except-pass
+    "S112",  # try-except-continue
+    "S307",  # Use of possibly insecure function; consider using `ast.literal_eval`
+
     # flake8-simplify (SIM)
+    "SIM101",  # Multiple `isinstance` calls for `{name}`, merge into a single call
     "SIM102",  # NestedIfStatements
     "SIM105",  # UseContextlibSuppress
     "SIM108",  # UseTernaryOperator
     "SIM114",  # if-with-same-arms
-    "SIM115",  # OpenFileWithContextHandler
     "SIM117",  # MultipleWithStatements
     "SIM118",  # KeyInDict
     "SIM201",  # NegateEqualOp
     "SIM300",  # yoda condition
+
+    # flake8-print (T20)
+    "T201",  # PrintUsed
+
+    # flake8-todos (TD)
+    "TD001",  # Invalid TODO tag
+    "TD003",  # Missing issue link on the line following this TODO
+    "TD004",  # Missing colon in TODO
+
+    # flake8-tidy-imports (TID)
+    "TID252",  # Prefer absolute imports over relative imports from parent modules
+
+    # tryceratops (TRY)
+    "TRY002",  # raise-vanilla-class
+    "TRY003",  # raise-vanilla-args
+    "TRY004",  # prefer-type-error
+    "TRY301",  # raise-within-try
+
+    # pyupgrade (UP)
+    "UP004",  # Class `{name}` inherits from `object`
+    "UP008",  # Use `super()` instead of `super(__class__, self)`
+    "UP009",  # UTF-8 encoding declaration is unnecessary
+    "UP015",  # Unnecessary mode argument
+    "UP024",  # Replace aliased errors with `OSError`
+    "UP028",  # Replace `yield` over for loop with `yield from`
+    "UP030",  # Use implicit references for positional format fields
+    "UP031",  # Use format specifiers instead of percent format
+    "UP032",  # Use f-string instead of `format` call
+    "UP034",  # Avoid extraneous parentheses
+    "UP036",  # Version block is outdated for minimum Python version
+    "UP039",  # Unnecessary parentheses after class definition
 ]
 lint.unfixable = [
     "E711"  # NoneComparison. Hard to fix b/c numpy has it's own None.
 ]
 
 [lint.extend-per-file-ignores]
-"__init__.py" = ["E402", "F401", "F403"]
+"__init__.py" = ["E402", "F401", "F403", "PT013"]
+"test_*.py" = [
+    "RUF015",  # Prefer next({iterable}) over single element slice
+]
+
+"glue/core/coordinates.py" = [
+    "G001",    # Logging statement uses `str.format`
+    "G010",    # Logging statement uses `warn` instead of `warning`
+]
 "glue/core/state.py" = [
     "SIM401",  # Use `rec.get('pretransform', None)` instead of an `if` block
     "B009",    # Do not call `getattr` with a constant attribute value.
 ]
 "glue/core/subset.py" = [
+    "COM818",  # Trailing comma on bare tuple prohibited
+    "NPY001",  # Type alias `np.bool` is deprecated, replace with builtin type
     "SIM401",  # Use `rec.get('pretransform', None)` instead of an `if` block
     "SIM910",  # Use `kwargs.get("label")` instead of `kwargs.get("label", None)`
 ]
 "glue/core/tests/test_data_region.py" = [
     "B011",    # Do not `assert False` (`python -O` removes these calls), raise `AssertionError()`
+    "PT004",   # Fixture `setup_method` does not return anything, add leading underscore
+    "PT015",   # Assertion always fails, replace with `pytest.fail()
 ]
 
 "glue/core/contracts.py" = ["B004"]  # Using `hasattr(x, "__call__")` to test if x is callable is unreliable
-"glue/dialogs/link_editor/state.py" = ["B010"]    # Do not call `setattr` with a constant attribute value
+"glue/dialogs/link_editor/state.py" = ["B010"]  # Do not call `setattr` with a constant attribute value
 
 "glue/plugins/coordinate_helpers/tests/test_link_helpers.py" = ["E402"]  # Module level import not at top of file
 "glue/core/tests/test_link_manager.py" = ["E713"]  # Test for membership should be `not in`
 "glue/core/tests/test_roi.py" = ["E721"]  # Do not compare types, use `isinstance()`
 
+"glue/config_gen.py" = ["EXE001"]              # Shebang is present but file is not executable
+"glue/main.py" = ["EXE001"]                    # Shebang is present but file is not executable
+"glue/core/tests/test_subset.py" = ["ICN001"]  # `matplotlib` should be imported as `mpl`
+"glue/plugins/wcs_autolinking/wcs_autolinking.py" = ["FURB187"]  # Use of assignment of `reversed` on list
+
+"glue/core/tests/test_join_on_key.py" = ["PLR0124"]  # Name compared with itself, consider replacing
+"glue/viewers/common/viewer.py" = ["PLW0642"]        # Reassigned `cls` variable in class method
+"glue/viewers/matplotlib/viewer.py" = ["Q003"]       # Change outer quotes to avoid escaping inner quotes
+
+"glue/utils/data.py" = ["S310"]  # Audit URL open for permitted schemes. Allowing use of `file:` or custom schemes is often unexpected.
+"glue/core/parse.py" = ["S311"]  # Standard pseudo-random generators are not suitable for cryptographic purposes
+"glue/viewers/matplotlib/tests/test_python_export.py" = ["S603"]  # `subprocess` call: check for execution of untrusted input
+
 "glue/tests/test_main.py" = ["SIM222"]    # Use `'loaded'` instead of `'loaded' or ...`
 "glue/core/component_id.py" = ["SIM110"]  # Use `return any(cid in link for link in self)` instead of `for` loop
 "glue/core/link_helpers.py" = ["SIM110"]  # Use `return any(cid in link for link in self)` instead of `for` loop
+"glue/core/hub.py" = ["SIM118"]           # Use `key in dict` instead of `key in dict.keys()`
+
+"glue/viewers/common/python_export.py" = ["SLOT000"]  # Subclasses of `str` should define `__slots__`
+"glue/utils/misc.py" = ["TRY300"]         # Consider moving this statement to an `else` block
 
 # TODO: fix these, on a per-subpackage basis.
 # When a general exclusion is being fixed, but it affects many subpackages, it

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,3 +12,36 @@ enabled = true
 url = "results/fig_comparison.html"
 message = "Click details to see the image test comparisons, for py311-test-visual"
 report_on_fail = true
+
+[tool.ruff]
+# ruff check: pycodestyle, Pyflakes, McCabe, flake8-bugbear, flake8-simplify
+lint.select = ["E", "F", "C90", "B", "SIM"]
+exclude=[
+    "glue/external/*",
+    "*_parsetab.py",
+    "*_lextab.py"
+]
+lint.ignore = [  # NOTE: non-permanent exclusions should be added to `.ruff.toml` instead.
+    # pycodestyle (E, W)
+    "E711",  # NoneComparison  (see unfixable)
+    "E741",  # AmbiguousVariableName. Physics variables are often poor code variables
+]
+
+[tool.ruff.lint.extend-per-file-ignores]
+"glue/config.py" = ["E402"]      # Imports are done as needed.
+
+[tool.ruff.lint.flake8-annotations]
+ignore-fully-untyped = true
+mypy-init-return = true
+
+[tool.ruff.lint.flake8-comprehensions]
+allow-dict-calls-with-keyword-arguments = true
+
+[tool.ruff.lint.flake8-type-checking]
+exempt-modules = []
+
+[tool.ruff.lint.isort]
+known-first-party = ["glue", "glue_core"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,20 +15,82 @@ report_on_fail = true
 
 [tool.ruff]
 # ruff check: pycodestyle, Pyflakes, McCabe, flake8-bugbear, flake8-simplify
-lint.select = ["E", "F", "C90", "B", "SIM"]
+lint.select = ["ALL"]
 exclude=[
     "glue/external/*",
     "*_parsetab.py",
     "*_lextab.py"
 ]
 lint.ignore = [  # NOTE: non-permanent exclusions should be added to `.ruff.toml` instead.
+
+    # flake8-builtins (A) : shadowing a Python built-in.
+    # New ones should be avoided and is up to maintainers to enforce.
+    "A00",
+
+    # flake8-commas (COM)
+    "COM812",  # TrailingCommaMissing
+    "COM819",  # TrailingCommaProhibited
+
+    # pydocstyle (D)
+    # Missing Docstrings
+    "D102",  # Missing docstring in public method. Don't check b/c docstring inheritance.
+    "D105",  # Missing docstring in magic method. Don't check b/c class docstring.
+    # Whitespace Issues
+    "D200",  # FitsOnOneLine
+    # Docstring Content Issues
+    "D410",  # BlankLineAfterSection. Using D412 instead.
+    "D400",  # EndsInPeriod.  NOTE: might want to revisit this.
+
     # pycodestyle (E, W)
     "E711",  # NoneComparison  (see unfixable)
     "E741",  # AmbiguousVariableName. Physics variables are often poor code variables
+
+    # flake8-fixme (FIX)
+    "FIX002",  # Line contains TODO | notes for improvements are OK iff the code works
+
+    # ISC001 shouldn't be used with ruff format
+    # https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
+    "ISC001",
+
+    # pep8-naming (N)
+    "N803",  # invalid-argument-name. Physics variables are often poor code variables
+    "N806",  # non-lowercase-variable-in-function. Physics variables are often poor code variables
+
+    # pandas-vet (PD)
+    "PD",
+
+    # flake8-self (SLF)
+    "SLF001", # private member access
+
+    # flake8-todos (TD)
+    "TD002",  # Missing author in TODO
+
+    # Ruff-specific rules (RUF)
+    "RUF001",  # ambiguous-unicode-character-string
+    "RUF002",  # ambiguous-unicode-character-docstring
+    "RUF005",  # unpack-instead-of-concatenating-to-collection-literal -- it's not clearly faster.
+    "RUF010",  # use conversion in f-string
+    "RUF012",  # Mutable class attributes should be annotated with `typing.ClassVar`
+    "RUF015",  # Prefer `next(iter(datasets.keys()))` over single element slice
+    "RUF021",  # Parenthesize `a and b` expressions when chaining `and` and `or` together
+    "RUF022",  # `__all__` is not sorted
+    "RUF100",  # Unused blanket `noqa` directive
 ]
 
 [tool.ruff.lint.extend-per-file-ignores]
+"setup.py" = ["INP001"]  # Part of configuration, not a package.
+".github/workflows/*.py" = ["INP001"]
+"test_*.py" = [
+    "ANN201",  # Public function without return type annotation
+    "B018",  # UselessExpression
+    "D",  # pydocstyle
+    "S101",  # Use of assert detected
+]
 "glue/config.py" = ["E402"]      # Imports are done as needed.
+"glue/conftest.py" = ["INP001"]  # Part of configuration, not a package.
+"doc/*.py" = [
+    "INP001",  # implicit-namespace-package. The examples are not a package.
+]
 
 [tool.ruff.lint.flake8-annotations]
 ignore-fully-untyped = true

--- a/tox.ini
+++ b/tox.ini
@@ -59,8 +59,11 @@ commands =
     docs: sphinx-build -W -n -b html -d _build/doctrees   . _build/html
 
 [testenv:codestyle]
-deps = flake8
 skipsdist = true
 skip_install = true
+description = Run all style and file checks with pre-commit
+deps =
+    pre-commit
 commands =
-    flake8 --max-line-length=100 --exclude=external glue doc
+    pre-commit install-hooks
+    pre-commit run --color always --all-files --show-diff-on-failure


### PR DESCRIPTION
## Description
This PR is adding
1. a [Ruff](https://docs.astral.sh/ruff/linter/) configuration to allow using `ruff check` as a linter in place of, among other checks, the current `codestyle` CI test. The setup is largely following the [Astropy example](https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions) with global and per-file ignores for all checks not passing in the present codebase. Like in Astropy, rules considered not applicable are placed as permanent exemptions in `pyproject.toml`, while currently failing roles are put in `.ruff.toml`, to be fixed in the code at a given time.
2. a `pre-commit` setup making this Ruff installation available as a local pre-commit hook and as runner for the `codestyle` job.

For usage I refer again to the Astropy documentation above; basic options for local usage are running
- `pre-commit install` to have checks (and where possible fixes) automatically applied on each commit
- `pre-commit run [--all-files]` to manually check staged files or the entire repo
- `ruff check` to directly run the linting checks with Ruff.

Fixes to the actual files, especially those with per-file exemptions at the end of `.ruff.toml` can be done in a follow-up step.