### PR TITLE
Fix int dtype test

### DIFF
--- a/glue/core/data_factories/tests/test_data_factories.py
+++ b/glue/core/data_factories/tests/test_data_factories.py
@@ -118,11 +118,11 @@ def test_csv_pandas_factory():
     assert isinstance(d.get_component(cat_comp), CategoricalComponent)
 
 
-def test_dtype_int():
+def test_dtype_int64():
     data = b'# a, b\n1, 1 \n2, 2 \n3, 3'
     with make_file(data, '.csv') as fname:
         d = df.load_data(fname)
-    assert d['a'].dtype == int
+    assert d['a'].dtype == np.int64
 
 
 def test_dtype_float():

--- a/glue/core/data_factories/tests/test_data_factories.py
+++ b/glue/core/data_factories/tests/test_data_factories.py
@@ -122,7 +122,7 @@ def test_dtype_int64():
     data = b'# a, b\n1, 1 \n2, 2 \n3, 3'
     with make_file(data, '.csv') as fname:
         d = df.load_data(fname)
-    assert d['a'].dtype == np.int64
+    assert d['a'].dtype.kind == 'i'
 
 
 def test_dtype_float():


### PR DESCRIPTION
During the update of the Debian package for **glue** I observed one failure when the [test runs on a 32-bit machine](https://salsa.debian.org/debian-astro-team/glue/-/jobs/7186302):

```
________________________________ test_dtype_int ________________________________
    def test_dtype_int():
        data = b'# a, b\n1, 1 \n2, 2 \n3, 3'
        with make_file(data, '.csv') as fname:
            d = df.load_data(fname)
>       assert d['a'].dtype == int
E       AssertionError: assert dtype('int64') == int
E        +  where dtype('int64') = array([1, 2, 3], dtype=int64).dtype
glue/core/data_factories/tests/test_data_factories.py:125: AssertionError
```

This patch fixes this by explicitly using `np.int64` instead of `int`.