### PR TITLE
fix: support relative paths for icons

### DIFF
--- a/glue/icons/__init__.py
+++ b/glue/icons/__init__.py
@@ -29,6 +29,9 @@ def icon_path(icon_name, icon_format='png'):
     icon_name += '.{0}'.format(icon_format)
 
     icon_file = importlib_resources.files("glue") / "icons" / icon_name
+    # when running on pyinstaller, the path might include ..
+    # so we need to convert it to an absolute path
+    icon_file = icon_file.resolve()
     if icon_file.is_file():
         return str(icon_file)
     else:


### PR DESCRIPTION
When using PyInstaller, importlib_resources.files("glue") can return a relative path.
If this path is not resolved, it will lead to an error like:

  File "glue/icons/__init__.py", line 35, in icon_path
RuntimeError: Icon does not exist: /Users/maartenbreddels/github/spacetelescope/jdaviz/standalone/dist/jdaviz/_internal/glue_jupyter/bqplot/common/../../icons/glue_polygon.svg

