### PR TITLE
Use relax=True in WCS->FITS header in coordinate helper

### DIFF
--- a/glue/core/coordinate_helpers.py
+++ b/glue/core/coordinate_helpers.py
@@ -189,7 +189,7 @@ def axis_label(wcs, axis):
         return wcs.world_axis_names[wcs.world_n_dim - 1 - axis].title()
 
     if isinstance(wcs, WCS):
-        header = wcs.to_header()
+        header = wcs.to_header(relax=True)
         num = _get_ndim(header) - axis  # number orientation reversed
         ax = header.get('CTYPE%i' % num)
         if ax is not None:


### PR DESCRIPTION
I'm loading an image into glue (specifically imviz) that uses FITS SIP coordinates. The SIP coordinates are "non-standard" according to `astropy.wcs.WCS`, so a warning is raised every time `wcs.to_header()` gets called in `coordinate_helpers.axis_label`, even though the WCS object in `data.coords` has the `astropy.wcs.SIP` coordinates.

This PR sets `relax=True` in `coordinate_helpers` so that warning doesn't concern the user.