### PR TITLE
TST: fix warnings/errors in test_roi

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
         # Forbid files which have a UTF-8 Unicode replacement character.
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.11.4"
+    rev: "v0.11.12"
     hooks:
       - id: ruff
         args: ["--fix", "--show-fixes"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ ci:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
         args: ["--enforce-all", "--maxkb=300"]
@@ -51,7 +51,7 @@ repos:
         # Forbid files which have a UTF-8 Unicode replacement character.
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.9.9"
+    rev: "v0.11.4"
     hooks:
       - id: ruff
         args: ["--fix", "--show-fixes"]

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,7 +1,7 @@
 extend = "pyproject.toml"
 lint.ignore = [
     # NOTE: to find a good code to fix, run:
-    # ruff --select="ALL" --statistics glue/<subpackage>
+    # ruff check --select="ALL" --statistics glue/<subpackage>
 
     # flake8-unused-arguments (ARG)
     "ARG001",  # unused-function-argument

--- a/glue/core/component.py
+++ b/glue/core/component.py
@@ -16,6 +16,8 @@ except ImportError:
 __all__ = ['Component', 'DerivedComponent', 'CategoricalComponent',
            'CoordinateComponent', 'DateTimeComponent', 'ExtendedComponent']
 
+logger = logging.getLogger(__name__)
+
 
 class Component(object):
 
@@ -80,7 +82,7 @@ class Component(object):
         return len(self._data.shape)
 
     def __getitem__(self, key):
-        logging.debug("Using %s to index data of shape %s", key, self.shape)
+        logger.debug("Using %s to index data of shape %s", key, self.shape)
         return self._data[key]
 
     @property

--- a/glue/core/state.py
+++ b/glue/core/state.py
@@ -92,6 +92,8 @@ from glue.utils.matplotlib import MATPLOTLIB_GE_36
 if MATPLOTLIB_GE_36:
     from matplotlib import colormaps
 
+logger = logging.getLogger(__name__)
+
 literals = tuple([type(None), float, int, bytes, bool])
 literals += tuple(s for s in np.ScalarType if s not in (np.datetime64, np.timedelta64))
 
@@ -312,7 +314,7 @@ class GlueSerializer(object):
         name = self._label(obj)
         assert name not in self._objs
 
-        logging.debug("Registering %r as %s", obj, name)
+        logger.debug("Registering %r as %s", obj, name)
         self._objs[name] = obj
         self._names[oid] = name
 
@@ -354,7 +356,7 @@ class GlueSerializer(object):
         self._working.add(oid)
 
         fun, version = self._dispatch(obj)
-        logging.debug("Serializing %s with %s", obj, fun)
+        logger.debug("Serializing %s with %s", obj, fun)
         result = fun(obj, self)
 
         if isinstance(obj, types.FunctionType):

--- a/glue/core/tests/test_roi.py
+++ b/glue/core/tests/test_roi.py
@@ -1216,7 +1216,7 @@ class TestPolyMpl(TestMpl):
         return MplPolygonalROI(self.axes)
 
     def test_proper_roi(self):
-        return isinstance(self.roi._roi, PolygonalROI)
+        assert isinstance(self.roi._roi, PolygonalROI)
 
     def send_events(self):
         ev0 = DummyEvent(5, 5, inaxes=self.axes)
@@ -1271,7 +1271,7 @@ class TestPickMpl(TestMpl):
         return MplPickROI(self.axes)
 
     def test_proper_roi(self):
-        return isinstance(self.roi._roi, PointROI)
+        assert isinstance(self.roi._roi, PointROI)
 
     def test_start_ignored_if_not_inaxes(self):
         ev = DummyEvent(0, 0, inaxes=None)

--- a/glue/utils/matplotlib.py
+++ b/glue/utils/matplotlib.py
@@ -18,6 +18,8 @@ from glue.utils.misc import DeferredMethod
 MATPLOTLIB_GE_30 = Version(__version__) >= Version('3')
 MATPLOTLIB_GE_36 = Version(__version__) >= Version('3.6')
 
+logger = logging.getLogger(__name__)
+
 
 __all__ = ['all_artists', 'new_artists', 'remove_artists',
            'get_extent', 'view_cascade', 'fast_limits', 'defer_draw',
@@ -97,7 +99,7 @@ def view_cascade(data, view):
     """
     shp = data.shape
     v2 = list(view)
-    logging.debug("image shape: %s, view: %s", shp, view)
+    logger.debug("image shape: %s, view: %s", shp, view)
 
     # choose stride length that roughly samples entire image
     # at roughly the same pixel count


### PR DESCRIPTION
## Description
This has raised a [PytestReturnNotNoneWarning: Expected None, but glue/core/tests/test_roi.py::TestPolyMpl::test_proper_roi returned True, which will be an error in a future version of pytest.  Did you mean to use `assert` instead of `return`?](https://github.com/glue-viz/glue/actions/runs/15138760563/job/42556992806#step:10:299) for some time, but as of pytest 8.4 apparently now has become an [error](https://github.com/glue-viz/glue/actions/runs/15443555763/job/43467133756?pr=2535).