### PR TITLE
Allow defaults to be customized state classes

### DIFF
--- a/glue/config.py
+++ b/glue/config.py
@@ -3,7 +3,7 @@ from importlib.machinery import SourceFileLoader
 import sys
 import types
 import warnings
-from collections import namedtuple
+from collections import namedtuple, defaultdict
 
 from glue.utils import format_choices
 
@@ -956,3 +956,8 @@ try:
                                 KeyboardShortcut, keyboard_shortcut)
 except ImportError:
     pass
+
+# The following is a global dictionary which can be used to set default
+# values on state classes as soon as the state class is initialized, avoiding
+# any callbacks.
+STATE_DEFAULTS = defaultdict(dict)

--- a/glue/core/state_objects.py
+++ b/glue/core/state_objects.py
@@ -12,6 +12,8 @@ from glue.core.subset import SliceSubsetState
 from glue.core.component_id import PixelComponentID
 from glue.core.exceptions import IncompatibleAttribute
 from glue.core.units import UnitConverter
+from glue.config import STATE_DEFAULTS
+
 
 __all__ = ['State', 'StateAttributeCacheHelper',
            'StateAttributeLimitsHelper', 'StateAttributeSingleValueHelper', 'StateAttributeHistogramHelper']
@@ -36,6 +38,9 @@ class State(HasCallbackProperties):
 
     def __init__(self, **kwargs):
         super(State, self).__init__()
+        if self.__class__ in STATE_DEFAULTS:
+            for name, value in STATE_DEFAULTS[self.__class__].items():
+                setattr(self, name, value)
         self.update_from_dict(kwargs)
 
     def update_from_state(self, state):


### PR DESCRIPTION
This implements a simple mechanism for overriding defaults for callback properties on state classes at initialization time, before any callbacks are set up. This allows e.g. jdaviz to change the default linewidth for the profile viewer to be always 3, saving a lot of time later. This could also be used to make layers invisible by default until shown, which could also save time.

Currently, this changes the default to a single value for a given class. We could potentially be smarter and have this be done through a callable which could have access to other non-default initial values (e.g. if it's a dataset, use linewidth 1, if it's a subset, use linewidth 3).


