### PR TITLE
Delay callbacks related to layers when adding datasets to viewers

### DIFF
--- a/glue/viewers/common/viewer.py
+++ b/glue/viewers/common/viewer.py
@@ -207,25 +207,27 @@ class Viewer(BaseViewer):
         if data not in self.session.data_collection:
             raise IncompatibleDataException("Data not in DataCollection")
 
-        # Create layer artist and add to container. First check whether any
-        # plugins want to make a custom layer artist.
-        layer = get_layer_artist_from_registry(data, self) or self.get_data_layer_artist(data)
+        with delay_callback(self.state, 'layers'):
 
-        if layer is None:
-            return False
+            # Create layer artist and add to container. First check whether any
+            # plugins want to make a custom layer artist.
+            layer = get_layer_artist_from_registry(data, self) or self.get_data_layer_artist(data)
 
-        # When adding a layer artist to the layer artist container, zorder
-        # gets set automatically - however since we call a forced update of the
-        # layer after adding it to the container we can ignore any callbacks
-        # related to zorder. We also then need to set layer.state.zorder manually.
-        with ignore_callback(layer.state, 'zorder'):
-            self._layer_artist_container.append(layer)
-        layer.update()
-        self.draw_legend()  # need to be called here because callbacks are ignored in previous step
+            if layer is None:
+                return False
 
-        # Add existing subsets to viewer
-        for subset in data.subsets:
-            self.add_subset(subset)
+            # When adding a layer artist to the layer artist container, zorder
+            # gets set automatically - however since we call a forced update of the
+            # layer after adding it to the container we can ignore any callbacks
+            # related to zorder. We also then need to set layer.state.zorder manually.
+            with ignore_callback(layer.state, 'zorder'):
+                self._layer_artist_container.append(layer)
+            layer.update()
+            self.draw_legend()  # need to be called here because callbacks are ignored in previous step
+
+            # Add existing subsets to viewer
+            for subset in data.subsets:
+                self.add_subset(subset)
 
         return True
 


### PR DESCRIPTION
This avoids calling the ``layers`` callback every single time a subset is added - this speeds things up when adding a dataset with multiple existing subsets.