### PR TITLE
Empty WCS autolink handle

### DIFF
--- a/glue/plugins/wcs_autolinking/tests/test_wcs_autolinking.py
+++ b/glue/plugins/wcs_autolinking/tests/test_wcs_autolinking.py
@@ -40,6 +40,22 @@ def test_wcs_autolink_emptywcs():
     links = wcs_autolink(dc)
     assert len(links) == 0
 
+def test_wcs_autolink_2D_emptywcs():
+
+    # No links should be found because the WCS don't actually have well defined
+    # physical types.
+
+    data1 = Data()
+    data1.coords = WCS(naxis=2)
+    data1['x'] = [[1, 2, 3]]
+
+    data2 = Data()
+    data2.coords = WCS(naxis=2)
+    data2['x'] = [[4, 5, 6]]
+
+    dc = DataCollection([data1, data2])
+    links = wcs_autolink(dc)
+    assert len(links) == 0
 
 def test_wcs_autolink_spectral_cube():
 

--- a/glue/plugins/wcs_autolinking/wcs_autolinking.py
+++ b/glue/plugins/wcs_autolinking/wcs_autolinking.py
@@ -111,6 +111,11 @@ class WCSLink(MultiLink):
 
         wcs1, wcs2 = data1.coords, data2.coords
 
+        if (wcs1.world_axis_physical_types.count(None) == wcs1.world_n_dim or
+            wcs2.world_axis_physical_types.count(None) == wcs2.world_n_dim):
+            raise IncompatibleWCS("Can't create WCS link between {0} and {1}".format(data1.label, data2.label))
+
+
         forwards = backwards = None
         if wcs1.pixel_n_dim == wcs2.pixel_n_dim and wcs1.world_n_dim == wcs2.world_n_dim:
             if (wcs1.world_axis_physical_types.count(None) == 0 and
@@ -127,6 +132,8 @@ class WCSLink(MultiLink):
 
                 self._physical_types_1 = wcs1.world_axis_physical_types
                 self._physical_types_2 = wcs2.world_axis_physical_types
+
+
 
         if not forwards or not backwards:
             # A generalized APE 14-compatible way


### PR DESCRIPTION
The astro PR fixes a broken world -> pixel on sliced 1D WCS 

WCSLink now checks for empty WCS property values on init 
Also adds 2D test to empty calls