### PR TITLE
Fix bug in fixed resolution buffer that occured when dealing with subclasses of BaseCartesianData

### DIFF
--- a/glue/core/fixed_resolution_buffer.py
+++ b/glue/core/fixed_resolution_buffer.py
@@ -252,7 +252,7 @@ def compute_fixed_resolution_buffer(data, bounds, target_data=None, target_cid=N
     # when we apply subset_state.
 
     target_cid_is_dask = target_cid is not None and isinstance(data, Data) and isinstance(data.get_component(target_cid), DaskComponent)
-    subset_over_dask_data = subset_state is not None and any([isinstance(data.get_component(comp), DaskComponent) for comp in data.main_components])
+    subset_over_dask_data = subset_state is not None and isinstance(data, Data) and any([isinstance(data.get_component(comp), DaskComponent) for comp in data.main_components])
 
     if target_cid_is_dask or subset_over_dask_data:
 

--- a/glue/core/tests/test_data_derived.py
+++ b/glue/core/tests/test_data_derived.py
@@ -51,6 +51,9 @@ class TestIndexedData:
         assert_equal(derived.compute_fixed_resolution_buffer(bounds=bounds, target_cid=self.x_id),
                      self.data.compute_fixed_resolution_buffer(bounds=bounds, target_cid=self.x_id))
 
+        assert_equal(derived.compute_fixed_resolution_buffer(bounds=bounds, subset_state=self.subset_state),
+                     self.data.compute_fixed_resolution_buffer(bounds=bounds, subset_state=self.subset_state))
+
         assert_equal(derived.compute_statistic('mean', self.x_id),
                      self.data.compute_statistic('mean', self.x_id))
 


### PR DESCRIPTION
This was an issue when computing subsets