### PR TITLE
Rename 3D scatter layer state and define cmap_name on state classes

### DIFF
--- a/glue/core/state_path_patches.txt
+++ b/glue/core/state_path_patches.txt
@@ -87,6 +87,6 @@ glue.viewers.table.qt.data_viewer.TableLayerArtist -> glue_qt.viewers.table.data
 glue.viewers.table.qt.data_viewer.TableViewer -> glue_qt.viewers.table.data_viewer.TableViewer
 glue.viewers.table.qt.TableLayerArtist -> glue_qt.viewers.table.TableLayerArtist
 glue.viewers.table.qt.TableViewer -> glue_qt.viewers.table.TableViewer
-glue_vispy_viewers.volume.layer_state.VolumeLayerState -> glue.viewers.volume3d.layer_state.VolumeLayerState
-glue_vispy_viewers.scatter.layer_state.ScatterLayerState -> glue.viewers.scatter3d.layer_state.ScatterLayerState
+glue_vispy_viewers.volume.layer_state.VolumeLayerState -> glue.viewers.volume3d.layer_state.VolumeLayerState3D
+glue_vispy_viewers.scatter.layer_state.ScatterLayerState -> glue.viewers.scatter3d.layer_state.ScatterLayerState3D
 glue_vispy_viewers.common.layer_state.VispyLayerState -> glue.viewers.common3d.layer_state.LayerState3D

--- a/glue/viewers/common3d/compat.py
+++ b/glue/viewers/common3d/compat.py
@@ -1,11 +1,11 @@
 import uuid
 
 from ..scatter3d.layer_state import ScatterLayerState
-from ..volume3d.layer_state import VolumeLayerState
+from ..volume3d.layer_state import VolumeLayerState3D
 
 STATE_CLASS = {}
 STATE_CLASS['ScatterLayerArtist'] = ScatterLayerState
-STATE_CLASS['VolumeLayerArtist'] = VolumeLayerState
+STATE_CLASS['VolumeLayerArtist'] = VolumeLayerState3D
 
 
 def update_3d_viewer_state(rec, context):

--- a/glue/viewers/scatter3d/layer_state.py
+++ b/glue/viewers/scatter3d/layer_state.py
@@ -137,6 +137,10 @@ class ScatterLayerState3D(LayerState3D):
         self.cmap_lim_helper.flip_limits()
 
     @property
+    def cmap_name(self):
+        return colormaps.name_from_cmap(self.cmap)
+
+    @property
     def point_sizes(self):
         if self.size_mode is None:
             return None

--- a/glue/viewers/scatter3d/layer_state.py
+++ b/glue/viewers/scatter3d/layer_state.py
@@ -7,10 +7,10 @@ from glue.core.state_objects import StateAttributeLimitsHelper
 from glue.core.data_combo_helper import ComponentIDComboHelper
 from ..common3d.layer_state import LayerState3D
 
-__all__ = ['ScatterLayerState']
+__all__ = ['ScatterLayerState3D']
 
 
-class ScatterLayerState(LayerState3D):
+class ScatterLayerState3D(LayerState3D):
     """
     A state object for scatter layers
     """
@@ -60,7 +60,7 @@ class ScatterLayerState(LayerState3D):
 
         self._sync_markersize = None
 
-        super(ScatterLayerState, self).__init__(layer=layer)
+        super(ScatterLayerState3D, self).__init__(layer=layer)
 
         if self.layer is not None:
 
@@ -68,8 +68,8 @@ class ScatterLayerState(LayerState3D):
             self.size = self.layer.style.markersize
             self.alpha = self.layer.style.alpha
 
-        ScatterLayerState.color_mode.set_choices(self, ['Fixed', 'Linear'])
-        ScatterLayerState.size_mode.set_choices(self, ['Fixed', 'Linear'])
+        ScatterLayerState3D.color_mode.set_choices(self, ['Fixed', 'Linear'])
+        ScatterLayerState3D.size_mode.set_choices(self, ['Fixed', 'Linear'])
 
         self.size_att_helper = ComponentIDComboHelper(self, 'size_att')
         self.cmap_att_helper = ComponentIDComboHelper(self, 'cmap_att')
@@ -92,8 +92,8 @@ class ScatterLayerState(LayerState3D):
         vector_origin_display = {'tail': 'Tail of vector',
                                  'middle': 'Middle of vector',
                                  'tip': 'Tip of vector'}
-        ScatterLayerState.vector_origin.set_choices(self, ['tail', 'middle', 'tip'])
-        ScatterLayerState.vector_origin.set_display_func(self, vector_origin_display.get)
+        ScatterLayerState3D.vector_origin.set_choices(self, ['tail', 'middle', 'tip'])
+        ScatterLayerState3D.vector_origin.set_display_func(self, vector_origin_display.get)
 
         self.add_callback('layer', self._on_layer_change)
         if layer is not None:
@@ -121,7 +121,7 @@ class ScatterLayerState(LayerState3D):
 
     def _layer_changed(self):
 
-        super(ScatterLayerState, self)._layer_changed()
+        super(ScatterLayerState3D, self)._layer_changed()
 
         if self._sync_markersize is not None:
             self._sync_markersize.stop_syncing()

--- a/glue/viewers/scatter3d/tests/test_layer_state.py
+++ b/glue/viewers/scatter3d/tests/test_layer_state.py
@@ -3,15 +3,15 @@ from numpy.testing import assert_allclose
 from glue.core import Data, DataCollection
 from glue.core.tests.test_state import clone
 
-from ..layer_state import ScatterLayerState
+from ..layer_state import ScatterLayerState3D
 
 
-class TestScatterLayerState:
+class TestScatterLayerState3D:
 
     def setup_method(self, method):
         self.data = Data(x=[1, 2, 3, 4, 5], label='test_data')
         self.data_collection = DataCollection([self.data])
-        self.state = ScatterLayerState(layer=self.data)
+        self.state = ScatterLayerState3D(layer=self.data)
 
     def test_size_syncs_to_layer_markersize(self):
         self.state.size = 15

--- a/glue/viewers/scatter3d/tests/test_viewer_state.py
+++ b/glue/viewers/scatter3d/tests/test_viewer_state.py
@@ -2,7 +2,7 @@ from glue.core import Data
 from glue.core.tests.test_state import clone
 
 from ..viewer_state import ScatterViewerState3D
-from ..layer_state import ScatterLayerState
+from ..layer_state import ScatterLayerState3D
 
 
 def get_choice_labels(choices):
@@ -18,15 +18,15 @@ class TestScatterViewerState3D:
         self.state = ScatterViewerState3D()
 
     def test_adding_layer_populates_att_helpers(self):
-        layer_state = ScatterLayerState(layer=self.data1)
+        layer_state = ScatterLayerState3D(layer=self.data1)
         self.state.layers.append(layer_state)
 
         choices = set(get_choice_labels(self.state.x_att_helper.choices))
         assert 'x' in choices
 
     def test_adding_second_layer_adds_its_components(self):
-        layer_state1 = ScatterLayerState(layer=self.data1)
-        layer_state2 = ScatterLayerState(layer=self.data2)
+        layer_state1 = ScatterLayerState3D(layer=self.data1)
+        layer_state2 = ScatterLayerState3D(layer=self.data2)
         self.state.layers.append(layer_state1)
         self.state.layers.append(layer_state2)
 
@@ -36,8 +36,8 @@ class TestScatterViewerState3D:
         assert 'b' in choices
 
     def test_removing_layer_updates_att_helpers(self):
-        layer_state1 = ScatterLayerState(layer=self.data1)
-        layer_state2 = ScatterLayerState(layer=self.data2)
+        layer_state1 = ScatterLayerState3D(layer=self.data1)
+        layer_state2 = ScatterLayerState3D(layer=self.data2)
         self.state.layers.append(layer_state1)
         self.state.layers.append(layer_state2)
 

--- a/glue/viewers/volume3d/layer_state.py
+++ b/glue/viewers/volume3d/layer_state.py
@@ -72,3 +72,7 @@ class VolumeLayerState(LayerState3D, StretchStateMixin):
 
     def flip_limits(self):
         self.lim_helper.flip_limits()
+
+    @property
+    def cmap_name(self):
+        return colormaps.name_from_cmap(self.cmap)

--- a/glue/viewers/volume3d/layer_state.py
+++ b/glue/viewers/volume3d/layer_state.py
@@ -7,10 +7,10 @@ from glue.core.data_combo_helper import ComponentIDComboHelper
 from glue.viewers.common.stretch_state_mixin import StretchStateMixin
 from ..common3d.layer_state import LayerState3D
 
-__all__ = ['VolumeLayerState']
+__all__ = ['VolumeLayerState3D']
 
 
-class VolumeLayerState(LayerState3D, StretchStateMixin):
+class VolumeLayerState3D(LayerState3D, StretchStateMixin):
     """
     A state object for volume layers
     """
@@ -29,7 +29,7 @@ class VolumeLayerState(LayerState3D, StretchStateMixin):
 
     def __init__(self, layer=None, **kwargs):
 
-        super(VolumeLayerState, self).__init__(layer=layer)
+        super(VolumeLayerState3D, self).__init__(layer=layer)
 
         if self.layer is not None:
 
@@ -42,7 +42,7 @@ class VolumeLayerState(LayerState3D, StretchStateMixin):
                                                      lower='v_min', upper='v_max',
                                                      cache=self._limits_cache)
 
-        VolumeLayerState.color_mode.set_choices(self, ['Fixed', 'Linear'])
+        VolumeLayerState3D.color_mode.set_choices(self, ['Fixed', 'Linear'])
 
         self.setup_stretch_callback()
 

--- a/glue/viewers/volume3d/tests/test_layer_state.py
+++ b/glue/viewers/volume3d/tests/test_layer_state.py
@@ -3,16 +3,16 @@ import numpy as np
 from glue.core import Data, DataCollection
 from glue.core.tests.test_state import clone
 
-from ..layer_state import VolumeLayerState
+from ..layer_state import VolumeLayerState3D
 
 
-class TestVolumeLayerState:
+class TestVolumeLayerState3D:
 
     def setup_method(self, method):
         self.data = Data(label='test_cube')
         self.data['x'] = np.arange(24).reshape((2, 3, 4))
         self.data_collection = DataCollection([self.data])
-        self.state = VolumeLayerState(layer=self.data)
+        self.state = VolumeLayerState3D(layer=self.data)
 
     def test_flip_limits(self):
         self.state.attribute = self.data.id['x']
@@ -25,7 +25,7 @@ class TestVolumeLayerState:
     def test_subset_has_fixed_vmin_vmax(self):
         subset = self.data.new_subset()
         subset.subset_state = self.data.id['x'] > 10
-        state = VolumeLayerState(layer=subset)
+        state = VolumeLayerState3D(layer=subset)
 
         assert state.vmin == 0
         assert state.vmax == 1


### PR DESCRIPTION
The scatter layer state class name should include 3D in the name