### PR TITLE
Fix missing API docs for 3D states

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -126,6 +126,30 @@ User Interface
    :no-inheritance-diagram:
    :inherited-members:
 
+.. automodapi:: glue.viewers.common3d.viewer_state
+  :no-inheritance-diagram:
+  :inherited-members:
+
+.. automodapi:: glue.viewers.common3d.layer_state
+  :no-inheritance-diagram:
+  :inherited-members:
+
+.. automodapi:: glue.viewers.scatter3d.viewer_state
+  :no-inheritance-diagram:
+  :inherited-members:
+
+.. automodapi:: glue.viewers.scatter3d.layer_state
+  :no-inheritance-diagram:
+  :inherited-members:
+
+.. automodapi:: glue.viewers.volume3d.viewer_state
+  :no-inheritance-diagram:
+  :inherited-members:
+
+.. automodapi:: glue.viewers.volume3d.layer_state
+  :no-inheritance-diagram:
+  :inherited-members:
+
 .. automodapi:: glue.core.application_base
    :no-inheritance-diagram:
 


### PR DESCRIPTION
Just an oversight, but causing doc build issues in downstream packages