### PR TITLE
Update methods to use `world_n_dim` instead of `self._data.ndim`

### DIFF
--- a/glue/core/component.py
+++ b/glue/core/component.py
@@ -236,13 +236,15 @@ class CoordinateComponent(Component):
     @property
     def units(self):
         if self.world:
-            return self._data.coords.world_axis_units[self._data.ndim - 1 - self.axis] or ''
+            world_n_dim = getattr(self._data.coords, 'world_n_dim', self._data.ndim)
+            return self._data.coords.world_axis_units[world_n_dim - 1 - self.axis] or ''
         else:
             return ''
 
     def _calculate(self, view=None):
 
         if self.world:
+            world_n_dim = getattr(self._data.coords, 'world_n_dim', self._data.ndim)
 
             # Calculating the world coordinates can be a bottleneck if we aren't
             # careful, so we need to make sure that if not all dimensions depend
@@ -268,7 +270,7 @@ class CoordinateComponent(Component):
             # convert these straight to world coordinates since the indices
             # of the pixel coordinates are the pixel coordinates themselves.
             if isinstance(view, (tuple, list)) and isinstance(view[0], np.ndarray):
-                axis = self._data.ndim - 1 - self.axis
+                axis = world_n_dim - 1 - self.axis
                 return pixel2world_single_axis(self._data.coords, *view[::-1],
                                                world_axis=axis)
 
@@ -328,7 +330,8 @@ class CoordinateComponent(Component):
             pix_coords = np.meshgrid(*pix_coords, indexing='ij', copy=False)
 
             # Finally we convert these to world coordinates
-            axis = self._data.ndim - 1 - self.axis
+            world_n_dim = getattr(self._data.coords, 'world_n_dim', self._data.ndim)
+            axis = world_n_dim - 1 - self.axis
             world_coords = pixel2world_single_axis(self._data.coords,
                                                    *pix_coords[::-1],
                                                    world_axis=axis)

--- a/glue/core/component.py
+++ b/glue/core/component.py
@@ -229,6 +229,13 @@ class CoordinateComponent(Component):
         self._data = data
         self.axis = axis
 
+        # From issue #2574: initialize world_n_dim and error for data ndim > world ndim.
+        if self.world and self._data:
+            self.world_n_dim = getattr(self._data.coords, 'world_n_dim', self._data.ndim)
+            if self.world_n_dim < self._data.ndim:
+                raise ValueError("World must have at least the same number of "
+                                 "dimensions as data.")
+
     @property
     def data(self):
         return self._calculate()
@@ -236,15 +243,13 @@ class CoordinateComponent(Component):
     @property
     def units(self):
         if self.world:
-            world_n_dim = getattr(self._data.coords, 'world_n_dim', self._data.ndim)
-            return self._data.coords.world_axis_units[world_n_dim - 1 - self.axis] or ''
+            return self._data.coords.world_axis_units[self.world_n_dim - 1 - self.axis] or ''
         else:
             return ''
 
     def _calculate(self, view=None):
 
         if self.world:
-            world_n_dim = getattr(self._data.coords, 'world_n_dim', self._data.ndim)
 
             # Calculating the world coordinates can be a bottleneck if we aren't
             # careful, so we need to make sure that if not all dimensions depend
@@ -260,7 +265,7 @@ class CoordinateComponent(Component):
             # To optimize this, we therefore essentially consider only the
             # dependent dimensions and then broacast the result to the full
             # array size at the very end.
-            axis = world_n_dim - 1 - self.axis
+            axis = self.world_n_dim - 1 - self.axis
 
             # view=None actually adds a dimension which is never what we really
             # mean, at least in glue.
@@ -318,7 +323,7 @@ class CoordinateComponent(Component):
                 else:
                     final_shape.append(self._data.shape[i])
 
-                if world_n_dim == self._data.ndim and i not in dep_coords:
+                if self.world_n_dim == self._data.ndim and i not in dep_coords:
                     # The axis is not dependent on this instance's axis, so we
                     # just compute the values once and broadcast along this
                     # dimension later.

--- a/glue/core/component.py
+++ b/glue/core/component.py
@@ -235,8 +235,8 @@ class CoordinateComponent(Component):
             if self.world_n_dim < self._data.ndim:
                 raise ValueError(f"World[{self.world_n_dim}] must have at least the same "
                                   "number of dimensions as data[{self._data.ndim}].")
-            else:
-                self.world_n_dim = getattr(self._data, 'ndim', 0)
+        else:
+            self.world_n_dim = getattr(self._data, 'ndim', 0)
 
     @property
     def data(self):

--- a/glue/core/component.py
+++ b/glue/core/component.py
@@ -234,7 +234,7 @@ class CoordinateComponent(Component):
             self.world_n_dim = getattr(self._data.coords, 'world_n_dim', self._data.ndim)
             if self.world_n_dim < self._data.ndim:
                 raise ValueError(f"World[{self.world_n_dim}] must have at least the same "
-                                  "number of dimensions as data[{self._data.ndim}].")
+                                 f"number of dimensions as data[{self._data.ndim}].")
         else:
             self.world_n_dim = getattr(self._data, 'ndim', 0)
 

--- a/glue/core/component.py
+++ b/glue/core/component.py
@@ -260,6 +260,7 @@ class CoordinateComponent(Component):
             # To optimize this, we therefore essentially consider only the
             # dependent dimensions and then broacast the result to the full
             # array size at the very end.
+            axis = world_n_dim - 1 - self.axis
 
             # view=None actually adds a dimension which is never what we really
             # mean, at least in glue.
@@ -270,7 +271,6 @@ class CoordinateComponent(Component):
             # convert these straight to world coordinates since the indices
             # of the pixel coordinates are the pixel coordinates themselves.
             if isinstance(view, (tuple, list)) and isinstance(view[0], np.ndarray):
-                axis = world_n_dim - 1 - self.axis
                 return pixel2world_single_axis(self._data.coords, *view[::-1],
                                                world_axis=axis)
 
@@ -318,7 +318,7 @@ class CoordinateComponent(Component):
                 else:
                     final_shape.append(self._data.shape[i])
 
-                if i not in dep_coords:
+                if world_n_dim == self._data.ndim and i not in dep_coords:
                     # The axis is not dependent on this instance's axis, so we
                     # just compute the values once and broadcast along this
                     # dimension later.
@@ -330,8 +330,6 @@ class CoordinateComponent(Component):
             pix_coords = np.meshgrid(*pix_coords, indexing='ij', copy=False)
 
             # Finally we convert these to world coordinates
-            world_n_dim = getattr(self._data.coords, 'world_n_dim', self._data.ndim)
-            axis = world_n_dim - 1 - self.axis
             world_coords = pixel2world_single_axis(self._data.coords,
                                                    *pix_coords[::-1],
                                                    world_axis=axis)

--- a/glue/core/component.py
+++ b/glue/core/component.py
@@ -230,11 +230,13 @@ class CoordinateComponent(Component):
         self.axis = axis
 
         # From issue #2574: initialize world_n_dim and error for data ndim > world ndim.
-        if self.world and self._data:
+        if hasattr(self._data, 'coords'):
             self.world_n_dim = getattr(self._data.coords, 'world_n_dim', self._data.ndim)
             if self.world_n_dim < self._data.ndim:
-                raise ValueError("World must have at least the same number of "
-                                 "dimensions as data.")
+                raise ValueError(f"World[{self.world_n_dim}] must have at least the same "
+                                  "number of dimensions as data[{self._data.ndim}].")
+            else:
+                self.world_n_dim = getattr(self._data, 'ndim', 0)
 
     @property
     def data(self):

--- a/glue/core/tests/test_component.py
+++ b/glue/core/tests/test_component.py
@@ -470,8 +470,8 @@ def test_coordinate_component_units_when_world_n_dim_exceeds_data_ndim():
     # Reset to check pixel_n_dim > world_n_dim
     data = core.Data()
     data.add_component(Component(np.zeros((3, 3, 3))), 'test')
-    with pytest.raises(ValueError, match="World must have at least the same number of "
-                                         "dimensions as data."):
+    with pytest.raises(ValueError, match=r"World must have at least the same number of "
+                                         r"dimensions as data\."):
         data.coords = MismatchedCoords(pixel_n_dim=3, world_n_dim=2)
 
 

--- a/glue/core/tests/test_component.py
+++ b/glue/core/tests/test_component.py
@@ -470,8 +470,8 @@ def test_coordinate_component_units_when_world_n_dim_exceeds_data_ndim():
     # Reset to check pixel_n_dim > world_n_dim
     data = core.Data()
     data.add_component(Component(np.zeros((3, 3, 3))), 'test')
-    with pytest.raises(ValueError, match=r"World must have at least the same number of "
-                                         r"dimensions as data\."):
+    with pytest.raises(ValueError, match=r"World\[2\] must have at least the same "
+                                         r"number of dimensions as data\[3\]."):
         data.coords = MismatchedCoords(pixel_n_dim=3, world_n_dim=2)
 
 

--- a/glue/core/tests/test_component.py
+++ b/glue/core/tests/test_component.py
@@ -418,8 +418,8 @@ def test_coordinate_component_units_when_world_n_dim_exceeds_data_ndim():
         # 2 pixel axes, 3 world axes: the third world axis is a
         # combination of the two pixel axes (stand-in for the kind of
         # dispersion/spatial-correlation WCS that triggered the bug).
-        def __init__(self):
-            super().__init__(pixel_n_dim=2, world_n_dim=3)
+        def __init__(self, pixel_n_dim, world_n_dim):
+            super().__init__(pixel_n_dim=pixel_n_dim, world_n_dim=world_n_dim)
 
         @property
         def world_axis_units(self):
@@ -442,7 +442,7 @@ def test_coordinate_component_units_when_world_n_dim_exceeds_data_ndim():
 
     data = core.Data()
     data.add_component(Component(np.zeros((3, 3))), 'test')
-    data.coords = MismatchedCoords()
+    data.coords = MismatchedCoords(pixel_n_dim=2, world_n_dim=3)
 
     # With ``world_n_dim - 1 - axis`` indexing, numpy data axis 0 maps
     # to world axis 2 and numpy data axis 1 to world axis 1. The old
@@ -466,6 +466,13 @@ def test_coordinate_component_units_when_world_n_dim_exceeds_data_ndim():
                                expected_axis0)
     np.testing.assert_allclose(CoordinateComponent(data, 1, world=True).data,
                                expected_axis1)
+
+    # Reset to check pixel_n_dim > world_n_dim
+    data = core.Data()
+    data.add_component(Component(np.zeros((3, 3, 3))), 'test')
+    with pytest.raises(ValueError, match="World must have at least the same number of "
+                                         "dimensions as data."):
+        data.coords = MismatchedCoords(pixel_n_dim=3, world_n_dim=2)
 
 
 class TestExtendedComponent(object):

--- a/glue/core/tests/test_component.py
+++ b/glue/core/tests/test_component.py
@@ -406,6 +406,68 @@ def test_coordinate_component_1d_coord():
     np.testing.assert_equal(data['Frequency'], [1, 2, 3, 4, 5])
 
 
+def test_coordinate_component_units_when_world_n_dim_exceeds_data_ndim():
+    # Regression test for issue #2574: when ``coords.world_n_dim`` is
+    # larger than ``data.ndim`` (e.g. a 3D WCS describing a 2D dataset,
+    # as for NIRSpec 2D spectra), ``CoordinateComponent.units`` must
+    # index into ``world_axis_units`` using ``world_n_dim``, not
+    # ``data.ndim`` -- otherwise the world components get whichever
+    # units happen to live at the data-ndim-offset slot.
+
+    class MismatchedCoords(Coordinates):
+        # 2 pixel axes, 3 world axes: the third world axis is a
+        # combination of the two pixel axes (stand-in for the kind of
+        # dispersion/spatial-correlation WCS that triggered the bug).
+        def __init__(self):
+            super().__init__(pixel_n_dim=2, world_n_dim=3)
+
+        @property
+        def world_axis_units(self):
+            return ['unit_world0', 'unit_world1', 'unit_world2']
+
+        @property
+        def axis_correlation_matrix(self):
+            # (world_n_dim, pixel_n_dim) = (3, 2).
+            return np.array([[True, True],
+                             [True, False],
+                             [False, True]])
+
+        def pixel_to_world_values(self, *pixel):
+            p0, p1 = pixel
+            return (p0 + p1, 1.0 * p0, 2.0 * p1)
+
+        def world_to_pixel_values(self, *world):
+            _w0, w1, w2 = world
+            return (w1 / 1.0, w2 / 2.0)
+
+    data = core.Data()
+    data.add_component(Component(np.zeros((3, 3))), 'test')
+    data.coords = MismatchedCoords()
+
+    # With ``world_n_dim - 1 - axis`` indexing, numpy data axis 0 maps
+    # to world axis 2 and numpy data axis 1 to world axis 1. The old
+    # ``data.ndim - 1 - axis`` form mapped axis 0 -> world index 1 and
+    # axis 1 -> world index 0, picking the wrong (or "missing") units.
+    assert CoordinateComponent(data, 0, world=True).units == 'unit_world2'
+    assert CoordinateComponent(data, 1, world=True).units == 'unit_world1'
+
+    # The world-coordinate data follows the same indexing convention.
+    # Numpy axis 0 -> world axis 2, whose values are ``2.0 * p1``
+    # where ``p1`` is the numpy-axis-0 pixel index. The grid for a
+    # (3, 3) array of axis-0 pixels is [[0,0,0],[1,1,1],[2,2,2]], so
+    # world values are 2x that.
+    expected_axis0 = np.array([[0., 0., 0.],
+                               [2., 2., 2.],
+                               [4., 4., 4.]])
+    expected_axis1 = np.array([[0., 1., 2.],
+                               [0., 1., 2.],
+                               [0., 1., 2.]])
+    np.testing.assert_allclose(CoordinateComponent(data, 0, world=True).data,
+                               expected_axis0)
+    np.testing.assert_allclose(CoordinateComponent(data, 1, world=True).data,
+                               expected_axis1)
+
+
 class TestExtendedComponent(object):
 
     def setup_method(self):


### PR DESCRIPTION
* This is done to correct for a units mismatch for data with higher dimensionality coordinates than data (e.g. 3D WCS with 2D data). See [Issue 2574](https://github.com/glue-viz/glue/issues/2574)