### PR TITLE
Fix issue with reference data choices and update attributes

### DIFF
--- a/glue/viewers/volume3d/tests/test_viewer_state.py
+++ b/glue/viewers/volume3d/tests/test_viewer_state.py
@@ -109,6 +109,10 @@ class TestVolumeViewerState3D:
         self.state.layers.append(MockLayerState(data2))
         assert VolumeViewerState3D.reference_data.get_choices(self.state) == [self.data, data2]
 
+        self.state.layers.pop(0)
+        assert VolumeViewerState3D.reference_data.get_choices(self.state) == [data2]
+
+
     def test_attribute_choices(self):
         self.state.layers.append(MockLayerState(self.data))
 

--- a/glue/viewers/volume3d/tests/test_viewer_state.py
+++ b/glue/viewers/volume3d/tests/test_viewer_state.py
@@ -2,6 +2,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 
 from glue.core import Data, DataCollection
+from glue.core.link_helpers import LinkSame
 from glue.core.tests.test_state import clone
 
 from ..viewer_state import VolumeViewerState3D
@@ -84,6 +85,51 @@ class TestVolumeViewerState3D:
 
         self.state.set_limits(0, 5, 0, 2, 0, 1.5)
         assert_allclose(self.state.clip_limits_relative, [0., 0.5, 0., 0.5, 0., 0.5])
+
+    def test_initial_attributes(self):
+        self.state.layers.append(MockLayerState(self.data))
+        pixel_ids = self.data.pixel_component_ids
+        assert self.state.x_att == pixel_ids[2]
+        assert self.state.y_att == pixel_ids[1]
+        assert self.state.z_att == pixel_ids[0]
+
+    def test_reference_data_choices(self):
+        self.state.layers.append(MockLayerState(self.data))
+        assert VolumeViewerState3D.reference_data.get_choices(self.state) == [self.data]
+
+        data2 = Data(label='cube2')
+        data2['x'] = np.arange(120).reshape((3, 4, 10))
+        self.data_collection.append(data2)
+        for i in range(3):
+            link = LinkSame(
+                    cid1=self.data.pixel_component_ids[i],
+                    cid2=data2.pixel_component_ids[i])
+            self.data_collection.add_link(link)
+
+        self.state.layers.append(MockLayerState(data2))
+        assert VolumeViewerState3D.reference_data.get_choices(self.state) == [self.data, data2]
+
+    def test_attribute_choices(self):
+        self.state.layers.append(MockLayerState(self.data))
+
+        assert self.state.x_att.parent == self.data
+        assert self.state.y_att.parent == self.data
+        assert self.state.z_att.parent == self.data
+
+        data2 = Data(label='cube2')
+        data2['x'] = np.arange(120).reshape((3, 4, 10))
+        self.data_collection.append(data2)
+        for i in range(3):
+            link = LinkSame(
+                    cid1=self.data.pixel_component_ids[i],
+                    cid2=data2.pixel_component_ids[i])
+            self.data_collection.add_link(link)
+        self.state.layers.append(MockLayerState(data2))
+
+        self.state.reference_data = data2
+        assert self.state.x_att.parent == data2
+        assert self.state.y_att.parent == data2
+        assert self.state.z_att.parent == data2
 
     def test_serialization(self):
         self.state.downsample = False

--- a/glue/viewers/volume3d/viewer_state.py
+++ b/glue/viewers/volume3d/viewer_state.py
@@ -44,8 +44,17 @@ class VolumeViewerState3D(ViewerState3D):
                 return layer_state.layer
 
     def _layers_changed(self, *args):
-        self._update_combo_ref_data()
-        self._set_reference_data()
+
+        # By default if any of the state properties change, this triggers a
+        # callback on anything listening to changes on self.layers - but here
+        # we just want to know if any layers have been removed/added so we keep
+        # track of the UUIDs of the layers and check this before continuing.
+        current_layers = [layer_state.layer.uuid for layer_state in self.layers]
+        if not hasattr(self, '_last_layers') or self._last_layers != current_layers:
+            self._update_combo_ref_data()
+            self._set_reference_data()
+            self._last_layers = current_layers
+            return
 
     def _update_combo_ref_data(self, *args):
         self.ref_data_helper.set_multiple_data(self.layers_data)

--- a/glue/viewers/volume3d/viewer_state.py
+++ b/glue/viewers/volume3d/viewer_state.py
@@ -26,7 +26,8 @@ class VolumeViewerState3D(ViewerState3D):
         self.ref_data_helper = ManualDataComboHelper(self, 'reference_data')
         self.slices = ()
 
-        self.add_callback('layers', self._layers_changed, echo_old=True)
+        self.add_callback('layers', self._layers_changed)
+        self.add_callback('reference_data', self._reference_data_changed)
         self.add_callback('x_att', self._on_xatt_changed, echo_old=True)
         self.add_callback('y_att', self._on_yatt_changed, echo_old=True)
         self.add_callback('z_att', self._on_zatt_changed, echo_old=True)
@@ -42,29 +43,33 @@ class VolumeViewerState3D(ViewerState3D):
             if getattr(layer_state.layer, 'ndim', None) >= 3:
                 return layer_state.layer
 
-    def _layers_changed(self, old_layers, new_layers):
-        if self.reference_data is not None and old_layers == new_layers:
-            return
+    def _layers_changed(self, *args):
         self._update_combo_ref_data()
         self._set_reference_data()
-        self._update_attributes()
 
     def _update_combo_ref_data(self, *args):
         self.ref_data_helper.set_multiple_data(self.layers_data)
 
     def _set_reference_data(self, *args):
         if self.reference_data is None:
-            self.slices = ()
             for layer in self.layers:
                 if isinstance(layer.layer, BaseData):
                     self.reference_data = layer.layer
                     return
+
+    def _reference_data_changed(self, data):
+        if data is None:
+            self.slices = ()
         else:
-            self.slices = (0,) * self.reference_data.ndim
+            self.slices = (0,) * data.ndim
 
-    def _update_attributes(self, *args):
+        with delay_callback(self, "x_att", "y_att", "z_att"):
+            self._update_attributes(data)
+            self._set_up_attributes(data)
 
-        data = self._first_3d_data()
+    def _update_attributes(self, data=None):
+
+        data = data or self._first_3d_data()
 
         if data is None:
 
@@ -79,8 +84,8 @@ class VolumeViewerState3D(ViewerState3D):
                 type(self).y_att.set_choices(self, pixel_ids)
                 type(self).z_att.set_choices(self, pixel_ids)
 
-    def _set_up_attributes(self, *args):
-        data = self._first_3d_data()
+    def _set_up_attributes(self, data=None):
+        data = data or self._first_3d_data()
         if data is not None:
             pixel_ids = data.pixel_component_ids
             self.x_att = pixel_ids[2]


### PR DESCRIPTION
This PR aims to fix #2576 by removing the check on the layers list, while also trying to resolve the issue that the check was put in there to work around. It also makes a couple of other tweaks to the attributes setup. The basic changes are:
* The reference data dropdown now gets updated on a `layers` callback
* x/y/z attribute choices are now set specifically from the reference data
* We set up default x/y/z attributes for the standard cube pixel coordinate ordering of 2, 1, 0 (currently we are just using 0, 1, 2). I'm not sure if there is any sort of convention for 4D+ cubes, but users can always change attributes anyways