### PR TITLE
Serialize callables such as numpy array functions by name reference when they don't match another saver

### DIFF
--- a/glue/core/state.py
+++ b/glue/core/state.py
@@ -363,6 +363,9 @@ class GlueSerializer(object):
             result['_type'] = 'types.FunctionType'
         elif isinstance(obj, types.MethodType):
             result['_type'] = 'types.MethodType'
+        elif fun is _save_named_callable:
+            # Reuse the function loader, which reconstructs from {'function': ref}
+            result['_type'] = 'types.FunctionType'
         else:
             result['_type'] = "%s.%s" % (type(obj).__module__,
                                          type(obj).__name__)
@@ -383,6 +386,13 @@ class GlueSerializer(object):
                     return self.dispatch[typ]
         except TypeError:  # no mro
             pass
+
+        # Fall back to serializing any callable that can be looked up again by
+        # its fully-qualified name. This catches callables that are neither
+        # FunctionType nor BuiltinFunctionType (e.g. numpy array functions such
+        # as np.nansum) and so match no type-keyed saver above.
+        if _is_referenceable_callable(obj):
+            return _save_named_callable, 1
 
         raise GlueSerializeError("Don't know how to serialize"
                                  " %r of type %s" % (obj, type(obj)))
@@ -1176,6 +1186,30 @@ def _load_coordinate_component_link(rec, context):
     pix2world = rec['pix2world']
     frm = list(map(context.object, rec['frm']))
     return CoordinateComponentLink(frm, to, coords, index, pix2world)
+
+
+def _is_referenceable_callable(obj):
+    """
+    Whether ``obj`` is a callable that can be reconstructed from its
+    fully-qualified ``module.name``. This covers callables that are neither
+    FunctionType nor BuiltinFunctionType, such as numpy's array functions
+    (e.g. np.nansum), which are instances of the private
+    numpy._ArrayFunctionDispatcher and so match no type-keyed saver.
+    """
+    if not callable(obj):
+        return False
+    module = getattr(obj, '__module__', None)
+    name = getattr(obj, '__name__', None)
+    if not module or not name:
+        return False
+    try:
+        return lookup_class_with_patches("%s.%s" % (module, name)) is obj
+    except Exception:
+        return False
+
+
+def _save_named_callable(obj, context):
+    return {'function': "%s.%s" % (obj.__module__, obj.__name__)}
 
 
 @saver(types.BuiltinFunctionType)

--- a/glue/core/tests/test_state.py
+++ b/glue/core/tests/test_state.py
@@ -137,6 +137,16 @@ def test_save_numpy_scalar():
     assert clone(np.float32(5)) == 5
 
 
+@pytest.mark.parametrize('func', [np.nansum, np.nanmean, np.nanmin,
+                                  np.nanmax, np.nanmedian])
+def test_save_numpy_array_function(func):
+    # numpy array functions such as np.nansum are instances of the private
+    # numpy._ArrayFunctionDispatcher and so are neither FunctionType nor
+    # BuiltinFunctionType; they should still serialize by name reference
+    # (regression test for collapse functions stored in AggregateSlice).
+    assert clone(func) is func
+
+
 @requires_astropy
 def tests_data_factory_double():
     # ensure double-cloning doesn't somehow lose lightweight references

--- a/glue/viewers/image/tests/test_viewer.py
+++ b/glue/viewers/image/tests/test_viewer.py
@@ -1,16 +1,49 @@
 import numpy as np
+import pytest
 from echo import delay_callback
 from glue.tests.visual.helpers import visual_test
 from glue.viewers.image.viewer import SimpleImageViewer
+from glue.viewers.image.state import AggregateSlice
 from glue.core.application_base import Application
 from glue.core.data import Data
 from glue.core.link_helpers import LinkSame
 from glue.core.data_region import RegionData
 from glue.core.data_derived import IndexedData
+from glue.core.tests.test_state import clone
 from astropy.wcs import WCS
 
 from shapely.geometry import Polygon, MultiPolygon, Point
 import shapely
+
+
+@pytest.mark.parametrize('func', [np.nansum, np.nanmean, np.nanmin,
+                                  np.nanmax, np.nanmedian])
+def test_serialize_aggregate_slice(func):
+
+    # Collapsing a cube with the profile tools stores the collapse function in
+    # an AggregateSlice on the image viewer state. Make sure such a state can
+    # be serialized even when the function (e.g. np.nansum) is an instance of
+    # numpy._ArrayFunctionDispatcher rather than a plain/builtin function.
+
+    data = Data(x=np.arange(60).reshape((3, 4, 5)), label='cube')
+
+    app = Application()
+    app.data_collection.append(data)
+
+    viewer = app.new_data_viewer(SimpleImageViewer)
+    viewer.add_data(data)
+
+    slices = list(viewer.state.slices)
+    slices[0] = AggregateSlice(slice(0, 3), 1, func)
+    viewer.state.slices = tuple(slices)
+
+    state2 = clone(viewer.state)
+
+    new_slice = state2.slices[0]
+    assert isinstance(new_slice, AggregateSlice)
+    assert new_slice.function is func
+    assert new_slice.slice == slice(0, 3)
+    assert new_slice.center == 1
 
 
 @visual_test


### PR DESCRIPTION
This should fix serialization issues when the image viewer has aggregated slices (e.g. collapsed based on profile viewer) and data has NaN values