### PR TITLE
Write the plugins config file atomically and tolerate duplicate options when reading it

### DIFF
--- a/glue/_plugin_helpers.py
+++ b/glue/_plugin_helpers.py
@@ -93,6 +93,13 @@ class PluginConfig(object):
 
         plugin_cfg = os.path.join(cfg_dir, 'plugins.cfg')
 
+        # Don't rewrite the file when nothing has changed. In the common case
+        # the config already lists every known plugin, so this avoids touching
+        # disk on every startup and removes almost all of the opportunity for
+        # concurrent processes to write the file at the same time.
+        if dict(PluginConfig.load().plugins) == dict(self.plugins):
+            return
+
         import configparser
 
         config = configparser.ConfigParser()
@@ -108,30 +115,30 @@ class PluginConfig(object):
         # destination in a single step, so a concurrent reader (e.g. another
         # process during a parallel test run) always sees either the old or the
         # new file, never a partially-written or interleaved one.
-        import time
         import tempfile
         fd, tmp_path = tempfile.mkstemp(dir=cfg_dir, prefix='plugins.cfg.',
                                         suffix='.tmp')
         try:
             with os.fdopen(fd, 'w') as fout:
                 config.write(fout)
-            # Windows refuses to rename over a file that another process or
-            # thread currently has open (PermissionError / WinError 5), unlike
-            # POSIX. Retry briefly to ride out those transient sharing windows.
-            for attempt in range(20):
-                try:
-                    os.replace(tmp_path, plugin_cfg)
-                    break
-                except PermissionError:
-                    if attempt == 19:
-                        raise
-                    time.sleep(0.05)
-        except BaseException:
             try:
-                os.remove(tmp_path)
+                os.replace(tmp_path, plugin_cfg)
             except OSError:
-                pass
-            raise
+                # Windows refuses to rename over a file that another process
+                # currently has open, unlike POSIX. That can only happen once a
+                # valid file already exists (every write is a whole-file rename)
+                # and the config is non-critical, so ignore it. A genuine
+                # failure leaves no file in place and is re-raised.
+                if not os.path.exists(plugin_cfg):
+                    raise
+        finally:
+            # Remove the temporary file if the rename did not consume it (an
+            # error, or an ignored Windows sharing conflict).
+            if os.path.exists(tmp_path):
+                try:
+                    os.remove(tmp_path)
+                except OSError:
+                    pass
 
     def filter(self, keep):
         """

--- a/glue/_plugin_helpers.py
+++ b/glue/_plugin_helpers.py
@@ -9,6 +9,7 @@
 import os
 import sys
 import warnings
+from pathlib import Path
 from collections import defaultdict
 
 if sys.version_info >= (3, 10):
@@ -122,7 +123,7 @@ class PluginConfig(object):
             with os.fdopen(fd, 'w') as fout:
                 config.write(fout)
             try:
-                os.replace(tmp_path, plugin_cfg)
+                Path(tmp_path).replace(plugin_cfg)
             except OSError:
                 # Windows refuses to rename over a file that another process
                 # currently has open, unlike POSIX. That can only happen once a

--- a/glue/_plugin_helpers.py
+++ b/glue/_plugin_helpers.py
@@ -8,6 +8,7 @@
 
 import os
 import sys
+import warnings
 from collections import defaultdict
 
 if sys.version_info >= (3, 10):
@@ -57,11 +58,20 @@ class PluginConfig(object):
 
         import configparser
 
-        # Use strict=False so that a file corrupted by a previous non-atomic or
-        # concurrent write (which may contain duplicate options) can still be
-        # read instead of raising DuplicateOptionError.
-        config = configparser.ConfigParser(strict=False)
-        read = config.read(plugin_cfg)
+        config = configparser.ConfigParser()
+        try:
+            read = config.read(plugin_cfg)
+        except configparser.Error as exc:
+            # The file may have been corrupted by a previous non-atomic or
+            # concurrent write and e.g. contain duplicate options. Fall back
+            # to a tolerant parse (last occurrence of an option wins) rather
+            # than failing - the file will be rewritten cleanly on the next
+            # save().
+            warnings.warn(f"Error while reading {plugin_cfg}:\n{exc}\n"
+                          f"Falling back to parsing the file with "
+                          f"strict=False.")
+            config = configparser.ConfigParser(strict=False)
+            read = config.read(plugin_cfg)
 
         if len(read) == 0 or not config.has_section('plugins'):
             return cls()

--- a/glue/_plugin_helpers.py
+++ b/glue/_plugin_helpers.py
@@ -87,19 +87,19 @@ class PluginConfig(object):
 
     def save(self):
 
-        # Import at runtime because some tests change this value. We also don't
-        # just import the variable directly otherwise it is cached.
-        from glue import config
-        cfg_dir = config.CFG_DIR
-
-        plugin_cfg = os.path.join(cfg_dir, 'plugins.cfg')
-
         # Don't rewrite the file when nothing has changed. In the common case
         # the config already lists every known plugin, so this avoids touching
         # disk on every startup and removes almost all of the opportunity for
         # concurrent processes to write the file at the same time.
         if dict(PluginConfig.load().plugins) == dict(self.plugins):
             return
+
+        # Import at runtime because some tests change this value. We also don't
+        # just import the variable directly otherwise it is cached.
+        from glue import config
+        cfg_dir = config.CFG_DIR
+
+        plugin_cfg = os.path.join(cfg_dir, 'plugins.cfg')
 
         import configparser
 
@@ -127,11 +127,17 @@ class PluginConfig(object):
             except OSError:
                 # Windows refuses to rename over a file that another process
                 # currently has open, unlike POSIX. That can only happen once a
-                # valid file already exists (every write is a whole-file rename)
-                # and the config is non-critical, so ignore it. A genuine
-                # failure leaves no file in place and is re-raised.
+                # valid file already exists (every write is a whole-file
+                # rename), so the old config stays in place; warn that the
+                # update was dropped rather than failing. A genuine failure
+                # leaves no file in place and is re-raised.
                 if not os.path.exists(plugin_cfg):
                     raise
+                warnings.warn(f"Could not write the updated plugin "
+                              f"configuration to {plugin_cfg} because the "
+                              f"file is in use by another process; the "
+                              f"existing configuration has been left "
+                              f"unchanged.")
         finally:
             # Remove the temporary file if the rename did not consume it (an
             # error, or an ignored Windows sharing conflict).

--- a/glue/_plugin_helpers.py
+++ b/glue/_plugin_helpers.py
@@ -57,7 +57,10 @@ class PluginConfig(object):
 
         import configparser
 
-        config = configparser.ConfigParser()
+        # Use strict=False so that a file corrupted by a previous non-atomic or
+        # concurrent write (which may contain duplicate options) can still be
+        # read instead of raising DuplicateOptionError.
+        config = configparser.ConfigParser(strict=False)
         read = config.read(plugin_cfg)
 
         if len(read) == 0 or not config.has_section('plugins'):
@@ -88,11 +91,26 @@ class PluginConfig(object):
         for key in sorted(self.plugins):
             config.set('plugins', key, value=str(int(self.plugins[key])))
 
-        if not os.path.exists(cfg_dir):
-            os.mkdir(cfg_dir)
+        os.makedirs(cfg_dir, exist_ok=True)
 
-        with open(plugin_cfg, 'w') as fout:
-            config.write(fout)
+        # Write atomically: serialize to a uniquely-named temporary file in the
+        # same directory and rename it into place. os.replace is atomic on both
+        # POSIX and Windows, so a concurrent reader (e.g. another process during
+        # a parallel test run) always sees either the old or the new file, never
+        # a partially-written or interleaved one.
+        import tempfile
+        fd, tmp_path = tempfile.mkstemp(dir=cfg_dir, prefix='plugins.cfg.',
+                                        suffix='.tmp')
+        try:
+            with os.fdopen(fd, 'w') as fout:
+                config.write(fout)
+            os.replace(tmp_path, plugin_cfg)
+        except BaseException:
+            try:
+                os.remove(tmp_path)
+            except OSError:
+                pass
+            raise
 
     def filter(self, keep):
         """

--- a/glue/_plugin_helpers.py
+++ b/glue/_plugin_helpers.py
@@ -104,17 +104,28 @@ class PluginConfig(object):
         os.makedirs(cfg_dir, exist_ok=True)
 
         # Write atomically: serialize to a uniquely-named temporary file in the
-        # same directory and rename it into place. os.replace is atomic on both
-        # POSIX and Windows, so a concurrent reader (e.g. another process during
-        # a parallel test run) always sees either the old or the new file, never
-        # a partially-written or interleaved one.
+        # same directory and rename it into place. os.replace overwrites the
+        # destination in a single step, so a concurrent reader (e.g. another
+        # process during a parallel test run) always sees either the old or the
+        # new file, never a partially-written or interleaved one.
+        import time
         import tempfile
         fd, tmp_path = tempfile.mkstemp(dir=cfg_dir, prefix='plugins.cfg.',
                                         suffix='.tmp')
         try:
             with os.fdopen(fd, 'w') as fout:
                 config.write(fout)
-            os.replace(tmp_path, plugin_cfg)
+            # Windows refuses to rename over a file that another process or
+            # thread currently has open (PermissionError / WinError 5), unlike
+            # POSIX. Retry briefly to ride out those transient sharing windows.
+            for attempt in range(20):
+                try:
+                    os.replace(tmp_path, plugin_cfg)
+                    break
+                except PermissionError:
+                    if attempt == 19:
+                        raise
+                    time.sleep(0.05)
         except BaseException:
             try:
                 os.remove(tmp_path)

--- a/glue/_pytest_plugin.py
+++ b/glue/_pytest_plugin.py
@@ -14,6 +14,8 @@ set ``PYTEST_DISABLE_PLUGIN_AUTOLOAD`` to disable autoloaded plugins entirely.
 import shutil
 import tempfile
 
+import pytest
+
 
 def pytest_addoption(parser):
     parser.addini('glue_isolate_config',
@@ -21,6 +23,9 @@ def pytest_addoption(parser):
                   type='bool', default=True)
 
 
+# tryfirst so the config dir is redirected before any other plugin or conftest
+# (e.g. glue's own) triggers plugin loading and writes into it.
+@pytest.hookimpl(tryfirst=True)
 def pytest_configure(config):
     if not config.getini('glue_isolate_config'):
         return
@@ -29,6 +34,7 @@ def pytest_configure(config):
 
     # mkdtemp creates a uniquely-named directory, so each process (and each
     # xdist worker) gets its own without needing to consult the worker id.
+    config._glue_original_cfg_dir = glue_config.CFG_DIR
     cfg_dir = tempfile.mkdtemp(prefix='glue-test-cfg-')
     config._glue_isolated_cfg_dir = cfg_dir
     glue_config.CFG_DIR = cfg_dir
@@ -37,4 +43,6 @@ def pytest_configure(config):
 def pytest_unconfigure(config):
     cfg_dir = getattr(config, '_glue_isolated_cfg_dir', None)
     if cfg_dir is not None:
+        from glue import config as glue_config
+        glue_config.CFG_DIR = getattr(config, '_glue_original_cfg_dir', glue_config.CFG_DIR)
         shutil.rmtree(cfg_dir, ignore_errors=True)

--- a/glue/_pytest_plugin.py
+++ b/glue/_pytest_plugin.py
@@ -1,0 +1,40 @@
+"""A pytest plugin, registered through the ``pytest11`` entry point, that
+isolates glue's configuration directory for the duration of a test run.
+
+It is loaded automatically whenever glue is installed, and gives each pytest
+process (including each pytest-xdist worker, which runs ``pytest_configure``
+independently) its own throwaway config directory. As a result tests never read
+from or write to the developer's real ``~/.glue``, and parallel workers never
+share ``plugins.cfg`` and race while rewriting it.
+
+Set ``glue_isolate_config = false`` in the pytest configuration to opt out, or
+set ``PYTEST_DISABLE_PLUGIN_AUTOLOAD`` to disable autoloaded plugins entirely.
+"""
+
+import shutil
+import tempfile
+
+
+def pytest_addoption(parser):
+    parser.addini('glue_isolate_config',
+                  help='Redirect glue config dir to a temporary location during tests.',
+                  type='bool', default=True)
+
+
+def pytest_configure(config):
+    if not config.getini('glue_isolate_config'):
+        return
+
+    from glue import config as glue_config
+
+    # mkdtemp creates a uniquely-named directory, so each process (and each
+    # xdist worker) gets its own without needing to consult the worker id.
+    cfg_dir = tempfile.mkdtemp(prefix='glue-test-cfg-')
+    config._glue_isolated_cfg_dir = cfg_dir
+    glue_config.CFG_DIR = cfg_dir
+
+
+def pytest_unconfigure(config):
+    cfg_dir = getattr(config, '_glue_isolated_cfg_dir', None)
+    if cfg_dir is not None:
+        shutil.rmtree(cfg_dir, ignore_errors=True)

--- a/glue/conftest.py
+++ b/glue/conftest.py
@@ -1,8 +1,6 @@
 import os
 import sys
 
-from glue.config import CFG_DIR as CFG_DIR_ORIG
-
 STDERR_ORIGINAL = sys.stderr
 
 ON_APPVEYOR = os.environ.get('APPVEYOR', 'False') == 'True'
@@ -40,12 +38,9 @@ def pytest_configure(config):
                 # that does noting, effectively disabling it.
                 setattr(helpers, attr, lambda f: f)
 
-    # Make sure we don't affect the real glue config dir
-    import tempfile
-    from glue import config
-    config.CFG_DIR = tempfile.mkdtemp()
-
-    # Force loading of plugins
+    # The config dir is redirected to a temporary location by the bundled
+    # pytest plugin (glue._pytest_plugin), so loading plugins here (and any
+    # writes it triggers) does not touch the real glue config dir.
     from glue.main import load_plugins
     load_plugins()
 
@@ -53,7 +48,3 @@ def pytest_configure(config):
 def pytest_unconfigure(config):
 
     os.environ.pop('GLUE_TESTING')
-
-    # Reset configuration directory to original one
-    from glue import config
-    config.CFG_DIR = CFG_DIR_ORIG

--- a/glue/tests/test_plugin_helpers.py
+++ b/glue/tests/test_plugin_helpers.py
@@ -7,6 +7,17 @@ import pytest
 from glue._plugin_helpers import PluginConfig
 
 
+def test_config_dir_isolated_by_pytest_plugin(request):
+    # The bundled pytest plugin (glue._pytest_plugin) redirects the config dir
+    # to a per-process temporary location during tests, which is what keeps
+    # parallel workers from sharing plugins.cfg. Skip only if it was disabled.
+    if not request.config.getini('glue_isolate_config'):
+        pytest.skip('glue config isolation disabled via glue_isolate_config')
+
+    import glue.config
+    assert os.path.basename(glue.config.CFG_DIR).startswith('glue-test-cfg-')
+
+
 def test_save_load_roundtrip(tmp_path, monkeypatch):
     monkeypatch.setattr('glue.config.CFG_DIR', str(tmp_path))
 

--- a/glue/tests/test_plugin_helpers.py
+++ b/glue/tests/test_plugin_helpers.py
@@ -1,0 +1,65 @@
+import os
+import configparser
+from concurrent.futures import ThreadPoolExecutor
+
+from glue._plugin_helpers import PluginConfig
+
+
+def test_save_load_roundtrip(tmp_path, monkeypatch):
+    monkeypatch.setattr('glue.config.CFG_DIR', str(tmp_path))
+
+    PluginConfig(plugins={'plugin_a': True, 'plugin_b': False}).save()
+
+    loaded = PluginConfig.load()
+    assert loaded.plugins['plugin_a'] is True
+    assert loaded.plugins['plugin_b'] is False
+
+
+def test_save_leaves_no_temporary_files(tmp_path, monkeypatch):
+    monkeypatch.setattr('glue.config.CFG_DIR', str(tmp_path))
+
+    PluginConfig(plugins={'plugin_a': True}).save()
+
+    assert os.listdir(tmp_path) == ['plugins.cfg']
+
+
+def test_load_tolerates_duplicate_options(tmp_path, monkeypatch):
+    # A file corrupted by a previous concurrent/non-atomic write can contain
+    # the same option twice. Reading it should not raise DuplicateOptionError.
+    monkeypatch.setattr('glue.config.CFG_DIR', str(tmp_path))
+
+    (tmp_path / 'plugins.cfg').write_text(
+        "[plugins]\ndendro_factory = 1\ndendro_factory = 1\n")
+
+    loaded = PluginConfig.load()
+    assert loaded.plugins['dendro_factory'] is True
+
+
+def test_concurrent_save_and_load(tmp_path, monkeypatch):
+    # Regression test: hammering save() from several threads while another
+    # thread repeatedly loads must never expose a partially written or
+    # duplicated config, because save() renames the file into place atomically.
+    monkeypatch.setattr('glue.config.CFG_DIR', str(tmp_path))
+
+    plugins = {'plugin_{0}'.format(i): True for i in range(50)}
+    plugin_cfg = str(tmp_path / 'plugins.cfg')
+
+    def writer():
+        for _ in range(50):
+            PluginConfig(plugins=plugins).save()
+
+    def reader():
+        # Parse strictly so that a torn or duplicated write raises instead of
+        # being silently tolerated; the atomic save() must prevent that.
+        for _ in range(200):
+            if os.path.exists(plugin_cfg):
+                configparser.ConfigParser(strict=True).read(plugin_cfg)
+
+    with ThreadPoolExecutor(max_workers=6) as executor:
+        futures = [executor.submit(writer) for _ in range(4)]
+        futures += [executor.submit(reader) for _ in range(2)]
+        for future in futures:
+            future.result()
+
+    assert os.listdir(tmp_path) == ['plugins.cfg']
+    assert PluginConfig.load().plugins == plugins

--- a/glue/tests/test_plugin_helpers.py
+++ b/glue/tests/test_plugin_helpers.py
@@ -2,6 +2,8 @@ import os
 import configparser
 from concurrent.futures import ThreadPoolExecutor
 
+import pytest
+
 from glue._plugin_helpers import PluginConfig
 
 
@@ -25,13 +27,15 @@ def test_save_leaves_no_temporary_files(tmp_path, monkeypatch):
 
 def test_load_tolerates_duplicate_options(tmp_path, monkeypatch):
     # A file corrupted by a previous concurrent/non-atomic write can contain
-    # the same option twice. Reading it should not raise DuplicateOptionError.
+    # the same option twice. Reading it should warn, not raise
+    # DuplicateOptionError.
     monkeypatch.setattr('glue.config.CFG_DIR', str(tmp_path))
 
     (tmp_path / 'plugins.cfg').write_text(
         "[plugins]\ndendro_factory = 1\ndendro_factory = 1\n")
 
-    loaded = PluginConfig.load()
+    with pytest.warns(UserWarning, match='Falling back to parsing the file'):
+        loaded = PluginConfig.load()
     assert loaded.plugins['dendro_factory'] is True
 
 

--- a/glue/tests/test_plugin_helpers.py
+++ b/glue/tests/test_plugin_helpers.py
@@ -54,10 +54,15 @@ def test_concurrent_save_and_load(tmp_path, monkeypatch):
 
     def reader():
         # Parse strictly so that a torn or duplicated write raises instead of
-        # being silently tolerated; the atomic save() must prevent that.
+        # being silently tolerated; the atomic save() must prevent that. A
+        # missing file is fine (read() returns []), and on Windows an open that
+        # races an atomic replace can be transiently denied, which is a sharing
+        # artifact rather than config corruption, so ignore PermissionError.
         for _ in range(200):
-            if os.path.exists(plugin_cfg):
+            try:
                 configparser.ConfigParser(strict=True).read(plugin_cfg)
+            except PermissionError:
+                pass
 
     with ThreadPoolExecutor(max_workers=6) as executor:
         futures = [executor.submit(writer) for _ in range(4)]

--- a/glue/tests/test_plugin_helpers.py
+++ b/glue/tests/test_plugin_helpers.py
@@ -52,7 +52,7 @@ def test_save_leaves_no_temporary_files(tmp_path, monkeypatch):
 
     PluginConfig(plugins={'plugin_a': True}).save()
 
-    assert os.listdir(tmp_path) == ['plugins.cfg']
+    assert [p.name for p in tmp_path.iterdir()] == ['plugins.cfg']
 
 
 def test_load_tolerates_duplicate_options(tmp_path, monkeypatch):
@@ -100,5 +100,5 @@ def test_concurrent_save_and_load(tmp_path, monkeypatch):
         for future in futures:
             future.result()
 
-    assert os.listdir(tmp_path) == ['plugins.cfg']
+    assert [p.name for p in tmp_path.iterdir()] == ['plugins.cfg']
     assert PluginConfig.load().plugins == plugins

--- a/glue/tests/test_plugin_helpers.py
+++ b/glue/tests/test_plugin_helpers.py
@@ -28,6 +28,25 @@ def test_save_load_roundtrip(tmp_path, monkeypatch):
     assert loaded.plugins['plugin_b'] is False
 
 
+def test_save_skips_write_when_unchanged(tmp_path, monkeypatch):
+    import tempfile
+
+    monkeypatch.setattr('glue.config.CFG_DIR', str(tmp_path))
+    PluginConfig(plugins={'plugin_a': True}).save()
+
+    with monkeypatch.context() as m:
+        def _fail(*args, **kwargs):
+            raise AssertionError('save() rewrote the file although nothing changed')
+        m.setattr(tempfile, 'mkstemp', _fail)
+
+        # Identical content must not touch disk at all.
+        PluginConfig(plugins={'plugin_a': True}).save()
+
+        # A genuine change must still attempt a write.
+        with pytest.raises(AssertionError):
+            PluginConfig(plugins={'plugin_a': False}).save()
+
+
 def test_save_leaves_no_temporary_files(tmp_path, monkeypatch):
     monkeypatch.setattr('glue.config.CFG_DIR', str(tmp_path))
 

--- a/glue/tests/test_plugin_helpers.py
+++ b/glue/tests/test_plugin_helpers.py
@@ -47,6 +47,26 @@ def test_save_skips_write_when_unchanged(tmp_path, monkeypatch):
             PluginConfig(plugins={'plugin_a': False}).save()
 
 
+def test_save_warns_when_rename_blocked(tmp_path, monkeypatch):
+    # Simulate Windows refusing the atomic rename because another process has
+    # the config file open: the existing file must be left in place and a
+    # warning emitted instead of the update being dropped silently.
+    from pathlib import Path
+
+    monkeypatch.setattr('glue.config.CFG_DIR', str(tmp_path))
+    PluginConfig(plugins={'plugin_a': True}).save()
+
+    def _blocked(self, target):
+        raise OSError('the file is in use by another process')
+    monkeypatch.setattr(Path, 'replace', _blocked)
+
+    with pytest.warns(UserWarning, match='file is in use by another process'):
+        PluginConfig(plugins={'plugin_a': False}).save()
+
+    assert [p.name for p in tmp_path.iterdir()] == ['plugins.cfg']
+    assert PluginConfig.load().plugins['plugin_a'] is True
+
+
 def test_save_leaves_no_temporary_files(tmp_path, monkeypatch):
     monkeypatch.setattr('glue.config.CFG_DIR', str(tmp_path))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,9 @@ build-backend = 'setuptools.build_meta'
 zip-safe = false
 include-package-data = false
 
+[project.entry-points."pytest11"]
+glue = "glue._pytest_plugin"
+
 [project.entry-points."glue.plugins"]
 coordinate_helpers = "glue.plugins.coordinate_helpers:setup"
 wcs_autolinking = "glue.plugins.wcs_autolinking:setup"


### PR DESCRIPTION
This should hopefully fix the issues seen in jdaviz  when running the tests in parallel