### PR TITLE
Check if reference data before updating volume attributes

### DIFF
--- a/glue/viewers/volume3d/viewer_state.py
+++ b/glue/viewers/volume3d/viewer_state.py
@@ -67,14 +67,19 @@ class VolumeViewerState3D(ViewerState3D):
                     return
 
     def _reference_data_changed(self, data):
-        if data is None:
-            self.slices = ()
-        else:
-            self.slices = (0,) * data.ndim
+        # This signal can get emitted if just the choices but not the actual
+        # reference data change, so we check here that the reference data has
+        # actually changed
+        if data is not getattr(self, '_last_reference_data', None):
+            self._last_reference_data = data
+            if data is None:
+                self.slices = ()
+            else:
+                self.slices = (0,) * data.ndim
 
-        with delay_callback(self, "x_att", "y_att", "z_att"):
-            self._update_attributes(data)
-            self._set_up_attributes(data)
+            with delay_callback(self, "x_att", "y_att", "z_att"):
+                self._update_attributes(data)
+                self._set_up_attributes(data)
 
     def _update_attributes(self, data=None):
 


### PR DESCRIPTION
This PR is a follow-up to #2577 (and hopefully the last piece of this story). The volume viewer state now has the problem that `_reference_data_changed` will be called even when the reference data hasn't actually changed, which has the problematic side effect of updating the x/y/z attributes whenever a new layer is added to the viewer. I'm not 100% sure but I think this issue ultimately comes from the combo helper. The approach adopted here is to copy what the image viewer state does, and store a `_last_reference_data` member that we can compare to inside the `_reference_data_changed` callback.