### PR TITLE
Pass viewer state through to superclass in 3D layer states

### DIFF
--- a/glue/viewers/scatter3d/layer_state.py
+++ b/glue/viewers/scatter3d/layer_state.py
@@ -56,11 +56,11 @@ class ScatterLayerState3D(LayerState3D):
     vy_attribute = CallbackPropertyAlias('vy_att')
     vz_attribute = CallbackPropertyAlias('vz_att')
 
-    def __init__(self, layer=None, **kwargs):
+    def __init__(self, layer=None, viewer_state=None, **kwargs):
 
         self._sync_markersize = None
 
-        super(ScatterLayerState3D, self).__init__(layer=layer, **kwargs)
+        super(ScatterLayerState3D, self).__init__(layer=layer, viewer_state=viewer_state)
 
         if self.layer is not None:
 

--- a/glue/viewers/scatter3d/layer_state.py
+++ b/glue/viewers/scatter3d/layer_state.py
@@ -60,7 +60,7 @@ class ScatterLayerState3D(LayerState3D):
 
         self._sync_markersize = None
 
-        super(ScatterLayerState3D, self).__init__(layer=layer)
+        super(ScatterLayerState3D, self).__init__(layer=layer, **kwargs)
 
         if self.layer is not None:
 

--- a/glue/viewers/scatter3d/tests/test_layer_state.py
+++ b/glue/viewers/scatter3d/tests/test_layer_state.py
@@ -4,6 +4,7 @@ from glue.core import Data, DataCollection
 from glue.core.tests.test_state import clone
 
 from ..layer_state import ScatterLayerState3D
+from ..viewer_state import ScatterViewerState3D
 
 
 class TestScatterLayerState3D:
@@ -11,7 +12,11 @@ class TestScatterLayerState3D:
     def setup_method(self, method):
         self.data = Data(x=[1, 2, 3, 4, 5], label='test_data')
         self.data_collection = DataCollection([self.data])
-        self.state = ScatterLayerState3D(layer=self.data)
+        self.viewer_state = ScatterViewerState3D()
+        self.state = ScatterLayerState3D(layer=self.data, viewer_state=self.viewer_state)
+
+    def test_viewer_state(self):
+        assert self.state.viewer_state == self.viewer_state
 
     def test_size_syncs_to_layer_markersize(self):
         self.state.size = 15

--- a/glue/viewers/volume3d/layer_state.py
+++ b/glue/viewers/volume3d/layer_state.py
@@ -29,7 +29,7 @@ class VolumeLayerState3D(LayerState3D, StretchStateMixin):
 
     def __init__(self, layer=None, **kwargs):
 
-        super(VolumeLayerState3D, self).__init__(layer=layer)
+        super(VolumeLayerState3D, self).__init__(layer=layer, **kwargs)
 
         if self.layer is not None:
 

--- a/glue/viewers/volume3d/layer_state.py
+++ b/glue/viewers/volume3d/layer_state.py
@@ -27,9 +27,9 @@ class VolumeLayerState3D(LayerState3D, StretchStateMixin):
     vmin = CallbackPropertyAlias('v_min')
     vmax = CallbackPropertyAlias('v_max')
 
-    def __init__(self, layer=None, **kwargs):
+    def __init__(self, layer=None, viewer_state=None, **kwargs):
 
-        super(VolumeLayerState3D, self).__init__(layer=layer, **kwargs)
+        super(VolumeLayerState3D, self).__init__(layer=layer, viewer_state=viewer_state)
 
         if self.layer is not None:
 

--- a/glue/viewers/volume3d/tests/test_layer_state.py
+++ b/glue/viewers/volume3d/tests/test_layer_state.py
@@ -4,6 +4,7 @@ from glue.core import Data, DataCollection
 from glue.core.tests.test_state import clone
 
 from ..layer_state import VolumeLayerState3D
+from ..viewer_state import VolumeViewerState3D
 
 
 class TestVolumeLayerState3D:
@@ -12,7 +13,11 @@ class TestVolumeLayerState3D:
         self.data = Data(label='test_cube')
         self.data['x'] = np.arange(24).reshape((2, 3, 4))
         self.data_collection = DataCollection([self.data])
-        self.state = VolumeLayerState3D(layer=self.data)
+        self.viewer_state = VolumeViewerState3D()
+        self.state = VolumeLayerState3D(layer=self.data, viewer_state=self.viewer_state)
+
+    def test_viewer_state(self):
+       assert self.state.viewer_state == self.viewer_state
 
     def test_flip_limits(self):
         self.state.attribute = self.data.id['x']


### PR DESCRIPTION
Currently the 3D layer state classes (scatter and volume) don't forward the viewer state keyword argument through to their superclasses. This means that their `viewer_state` members are not set correctly (they end up being `None`). Note that the base `LayerArtist` class explicitly sets this [here](https://github.com/glue-viz/glue/blob/main/glue/viewers/common/layer_artist.py#L25).