### PR TITLE
Add vertical and horizontal line modes to scatter layers

### DIFF
--- a/glue/viewers/scatter/layer_artist.py
+++ b/glue/viewers/scatter/layer_artist.py
@@ -39,7 +39,22 @@ LIMIT_PROPERTIES = set(['x_min', 'x_max', 'y_min', 'y_max'])
 DATA_PROPERTIES = set(['layer', 'x_att', 'y_att', 'cmap_mode', 'size_mode', 'density_map',
                        'xerr_att', 'yerr_att', 'xerr_visible', 'yerr_visible',
                        'vector_visible', 'vx_att', 'vy_att', 'vector_arrowhead', 'vector_mode',
-                       'vector_origin', 'line_visible', 'markers_visible', 'vector_scaling'])
+                       'vector_origin', 'line_visible', 'markers_visible', 'vector_scaling',
+                       'vline_visible', 'hline_visible'])
+
+
+def values_to_segments(values, horizontal=False):
+    """
+    Construct segments for a `~matplotlib.collections.LineCollection` with one
+    full-height vertical (or full-width horizontal) line per value, where the
+    direction along the lines is in axes fraction coordinates (0 to 1).
+    """
+    segments = np.zeros((len(values), 2, 2))
+    along, across = (0, 1) if horizontal else (1, 0)
+    segments[:, 0, across] = values
+    segments[:, 1, across] = values
+    segments[:, 1, along] = 1
+    return segments
 
 
 def ravel_artists(errorbar_artist):
@@ -162,6 +177,22 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
         # See also https://github.com/matplotlib/matplotlib/issues/13799
         self._errorbar_keep = None
 
+        self._line_mode_auto_checked = False
+
+    def _auto_enable_line_mode(self, x, y):
+        # If, the first time the data are accessed, only one of the two
+        # attributes can be resolved, the only meaningful way to show the layer
+        # is as vertical or horizontal lines, so we enable the relevant mode.
+        # This is done only once so that users can subsequently turn the lines
+        # off without them coming back on every update.
+        if self._line_mode_auto_checked:
+            return
+        self._line_mode_auto_checked = True
+        if x is None and not self.state.hline_visible:
+            self.state.hline_visible = True
+        elif y is None and not self.state.vline_visible:
+            self.state.vline_visible = True
+
     def _set_axes(self, axes):
         self.axes = axes
         self.scatter_artist = self.axes.scatter([], [])
@@ -170,6 +201,15 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
         self.vector_artist = None
         self.line_collection = ColoredLineCollection([], [])
         self.axes.add_collection(self.line_collection)
+        # The vertical/horizontal line collections use blended transforms so
+        # that the lines always span the full height/width of the axes
+        # regardless of the limits along the other direction.
+        self.vline_collection = LineCollection(np.zeros((0, 2, 2)),
+                                               transform=self.axes.get_xaxis_transform())
+        self.axes.add_collection(self.vline_collection)
+        self.hline_collection = LineCollection(np.zeros((0, 2, 2)),
+                                               transform=self.axes.get_yaxis_transform())
+        self.axes.add_collection(self.hline_collection)
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", message='All-NaN slice encountered')
             self.density_artist = GenericDensityArtist(self.axes, color='white',
@@ -181,7 +221,8 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
         self.axes.add_artist(self.density_artist)
         self.mpl_artists = [self.scatter_artist, self.plot_artist,
                             self.errorbar_artist, self.vector_artist,
-                            self.line_collection, self.density_artist]
+                            self.line_collection, self.vline_collection,
+                            self.hline_collection, self.density_artist]
 
     def compute_density_map(self, *args, **kwargs):
         try:
@@ -201,30 +242,36 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
         if len(self.mpl_artists) == 0:
             return
 
-        try:
-            if not self.state.density_map:
+        x = y = None
+
+        if not self.state.density_map:
+
+            try:
                 x = ensure_numerical(self.layer[self._viewer_state.x_att].ravel())
                 if x.dtype.kind == 'M':
                     x = datetime64_to_mpl(x)
+            except (IncompatibleAttribute, IndexError):
+                pass
 
-        except (IncompatibleAttribute, IndexError):
-            # The following includes a call to self.clear()
-            self.disable_invalid_attributes(self._viewer_state.x_att)
-            return
-        else:
-            self.enable()
-
-        try:
-            if not self.state.density_map:
+            try:
                 y = ensure_numerical(self.layer[self._viewer_state.y_att].ravel())
                 if y.dtype.kind == 'M':
                     y = datetime64_to_mpl(y)
-        except (IncompatibleAttribute, IndexError):
-            # The following includes a call to self.clear()
-            self.disable_invalid_attributes(self._viewer_state.y_att)
-            return
-        else:
-            self.enable()
+            except (IncompatibleAttribute, IndexError):
+                pass
+
+            # If only one of the two attributes can be resolved for the layer,
+            # we can still show the values as vertical or horizontal lines, so
+            # we only disable the layer if neither attribute can be resolved.
+            if x is None and y is None:
+                # The following includes a call to self.clear()
+                self.disable_invalid_attributes(self._viewer_state.x_att,
+                                                self._viewer_state.y_att)
+                return
+            else:
+                self.enable()
+
+            self._auto_enable_line_mode(x, y)
 
         if self.state.markers_visible:
 
@@ -233,6 +280,9 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
                 # ability of the density artist to call a custom histogram
                 # method which is defined on this class and does the data
                 # access.
+                self.plot_artist.set_data([], [])
+                self.scatter_artist.set_offsets(np.zeros((0, 2)))
+            elif x is None or y is None:
                 self.plot_artist.set_data([], [])
                 self.scatter_artist.set_offsets(np.zeros((0, 2)))
             else:
@@ -264,7 +314,7 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
             self.plot_artist.set_data([], [])
             self.scatter_artist.set_offsets(np.zeros((0, 2)))
 
-        if self.state.line_visible:
+        if self.state.line_visible and x is not None and y is not None:
             if self.state.cmap_mode == 'Fixed':
                 self.line_collection.set_points(x, y, oversample=False)
             else:
@@ -279,6 +329,16 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
         else:
             self.line_collection.set_points([], [])
 
+        if self.state.vline_visible and x is not None:
+            self.vline_collection.set_segments(values_to_segments(x))
+        else:
+            self.vline_collection.set_segments(np.zeros((0, 2, 2)))
+
+        if self.state.hline_visible and y is not None:
+            self.hline_collection.set_segments(values_to_segments(y, horizontal=True))
+        else:
+            self.hline_collection.set_segments(np.zeros((0, 2, 2)))
+
         for eartist in ravel_artists(self.errorbar_artist):
             try:
                 eartist.remove()
@@ -289,7 +349,7 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
             self.vector_artist.remove()
             self.vector_artist = None
 
-        if self.state.vector_visible:
+        if self.state.vector_visible and x is not None and y is not None:
 
             if self.state.vx_att is not None and self.state.vy_att is not None:
 
@@ -324,7 +384,7 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
                                                   )
             self.mpl_artists[self.vector_index] = self.vector_artist
 
-        if self.state.xerr_visible or self.state.yerr_visible:
+        if (self.state.xerr_visible or self.state.yerr_visible) and x is not None and y is not None:
 
             keep = ~np.isnan(x) & ~np.isnan(y)
 
@@ -461,6 +521,26 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
             if force or 'linestyle' in changed:
                 self.line_collection.set_linestyle(self.state.linestyle)
 
+        for collection, lines_visible in ((self.vline_collection, self.state.vline_visible),
+                                          (self.hline_collection, self.state.hline_visible)):
+
+            if lines_visible:
+
+                if self.state.cmap_mode == 'Fixed':
+                    if force or 'color' in changed or 'cmap_mode' in changed:
+                        collection.set_array(None)
+                        collection.set_color(self.state.color)
+                elif force or any(prop in changed for prop in CMAP_PROPERTIES):
+                    c = ensure_numerical(self.layer[self.state.cmap_att].ravel())
+                    collection.set_color(None)
+                    set_mpl_artist_cmap(collection, c, self.state)
+
+                if force or 'linewidth' in changed:
+                    collection.set_linewidth(self.state.linewidth)
+
+                if force or 'linestyle' in changed:
+                    collection.set_linestyle(self.state.linestyle)
+
         if self.state.vector_visible and self.vector_artist is not None:
 
             if self.state.cmap_mode == 'Fixed':
@@ -495,6 +575,7 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
 
         for artist in [self.scatter_artist, self.plot_artist,
                        self.vector_artist, self.line_collection,
+                       self.vline_collection, self.hline_collection,
                        self.density_artist]:
 
             if artist is None:
@@ -581,6 +662,12 @@ class ScatterLayerArtist(MatplotlibLayerArtist):
 
             if self.state.line_visible:
                 handles.append(self.line_collection)
+
+            if self.state.vline_visible:
+                handles.append(self.vline_collection)
+
+            if self.state.hline_visible:
+                handles.append(self.hline_collection)
 
             if self.state.vector_visible:
                 handles.append(self.vector_artist)

--- a/glue/viewers/scatter/python_export.py
+++ b/glue/viewers/scatter/python_export.py
@@ -1,3 +1,4 @@
+from glue.core.exceptions import IncompatibleAttribute
 from glue.viewers.common.python_export import code, serialize_options
 
 
@@ -5,6 +6,16 @@ def python_export_scatter_layer(layer, *args):
 
     if len(layer.mpl_artists) == 0 or not layer.enabled or not layer.visible:
         return [], None
+
+    def resolvable(att):
+        try:
+            layer.layer[att]
+        except (IncompatibleAttribute, IndexError):
+            return False
+        return True
+
+    x_available = resolvable(layer._viewer_state.x_att)
+    y_available = resolvable(layer._viewer_state.y_att)
 
     script = ""
     imports = ["import numpy as np"]
@@ -31,15 +42,18 @@ def python_export_scatter_layer(layer, *args):
     x_transform_close = ")" if degrees else ""
     y_transform_open = "np.radians(" if degrees and full_sphere else ""
     y_transform_close = ")" if degrees and full_sphere else ""
-    script += "x = {0}layer_data['{1}']{2}\n".format(x_transform_open, layer._viewer_state.x_att.label, x_transform_close)
-    script += "y = {0}layer_data['{1}']{2}\n".format(y_transform_open, layer._viewer_state.y_att.label, y_transform_close)
+    if x_available:
+        script += "x = {0}layer_data['{1}']{2}\n".format(x_transform_open, layer._viewer_state.x_att.label, x_transform_close)
+    if y_available:
+        script += "y = {0}layer_data['{1}']{2}\n".format(y_transform_open, layer._viewer_state.y_att.label, y_transform_close)
     if full_sphere:
         script += "x = np.mod(x + np.pi, 2 * np.pi) - np.pi\n"
         if layer._viewer_state.x_min > layer._viewer_state.x_max:
             script += "x = np.negative(x)\n"
         if layer._viewer_state.y_min > layer._viewer_state.y_max:
             script += "y = np.negative(y)\n"
-    script += "keep = ~np.isnan(x) & ~np.isnan(y)\n\n"
+    if x_available and y_available:
+        script += "keep = ~np.isnan(x) & ~np.isnan(y)\n\n"
     if polar:
         script += 'ax.xaxis.set_major_locator(ThetaLocator(AutoLocator()))\n'
         script += 'ax.xaxis.set_major_formatter({0}("{1}"))\n'.format(theta_formatter, layer._viewer_state.x_axislabel)
@@ -55,7 +69,7 @@ def python_export_scatter_layer(layer, *args):
         if layer._viewer_state.plot_mode != 'lambert':
             script += 'ax.yaxis.set_major_formatter({0}())\n'.format(theta_formatter)
 
-    if layer.state.cmap_mode == 'Linear':
+    if layer.state.cmap_mode == 'Linear' and x_available and y_available:
 
         script += "# Set up colors\n"
         script += "colors = layer_data['{0}']\n".format(layer.state.cmap_att.label)
@@ -64,7 +78,7 @@ def python_export_scatter_layer(layer, *args):
         script += "keep &= ~np.isnan(colors)\n"
         script += "colors = plt.cm.{0}((colors - cmap_vmin) / (cmap_vmax - cmap_vmin))\n\n".format(layer.state.cmap.name)
 
-    if layer.state.size_mode == 'Linear':
+    if layer.state.size_mode == 'Linear' and x_available and y_available:
 
         script += "# Set up size values\n"
         script += "sizes = layer_data['{0}']\n".format(layer.state.size_att.label)
@@ -73,7 +87,7 @@ def python_export_scatter_layer(layer, *args):
         script += "keep &= ~np.isnan(sizes)\n"
         script += "sizes = 30 * (np.clip((sizes - size_vmin) / (size_vmax - size_vmin), 0, 1) * 0.95 + 0.05) * {0}\n\n".format(layer.state.size_scaling)
 
-    if layer.state.markers_visible:
+    if layer.state.markers_visible and x_available and y_available:
         if layer.state.density_map:
 
             imports += ["from mpl_scatter_density import ScatterDensityArtist"]
@@ -150,7 +164,7 @@ def python_export_scatter_layer(layer, *args):
 
                 script += "layer_handles.append(scatter_artist)\n\n"
 
-    if layer.state.vector_visible:
+    if layer.state.vector_visible and x_available and y_available:
 
         if layer.state.vx_att is not None and layer.state.vy_att is not None:
 
@@ -194,7 +208,7 @@ def python_export_scatter_layer(layer, *args):
         script += "vector_artist = ax.quiver(x[keep], y[keep], vx, vy, {0})\n".format(serialize_options(options))
         script += "layer_handles.append(vector_artist)\n\n"
 
-    if layer.state.xerr_visible or layer.state.yerr_visible:
+    if (layer.state.xerr_visible or layer.state.yerr_visible) and x_available and y_available:
 
         if layer.state.xerr_visible and layer.state.xerr_att is not None:
             xerr = code("xerr[keep]")
@@ -220,7 +234,7 @@ def python_export_scatter_layer(layer, *args):
         script += "error_artist = ax.errorbar(x[keep], y[keep], {0})\n".format(serialize_options(options))
         script += "layer_handles.append(error_artist)\n\n"
 
-    if layer.state.line_visible:
+    if layer.state.line_visible and x_available and y_available:
 
         options = dict(color=layer.state.color,
                        linewidth=layer.state.linewidth,
@@ -234,6 +248,26 @@ def python_export_scatter_layer(layer, *args):
             imports.append("from glue.viewers.scatter.layer_artist import plot_colored_line")
             script += "line_collection = plot_colored_line(ax, x, y, {0})\n".format(serialize_options(options))
             script += "layer_handles.append(line_collection)\n\n"
+
+    for direction, available in (('v', x_available), ('h', y_available)):
+
+        if not getattr(layer.state, direction + 'line_visible') or not available:
+            continue
+
+        options = dict(colors=layer.state.color,
+                       linewidth=layer.state.linewidth,
+                       linestyle=layer.state.linestyle,
+                       alpha=layer.state.alpha,
+                       zorder=layer.state.zorder)
+
+        if direction == 'v':
+            options['transform'] = code('ax.get_xaxis_transform()')
+            script += "vline_artist = ax.vlines(x, 0, 1, {0})\n".format(serialize_options(options))
+            script += "layer_handles.append(vline_artist)\n\n"
+        else:
+            options['transform'] = code('ax.get_yaxis_transform()')
+            script += "hline_artist = ax.hlines(y, 0, 1, {0})\n".format(serialize_options(options))
+            script += "layer_handles.append(hline_artist)\n\n"
 
     script += "legend_handles.append(tuple(layer_handles))\n"
     script += "legend_labels.append(layer_data.label)\n\n"

--- a/glue/viewers/scatter/state.py
+++ b/glue/viewers/scatter/state.py
@@ -264,6 +264,11 @@ class ScatterLayerState(MatplotlibLayerState, StretchStateMixin):
     vector_origin = DDSCProperty(default_index=1, docstring="Whether to place the vector so that the origin is at the tail, middle, or tip")
     vector_scaling = DDCProperty(1, docstring="The relative scaling of the arrow length")
 
+    # Vertical and horizontal lines
+
+    vline_visible = DDCProperty(False, docstring="Whether to show full-height vertical lines at each x position")
+    hline_visible = DDCProperty(False, docstring="Whether to show full-width horizontal lines at each y position")
+
     def __init__(self, viewer_state=None, layer=None, **kwargs):
 
         super(ScatterLayerState, self).__init__(viewer_state=viewer_state, layer=layer)

--- a/glue/viewers/scatter/tests/test_python_export.py
+++ b/glue/viewers/scatter/tests/test_python_export.py
@@ -6,6 +6,7 @@ from astropy.utils import NumpyRNGContext
 
 from glue.core import Data, DataCollection
 from glue.core.application_base import Application
+from glue.core.link_helpers import LinkSame
 from glue.viewers.scatter.viewer import SimpleScatterViewer
 from glue.viewers.matplotlib.tests.test_python_export import BaseTestExportPython, random_with_nan
 
@@ -104,6 +105,21 @@ class TestExportPython(BaseTestExportPython):
         self.viewer.state.layers[0].cmap_vmax = 0.7
         self.viewer.state.layers[0].cmap = plt.cm.BuGn
         self.test_line(tmpdir)
+
+    def test_vline_hline(self, tmpdir):
+        self.viewer.state.layers[0].vline_visible = True
+        self.viewer.state.layers[0].hline_visible = True
+        self.viewer.state.layers[0].linewidth = 2
+        self.viewer.state.layers[0].color = 'purple'
+        self.viewer.state.layers[0].alpha = 0.5
+        self.assert_same(tmpdir)
+
+    def test_vline_only_x_linked(self, tmpdir):
+        lines = Data(positions=self.data['a'][:10], label='lines')
+        self.data_collection.append(lines)
+        self.data_collection.add_link(LinkSame(lines.id['positions'], self.data.id['a']))
+        self.viewer.add_data(lines)
+        self.assert_same(tmpdir)
 
     def test_errorbarx(self, tmpdir):
         self.viewer.state.layers[0].xerr_visible = True

--- a/glue/viewers/scatter/tests/test_viewer.py
+++ b/glue/viewers/scatter/tests/test_viewer.py
@@ -131,3 +131,91 @@ def test_indexed_data():
 
     assert viewer.state.x_att is data_2d.main_components[0]
     assert viewer.state.y_att is data_2d.main_components[1]
+
+
+def test_vertical_horizontal_lines():
+
+    # A layer for which only one of the two attributes can be resolved via
+    # links should be shown as full-height vertical (or full-width horizontal)
+    # lines rather than being disabled.
+
+    spectrum = Data(wavelength=np.linspace(400, 700, 100),
+                    flux=np.random.random(100), label='spectrum')
+    lines = Data(position=[450., 550., 650.], label='lines')
+
+    app = Application()
+    app.data_collection.append(spectrum)
+    app.data_collection.append(lines)
+
+    viewer = app.new_data_viewer(SimpleScatterViewer)
+    viewer.add_data(spectrum)
+    viewer.state.x_att = spectrum.id['wavelength']
+    viewer.state.y_att = spectrum.id['flux']
+
+    viewer.add_data(lines)
+    artist = viewer.layers[1]
+
+    # Without any links the layer cannot be shown at all
+    assert not artist.enabled
+    assert not artist.state.vline_visible
+
+    # Linking the line positions to the x attribute should enable the layer
+    # and automatically turn on the vertical line mode
+    app.data_collection.add_link(LinkSame(lines.id['position'], spectrum.id['wavelength']))
+
+    assert artist.enabled
+    assert artist.state.vline_visible
+    assert not artist.state.hline_visible
+
+    segments = artist.vline_collection.get_segments()
+    assert len(segments) == 3
+    assert_allclose(segments[0], [[450, 0], [450, 1]])
+
+    # The lines span the full height of the axes independently of the y limits
+    assert artist.vline_collection.get_transform() is artist.axes.get_xaxis_transform()
+
+    # Markers cannot be shown since the y attribute cannot be resolved
+    assert len(artist.plot_artist.get_xdata()) == 0
+
+    # The vertical line mode is only enabled automatically once, so it should
+    # stay off if turned off explicitly
+    artist.state.vline_visible = False
+    assert len(artist.vline_collection.get_segments()) == 0
+    artist.update()
+    assert not artist.state.vline_visible
+    artist.state.vline_visible = True
+
+    # Once the y attribute is also linked, the markers appear as usual and the
+    # vertical lines remain
+    app.data_collection.add_link(LinkSame(lines.id['position'], spectrum.id['flux']))
+
+    assert len(artist.plot_artist.get_xdata()) == 3
+    assert len(artist.vline_collection.get_segments()) == 3
+
+
+def test_vertical_horizontal_lines_both_attributes():
+
+    # Check the vertical and horizontal line modes for a normal layer where
+    # both attributes are present
+
+    data = Data(x=[1., 2., 3.], y=[4., 5., 6.], label='data')
+
+    app = Application()
+    app.data_collection.append(data)
+
+    viewer = app.new_data_viewer(SimpleScatterViewer)
+    viewer.add_data(data)
+    artist = viewer.layers[0]
+
+    # Neither mode should have been enabled automatically
+    assert not artist.state.vline_visible
+    assert not artist.state.hline_visible
+
+    artist.state.vline_visible = True
+    artist.state.hline_visible = True
+
+    assert len(artist.vline_collection.get_segments()) == 3
+    segments = artist.hline_collection.get_segments()
+    assert len(segments) == 3
+    assert_allclose(segments[0], [[0, 4], [1, 4]])
+    assert artist.hline_collection.get_transform() is artist.axes.get_yaxis_transform()


### PR DESCRIPTION
It's possible to now show vertical or horizontal lines in the scatter viewer, and this is automatically selected if only one of the attributes is linked.