### PR TITLE
Remove VisPy volume layer state patch

### DIFF
--- a/glue/core/state_path_patches.txt
+++ b/glue/core/state_path_patches.txt
@@ -87,6 +87,5 @@ glue.viewers.table.qt.data_viewer.TableLayerArtist -> glue_qt.viewers.table.data
 glue.viewers.table.qt.data_viewer.TableViewer -> glue_qt.viewers.table.data_viewer.TableViewer
 glue.viewers.table.qt.TableLayerArtist -> glue_qt.viewers.table.TableLayerArtist
 glue.viewers.table.qt.TableViewer -> glue_qt.viewers.table.TableViewer
-glue_vispy_viewers.volume.layer_state.VolumeLayerState -> glue.viewers.volume3d.layer_state.VolumeLayerState3D
 glue_vispy_viewers.scatter.layer_state.ScatterLayerState -> glue.viewers.scatter3d.layer_state.ScatterLayerState3D
 glue_vispy_viewers.common.layer_state.VispyLayerState -> glue.viewers.common3d.layer_state.LayerState3D


### PR DESCRIPTION
If we want https://github.com/glue-viz/glue-vispy-viewers/pull/411 as it currently is, I think we need this patch as the VisPy volume layer state would then be a subclass of the glue-core volume viewer state.
