### PR TITLE
Support APE-14 low-level WCS in WCSLink and wcs_autolink

### DIFF
--- a/glue/plugins/wcs_autolinking/tests/test_wcs_autolinking.py
+++ b/glue/plugins/wcs_autolinking/tests/test_wcs_autolinking.py
@@ -1,10 +1,13 @@
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
+from astropy import units as u
 from astropy.wcs import WCS
+from astropy.wcs.wcsapi import BaseLowLevelWCS
 
 from glue.core import Data, DataCollection
 from glue.plugins.wcs_autolinking.wcs_autolinking import (wcs_autolink, WCSLink,
+                                                          IncompatibleWCS,
                                                           OffsetLink, AffineLink,
                                                           NoAffineApproximation)
 from glue.core.link_helpers import MultiLink
@@ -504,6 +507,316 @@ def test_cube_has_celestial_and_cube_without_celestial_axes_2():
     dc = DataCollection([data1, data2])
     links = wcs_autolink(dc)
     assert len(links) == 1
+
+
+class SimpleLowLevelWCS(BaseLowLevelWCS):
+    """
+    A minimal APE-14 low-level-only WCS (not a BaseHighLevelWCS), with
+    world = scale * pixel along each axis.
+    """
+
+    def __init__(self, scales, physical_types, units):
+        self._scales = scales
+        self._physical_types = list(physical_types)
+        self._units = list(units)
+
+    @property
+    def pixel_n_dim(self):
+        return len(self._scales)
+
+    @property
+    def world_n_dim(self):
+        return len(self._scales)
+
+    @property
+    def world_axis_physical_types(self):
+        return self._physical_types
+
+    @property
+    def world_axis_units(self):
+        return self._units
+
+    @property
+    def axis_correlation_matrix(self):
+        return np.identity(self.world_n_dim, dtype=bool)
+
+    def pixel_to_world_values(self, *pixel):
+        world = [np.asarray(p) * s for p, s in zip(pixel, self._scales)]
+        return world[0] if self.world_n_dim == 1 else tuple(world)
+
+    def world_to_pixel_values(self, *world):
+        pixel = [np.asarray(w) / s for w, s in zip(world, self._scales)]
+        return pixel[0] if self.pixel_n_dim == 1 else tuple(pixel)
+
+    @property
+    def world_axis_object_components(self):
+        return [(f'world{i}', 0, 'value') for i in range(self.world_n_dim)]
+
+    @property
+    def world_axis_object_classes(self):
+        return {f'world{i}': (u.Quantity, (), {'unit': unit})
+                for i, unit in enumerate(self._units)}
+
+
+class CoupledLowLevelWCS(SimpleLowLevelWCS):
+    """
+    A 3D low-level WCS with a non-trivial axis_correlation_matrix: the two
+    celestial world axes each depend on the same two pixel axes (as for
+    celestial -TAB axes), and the axis order is not simply reversed.
+    """
+
+    def __init__(self):
+        super().__init__((1, 1, 1),
+                         ['custom:pos.helioprojective.lon',
+                          'custom:pos.helioprojective.lat',
+                          'time'],
+                         ['arcsec', 'arcsec', 's'])
+
+    @property
+    def axis_correlation_matrix(self):
+        return np.array([[False, True, True],
+                         [False, True, True],
+                         [True, False, False]])
+
+    def pixel_to_world_values(self, p0, p1, p2):
+        return (np.asarray(p1) + np.asarray(p2),
+                np.asarray(p1) - np.asarray(p2),
+                np.asarray(p0))
+
+    def world_to_pixel_values(self, lon, lat, time):
+        return (np.asarray(time),
+                (np.asarray(lon) + np.asarray(lat)) / 2,
+                (np.asarray(lon) - np.asarray(lat)) / 2)
+
+
+class BrokenLowLevelWCS(SimpleLowLevelWCS):
+    """A low-level WCS whose world-to-pixel transform always fails."""
+
+    def world_to_pixel_values(self, *world):
+        raise ValueError("cannot transform")
+
+
+HPC_TYPES = ['custom:pos.helioprojective.lon', 'custom:pos.helioprojective.lat']
+
+
+def _low_level_data(label, wcs, shape):
+    data = Data(label=label)
+    data.coords = wcs
+    data['x'] = np.ones(shape)
+    return data
+
+
+def test_wcs_autolink_low_level():
+
+    # Datasets whose coords only implement the low-level APE-14 API should
+    # be linked through their matching physical types.
+
+    data1 = _low_level_data('Data 1', SimpleLowLevelWCS((1, 2), HPC_TYPES, ['arcsec'] * 2), (3, 4))
+    data2 = _low_level_data('Data 2', SimpleLowLevelWCS((2, 4), HPC_TYPES, ['arcsec'] * 2), (3, 4))
+
+    dc = DataCollection([data1, data2])
+    links = wcs_autolink(dc)
+    assert len(links) == 1
+    link = links[0]
+    assert len(link) == 4
+
+    # world = scale * pixel, so pixel2 = pixel1 * scale1 / scale2
+    assert_allclose(link.forwards(3.0, 8.0), (1.5, 4.0))
+    assert_allclose(link.backwards(1.5, 4.0), (3.0, 8.0))
+
+
+def test_wcs_autolink_low_level_and_fits_wcs():
+
+    # A low-level-only WCS should also link to an astropy WCS.
+
+    data1 = _low_level_data('Data 1', SimpleLowLevelWCS((2,), ['em.freq'], ['Hz']), 3)
+
+    wcs2 = WCS(naxis=1)
+    wcs2.wcs.ctype = ['FREQ']
+    wcs2.wcs.cunit = ['Hz']
+    wcs2.wcs.set()
+
+    data2 = _low_level_data('Data 2', wcs2, 3)
+
+    dc = DataCollection([data1, data2])
+    links = wcs_autolink(dc)
+    assert len(links) == 1
+    link = links[0]
+    assert len(link) == 2
+
+    # low-level pixel p -> 2 * p Hz; astropy world = pixel + 1, so pixel = 2 * p - 1
+    assert_allclose(link.forwards(3.0), 5.0)
+    assert_allclose(link.backwards(5.0), 3.0)
+
+
+def test_wcs_autolink_low_level_disjoint():
+
+    # No matching physical types: no link and no exception.
+
+    data1 = _low_level_data('Data 1', SimpleLowLevelWCS((1,), ['custom:spam'], ['']), 3)
+    data2 = _low_level_data('Data 2', SimpleLowLevelWCS((1, 1), ['custom:eggs', 'custom:ham'], ['', '']), (3, 4))
+
+    dc = DataCollection([data1, data2])
+    assert wcs_autolink(dc) == []
+
+    with pytest.raises(IncompatibleWCS):
+        WCSLink(data1, data2)
+
+
+def test_wcs_autolink_low_level_transform_failure():
+
+    # Matching physical types whose world objects cannot actually be
+    # transformed (e.g. helioprojective frames where one WCS carries no
+    # observer) should skip cleanly, never traceback.
+
+    data1 = _low_level_data('Data 1', SimpleLowLevelWCS((1, 1), HPC_TYPES, ['arcsec'] * 2), (3, 4))
+    data2 = _low_level_data('Data 2', BrokenLowLevelWCS((1, 1), HPC_TYPES, ['arcsec'] * 2), (3, 4))
+
+    dc = DataCollection([data1, data2])
+    assert wcs_autolink(dc) == []
+
+    with pytest.raises(IncompatibleWCS):
+        WCSLink(data1, data2)
+
+
+def test_wcs_autolink_correlated_axes():
+
+    # The pixel axes to keep must come from axis_correlation_matrix, not from
+    # assuming world axis i maps to pixel axis world_n_dim - i - 1. Here the
+    # two matched world axes are both coupled to WCS pixel axes 1 and 2, i.e.
+    # numpy axes 1 and 0, while the old assumption would have kept 2 and 1.
+
+    data1 = _low_level_data('Data 1', CoupledLowLevelWCS(), (2, 3, 4))
+    data2 = _low_level_data('Data 2', SimpleLowLevelWCS((1, 1), HPC_TYPES, ['arcsec'] * 2), (3, 4))
+
+    dc = DataCollection([data1, data2])
+    links = wcs_autolink(dc)
+    assert len(links) == 1
+    link = links[0]
+    assert len(link) == 4
+
+    assert [cid.axis for cid in link.cids1] == [1, 0]
+    assert [cid.axis for cid in link.cids2] == [1, 0]
+
+    # lon = p1 + p2, lat = p1 - p2 and the second dataset has world == pixel
+    assert_allclose(link.forwards(3.0, 1.0), (4.0, 2.0))
+    assert_allclose(link.backwards(4.0, 2.0), (3.0, 1.0))
+
+
+class FullyCoupledLowLevelWCS(CoupledLowLevelWCS):
+    """A 3D low-level WCS whose celestial world axes depend on all pixel axes."""
+
+    @property
+    def axis_correlation_matrix(self):
+        return np.array([[True, True, True],
+                         [True, True, True],
+                         [True, False, False]])
+
+    def pixel_to_world_values(self, p0, p1, p2):
+        p0, p1, p2 = np.asarray(p0), np.asarray(p1), np.asarray(p2)
+        return p1 + p2 + p0, p1 - p2 + p0, p0
+
+    def world_to_pixel_values(self, lon, lat, time):
+        lon, lat, time = np.asarray(lon), np.asarray(lat), np.asarray(time)
+        return time, (lon + lat) / 2 - time, (lon - lat) / 2
+
+
+def test_wcs_autolink_low_level_disjoint_same_ndim():
+
+    # Same-dimensionality low-level pairs with disjoint physical types must
+    # not be linked positionally by the transform probe (regression test:
+    # wrapped low-level WCSes produce plain Quantities, so the probe cannot
+    # detect the type mismatch and must not be trusted for them).
+
+    data1 = _low_level_data('Data 1', SimpleLowLevelWCS((1,), ['custom:spam'], ['']), 3)
+    data2 = _low_level_data('Data 2', SimpleLowLevelWCS((2,), ['custom:eggs'], ['']), 3)
+
+    dc = DataCollection([data1, data2])
+    assert wcs_autolink(dc) == []
+
+    with pytest.raises(IncompatibleWCS):
+        WCSLink(data1, data2)
+
+
+def test_wcs_autolink_low_level_world_order_mismatch():
+
+    # Matched world axes in different orders on the two sides would be
+    # silently transposed by positional Quantity pairing, so such low-level
+    # pairs are refused.
+
+    data1 = _low_level_data('Data 1', SimpleLowLevelWCS((1, 1), HPC_TYPES, ['arcsec'] * 2), (3, 4))
+    data2 = _low_level_data('Data 2', SimpleLowLevelWCS((1, 1), HPC_TYPES[::-1], ['arcsec'] * 2), (3, 4))
+
+    dc = DataCollection([data1, data2])
+    assert wcs_autolink(dc) == []
+
+    with pytest.raises(IncompatibleWCS):
+        WCSLink(data1, data2)
+
+
+def test_wcs_autolink_ndim_mismatch():
+
+    # A dataset whose array dimensionality does not match its WCS must be
+    # skipped cleanly without breaking autolinking of the other datasets.
+
+    data1 = _low_level_data('Data 1', SimpleLowLevelWCS((1, 1, 1),
+                                                        HPC_TYPES + ['time'],
+                                                        ['arcsec', 'arcsec', 's']), (3, 4))
+    data2 = _low_level_data('Data 2', SimpleLowLevelWCS((1, 1), HPC_TYPES, ['arcsec'] * 2), (3, 4))
+    data3 = _low_level_data('Data 3', SimpleLowLevelWCS((2, 2), HPC_TYPES, ['arcsec'] * 2), (3, 4))
+
+    dc = DataCollection([data1, data2, data3])
+    links = wcs_autolink(dc)
+    assert len(links) == 1
+    assert {links[0].data1, links[0].data2} == {data2, data3}
+
+
+def test_wcs_autolink_low_level_11d():
+
+    # Regression test for lexical sorting of the kept numpy axes, which
+    # misorders single- vs double-digit axis indices for ndim >= 11.
+
+    types1 = [None] * 11
+    types1[0] = 'em.wl'    # WCS pixel axis 0 -> numpy axis 10
+    types1[8] = 'time'     # WCS pixel axis 8 -> numpy axis 2
+    scales1 = [1.0] * 11
+    scales1[0] = 2.0
+    scales1[8] = 3.0
+
+    shape1 = [1] * 11
+    shape1[10], shape1[2] = 3, 4
+
+    data1 = _low_level_data('Data 1', SimpleLowLevelWCS(scales1, types1, [''] * 11), tuple(shape1))
+    data2 = _low_level_data('Data 2', SimpleLowLevelWCS((1, 1), ['em.wl', 'time'], ['', '']), (3, 4))
+
+    dc = DataCollection([data1, data2])
+    links = wcs_autolink(dc)
+    assert len(links) == 1
+    link = links[0]
+
+    assert [cid.axis for cid in link.cids1] == [10, 2]
+    assert [cid.axis for cid in link.cids2] == [1, 0]
+
+    # world = scale * pixel on both sides
+    assert_allclose(link.forwards(3.0, 1.0), (6.0, 3.0))
+    assert_allclose(link.backwards(6.0, 3.0), (3.0, 1.0))
+
+
+def test_wcs_autolink_all_axes_coupled():
+
+    # A 3D WCS whose matched world axes are coupled to every pixel axis
+    # against a 2D dataset: the sliced WCSes end up with incompatible world
+    # objects, which should be skipped cleanly (regression test for an
+    # IndexError caused by slicing_axes1/slicing_axes2 aliasing one list).
+
+    data1 = _low_level_data('Data 1', FullyCoupledLowLevelWCS(), (2, 3, 4))
+    data2 = _low_level_data('Data 2', SimpleLowLevelWCS((1, 1), HPC_TYPES, ['arcsec'] * 2), (3, 4))
+
+    dc = DataCollection([data1, data2])
+    assert wcs_autolink(dc) == []
+
+    with pytest.raises(IncompatibleWCS):
+        WCSLink(data1, data2)
 
 
 def test_wcs_offset_approximation():

--- a/glue/plugins/wcs_autolinking/tests/test_wcs_autolinking.py
+++ b/glue/plugins/wcs_autolinking/tests/test_wcs_autolinking.py
@@ -738,20 +738,26 @@ def test_wcs_autolink_low_level_disjoint_same_ndim():
         WCSLink(data1, data2)
 
 
-def test_wcs_autolink_low_level_world_order_mismatch():
+def test_wcs_autolink_low_level_world_order_permutation():
 
     # Matched world axes in different orders on the two sides would be
     # silently transposed by positional Quantity pairing, so such low-level
-    # pairs are refused.
+    # pairs are linked through explicitly type-matched world values,
+    # including unit conversion.
 
-    data1 = _low_level_data('Data 1', SimpleLowLevelWCS((1, 1), HPC_TYPES, ['arcsec'] * 2), (3, 4))
-    data2 = _low_level_data('Data 2', SimpleLowLevelWCS((1, 1), HPC_TYPES[::-1], ['arcsec'] * 2), (3, 4))
+    data1 = _low_level_data('Data 1', SimpleLowLevelWCS((1, 2), HPC_TYPES, ['arcsec'] * 2), (3, 4))
+    data2 = _low_level_data('Data 2', SimpleLowLevelWCS((1, 1), HPC_TYPES[::-1], ['arcmin'] * 2), (3, 4))
 
     dc = DataCollection([data1, data2])
-    assert wcs_autolink(dc) == []
+    links = wcs_autolink(dc)
+    assert len(links) == 1
+    link = links[0]
+    assert len(link) == 4
 
-    with pytest.raises(IncompatibleWCS):
-        WCSLink(data1, data2)
+    # lon = pixel0 arcsec, lat = 2 * pixel1 arcsec on one side;
+    # lat, lon = pixels in arcmin on the other
+    assert_allclose(link.forwards(3.0, 6.0), (0.2, 0.05))
+    assert_allclose(link.backwards(0.2, 0.05), (3.0, 6.0))
 
 
 def test_wcs_autolink_ndim_mismatch():
@@ -804,19 +810,104 @@ def test_wcs_autolink_low_level_11d():
 
 def test_wcs_autolink_all_axes_coupled():
 
-    # A 3D WCS whose matched world axes are coupled to every pixel axis
-    # against a 2D dataset: the sliced WCSes end up with incompatible world
-    # objects, which should be skipped cleanly (regression test for an
-    # IndexError caused by slicing_axes1/slicing_axes2 aliasing one list).
+    # A 3D WCS whose matched world axes are also weakly coupled to the pixel
+    # axis of an unmatched world axis (time), against a 2D dataset: the
+    # dispensable time axis is sliced away (the link is exact at its first
+    # exposure) so that the celestial axes can be linked. This is also a
+    # regression test for an IndexError caused by slicing_axes1/slicing_axes2
+    # aliasing one list.
 
     data1 = _low_level_data('Data 1', FullyCoupledLowLevelWCS(), (2, 3, 4))
     data2 = _low_level_data('Data 2', SimpleLowLevelWCS((1, 1), HPC_TYPES, ['arcsec'] * 2), (3, 4))
 
     dc = DataCollection([data1, data2])
-    assert wcs_autolink(dc) == []
+    links = wcs_autolink(dc)
+    assert len(links) == 1
+    link = links[0]
+    assert len(link) == 4
 
-    with pytest.raises(IncompatibleWCS):
-        WCSLink(data1, data2)
+    # The time pixel axis (numpy 2) is sliced away at index 0
+    assert [cid.axis for cid in link.cids1] == [1, 0]
+    assert [cid.axis for cid in link.cids2] == [1, 0]
+
+    # At time pixel 0: lon = p1 + p2, lat = p1 - p2, and the second dataset
+    # has world == pixel
+    assert_allclose(link.forwards(3.0, 1.0), (4.0, 2.0))
+    assert_allclose(link.backwards(4.0, 2.0), (3.0, 1.0))
+
+
+class SJILikeWCS(SimpleLowLevelWCS):
+    """3D imager: celestial world axes weakly coupled to the time axis."""
+
+    def __init__(self):
+        super().__init__((1, 1, 1),
+                         HPC_TYPES + ['time'],
+                         ['arcsec', 'arcsec', 's'])
+
+    @property
+    def axis_correlation_matrix(self):
+        return np.array([[True, False, True],
+                         [False, True, True],
+                         [False, False, True]])
+
+    def pixel_to_world_values(self, p0, p1, p2):
+        p0, p1, p2 = np.asarray(p0), np.asarray(p1), np.asarray(p2)
+        return p0 + 0.1 * p2, p1 + 0.1 * p2, p2
+
+    def world_to_pixel_values(self, lon, lat, time):
+        lon, lat, time = np.asarray(lon), np.asarray(lat), np.asarray(time)
+        return lon - 0.1 * time, lat - 0.1 * time, time
+
+
+class RasterLikeWCS(SimpleLowLevelWCS):
+    """3D spectrograph: (wavelength, lat, lon) with coupled celestial axes."""
+
+    def __init__(self):
+        super().__init__((1, 1, 1),
+                         ['em.wl'] + HPC_TYPES[::-1],
+                         ['m', 'arcsec', 'arcsec'])
+
+    @property
+    def axis_correlation_matrix(self):
+        return np.array([[True, False, False],
+                         [False, True, True],
+                         [False, True, True]])
+
+    def pixel_to_world_values(self, w0, w1, w2):
+        w0, w1, w2 = np.asarray(w0), np.asarray(w1), np.asarray(w2)
+        return 2 * w0, w1 + w2, w1 - w2
+
+    def world_to_pixel_values(self, wl, lat, lon):
+        wl, lat, lon = np.asarray(wl), np.asarray(lat), np.asarray(lon)
+        return wl / 2, (lat + lon) / 2, (lat - lon) / 2
+
+
+def test_wcs_autolink_iris_like():
+
+    # The IRIS SJI + raster shape: an imager whose celestial axes are weakly
+    # coupled to its time axis, and a spectrograph whose coupled celestial
+    # axes appear in the opposite world order. The imager's time axis must be
+    # sliced away (the link is exact at its first exposure) and the celestial
+    # values permuted by physical type rather than paired positionally.
+
+    data1 = _low_level_data('sji', SJILikeWCS(), (2, 3, 4))
+    data2 = _low_level_data('raster', RasterLikeWCS(), (2, 3, 4))
+
+    dc = DataCollection([data1, data2])
+    links = wcs_autolink(dc)
+    assert len(links) == 1
+    link = links[0]
+    assert len(link) == 4
+
+    # The imager keeps its celestial pixel axes (numpy 2 and 1), the
+    # spectrograph keeps numpy 1 and 0 (the wavelength axis is sliced away)
+    assert [cid.axis for cid in link.cids1] == [2, 1]
+    assert [cid.axis for cid in link.cids2] == [1, 0]
+
+    # At time pixel 0: lon = sji_x, lat = sji_y; on the spectrograph
+    # lat = w1 + w2 and lon = w1 - w2
+    assert_allclose(link.forwards(3.0, 1.0), (2.0, -1.0))
+    assert_allclose(link.backwards(2.0, -1.0), (3.0, 1.0))
 
 
 def test_wcs_offset_approximation():

--- a/glue/plugins/wcs_autolinking/tests/test_wcs_autolinking.py
+++ b/glue/plugins/wcs_autolinking/tests/test_wcs_autolinking.py
@@ -647,6 +647,9 @@ def test_wcs_autolink_low_level_and_fits_wcs():
     # low-level pixel p -> 2 * p Hz; astropy world = pixel + 1, so pixel = 2 * p - 1
     assert_allclose(link.forwards(3.0), 5.0)
     assert_allclose(link.backwards(5.0), 3.0)
+    pixels = np.arange(6)
+    assert_allclose(link.forwards(pixels), 2 * pixels - 1)
+    assert_allclose(link.backwards(2 * pixels - 1), pixels)
 
 
 def test_wcs_autolink_low_level_disjoint():

--- a/glue/plugins/wcs_autolinking/wcs_autolinking.py
+++ b/glue/plugins/wcs_autolinking/wcs_autolinking.py
@@ -1,8 +1,10 @@
 import copy
 
 import numpy as np
+from astropy.wcs import WCS
 from astropy.wcs.utils import pixel_to_pixel
-from astropy.wcs.wcsapi import BaseHighLevelWCS, SlicedLowLevelWCS, HighLevelWCSWrapper
+from astropy.wcs.wcsapi import (BaseHighLevelWCS, BaseLowLevelWCS,
+                                SlicedLowLevelWCS, HighLevelWCSWrapper)
 from scipy.optimize import leastsq
 from glue.config import autolinker, link_helper
 from glue.core.link_helpers import MultiLink
@@ -111,14 +113,36 @@ class WCSLink(MultiLink):
 
         wcs1, wcs2 = data1.coords, data2.coords
 
-        if (wcs1.world_axis_physical_types.count(None) == wcs1.world_n_dim or
-            wcs2.world_axis_physical_types.count(None) == wcs2.world_n_dim):
+        # The probe-based fast path below is only trustworthy for WCSes that
+        # natively implement the high-level API: their typed world objects
+        # (SkyCoord, SpectralCoord, ...) fail loudly for mismatched physical
+        # types, whereas wrapped bare low-level WCSes produce plain Quantities
+        # that transform positionally regardless of physical type.
+        both_high_level = (isinstance(wcs1, BaseHighLevelWCS) and
+                           isinstance(wcs2, BaseHighLevelWCS))
+
+        # The high-level API is required by pixel_to_pixel below, but coords
+        # may be a bare low-level (APE 14) WCS object, so wrap those.
+        if not isinstance(wcs1, BaseHighLevelWCS):
+            wcs1 = HighLevelWCSWrapper(wcs1)
+        if not isinstance(wcs2, BaseHighLevelWCS):
+            wcs2 = HighLevelWCSWrapper(wcs2)
+
+        wcs1_ll = wcs1.low_level_wcs
+        wcs2_ll = wcs2.low_level_wcs
+
+        if (wcs1_ll.world_axis_physical_types.count(None) == wcs1_ll.world_n_dim or
+            wcs2_ll.world_axis_physical_types.count(None) == wcs2_ll.world_n_dim):
+            raise IncompatibleWCS(f"Can't create WCS link between {data1.label} and {data2.label}")
+
+        if data1.ndim != wcs1_ll.pixel_n_dim or data2.ndim != wcs2_ll.pixel_n_dim:
             raise IncompatibleWCS(f"Can't create WCS link between {data1.label} and {data2.label}")
 
         forwards = backwards = None
-        if wcs1.pixel_n_dim == wcs2.pixel_n_dim and wcs1.world_n_dim == wcs2.world_n_dim:
-            if (wcs1.world_axis_physical_types.count(None) == 0 and
-                    wcs2.world_axis_physical_types.count(None) == 0):
+        if (both_high_level and wcs1_ll.pixel_n_dim == wcs2_ll.pixel_n_dim and
+                wcs1_ll.world_n_dim == wcs2_ll.world_n_dim):
+            if (wcs1_ll.world_axis_physical_types.count(None) == 0 and
+                    wcs2_ll.world_axis_physical_types.count(None) == 0):
 
                 # The easiest way to check if the WCSes are compatible is to simply try and
                 # see if values can be transformed for a single pixel. In future we might
@@ -129,82 +153,119 @@ class WCSLink(MultiLink):
                                                                                        data1.pixel_component_ids[::-1],
                                                                                        data2.pixel_component_ids[::-1])
 
-                self._physical_types_1 = wcs1.world_axis_physical_types
-                self._physical_types_2 = wcs2.world_axis_physical_types
+                self._physical_types_1 = wcs1_ll.world_axis_physical_types
+                self._physical_types_2 = wcs2_ll.world_axis_physical_types
 
         if not forwards or not backwards:
             # A generalized APE 14-compatible way
             # Handle also the extra-spatial axes such as those of the time and wavelength dimensions
 
-            wcs1_celestial_physical_types = wcs2_celestial_physical_types = []
+            # NOTE: these must not be aliased to a single list - each side's
+            # axes have to be collected independently.
+            wcs1_celestial_physical_types = []
+            wcs2_celestial_physical_types = []
 
-            slicing_axes1 = slicing_axes2 = []
+            slicing_axes1 = []
+            slicing_axes2 = []
 
             cids1 = data1.pixel_component_ids
             cids2 = data2.pixel_component_ids
 
-            if wcs1.has_celestial and wcs2.has_celestial:
-                wcs1_celestial_physical_types = wcs1.celestial.world_axis_physical_types
-                wcs2_celestial_physical_types = wcs2.celestial.world_axis_physical_types
+            # The celestial special case links different sky frames (e.g.
+            # galactic to equatorial) through SkyCoord, and relies on
+            # astropy.wcs.WCS-only attributes, so only take it for astropy WCS
+            # pairs. Everything else falls through to physical-type matching.
+            if (isinstance(wcs1_ll, WCS) and isinstance(wcs2_ll, WCS) and
+                    wcs1_ll.has_celestial and wcs2_ll.has_celestial):
+                wcs1_celestial_physical_types = wcs1_ll.celestial.world_axis_physical_types
+                wcs2_celestial_physical_types = wcs2_ll.celestial.world_axis_physical_types
 
-                cids1_celestial = [cids1[wcs1.wcs.naxis - wcs1.wcs.lng - 1],
-                                   cids1[wcs1.wcs.naxis - wcs1.wcs.lat - 1]]
-                cids2_celestial = [cids2[wcs2.wcs.naxis - wcs2.wcs.lng - 1],
-                                   cids2[wcs2.wcs.naxis - wcs2.wcs.lat - 1]]
+                cids1_celestial = [cids1[wcs1_ll.wcs.naxis - wcs1_ll.wcs.lng - 1],
+                                   cids1[wcs1_ll.wcs.naxis - wcs1_ll.wcs.lat - 1]]
+                cids2_celestial = [cids2[wcs2_ll.wcs.naxis - wcs2_ll.wcs.lng - 1],
+                                   cids2[wcs2_ll.wcs.naxis - wcs2_ll.wcs.lat - 1]]
 
-                if wcs1.celestial.wcs.lng > wcs1.celestial.wcs.lat:
+                if wcs1_ll.celestial.wcs.lng > wcs1_ll.celestial.wcs.lat:
                     cids1_celestial = cids1_celestial[::-1]
 
-                if wcs2.celestial.wcs.lng > wcs2.celestial.wcs.lat:
+                if wcs2_ll.celestial.wcs.lng > wcs2_ll.celestial.wcs.lat:
                     cids2_celestial = cids2_celestial[::-1]
 
                 slicing_axes1 = [cids1_celestial[0].axis, cids1_celestial[1].axis]
                 slicing_axes2 = [cids2_celestial[0].axis, cids2_celestial[1].axis]
 
-            wcs1_sliced_physical_types = wcs2_sliced_physical_types = []
+            wcs1_sliced_physical_types = list(wcs1_celestial_physical_types)
+            wcs2_sliced_physical_types = list(wcs2_celestial_physical_types)
 
-            if wcs1_celestial_physical_types is not None:
-                wcs1_sliced_physical_types = wcs1_celestial_physical_types
+            # For each pair of matching physical types, keep all the pixel
+            # axes correlated with the matched world axis - APE 14 guarantees
+            # neither a one-to-one nor a reversed world/pixel correspondence
+            # (e.g. celestial -TAB axes couple two pixel axes to each world
+            # axis). Pixel axes are in x-fastest order, hence the reversal to
+            # get numpy axes.
+            matrix1 = wcs1_ll.axis_correlation_matrix
+            matrix2 = wcs2_ll.axis_correlation_matrix
 
-            if wcs2_celestial_physical_types is not None:
-                wcs2_sliced_physical_types = wcs2_celestial_physical_types
-
-            for i, physical_type1 in enumerate(wcs1.world_axis_physical_types):
+            for i, physical_type1 in enumerate(wcs1_ll.world_axis_physical_types):
                 if physical_type1 is not None:
-                    for j, physical_type2 in enumerate(wcs2.world_axis_physical_types):
+                    for j, physical_type2 in enumerate(wcs2_ll.world_axis_physical_types):
                         if physical_type1 == physical_type2:
                             if physical_type1 not in wcs1_sliced_physical_types:
-                                slicing_axes1.append(wcs1.world_n_dim - i - 1)
+                                for pixel_axis in np.nonzero(matrix1[i])[0]:
+                                    numpy_axis = int(wcs1_ll.pixel_n_dim - 1 - pixel_axis)
+                                    if numpy_axis not in slicing_axes1:
+                                        slicing_axes1.append(numpy_axis)
                                 wcs1_sliced_physical_types.append(physical_type1)
                             if physical_type2 not in wcs2_sliced_physical_types:
-                                slicing_axes2.append(wcs2.world_n_dim - j - 1)
+                                for pixel_axis in np.nonzero(matrix2[j])[0]:
+                                    numpy_axis = int(wcs2_ll.pixel_n_dim - 1 - pixel_axis)
+                                    if numpy_axis not in slicing_axes2:
+                                        slicing_axes2.append(numpy_axis)
                                 wcs2_sliced_physical_types.append(physical_type2)
 
-            slicing_axes1 = sorted(slicing_axes1, key=str, reverse=True)
-            slicing_axes2 = sorted(slicing_axes2, key=str, reverse=True)
+            if not slicing_axes1 or not slicing_axes2:
+                raise IncompatibleWCS(f"Can't create WCS link between {data1.label} and {data2.label}")
+
+            slicing_axes1 = sorted(slicing_axes1, reverse=True)
+            slicing_axes2 = sorted(slicing_axes2, reverse=True)
 
             # Generate slices for the wcs slicing
-            slices1 = [slice(None)] * wcs1.world_n_dim
-            slices2 = [slice(None)] * wcs2.world_n_dim
+            slices1 = [slice(None)] * wcs1_ll.pixel_n_dim
+            slices2 = [slice(None)] * wcs2_ll.pixel_n_dim
 
-            for i in range(wcs1.world_n_dim):
+            for i in range(wcs1_ll.pixel_n_dim):
                 if i not in slicing_axes1:
                     slices1[i] = 0
 
-            for j in range(wcs2.world_n_dim):
+            for j in range(wcs2_ll.pixel_n_dim):
                 if j not in slicing_axes2:
                     slices2[j] = 0
 
-            wcs1_sliced = SlicedLowLevelWCS(wcs1, tuple(slices1))
-            wcs2_sliced = SlicedLowLevelWCS(wcs2, tuple(slices2))
+            wcs1_sliced = SlicedLowLevelWCS(wcs1_ll, tuple(slices1))
+            wcs2_sliced = SlicedLowLevelWCS(wcs2_ll, tuple(slices2))
+
+            # When a wrapped low-level WCS is involved, pixel_to_pixel pairs
+            # its plain-Quantity world objects positionally, so if the matched
+            # world axes appear in different orders on the two sides the link
+            # would silently transpose them - refuse instead. Natively
+            # high-level pairs are safe: their typed world objects (e.g.
+            # SkyCoord) are matched by class, not position. Linking reordered
+            # low-level pairs would need an explicit physical-type permutation
+            # of the world values.
+            types1 = list(wcs1_sliced.world_axis_physical_types)
+            types2 = list(wcs2_sliced.world_axis_physical_types)
+            if (not both_high_level and types1 != types2 and
+                    sorted(map(str, types1)) == sorted(map(str, types2))):
+                raise IncompatibleWCS(f"Can't create WCS link between {data1.label} and {data2.label} "
+                                      f"(matched world axes are in different orders)")
+
             wcs1_final = HighLevelWCSWrapper(copy.copy(wcs1_sliced))
             wcs2_final = HighLevelWCSWrapper(copy.copy(wcs2_sliced))
 
+            # slicing_axes are sorted in descending numpy-axis order, which
+            # matches the pixel argument order of the sliced WCSes
             cids1_sliced = [cids1[x] for x in slicing_axes1]
-            cids1_sliced = sorted(cids1_sliced, key=str, reverse=True)
-
             cids2_sliced = [cids2[x] for x in slicing_axes2]
-            cids2_sliced = sorted(cids2_sliced, key=str, reverse=True)
 
             pixel_cids1, pixel_cids2, forwards, backwards = get_cids_and_functions(
                 wcs1_final, wcs2_final, cids1_sliced, cids2_sliced)
@@ -316,9 +377,11 @@ class WCSLink(MultiLink):
 @autolinker('Astronomy WCS')
 def wcs_autolink(data_collection):
 
-    # Find subset of datasets with WCS coordinates
+    # Find subset of datasets with WCS coordinates - low-level-only (APE 14)
+    # WCS objects are accepted too, and get wrapped by WCSLink.
     wcs_datasets = [data for data in data_collection
-                    if hasattr(data, 'coords') and isinstance(data.coords, BaseHighLevelWCS)]
+                    if hasattr(data, 'coords') and
+                    isinstance(data.coords, (BaseHighLevelWCS, BaseLowLevelWCS))]
 
     # Only continue if there are at least two such datasets
     if len(wcs_datasets) < 2:

--- a/glue/plugins/wcs_autolinking/wcs_autolinking.py
+++ b/glue/plugins/wcs_autolinking/wcs_autolinking.py
@@ -79,7 +79,7 @@ class IncompatibleWCS(Exception):
     pass
 
 
-def get_cids_and_functions(wcs1, wcs2, pixel_cids1, pixel_cids2,
+def get_cids_and_functions(wcs1, wcs2, pixel_cids1, pixel_cids2, *,
                            forwards=None, backwards=None):
 
     if forwards is None:
@@ -145,7 +145,7 @@ def permuted_values_functions(wcs1, wcs2):
             return values
         return (np.asarray(values) * u.Unit(unit_in)).to_value(u.Unit(unit_out))
 
-    def transform(wcs_in, wcs_out, types_in, units_in, types_out, units_out, pixel_input):
+    def transform(wcs_in, wcs_out, pixel_input, *, types_in, units_in, types_out, units_out):
         world_in = wcs_in.pixel_to_world_values(*pixel_input)
         if wcs_in.world_n_dim == 1:
             world_in = (world_in,)
@@ -156,10 +156,12 @@ def permuted_values_functions(wcs1, wcs2):
         return wcs_out.world_to_pixel_values(*world_out)
 
     def forwards(*pixel_input):
-        return transform(wcs1, wcs2, types1, units1, types2, units2, pixel_input)
+        return transform(wcs1, wcs2, pixel_input, types_in=types1, units_in=units1,
+                         types_out=types2, units_out=units2)
 
     def backwards(*pixel_input):
-        return transform(wcs2, wcs1, types2, units2, types1, units1, pixel_input)
+        return transform(wcs2, wcs1, pixel_input, types_in=types2, units_in=units2,
+                         types_out=types1, units_out=units1)
 
     return forwards, backwards
 

--- a/glue/plugins/wcs_autolinking/wcs_autolinking.py
+++ b/glue/plugins/wcs_autolinking/wcs_autolinking.py
@@ -1,6 +1,7 @@
 import copy
 
 import numpy as np
+from astropy import units as u
 from astropy.wcs import WCS
 from astropy.wcs.utils import pixel_to_pixel
 from astropy.wcs.wcsapi import (BaseHighLevelWCS, BaseLowLevelWCS,
@@ -78,13 +79,16 @@ class IncompatibleWCS(Exception):
     pass
 
 
-def get_cids_and_functions(wcs1, wcs2, pixel_cids1, pixel_cids2):
+def get_cids_and_functions(wcs1, wcs2, pixel_cids1, pixel_cids2,
+                           forwards=None, backwards=None):
 
-    def forwards(*pixel_input):
-        return pixel_to_pixel(wcs1, wcs2, *pixel_input)
+    if forwards is None:
+        def forwards(*pixel_input):
+            return pixel_to_pixel(wcs1, wcs2, *pixel_input)
 
-    def backwards(*pixel_input):
-        return pixel_to_pixel(wcs2, wcs1, *pixel_input)
+    if backwards is None:
+        def backwards(*pixel_input):
+            return pixel_to_pixel(wcs2, wcs1, *pixel_input)
 
     pixel_input = [0] * len(pixel_cids1)
 
@@ -97,6 +101,67 @@ def get_cids_and_functions(wcs1, wcs2, pixel_cids1, pixel_cids2):
         return None, None, None, None
 
     return pixel_cids1, pixel_cids2, forwards, backwards
+
+
+def kept_numpy_axes(wcs_ll, matched_world_axes):
+    """
+    The numpy axes to keep when slicing ``wcs_ll`` down to its matched world
+    axes: every pixel axis correlated with a matched world axis, except that
+    pixel axes also driving unmatched world axes are sliced away as long as
+    every matched world axis remains supported by another pixel axis (e.g.
+    the time axis of an SJI cube, which the celestial axes are weakly
+    coupled to - the link is then exact at the first exposure).
+    """
+    matrix = wcs_ll.axis_correlation_matrix
+    keep = set()
+    for world_axis in matched_world_axes:
+        keep |= {int(pixel_axis) for pixel_axis in np.nonzero(matrix[world_axis])[0]}
+    unmatched = [w for w in range(wcs_ll.world_n_dim) if w not in matched_world_axes]
+    for pixel_axis in sorted(keep):
+        if any(matrix[w, pixel_axis] for w in unmatched):
+            trial = keep - {pixel_axis}
+            if trial and all(any(matrix[w, p] for p in trial) for w in matched_world_axes):
+                keep = trial
+    # pixel axes are in x-fastest order, numpy axes are reversed
+    return {int(wcs_ll.pixel_n_dim - 1 - pixel_axis) for pixel_axis in keep}
+
+
+def permuted_values_functions(wcs1, wcs2):
+    """
+    Pixel-to-pixel transform functions for two sliced low-level WCSes whose
+    matched world axes have the same physical types in a different order,
+    going through world *values* with an explicit type-matched permutation
+    (and unit conversion). pixel_to_pixel cannot be used for these: wrapped
+    low-level WCSes produce plain Quantity world objects, which it pairs
+    positionally, silently transposing the axes.
+    """
+    types1 = [str(t) for t in wcs1.world_axis_physical_types]
+    types2 = [str(t) for t in wcs2.world_axis_physical_types]
+    units1 = [unit or '' for unit in wcs1.world_axis_units]
+    units2 = [unit or '' for unit in wcs2.world_axis_units]
+
+    def convert(values, unit_in, unit_out):
+        if unit_in == unit_out:
+            return values
+        return (np.asarray(values) * u.Unit(unit_in)).to_value(u.Unit(unit_out))
+
+    def transform(wcs_in, wcs_out, types_in, units_in, types_out, units_out, pixel_input):
+        world_in = wcs_in.pixel_to_world_values(*pixel_input)
+        if wcs_in.world_n_dim == 1:
+            world_in = (world_in,)
+        world_out = []
+        for world_axis, physical_type in enumerate(types_out):
+            in_axis = types_in.index(physical_type)
+            world_out.append(convert(world_in[in_axis], units_in[in_axis], units_out[world_axis]))
+        return wcs_out.world_to_pixel_values(*world_out)
+
+    def forwards(*pixel_input):
+        return transform(wcs1, wcs2, types1, units1, types2, units2, pixel_input)
+
+    def backwards(*pixel_input):
+        return transform(wcs2, wcs1, types2, units2, types1, units1, pixel_input)
+
+    return forwards, backwards
 
 
 @link_helper(category='Astronomy')
@@ -165,8 +230,8 @@ class WCSLink(MultiLink):
             wcs1_celestial_physical_types = []
             wcs2_celestial_physical_types = []
 
-            slicing_axes1 = []
-            slicing_axes2 = []
+            matched_world1 = []
+            matched_world2 = []
 
             cids1 = data1.pixel_component_ids
             cids2 = data2.pixel_component_ids
@@ -179,57 +244,34 @@ class WCSLink(MultiLink):
                     wcs1_ll.has_celestial and wcs2_ll.has_celestial):
                 wcs1_celestial_physical_types = wcs1_ll.celestial.world_axis_physical_types
                 wcs2_celestial_physical_types = wcs2_ll.celestial.world_axis_physical_types
-
-                cids1_celestial = [cids1[wcs1_ll.wcs.naxis - wcs1_ll.wcs.lng - 1],
-                                   cids1[wcs1_ll.wcs.naxis - wcs1_ll.wcs.lat - 1]]
-                cids2_celestial = [cids2[wcs2_ll.wcs.naxis - wcs2_ll.wcs.lng - 1],
-                                   cids2[wcs2_ll.wcs.naxis - wcs2_ll.wcs.lat - 1]]
-
-                if wcs1_ll.celestial.wcs.lng > wcs1_ll.celestial.wcs.lat:
-                    cids1_celestial = cids1_celestial[::-1]
-
-                if wcs2_ll.celestial.wcs.lng > wcs2_ll.celestial.wcs.lat:
-                    cids2_celestial = cids2_celestial[::-1]
-
-                slicing_axes1 = [cids1_celestial[0].axis, cids1_celestial[1].axis]
-                slicing_axes2 = [cids2_celestial[0].axis, cids2_celestial[1].axis]
+                matched_world1 = [wcs1_ll.wcs.lng, wcs1_ll.wcs.lat]
+                matched_world2 = [wcs2_ll.wcs.lng, wcs2_ll.wcs.lat]
 
             wcs1_sliced_physical_types = list(wcs1_celestial_physical_types)
             wcs2_sliced_physical_types = list(wcs2_celestial_physical_types)
-
-            # For each pair of matching physical types, keep all the pixel
-            # axes correlated with the matched world axis - APE 14 guarantees
-            # neither a one-to-one nor a reversed world/pixel correspondence
-            # (e.g. celestial -TAB axes couple two pixel axes to each world
-            # axis). Pixel axes are in x-fastest order, hence the reversal to
-            # get numpy axes.
-            matrix1 = wcs1_ll.axis_correlation_matrix
-            matrix2 = wcs2_ll.axis_correlation_matrix
 
             for i, physical_type1 in enumerate(wcs1_ll.world_axis_physical_types):
                 if physical_type1 is not None:
                     for j, physical_type2 in enumerate(wcs2_ll.world_axis_physical_types):
                         if physical_type1 == physical_type2:
                             if physical_type1 not in wcs1_sliced_physical_types:
-                                for pixel_axis in np.nonzero(matrix1[i])[0]:
-                                    numpy_axis = int(wcs1_ll.pixel_n_dim - 1 - pixel_axis)
-                                    if numpy_axis not in slicing_axes1:
-                                        slicing_axes1.append(numpy_axis)
+                                matched_world1.append(i)
                                 wcs1_sliced_physical_types.append(physical_type1)
                             if physical_type2 not in wcs2_sliced_physical_types:
-                                for pixel_axis in np.nonzero(matrix2[j])[0]:
-                                    numpy_axis = int(wcs2_ll.pixel_n_dim - 1 - pixel_axis)
-                                    if numpy_axis not in slicing_axes2:
-                                        slicing_axes2.append(numpy_axis)
+                                matched_world2.append(j)
                                 wcs2_sliced_physical_types.append(physical_type2)
+
+            # For each matched world axis, keep the pixel axes it is
+            # correlated with - APE 14 guarantees neither a one-to-one nor a
+            # reversed world/pixel correspondence (e.g. celestial -TAB axes
+            # couple two pixel axes to each world axis).
+            slicing_axes1 = sorted(kept_numpy_axes(wcs1_ll, matched_world1), reverse=True)
+            slicing_axes2 = sorted(kept_numpy_axes(wcs2_ll, matched_world2), reverse=True)
 
             if not slicing_axes1 or not slicing_axes2:
                 raise IncompatibleWCS(f"Can't create WCS link between {data1.label} and {data2.label}")
 
-            slicing_axes1 = sorted(slicing_axes1, reverse=True)
-            slicing_axes2 = sorted(slicing_axes2, reverse=True)
-
-            # Generate slices for the wcs slicing
+            # Generate slices for the wcs slicing (numpy order)
             slices1 = [slice(None)] * wcs1_ll.pixel_n_dim
             slices2 = [slice(None)] * wcs2_ll.pixel_n_dim
 
@@ -244,31 +286,35 @@ class WCSLink(MultiLink):
             wcs1_sliced = SlicedLowLevelWCS(wcs1_ll, tuple(slices1))
             wcs2_sliced = SlicedLowLevelWCS(wcs2_ll, tuple(slices2))
 
-            # When a wrapped low-level WCS is involved, pixel_to_pixel pairs
-            # its plain-Quantity world objects positionally, so if the matched
-            # world axes appear in different orders on the two sides the link
-            # would silently transpose them - refuse instead. Natively
-            # high-level pairs are safe: their typed world objects (e.g.
-            # SkyCoord) are matched by class, not position. Linking reordered
-            # low-level pairs would need an explicit physical-type permutation
-            # of the world values.
-            types1 = list(wcs1_sliced.world_axis_physical_types)
-            types2 = list(wcs2_sliced.world_axis_physical_types)
-            if (not both_high_level and types1 != types2 and
-                    sorted(map(str, types1)) == sorted(map(str, types2))):
-                raise IncompatibleWCS(f"Can't create WCS link between {data1.label} and {data2.label} "
-                                      f"(matched world axes are in different orders)")
-
-            wcs1_final = HighLevelWCSWrapper(copy.copy(wcs1_sliced))
-            wcs2_final = HighLevelWCSWrapper(copy.copy(wcs2_sliced))
-
             # slicing_axes are sorted in descending numpy-axis order, which
             # matches the pixel argument order of the sliced WCSes
             cids1_sliced = [cids1[x] for x in slicing_axes1]
             cids2_sliced = [cids2[x] for x in slicing_axes2]
 
-            pixel_cids1, pixel_cids2, forwards, backwards = get_cids_and_functions(
-                wcs1_final, wcs2_final, cids1_sliced, cids2_sliced)
+            types1 = [str(t) for t in wcs1_sliced.world_axis_physical_types]
+            types2 = [str(t) for t in wcs2_sliced.world_axis_physical_types]
+
+            if not both_high_level and types1 != types2 and sorted(types1) == sorted(types2):
+                if len(set(types1)) != len(types1) or 'None' in types1:
+                    # Duplicated or unknown physical types cannot be paired
+                    # reliably across a reordering
+                    raise IncompatibleWCS(f"Can't create WCS link between {data1.label} and {data2.label}")
+                # Wrapped low-level WCSes produce plain-Quantity world
+                # objects, which pixel_to_pixel pairs positionally - that
+                # would silently transpose the axes here, so transform
+                # through explicitly type-matched world values instead.
+                # Natively high-level pairs don't need this: their typed
+                # world objects (e.g. SkyCoord) are matched by class.
+                forwards_permuted, backwards_permuted = permuted_values_functions(wcs1_sliced, wcs2_sliced)
+                pixel_cids1, pixel_cids2, forwards, backwards = get_cids_and_functions(
+                    None, None, cids1_sliced, cids2_sliced,
+                    forwards=forwards_permuted, backwards=backwards_permuted)
+            else:
+                wcs1_final = HighLevelWCSWrapper(copy.copy(wcs1_sliced))
+                wcs2_final = HighLevelWCSWrapper(copy.copy(wcs2_sliced))
+
+                pixel_cids1, pixel_cids2, forwards, backwards = get_cids_and_functions(
+                    wcs1_final, wcs2_final, cids1_sliced, cids2_sliced)
 
             self._physical_types_1 = wcs1_sliced_physical_types
             self._physical_types_2 = wcs2_sliced_physical_types

--- a/glue/plugins/wcs_autolinking/wcs_autolinking.py
+++ b/glue/plugins/wcs_autolinking/wcs_autolinking.py
@@ -285,8 +285,12 @@ class WCSLink(MultiLink):
                 if j not in slicing_axes2:
                     slices2[j] = 0
 
-            wcs1_sliced = SlicedLowLevelWCS(wcs1_ll, tuple(slices1))
-            wcs2_sliced = SlicedLowLevelWCS(wcs2_ll, tuple(slices2))
+            # Avoid a no-op slice: Astropy 6's sliced wrapper cannot handle
+            # the scalar world/pixel return values of an already-1D WCS.
+            wcs1_sliced = (wcs1_ll if len(slicing_axes1) == wcs1_ll.pixel_n_dim
+                           else SlicedLowLevelWCS(wcs1_ll, tuple(slices1)))
+            wcs2_sliced = (wcs2_ll if len(slicing_axes2) == wcs2_ll.pixel_n_dim
+                           else SlicedLowLevelWCS(wcs2_ll, tuple(slices2)))
 
             # slicing_axes are sorted in descending numpy-axis order, which
             # matches the pixel argument order of the sliced WCSes


### PR DESCRIPTION
Datasets whose `coords` only implement the low-level APE-14 API (a `BaseWCSWrapper` around gWCS or a `-TAB` WCS, as glue-solar builds for IRIS data) never autolink: `wcs_autolink` keeps `BaseHighLevelWCS` only, and `WCSLink(sji, raster)` crashes on `has_celestial`.

- `wcs_autolink` accepts `BaseLowLevelWCS`; `WCSLink` wraps it in `HighLevelWCSWrapper`.
- The celestial cross-frame special case applies to astropy `WCS` pairs only; everything else matches on `world_axis_physical_types`.
- Pixel axes per matched world axis come from `axis_correlation_matrix`; axes that only drive unmatched world axes are sliced away (an SJI's time axis: the link is exact at exposure 0).
- Matched types in a different order transform through world values with an explicit permutation.
- Mismatched or untransformable pairs raise `IncompatibleWCS` and are skipped.

Verified on real IRIS Level 2 data (SJI gWCS + raster `-TAB`): one link, sky positions agree to 3e-7 arcsec, exact round trip. 11 new tests on synthetic low-level WCS fixtures; existing tests unchanged.

Note for wrapper authors (#2152): a wrapper that changes `world_axis_units` must keep `world_axis_object_classes`/`components` coherent, or the pair is reported incompatible.

Refs #2152. Downstream: glue-viz/glue-solar#44.

Label: enhancement.
