### PR TITLE
Add a 'slice' collapse function to the profile viewer

### DIFF
--- a/glue/viewers/profile/layer_artist.py
+++ b/glue/viewers/profile/layer_artist.py
@@ -132,7 +132,8 @@ class ProfileLayerArtist(MatplotlibLayerArtist):
         changed = self.pop_changed_properties()
 
         if force or any(prop in changed for prop in ('layer', 'x_att', 'attribute', 'function', 'normalize',
-                                                     'v_min', 'v_max', 'visible', 'x_display_unit', 'y_display_unit')):
+                                                     'slices', 'v_min', 'v_max', 'visible',
+                                                     'x_display_unit', 'y_display_unit')):
             self._calculate_profile(reset=force)
             force = True
 

--- a/glue/viewers/profile/python_export.py
+++ b/glue/viewers/profile/python_export.py
@@ -16,16 +16,32 @@ def python_export_profile_layer(layer, *args):
     if isinstance(layer.state.layer, Subset):
         script += "base_data = layer_data.data\n"
         script += "cid = base_data.find_component_id('{0}')\n".format(layer.state.attribute.label)
+    else:
+        script += "base_data = layer_data\n"
+        script += "cid = layer_data.find_component_id('{0}')\n".format(layer.state.attribute.label)
+    if layer._viewer_state.function == 'slice':
+        slices = tuple(layer._viewer_state.slices or ())
+        script += "data_view = list({0}) if base_data.ndim == {1} else [0] * base_data.ndim\n".format(slices, len(slices))
+        script += "data_view[profile_axis] = slice(None)\n"
+        script += "profile_values = base_data.get_data(cid, view=tuple(data_view))\n"
+        if isinstance(layer.state.layer, Subset):
+            script += "mask = base_data.get_mask(layer_data.subset_state, view=tuple(data_view))\n"
+            script += "profile_values = np.where(mask, profile_values, np.nan)\n"
+        script += "\n"
+    elif isinstance(layer.state.layer, Subset):
         script += "profile_values = base_data.compute_statistic('{0}', cid, axis=collapsed_axes, subset_state=layer_data.subset_state)\n\n".format(layer._viewer_state.function)
     else:
-        script += "cid = layer_data.find_component_id('{0}')\n".format(layer.state.attribute.label)
         script += "profile_values = layer_data.compute_statistic('{0}', cid, axis=collapsed_axes)\n\n".format(layer._viewer_state.function)
 
     script += "# Extract the values for the x-axis\n"
     script += "axis_view = [0] * layer_data.ndim\n"
     script += "axis_view[profile_axis] = slice(None)\n"
     script += "profile_x_values = layer_data['{0}', tuple(axis_view)]\n".format(layer._viewer_state.x_att)
-    script += "keep = ~np.isnan(profile_values) & ~np.isnan(profile_x_values)\n\n"
+    if layer._viewer_state.function == 'slice':
+        # NaN values should produce gaps in the line, as in the live viewer
+        script += "keep = slice(None)\n\n"
+    else:
+        script += "keep = ~np.isnan(profile_values) & ~np.isnan(profile_x_values)\n\n"
 
     if layer._viewer_state.normalize:
         script += "# Normalize the profile data\n"

--- a/glue/viewers/profile/python_export.py
+++ b/glue/viewers/profile/python_export.py
@@ -1,5 +1,6 @@
 from glue.viewers.common.python_export import serialize_options
 from glue.core import Subset
+from glue.core.link_manager import is_convertible_to_single_pixel_cid
 
 
 def python_export_profile_layer(layer, *args):
@@ -20,12 +21,16 @@ def python_export_profile_layer(layer, *args):
         script += "base_data = layer_data\n"
         script += "cid = layer_data.find_component_id('{0}')\n".format(layer.state.attribute.label)
     if layer._viewer_state.function == 'slice':
-        slices = tuple(layer._viewer_state.slices or ())
-        script += "data_view = list({0}) if base_data.ndim == {1} else [0] * base_data.ndim\n".format(slices, len(slices))
-        script += "data_view[profile_axis] = slice(None)\n"
-        script += "profile_values = base_data.get_data(cid, view=tuple(data_view))\n"
         if isinstance(layer.state.layer, Subset):
-            script += "mask = base_data.get_mask(layer_data.subset_state, view=tuple(data_view))\n"
+            slice_data = layer.state.layer.data
+        else:
+            slice_data = layer.state.layer
+        pix_cid = is_convertible_to_single_pixel_cid(layer.state.layer,
+                                                     layer._viewer_state.x_att_pixel)
+        script += "data_view = {0}\n".format(layer.state.slice_view(slice_data, pix_cid))
+        script += "profile_values = base_data.get_data(cid, view=data_view)\n"
+        if isinstance(layer.state.layer, Subset):
+            script += "mask = base_data.get_mask(layer_data.subset_state, view=data_view)\n"
             script += "profile_values = np.where(mask, profile_values, np.nan)\n"
         script += "\n"
     elif isinstance(layer.state.layer, Subset):
@@ -36,7 +41,9 @@ def python_export_profile_layer(layer, *args):
     script += "# Extract the values for the x-axis\n"
     script += "axis_view = [0] * layer_data.ndim\n"
     script += "axis_view[profile_axis] = slice(None)\n"
-    script += "profile_x_values = layer_data['{0}', tuple(axis_view)]\n".format(layer._viewer_state.x_att)
+    # NOTE: x values come from base_data - indexing a Subset applies the
+    # subset mask, which would give a different length than profile_values
+    script += "profile_x_values = base_data['{0}', tuple(axis_view)]\n".format(layer._viewer_state.x_att)
     if layer._viewer_state.function == 'slice':
         # NaN values should produce gaps in the line, as in the live viewer
         script += "keep = slice(None)\n\n"

--- a/glue/viewers/profile/python_export.py
+++ b/glue/viewers/profile/python_export.py
@@ -39,8 +39,11 @@ def python_export_profile_layer(layer, *args):
         script += "profile_values = layer_data.compute_statistic('{0}', cid, axis=collapsed_axes)\n\n".format(layer._viewer_state.function)
 
     script += "# Extract the values for the x-axis\n"
-    script += "axis_view = [0] * layer_data.ndim\n"
-    script += "axis_view[profile_axis] = slice(None)\n"
+    if layer._viewer_state.function == 'slice':
+        script += "axis_view = data_view\n"
+    else:
+        script += "axis_view = [0] * layer_data.ndim\n"
+        script += "axis_view[profile_axis] = slice(None)\n"
     # NOTE: x values come from base_data - indexing a Subset applies the
     # subset mask, which would give a different length than profile_values
     script += "profile_x_values = base_data['{0}', tuple(axis_view)]\n".format(layer._viewer_state.x_att)

--- a/glue/viewers/profile/state.py
+++ b/glue/viewers/profile/state.py
@@ -23,7 +23,8 @@ FUNCTIONS = OrderedDict([('maximum', 'Maximum'),
                          ('minimum', 'Minimum'),
                          ('mean', 'Mean'),
                          ('median', 'Median'),
-                         ('sum', 'Sum')])
+                         ('sum', 'Sum'),
+                         ('slice', 'Slice')])
 
 
 class ProfileViewerState(MatplotlibDataViewerState):
@@ -47,6 +48,9 @@ class ProfileViewerState(MatplotlibDataViewerState):
 
     function = DDSCProperty(docstring='The function to use for collapsing data')
 
+    slices = DDCProperty(docstring='The current slice along all dimensions, '
+                                   'used when function is ``\'slice\'``')
+
     normalize = DDCProperty(False, docstring='Whether to normalize all profiles '
                                              'to the [0:1] range')
 
@@ -65,6 +69,7 @@ class ProfileViewerState(MatplotlibDataViewerState):
         self.add_callback('y_display_unit', self._convert_units_y_limits, echo_old=True)
         self.add_callback('normalize', self._reset_y_limits)
         self.add_callback('function', self._reset_y_limits)
+        self.add_callback('slices', self._reset_y_limits)
 
         self.x_att_helper = ComponentIDComboHelper(self, 'x_att',
                                                    numeric=False, datetime=False, categorical=False,
@@ -313,7 +318,7 @@ class ProfileViewerState(MatplotlibDataViewerState):
         if self.reference_data is not getattr(self, '_last_reference_data', None):
             self._last_reference_data = self.reference_data
 
-            with delay_callback(self, 'x_att'):
+            with delay_callback(self, 'x_att', 'slices'):
 
                 if self.reference_data is None:
                     self.x_att_helper.set_multiple_data([])
@@ -326,9 +331,16 @@ class ProfileViewerState(MatplotlibDataViewerState):
                         self.x_att_helper.world_coord = False
                         self.x_att = self.reference_data.pixel_component_ids[0]
 
+                self._set_default_slices()
                 self._update_att()
 
         self.reset_limits()
+
+    def _set_default_slices(self):
+        if self.reference_data is None:
+            self.slices = ()
+        else:
+            self.slices = (0,) * self.reference_data.ndim
 
     def _update_priority(self, name):
         if name == 'layers':
@@ -440,6 +452,7 @@ class ProfileLayerState(MatplotlibLayerState, HubListener):
             self.viewer_state.add_callback('x_display_unit', self.reset_cache, priority=100000)
             self.viewer_state.add_callback('y_display_unit', self.reset_cache, priority=100000)
             self.viewer_state.add_callback('function', self.reset_cache, priority=100000)
+            self.viewer_state.add_callback('slices', self.reset_cache, priority=100000)
             if self.is_callback_property('attribute'):
                 self.add_callback('attribute', self.reset_cache, priority=100000)
             self._viewer_callbacks_set = True
@@ -470,7 +483,17 @@ class ProfileLayerState(MatplotlibLayerState, HubListener):
             data = self.layer
             subset_state = None
 
-        profile_values = data.compute_statistic(self.viewer_state.function, self.attribute, axis=axes, subset_state=subset_state)
+        if self.viewer_state.function == 'slice':
+            view = list(self.viewer_state.slices or ())
+            if len(view) != data.ndim:
+                view = [0] * data.ndim
+            view[pix_cid.axis] = slice(None)
+            profile_values = data.get_data(self.attribute, view=tuple(view))
+            if subset_state is not None:
+                mask = data.get_mask(subset_state, view=tuple(view))
+                profile_values = np.where(mask, profile_values, np.nan)
+        else:
+            profile_values = data.compute_statistic(self.viewer_state.function, self.attribute, axis=axes, subset_state=subset_state)
 
         if np.all(np.isnan(profile_values)):
             self._profile_cache = [], []

--- a/glue/viewers/profile/state.py
+++ b/glue/viewers/profile/state.py
@@ -12,7 +12,7 @@ from glue.viewers.matplotlib.state import (MatplotlibDataViewerState,
 from glue.core.data_combo_helper import ManualDataComboHelper, ComponentIDComboHelper
 from glue.utils import defer_draw, avoid_circular
 from glue.core.link_manager import is_convertible_to_single_pixel_cid
-from glue.core.exceptions import IncompatibleDataException
+from glue.core.exceptions import IncompatibleAttribute, IncompatibleDataException
 from glue.core.message import SubsetUpdateMessage
 from glue.core.units import find_unit_choices, UnitConverter
 
@@ -439,6 +439,37 @@ class ProfileLayerState(MatplotlibLayerState, HubListener):
         self.update_profile()
         return self._profile_cache
 
+    def slice_view(self, data, pix_cid):
+        """
+        The view used when the collapse function is 'slice': the current
+        viewer slices with `slice(None)` along the profile axis, translated
+        from the reference data's frame into ``data``'s own pixel indices.
+        """
+        ref = self.viewer_state.reference_data
+        slices = list(self.viewer_state.slices or ())
+        if len(slices) != ref.ndim:
+            slices = [0] * ref.ndim
+        if data is ref:
+            view = slices
+        else:
+            # Translate the reference-data slice point into this dataset's
+            # own pixel indices through the pixel links
+            point = tuple(np.array([s]) for s in slices)
+            view = []
+            for axis in range(data.ndim):
+                if axis == pix_cid.axis:
+                    view.append(0)
+                    continue
+                try:
+                    index = int(np.round(ref[data.pixel_component_ids[axis], point][0]))
+                except IncompatibleAttribute:
+                    raise IncompatibleDataException()
+                if index < 0 or index >= data.shape[axis]:
+                    raise IncompatibleDataException()
+                view.append(index)
+        view[pix_cid.axis] = slice(None)
+        return tuple(view)
+
     def update_profile(self, update_limits=True):
 
         if self._profile_cache is not None:
@@ -484,13 +515,10 @@ class ProfileLayerState(MatplotlibLayerState, HubListener):
             subset_state = None
 
         if self.viewer_state.function == 'slice':
-            view = list(self.viewer_state.slices or ())
-            if len(view) != data.ndim:
-                view = [0] * data.ndim
-            view[pix_cid.axis] = slice(None)
-            profile_values = data.get_data(self.attribute, view=tuple(view))
+            view = self.slice_view(data, pix_cid)
+            profile_values = data.get_data(self.attribute, view=view)
             if subset_state is not None:
-                mask = data.get_mask(subset_state, view=tuple(view))
+                mask = data.get_mask(subset_state, view=view)
                 profile_values = np.where(mask, profile_values, np.nan)
         else:
             profile_values = data.compute_statistic(self.viewer_state.function, self.attribute, axis=axes, subset_state=subset_state)

--- a/glue/viewers/profile/state.py
+++ b/glue/viewers/profile/state.py
@@ -526,8 +526,11 @@ class ProfileLayerState(MatplotlibLayerState, HubListener):
         if np.all(np.isnan(profile_values)):
             self._profile_cache = [], []
         else:
-            axis_view = [0] * data.ndim
-            axis_view[pix_cid.axis] = slice(None)
+            if self.viewer_state.function == 'slice':
+                axis_view = view
+            else:
+                axis_view = [0] * data.ndim
+                axis_view[pix_cid.axis] = slice(None)
             axis_values = data[self.viewer_state.x_att, tuple(axis_view)]
 
             converter = UnitConverter()

--- a/glue/viewers/profile/tests/test_python_export.py
+++ b/glue/viewers/profile/tests/test_python_export.py
@@ -68,8 +68,9 @@ class TestExportPython(BaseTestExportPython):
         self.assert_same(tmpdir)
 
     def test_slice_subset(self, tmpdir):
+        # The subset mask is deliberately partial along the profile axis
         self.viewer.state.function = 'slice'
-        self.data_collection.new_subset_group('mysubset', self.data.id['x'] > 0.25)
+        self.data_collection.new_subset_group('mysubset', self.data.pixel_component_ids[0] > 0.5)
         self.assert_same(tmpdir)
 
     def test_normalization(self, tmpdir):

--- a/glue/viewers/profile/tests/test_python_export.py
+++ b/glue/viewers/profile/tests/test_python_export.py
@@ -62,6 +62,16 @@ class TestExportPython(BaseTestExportPython):
         self.viewer.state.function = 'sum'
         self.assert_same(tmpdir)
 
+    def test_slice(self, tmpdir):
+        self.viewer.state.function = 'slice'
+        self.viewer.state.slices = (0, 2, 1)
+        self.assert_same(tmpdir)
+
+    def test_slice_subset(self, tmpdir):
+        self.viewer.state.function = 'slice'
+        self.data_collection.new_subset_group('mysubset', self.data.id['x'] > 0.25)
+        self.assert_same(tmpdir)
+
     def test_normalization(self, tmpdir):
         self.viewer.state.normalize = True
         self.assert_same(tmpdir)

--- a/glue/viewers/profile/tests/test_python_export.py
+++ b/glue/viewers/profile/tests/test_python_export.py
@@ -1,10 +1,43 @@
 from astropy.utils import NumpyRNGContext
+from astropy.wcs import WCS
+import numpy as np
+import pytest
+import matplotlib.pyplot as plt
+from numpy.testing import assert_allclose
 
 from glue.core import Data, DataCollection
 from glue.core.application_base import Application
 from glue.viewers.profile.viewer import SimpleProfileViewer
 from glue.viewers.matplotlib.tests.test_python_export import BaseTestExportPython, random_with_nan
 from glue.viewers.profile.tests.test_state import SimpleCoordinates
+from glue.viewers.profile.python_export import python_export_profile_layer
+
+
+@pytest.mark.parametrize('subset', [False, True])
+def test_slice_world_coordinate_export(subset, request):
+    wcs = WCS(naxis=2)
+    wcs.wcs.ctype = ['WAVE', 'LINEAR']
+    wcs.wcs.cunit = ['m', '']
+    wcs.wcs.crpix = [1, 1]
+    wcs.wcs.crval = [1, 0]
+    wcs.wcs.pc = [[1, 10], [0, 1]]
+    data = Data(flux=np.arange(12).reshape(3, 4), coords=wcs)
+    app = Application(DataCollection([data]))
+    viewer = app.new_data_viewer(SimpleProfileViewer)
+    request.addfinalizer(lambda: plt.close(viewer.figure))
+    viewer.add_data(data)
+    viewer.state.x_att = data.world_component_ids[1]
+    viewer.state.function = 'slice'
+    viewer.state.slices = (2, 0)
+    if subset:
+        app.data_collection.new_subset_group('selected', data.id['flux'] > 8)
+    artist = viewer.layers[-1]
+    imports, script = python_export_profile_layer(artist)
+    namespace = dict(layer_data=artist.state.layer, ax=viewer.axes,
+                     legend_handles=[], legend_labels=[])
+    exec('\n'.join(imports) + '\n' + script, namespace)  # noqa: S102 - test the trusted exporter output
+    assert_allclose(namespace['profile_x_values'], [21, 22, 23, 24])
+    assert_allclose(namespace['profile_values'], [np.nan if subset else 8, 9, 10, 11])
 
 
 class TestExportPython(BaseTestExportPython):

--- a/glue/viewers/profile/tests/test_state.py
+++ b/glue/viewers/profile/tests/test_state.py
@@ -196,6 +196,71 @@ class TestProfileViewerState:
         assert_allclose(y, [3.5, 11.5, 19.5])
 
 
+def test_slice_function_linked():
+
+    # Slices are defined on the reference data and must be translated into
+    # the pixel frame of other linked layers
+
+    from glue.core.link_helpers import LinkSame
+
+    data1 = Data(x=np.arange(24).reshape((3, 4, 2)).astype(float), label='d1')
+    data2 = Data(y=np.arange(24).reshape((4, 3, 2)).astype(float), label='d2')
+
+    dc = DataCollection([data1, data2])
+    p1 = data1.pixel_component_ids
+    p2 = data2.pixel_component_ids
+    # data2's first two axes are swapped relative to data1
+    dc.add_link(LinkSame(p1[0], p2[1]))
+    dc.add_link(LinkSame(p1[1], p2[0]))
+    dc.add_link(LinkSame(p1[2], p2[2]))
+
+    viewer_state = ProfileViewerState()
+    layer1 = ProfileLayerState(viewer_state=viewer_state, layer=data1)
+    viewer_state.layers.append(layer1)
+    layer2 = ProfileLayerState(viewer_state=viewer_state, layer=data2)
+    viewer_state.layers.append(layer2)
+    viewer_state.reference_data = data1
+    viewer_state.function = 'slice'
+    viewer_state.slices = (0, 2, 1)
+
+    _, y = layer1.profile
+    assert_allclose(y, data1['x'][:, 2, 1])
+
+    _, y = layer2.profile
+    assert_allclose(y, data2['y'][2, :, 1])
+
+
+def test_slice_function_out_of_bounds():
+
+    # A slice point that falls outside a linked layer raises
+    # IncompatibleDataException instead of silently plotting wrong values
+
+    from glue.core.exceptions import IncompatibleDataException
+    from glue.core.link_helpers import LinkSame
+
+    data1 = Data(x=np.arange(24).reshape((3, 4, 2)).astype(float), label='d1')
+    data2 = Data(y=np.arange(12).reshape((3, 2, 2)).astype(float), label='d2')
+
+    dc = DataCollection([data1, data2])
+    for cid1, cid2 in zip(data1.pixel_component_ids, data2.pixel_component_ids):
+        dc.add_link(LinkSame(cid1, cid2))
+
+    viewer_state = ProfileViewerState()
+    layer1 = ProfileLayerState(viewer_state=viewer_state, layer=data1)
+    viewer_state.layers.append(layer1)
+    layer2 = ProfileLayerState(viewer_state=viewer_state, layer=data2)
+    viewer_state.layers.append(layer2)
+    viewer_state.reference_data = data1
+    viewer_state.function = 'slice'
+    viewer_state.slices = (0, 3, 1)
+
+    _, y = layer1.profile
+    assert_allclose(y, data1['x'][:, 3, 1])
+
+    with pytest.raises(IncompatibleDataException):
+        layer2.profile
+
+
 def test_slice_function_1d():
 
     # For 1D data the slice function should just return the data itself

--- a/glue/viewers/profile/tests/test_state.py
+++ b/glue/viewers/profile/tests/test_state.py
@@ -95,6 +95,38 @@ class TestProfileViewerState:
         _x, y = self.layer_state.profile
         assert_allclose(y, [3.5, 11.5, 19.5])
 
+    def test_slice_function(self):
+
+        self.viewer_state.function = 'slice'
+
+        # Default slices are all zero
+        assert self.viewer_state.slices == (0, 0, 0)
+        x, y = self.layer_state.profile
+        assert_allclose(x, [0, 2, 4])
+        assert_allclose(y, self.data['x'][:, 0, 0])
+
+        self.viewer_state.slices = (0, 2, 1)
+        x, y = self.layer_state.profile
+        assert_allclose(y, self.data['x'][:, 2, 1])
+
+        self.viewer_state.x_att = self.data.pixel_component_ids[1]
+        x, y = self.layer_state.profile
+        assert_allclose(x, [0, 1, 2, 3])
+        assert_allclose(y, self.data['x'][0, :, 1])
+
+    def test_slice_function_subset(self):
+
+        self.viewer_state.function = 'slice'
+
+        subset = self.data.new_subset()
+        subset.subset_state = self.data.id['x'] > 10
+
+        self.layer_state.layer = subset
+
+        x, y = self.layer_state.profile
+        assert_allclose(x, [0, 2, 4])
+        assert_allclose(y, [np.nan, np.nan, 16])
+
     def test_subset(self):
 
         subset = self.data.new_subset()
@@ -162,6 +194,23 @@ class TestProfileViewerState:
         x, y = self.layer_state.profile
         assert_allclose(x, [0, 2, 4])
         assert_allclose(y, [3.5, 11.5, 19.5])
+
+
+def test_slice_function_1d():
+
+    # For 1D data the slice function should just return the data itself
+
+    data = Data(y=[1., 2., 3.], label='d1')
+    DataCollection([data])
+
+    viewer_state = ProfileViewerState()
+    layer_state = ProfileLayerState(viewer_state=viewer_state, layer=data)
+    viewer_state.layers.append(layer_state)
+    viewer_state.function = 'slice'
+
+    x, y = layer_state.profile
+    assert_allclose(x, [0, 1, 2])
+    assert_allclose(y, [1, 2, 3])
 
 
 @pytest.mark.parametrize(('value', 'limits'),

--- a/glue/viewers/profile/tests/test_state.py
+++ b/glue/viewers/profile/tests/test_state.py
@@ -196,6 +196,43 @@ class TestProfileViewerState:
         assert_allclose(y, [3.5, 11.5, 19.5])
 
 
+@pytest.mark.parametrize('display_unit', [None, 'cm'])
+@pytest.mark.parametrize('linked', [False, True])
+def test_slice_world_coordinates(display_unit, linked):
+    from astropy.wcs import WCS
+    from glue.core.link_helpers import LinkSame
+
+    wcs = WCS(naxis=2)
+    wcs.wcs.ctype = ['WAVE', 'LINEAR']
+    wcs.wcs.cunit = ['m', '']
+    wcs.wcs.crpix = [1, 1]
+    wcs.wcs.crval = [1, 0]
+    wcs.wcs.pc = [[1, 10], [0, 1]]
+    data = Data(flux=np.arange(12).reshape(3, 4), coords=wcs)
+    dc = DataCollection([data])
+    state = ProfileViewerState()
+    layer = ProfileLayerState(viewer_state=state, layer=data)
+    state.layers.append(layer)
+    if linked:
+        target = Data(flux=data['flux'].T)
+        dc.append(target)
+        for axis in range(2):
+            dc.add_link(LinkSame(data.pixel_component_ids[axis], target.pixel_component_ids[1 - axis]))
+        layer = ProfileLayerState(viewer_state=state, layer=target)
+        state.layers.append(layer)
+    state.reference_data = data
+    state.x_att = data.world_component_ids[1]
+    state.function = 'slice'
+    state.x_display_unit = display_unit
+    scale = 100 if display_unit == 'cm' else 1
+
+    for row in (2, 1):
+        state.slices = (row, 0)
+        x, y = layer.profile
+        assert_allclose(x, (1 + 10 * row + np.arange(4)) * scale)
+        assert_allclose(y, data['flux'][row, :])
+
+
 def test_slice_function_linked():
 
     # Slices are defined on the reference data and must be translated into

--- a/glue/viewers/profile/tests/test_viewer.py
+++ b/glue/viewers/profile/tests/test_viewer.py
@@ -174,6 +174,28 @@ def test_unit_conversion():
     viewer.state.y_display_unit = 'mJy'
 
 
+def test_unit_conversion_slice():
+
+    # The slice function should apply display unit conversion like the others
+
+    settings.UNIT_CONVERTER = 'test-spectral2'
+
+    d1 = Data(f1=[1., 2., 3.])
+    d1.get_component('f1').units = 'Jy'
+
+    app = Application()
+    app.session.data_collection.append(d1)
+
+    viewer = app.new_data_viewer(SimpleProfileViewer)
+    viewer.add_data(d1)
+    viewer.state.function = 'slice'
+    viewer.state.y_display_unit = 'mJy'
+
+    x, y = viewer.state.layers[0].profile
+    assert_allclose(x, [0, 1, 2])
+    assert_allclose(y, [1000, 2000, 3000])
+
+
 def test_indexed_data():
 
     # Make sure that the profile viewer works properly with IndexedData objects


### PR DESCRIPTION
Adds a `'slice'` collapse function to the profile viewer: the profile shows the data along the profile axis at the point given by the new `ProfileViewerState.slices` property (mirrors `ImageViewerState.slices`) instead of a collapsed statistic. Subset layers mask values outside the subset with NaN; display units apply as before.

For layers whose dataset is not the reference data, `ProfileLayerState.slice_view` translates the slice point through the pixel links and raises `IncompatibleDataException` (layer disabled) for unlinked axes or out-of-range points. The python export emits the equivalent code and now takes x values from the parent data rather than the Subset.

Motivation: a single-pixel spectrum (IRIS raster browsing) cannot be expressed as a statistic. First of two PRs restarting #2248; the second adds opt-in WCSAxes formatting, and glue-qt sliders follow in a glue-qt PR.

Known limitation: `slices` out of range for the reference data itself raises IndexError (the Qt sliders are bounded).

Label: enhancement.
