### PR TITLE
Serialize preferred_cmap by name and skip any unserializable meta value

### DIFF
--- a/glue/core/state.py
+++ b/glue/core/state.py
@@ -743,7 +743,12 @@ def _load_roi(roi, context):
 
 @saver(VisualAttributes)
 def _save_style(style, context):
-    return dict((a, getattr(style, a)) for a in style._atts)
+    result = dict((a, getattr(style, a)) for a in style._atts)
+    # preferred_cmap may be a Colormap object, which is not JSON-serializable
+    # (and is never restored by _load_style) - store its name instead
+    if 'preferred_cmap' in result:
+        result['preferred_cmap'] = getattr(result['preferred_cmap'], 'name', result['preferred_cmap'])
+    return result
 
 
 @loader(VisualAttributes)
@@ -1030,7 +1035,7 @@ def _save_data_5(data, context):
         try:
             context.do(key)
             context.do(value)
-        except GlueSerializeError:
+        except Exception:  # noqa: BLE001 - e.g. np.save TypeError on Quantity values
             continue
         else:
             meta_filtered[key] = value

--- a/glue/core/tests/test_state.py
+++ b/glue/core/tests/test_state.py
@@ -102,6 +102,36 @@ def test_data_style():
     assert d2.style.color == 'blue'
 
 
+def test_save_style_colormap_object():
+    # preferred_cmap is a Colormap object (the setter converts names to
+    # objects), which is not JSON-serializable; it is saved by name and, as
+    # before, not restored by _load_style
+    from matplotlib import cm
+    d = core.Data(x=[1, 2, 3])
+    d.style.preferred_cmap = cm.viridis
+    gs = GlueSerializer(d)
+    dump = gs.dumps()
+    assert json.loads(dump)[gs.id(d)]['style']['preferred_cmap'] == 'viridis'
+    d2 = GlueUnSerializer.loads(dump).object(gs.id(d))
+    assert d2.style.preferred_cmap is None
+
+
+@requires_astropy
+def test_save_meta_quantity():
+    # A Quantity in Data.meta reaches the np.ndarray saver, which raises a
+    # TypeError rather than GlueSerializeError; it should be dropped like any
+    # other unserializable value instead of aborting the whole save
+    import astropy.units as u
+    d = core.Data(x=[1, 2, 3])
+    d.meta['exposure'] = 4 * u.s
+    d.meta['name'] = 'test'
+    d.meta['count'] = 3
+    d2 = clone(d)
+    assert 'exposure' not in d2.meta
+    assert d2.meta['name'] == 'test'
+    assert d2.meta['count'] == 3
+
+
 def test_user_patch_is_called():
     @session_patch()
     def a_patch(session):


### PR DESCRIPTION
Two session-save crashes:

- Any `Data` whose `style.preferred_cmap` is a `Colormap` object (the setter turns even a string into one) fails with `TypeError: Object of type ListedColormap is not JSON serializable`. `_save_style` now stores the colormap name; `_load_style` already discards the key.
- A `Quantity` value in `data.meta` reaches `@saver(np.ndarray)` and fails inside `np.save`; `_save_data_5` only caught `GlueSerializeError`. It now skips any meta value that fails to serialize.

Tests: `test_save_style_colormap_object`, `test_save_meta_quantity`.

Label: bug.
