### PR TITLE
Keep correlated world inputs in world2pixel_single_axis

### DIFF
--- a/glue/core/coordinate_helpers.py
+++ b/glue/core/coordinate_helpers.py
@@ -101,7 +101,13 @@ def world2pixel_single_axis(wcs, *world, pixel_axis=None):
 
     # Now find all the world coordinates that are needed to calculate this
     # world coordinate, using the axis correlation matrix
-    world_dep = wcs.axis_correlation_matrix[:, pixel_axis]
+    matrix = wcs.axis_correlation_matrix
+    world_dep = matrix[:, pixel_axis].copy()
+    # Also keep world axes that share a pixel axis with those: they are
+    # needed to invert the requested pixel axis (e.g. the time axis of a
+    # cube whose celestial axes depend on time) - transitive closure
+    for _ in range(matrix.shape[0]):
+        world_dep |= (matrix & matrix[world_dep].any(axis=0)).any(axis=1)
 
     for iw, w in enumerate(world):
         if world_dep[iw]:

--- a/glue/core/tests/test_coordinates.py
+++ b/glue/core/tests/test_coordinates.py
@@ -8,7 +8,8 @@ from glue.core.tests.test_state import clone
 from glue.tests.helpers import requires_astropy
 
 from ..coordinate_helpers import (axis_label, world_axis,
-                                  pixel2world_single_axis, dependent_axes)
+                                  pixel2world_single_axis,
+                                  world2pixel_single_axis, dependent_axes)
 from ..coordinates import (coordinates_from_header, IdentityCoordinates,
                            WCSCoordinates, AffineCoordinates,
                            header_from_string)
@@ -393,6 +394,41 @@ def test_pixel2world_single_axis_affine_1d():
     assert_allclose(pixel2world_single_axis(coord, x, world_axis=0), expected)
     assert_allclose(pixel2world_single_axis(coord, x.reshape((1, 3)), world_axis=0), expected.reshape((1, 3)))
     assert_allclose(pixel2world_single_axis(coord, x.reshape((3, 1)), world_axis=0), expected.reshape((3, 1)))
+
+
+@requires_astropy
+def test_world2pixel_single_axis_correlated_axes():
+
+    # Regression test for a bug in world2pixel_single_axis which collapsed
+    # every world input not directly correlated with the requested pixel axis
+    # to a scalar, even when it is needed to invert that pixel axis (e.g. the
+    # time axis of a cube whose celestial axes depend on time)
+
+    from astropy.wcs.wcsapi import BaseLowLevelWCS
+
+    class CorrelatedWCS(BaseLowLevelWCS):
+        # pixel axes (x, t); world lon = x + 10 * t depends on both, time = t
+        pixel_n_dim = world_n_dim = 2
+        world_axis_physical_types = ['custom:pos.helioprojective.lon', 'time']
+        world_axis_units = ['arcsec', 's']
+        world_axis_object_components = [('c', 0, 'value'), ('t', 0, 'value')]
+        world_axis_object_classes = {'c': (float, (), {}), 't': (float, (), {})}
+        array_shape = pixel_shape = None
+        axis_correlation_matrix = np.array([[True, True], [False, True]])
+
+        def pixel_to_world_values(self, x, t):
+            return x + 10 * t, t
+
+        def world_to_pixel_values(self, lon, t):
+            return lon - 10 * t, t
+
+    wcs = CorrelatedWCS()
+    lon = np.array([5., 15., 25.])
+    t = np.array([0., 1., 2.])
+
+    # All three points sit at pixel x = 5, which needs t per element
+    assert_allclose(world2pixel_single_axis(wcs, lon, t, pixel_axis=0), [5, 5, 5])
+    assert_allclose(world2pixel_single_axis(wcs, lon, t, pixel_axis=1), [0, 1, 2])
 
 
 def test_affine():


### PR DESCRIPTION
`world2pixel_single_axis` keeps only the world inputs directly correlated with the requested pixel axis and collapses the others to their first element. Inverting pixel axis x of a cube whose celestial axes depend on (x, y, t) needs the time value per element, so world-coordinate links into such a WCS (an IRIS SJI gWCS, for example) were evaluated at the first exposure: derived x for three frames came out as [21.05, 144.96, 275.06] where the direct inverse gives [21.05, 20.62, 21.24].

The needed world axes are now the transitive closure over shared pixel axes. Test: a synthetic two-pixel-axis WCS whose longitude depends on both axes.

Label: bug.
