### PR TITLE
Use matplotlib's date epoch in datetime64 <-> mpl conversions

### DIFF
--- a/glue/utils/matplotlib.py
+++ b/glue/utils/matplotlib.py
@@ -446,7 +446,11 @@ SEC_PER_MIN = 60.
 SEC_PER_HOUR = SEC_PER_MIN * MIN_PER_HOUR
 SEC_PER_DAY = SEC_PER_HOUR * HOURS_PER_DAY
 
-T0 = np.datetime64('0001-01-01T00:00:00').astype('datetime64[s]')
+def _t0():
+    # matplotlib >= 3.3 counts days from a configurable epoch (1970-01-01 by
+    # default) rather than from 0001-01-01 (+1 day); follow it so that the
+    # date locators/formatters label glue's datetime64 axes correctly
+    return np.datetime64(dates.get_epoch()).astype('datetime64[s]')
 
 
 def datetime64_to_mpl(d):
@@ -462,9 +466,9 @@ def datetime64_to_mpl(d):
     # seconds.  That should get out to +/-2e11 years.
     extra = d - d.astype('datetime64[s]')
     extra = extra.astype('timedelta64[ns]')
-    dt = (d.astype('datetime64[s]') - T0).astype(np.float64)
+    dt = (d.astype('datetime64[s]') - _t0()).astype(np.float64)
     dt += extra.astype(np.float64) / 1.0e9
-    dt = dt / SEC_PER_DAY + 1.0
+    dt = dt / SEC_PER_DAY
 
     return dt
 
@@ -473,8 +477,8 @@ def mpl_to_datetime64(dt):
 
     dt = np.asarray(dt, np.float64)
 
-    dt = (dt - 1.0) * SEC_PER_DAY
-    dt_s = dt.astype(np.int64) + T0.astype(np.int64)
+    dt = dt * SEC_PER_DAY
+    dt_s = dt.astype(np.int64) + _t0().astype(np.int64)
     dt_ns = ((dt % 1) * 1e9).astype(np.int64)
 
     dt_s = np.array(dt_s, dtype='datetime64[s]')

--- a/glue/utils/matplotlib.py
+++ b/glue/utils/matplotlib.py
@@ -478,7 +478,7 @@ def mpl_to_datetime64(dt):
     dt = np.asarray(dt, np.float64)
 
     dt = dt * SEC_PER_DAY
-    dt_s = dt.astype(np.int64) + _t0().astype(np.int64)
+    dt_s = np.floor(dt).astype(np.int64) + _t0().astype(np.int64)
     dt_ns = ((dt % 1) * 1e9).astype(np.int64)
 
     dt_s = np.array(dt_s, dtype='datetime64[s]')

--- a/glue/utils/tests/test_matplotlib.py
+++ b/glue/utils/tests/test_matplotlib.py
@@ -2,6 +2,7 @@
 
 import pytest
 import numpy as np
+import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
 from matplotlib.patches import Circle
 from matplotlib.artist import Artist
@@ -184,7 +185,11 @@ def test_freeze_margins():
 
 
 def test_mpl_datetime64():
-    # Make sure the mpl <-> datetime64 conversion round-trips
-    mpl1 = 719313
+    # Make sure the mpl <-> datetime64 conversion round-trips and agrees with
+    # matplotlib's own epoch (1970-01-01 since matplotlib 3.3, configurable)
+    mpl1 = 18875.5
     mpl2 = datetime64_to_mpl(mpl_to_datetime64(mpl1))
     assert mpl1 == mpl2
+    dt = np.array(['2021-09-05T12:00:00'], dtype='datetime64[s]')
+    assert_allclose(datetime64_to_mpl(dt), mdates.date2num(dt))
+    assert mpl_to_datetime64(mdates.date2num(dt)) == dt

--- a/glue/utils/tests/test_matplotlib.py
+++ b/glue/utils/tests/test_matplotlib.py
@@ -184,6 +184,17 @@ def test_freeze_margins():
     np.testing.assert_allclose(bbox.y1, 0.5)
 
 
+@pytest.mark.parametrize('epoch', ['1970-01-01T00:00:00', '2000-01-01T00:00:00'])
+@pytest.mark.parametrize('scalar', [False, True])
+def test_mpl_datetime64_before_epoch(monkeypatch, epoch, scalar):
+    monkeypatch.setattr(mdates, 'get_epoch', lambda: epoch)
+    offsets = np.array([-1500, -500, 0, 500, 1500], dtype='timedelta64[ms]')
+    values = np.datetime64(epoch) + offsets
+    if scalar:
+        values = values[0]
+    np.testing.assert_array_equal(mpl_to_datetime64(datetime64_to_mpl(values)), values)
+
+
 def test_mpl_datetime64():
     # Make sure the mpl <-> datetime64 conversion round-trips and agrees with
     # matplotlib's own epoch (1970-01-01 since matplotlib 3.3, configurable)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ authors = [
 
 dependencies = [
     "numpy>=1.17",
-    "matplotlib>=3.2",
+    "matplotlib>=3.3",
     "scipy>=1.1",
     "pandas>=1.2",
     "astropy>=4.0",


### PR DESCRIPTION
`datetime64_to_mpl` and `mpl_to_datetime64` count days from 0001-01-01 (+1), but matplotlib >= 3.3 counts from a configurable epoch (default 1970-01-01) and glue never calls `set_epoch`, so every datetime axis is mislabelled: `num2date(datetime64_to_mpl(2021-09-05))` gives 3990-09-06, and a scatter viewer with a datetime x axis shows the wrong day.

Both conversions now use `matplotlib.dates.get_epoch()`. `test_mpl_datetime64` asserts agreement with `date2num` both ways. The matplotlib floor moves from 3.2 to 3.3 (`get_epoch`).

Label: bug.
