### PR TITLE
Add opt-in WCSAxes support to the profile viewer

### DIFF
--- a/glue/viewers/profile/layer_artist.py
+++ b/glue/viewers/profile/layer_artist.py
@@ -132,7 +132,8 @@ class ProfileLayerArtist(MatplotlibLayerArtist):
         changed = self.pop_changed_properties()
 
         if force or any(prop in changed for prop in ('layer', 'x_att', 'attribute', 'function', 'normalize',
-                                                     'v_min', 'v_max', 'visible', 'x_display_unit', 'y_display_unit')):
+                                                     'slices', 'v_min', 'v_max', 'visible',
+                                                     'x_display_unit', 'y_display_unit')):
             self._calculate_profile(reset=force)
             force = True
 

--- a/glue/viewers/profile/python_export.py
+++ b/glue/viewers/profile/python_export.py
@@ -16,16 +16,32 @@ def python_export_profile_layer(layer, *args):
     if isinstance(layer.state.layer, Subset):
         script += "base_data = layer_data.data\n"
         script += "cid = base_data.find_component_id('{0}')\n".format(layer.state.attribute.label)
+    else:
+        script += "base_data = layer_data\n"
+        script += "cid = layer_data.find_component_id('{0}')\n".format(layer.state.attribute.label)
+    if layer._viewer_state.function == 'slice':
+        slices = tuple(layer._viewer_state.slices or ())
+        script += "data_view = list({0}) if base_data.ndim == {1} else [0] * base_data.ndim\n".format(slices, len(slices))
+        script += "data_view[profile_axis] = slice(None)\n"
+        script += "profile_values = base_data.get_data(cid, view=tuple(data_view))\n"
+        if isinstance(layer.state.layer, Subset):
+            script += "mask = base_data.get_mask(layer_data.subset_state, view=tuple(data_view))\n"
+            script += "profile_values = np.where(mask, profile_values, np.nan)\n"
+        script += "\n"
+    elif isinstance(layer.state.layer, Subset):
         script += "profile_values = base_data.compute_statistic('{0}', cid, axis=collapsed_axes, subset_state=layer_data.subset_state)\n\n".format(layer._viewer_state.function)
     else:
-        script += "cid = layer_data.find_component_id('{0}')\n".format(layer.state.attribute.label)
         script += "profile_values = layer_data.compute_statistic('{0}', cid, axis=collapsed_axes)\n\n".format(layer._viewer_state.function)
 
     script += "# Extract the values for the x-axis\n"
     script += "axis_view = [0] * layer_data.ndim\n"
     script += "axis_view[profile_axis] = slice(None)\n"
     script += "profile_x_values = layer_data['{0}', tuple(axis_view)]\n".format(layer._viewer_state.x_att)
-    script += "keep = ~np.isnan(profile_values) & ~np.isnan(profile_x_values)\n\n"
+    if layer._viewer_state.function == 'slice':
+        # NaN values should produce gaps in the line, as in the live viewer
+        script += "keep = slice(None)\n\n"
+    else:
+        script += "keep = ~np.isnan(profile_values) & ~np.isnan(profile_x_values)\n\n"
 
     if layer._viewer_state.normalize:
         script += "# Normalize the profile data\n"

--- a/glue/viewers/profile/python_export.py
+++ b/glue/viewers/profile/python_export.py
@@ -41,9 +41,15 @@ def python_export_profile_layer(layer, *args):
     script += "# Extract the values for the x-axis\n"
     script += "axis_view = [0] * layer_data.ndim\n"
     script += "axis_view[profile_axis] = slice(None)\n"
+    if layer._viewer_state.wcsaxes_active:
+        # WCSAxes formats world tick labels from the pixel positions, so the
+        # profile is plotted in pixel coordinates
+        x_att = layer._viewer_state.x_att_pixel
+    else:
+        x_att = layer._viewer_state.x_att
     # NOTE: x values come from base_data - indexing a Subset applies the
     # subset mask, which would give a different length than profile_values
-    script += "profile_x_values = base_data['{0}', tuple(axis_view)]\n".format(layer._viewer_state.x_att)
+    script += "profile_x_values = base_data['{0}', tuple(axis_view)]\n".format(x_att)
     if layer._viewer_state.function == 'slice':
         # NaN values should produce gaps in the line, as in the live viewer
         script += "keep = slice(None)\n\n"

--- a/glue/viewers/profile/python_export.py
+++ b/glue/viewers/profile/python_export.py
@@ -1,5 +1,6 @@
 from glue.viewers.common.python_export import serialize_options
 from glue.core import Subset
+from glue.core.link_manager import is_convertible_to_single_pixel_cid
 
 
 def python_export_profile_layer(layer, *args):
@@ -20,12 +21,16 @@ def python_export_profile_layer(layer, *args):
         script += "base_data = layer_data\n"
         script += "cid = layer_data.find_component_id('{0}')\n".format(layer.state.attribute.label)
     if layer._viewer_state.function == 'slice':
-        slices = tuple(layer._viewer_state.slices or ())
-        script += "data_view = list({0}) if base_data.ndim == {1} else [0] * base_data.ndim\n".format(slices, len(slices))
-        script += "data_view[profile_axis] = slice(None)\n"
-        script += "profile_values = base_data.get_data(cid, view=tuple(data_view))\n"
         if isinstance(layer.state.layer, Subset):
-            script += "mask = base_data.get_mask(layer_data.subset_state, view=tuple(data_view))\n"
+            slice_data = layer.state.layer.data
+        else:
+            slice_data = layer.state.layer
+        pix_cid = is_convertible_to_single_pixel_cid(layer.state.layer,
+                                                     layer._viewer_state.x_att_pixel)
+        script += "data_view = {0}\n".format(layer.state.slice_view(slice_data, pix_cid))
+        script += "profile_values = base_data.get_data(cid, view=data_view)\n"
+        if isinstance(layer.state.layer, Subset):
+            script += "mask = base_data.get_mask(layer_data.subset_state, view=data_view)\n"
             script += "profile_values = np.where(mask, profile_values, np.nan)\n"
         script += "\n"
     elif isinstance(layer.state.layer, Subset):
@@ -36,7 +41,9 @@ def python_export_profile_layer(layer, *args):
     script += "# Extract the values for the x-axis\n"
     script += "axis_view = [0] * layer_data.ndim\n"
     script += "axis_view[profile_axis] = slice(None)\n"
-    script += "profile_x_values = layer_data['{0}', tuple(axis_view)]\n".format(layer._viewer_state.x_att)
+    # NOTE: x values come from base_data - indexing a Subset applies the
+    # subset mask, which would give a different length than profile_values
+    script += "profile_x_values = base_data['{0}', tuple(axis_view)]\n".format(layer._viewer_state.x_att)
     if layer._viewer_state.function == 'slice':
         # NaN values should produce gaps in the line, as in the live viewer
         script += "keep = slice(None)\n\n"

--- a/glue/viewers/profile/python_export.py
+++ b/glue/viewers/profile/python_export.py
@@ -39,8 +39,11 @@ def python_export_profile_layer(layer, *args):
         script += "profile_values = layer_data.compute_statistic('{0}', cid, axis=collapsed_axes)\n\n".format(layer._viewer_state.function)
 
     script += "# Extract the values for the x-axis\n"
-    script += "axis_view = [0] * layer_data.ndim\n"
-    script += "axis_view[profile_axis] = slice(None)\n"
+    if layer._viewer_state.function == 'slice':
+        script += "axis_view = data_view\n"
+    else:
+        script += "axis_view = [0] * layer_data.ndim\n"
+        script += "axis_view[profile_axis] = slice(None)\n"
     # NOTE: x values come from base_data - indexing a Subset applies the
     # subset mask, which would give a different length than profile_values
     script += "profile_x_values = base_data['{0}', tuple(axis_view)]\n".format(layer._viewer_state.x_att)

--- a/glue/viewers/profile/state.py
+++ b/glue/viewers/profile/state.py
@@ -52,6 +52,10 @@ class ProfileViewerState(MatplotlibDataViewerState):
     slices = DDCProperty(docstring='The current slice along all dimensions, '
                                    'used when function is ``\'slice\'``')
 
+    x_limits_pixel = DDCProperty(False, docstring='Whether x_min/x_max are in pixel '
+                                                  'coordinates (WCSAxes mode) rather '
+                                                  'than world/display values')
+
     normalize = DDCProperty(False, docstring='Whether to normalize all profiles '
                                              'to the [0:1] range')
 
@@ -270,6 +274,8 @@ class ProfileViewerState(MatplotlibDataViewerState):
         with delay_callback(self, 'x_min', 'x_max'):
             self.x_min = x_min
             self.x_max = x_max
+
+        self.x_limits_pixel = self.wcsaxes_active
 
     def _reset_y_limits(self, *event):
         if self.normalize:

--- a/glue/viewers/profile/state.py
+++ b/glue/viewers/profile/state.py
@@ -4,6 +4,7 @@ from glue.core.hub import HubListener
 import numpy as np
 
 from glue.core import Subset, Data
+from glue.core.coordinates import LegacyCoordinates
 from echo import delay_callback
 from glue.viewers.matplotlib.state import (MatplotlibDataViewerState,
                                            MatplotlibLayerState,
@@ -54,6 +55,10 @@ class ProfileViewerState(MatplotlibDataViewerState):
     normalize = DDCProperty(False, docstring='Whether to normalize all profiles '
                                              'to the [0:1] range')
 
+    #: Set to `True` by viewers whose axes are WCSAxes, enabling WCS-formatted
+    #: tick labels (see :attr:`~ProfileViewerState.wcsaxes_active`)
+    wcsaxes = False
+
     # TODO: add function to use
 
     def __init__(self, **kwargs):
@@ -96,6 +101,14 @@ class ProfileViewerState(MatplotlibDataViewerState):
             old_unit != new_unit and
             self.reference_data is not None
         ):
+
+            if self.wcsaxes and self._wcsaxes_with_unit(old_unit) != self._wcsaxes_with_unit(new_unit):
+                # Crossing into or out of WCSAxes mode switches the x axis
+                # between pixel and world coordinates, so the previous limits
+                # cannot be converted - reset them instead.
+                self._reset_x_limits()
+                self._previous_x_att = self.x_att
+                return
 
             limits = np.array([self.x_min, self.x_max])
 
@@ -169,6 +182,45 @@ class ProfileViewerState(MatplotlibDataViewerState):
     def _display_world(self):
         return getattr(self.reference_data, 'coords', None) is not None
 
+    @property
+    def wcsaxes_active(self):
+        """
+        Whether profiles are drawn in pixel coordinates, with world tick
+        labels formatted by WCSAxes. This is the case when the viewer uses
+        WCSAxes, a world component with real coordinates is shown on the x
+        axis, and no display unit override is active - a unit override needs
+        plain numeric axes.
+        """
+        return self.wcsaxes and self._wcsaxes_with_unit(self.x_display_unit)
+
+    def _wcsaxes_with_unit(self, unit):
+        coords = getattr(self.reference_data, 'coords', None)
+        if coords is None or isinstance(coords, LegacyCoordinates):
+            return False
+        if self.x_att is None or self.x_att in self.reference_data.pixel_component_ids:
+            return False
+        native = self.reference_data.get_component(self.x_att).units or ''
+        return (unit or '') == native
+
+    @property
+    def wcsaxes_slice(self):
+        """
+        Returns slicing information usable by WCSAxes - an iterable in WCS
+        axis order with ``'x'`` for the profile dimension and the current
+        slice index for the others.
+        """
+        if self.reference_data is None or self.x_att_pixel is None:
+            return None
+        slices = []
+        for i in range(self.reference_data.ndim):
+            if i == self.x_att_pixel.axis:
+                slices.append('x')
+            elif self.slices is not None and len(self.slices) == self.reference_data.ndim:
+                slices.append(self.slices[i])
+            else:
+                slices.append(0)
+        return tuple(slices[::-1])
+
     @defer_draw
     def _update_att(self, *args):
         if self.x_att is not None:
@@ -198,6 +250,10 @@ class ProfileViewerState(MatplotlibDataViewerState):
 
         if self.x_att in data.pixel_component_ids:
             x_min, x_max = -0.5, data.shape[self.x_att.axis] - 0.5
+        elif self.wcsaxes_active:
+            # Profiles are plotted in pixel coordinates when WCSAxes draws
+            # the world tick labels
+            x_min, x_max = -0.5, data.shape[self.x_att_pixel.axis] - 0.5
         else:
             axis = data.world_component_ids.index(self.x_att)
             axis_view = [0] * data.ndim
@@ -205,10 +261,11 @@ class ProfileViewerState(MatplotlibDataViewerState):
             axis_values = data[self.x_att, tuple(axis_view)]
             x_min, x_max = np.nanmin(axis_values), np.nanmax(axis_values)
 
-        converter = UnitConverter()
-        x_min, x_max = converter.to_unit(self.reference_data,
-                                         self.x_att, np.array([x_min, x_max]),
-                                         self.x_display_unit)
+        if not self.wcsaxes_active:
+            converter = UnitConverter()
+            x_min, x_max = converter.to_unit(self.reference_data,
+                                             self.x_att, np.array([x_min, x_max]),
+                                             self.x_display_unit)
 
         with delay_callback(self, 'x_min', 'x_max'):
             self.x_min = x_min
@@ -528,12 +585,19 @@ class ProfileLayerState(MatplotlibLayerState, HubListener):
         else:
             axis_view = [0] * data.ndim
             axis_view[pix_cid.axis] = slice(None)
-            axis_values = data[self.viewer_state.x_att, tuple(axis_view)]
 
             converter = UnitConverter()
-            axis_values = converter.to_unit(self.viewer_state.reference_data,
-                                            self.viewer_state.x_att, axis_values,
-                                            self.viewer_state.x_display_unit)
+
+            if self.viewer_state.wcsaxes_active:
+                # WCSAxes formats world tick labels from the pixel positions,
+                # so the profile is plotted in pixel coordinates
+                axis_values = data[self.viewer_state.x_att_pixel, tuple(axis_view)]
+            else:
+                axis_values = data[self.viewer_state.x_att, tuple(axis_view)]
+                axis_values = converter.to_unit(self.viewer_state.reference_data,
+                                                self.viewer_state.x_att, axis_values,
+                                                self.viewer_state.x_display_unit)
+
             profile_values = converter.to_unit(data, self.attribute, profile_values,
                                                self.viewer_state.y_display_unit)
 

--- a/glue/viewers/profile/state.py
+++ b/glue/viewers/profile/state.py
@@ -23,7 +23,8 @@ FUNCTIONS = OrderedDict([('maximum', 'Maximum'),
                          ('minimum', 'Minimum'),
                          ('mean', 'Mean'),
                          ('median', 'Median'),
-                         ('sum', 'Sum')])
+                         ('sum', 'Sum'),
+                         ('slice', 'Slice')])
 
 
 class ProfileViewerState(MatplotlibDataViewerState):
@@ -47,6 +48,9 @@ class ProfileViewerState(MatplotlibDataViewerState):
 
     function = DDSCProperty(docstring='The function to use for collapsing data')
 
+    slices = DDCProperty(docstring='The current slice along all dimensions, '
+                                   'used when function is ``\'slice\'``')
+
     normalize = DDCProperty(False, docstring='Whether to normalize all profiles '
                                              'to the [0:1] range')
 
@@ -65,6 +69,7 @@ class ProfileViewerState(MatplotlibDataViewerState):
         self.add_callback('y_display_unit', self._convert_units_y_limits, echo_old=True)
         self.add_callback('normalize', self._reset_y_limits)
         self.add_callback('function', self._reset_y_limits)
+        self.add_callback('slices', self._reset_y_limits)
 
         self.x_att_helper = ComponentIDComboHelper(self, 'x_att',
                                                    numeric=False, datetime=False, categorical=False,
@@ -313,7 +318,7 @@ class ProfileViewerState(MatplotlibDataViewerState):
         if self.reference_data is not getattr(self, '_last_reference_data', None):
             self._last_reference_data = self.reference_data
 
-            with delay_callback(self, 'x_att'):
+            with delay_callback(self, 'x_att', 'slices'):
 
                 if self.reference_data is None:
                     self.x_att_helper.set_multiple_data([])
@@ -326,9 +331,16 @@ class ProfileViewerState(MatplotlibDataViewerState):
                         self.x_att_helper.world_coord = False
                         self.x_att = self.reference_data.pixel_component_ids[0]
 
+                self._set_default_slices()
                 self._update_att()
 
         self.reset_limits()
+
+    def _set_default_slices(self):
+        if self.reference_data is None:
+            self.slices = ()
+        else:
+            self.slices = (0,) * self.reference_data.ndim
 
     def _update_priority(self, name):
         if name == 'layers':
@@ -440,6 +452,7 @@ class ProfileLayerState(MatplotlibLayerState, HubListener):
             self.viewer_state.add_callback('x_display_unit', self.reset_cache, priority=100000)
             self.viewer_state.add_callback('y_display_unit', self.reset_cache, priority=100000)
             self.viewer_state.add_callback('function', self.reset_cache, priority=100000)
+            self.viewer_state.add_callback('slices', self.reset_cache, priority=100000)
             if self.is_callback_property('attribute'):
                 self.add_callback('attribute', self.reset_cache, priority=100000)
             self._viewer_callbacks_set = True
@@ -470,7 +483,17 @@ class ProfileLayerState(MatplotlibLayerState, HubListener):
             data = self.layer
             subset_state = None
 
-        profile_values = data.compute_statistic(self.viewer_state.function, self.attribute, axis=axes, subset_state=subset_state)
+        if self.viewer_state.function == 'slice':
+            view = list(self.viewer_state.slices or ())
+            if len(view) != data.ndim:
+                view = [0] * data.ndim
+            view[pix_cid.axis] = slice(None)
+            profile_values = data.get_data(self.attribute, view=tuple(view))
+            if subset_state is not None:
+                mask = data.get_mask(subset_state, view=tuple(view))
+                profile_values = np.where(mask, profile_values, np.nan)
+        else:
+            profile_values = data.compute_statistic(self.viewer_state.function, self.attribute, axis=axes, subset_state=subset_state)
 
         if np.all(np.isnan(profile_values)):
             self._profile_cache = [], []

--- a/glue/viewers/profile/state.py
+++ b/glue/viewers/profile/state.py
@@ -12,7 +12,7 @@ from glue.viewers.matplotlib.state import (MatplotlibDataViewerState,
 from glue.core.data_combo_helper import ManualDataComboHelper, ComponentIDComboHelper
 from glue.utils import defer_draw, avoid_circular
 from glue.core.link_manager import is_convertible_to_single_pixel_cid
-from glue.core.exceptions import IncompatibleDataException
+from glue.core.exceptions import IncompatibleAttribute, IncompatibleDataException
 from glue.core.message import SubsetUpdateMessage
 from glue.core.units import find_unit_choices, UnitConverter
 
@@ -439,6 +439,37 @@ class ProfileLayerState(MatplotlibLayerState, HubListener):
         self.update_profile()
         return self._profile_cache
 
+    def slice_view(self, data, pix_cid):
+        """
+        The view used when the collapse function is 'slice': the current
+        viewer slices with `slice(None)` along the profile axis, translated
+        from the reference data's frame into ``data``'s own pixel indices.
+        """
+        ref = self.viewer_state.reference_data
+        slices = list(self.viewer_state.slices or ())
+        if len(slices) != ref.ndim:
+            slices = [0] * ref.ndim
+        if data is ref:
+            view = slices
+        else:
+            # Translate the reference-data slice point into this dataset's
+            # own pixel indices through the pixel links
+            point = tuple(np.array([s]) for s in slices)
+            view = []
+            for axis in range(data.ndim):
+                if axis == pix_cid.axis:
+                    view.append(0)
+                    continue
+                try:
+                    index = int(np.round(ref[data.pixel_component_ids[axis], point][0]))
+                except IncompatibleAttribute:
+                    raise IncompatibleDataException()
+                if index < 0 or index >= data.shape[axis]:
+                    raise IncompatibleDataException()
+                view.append(index)
+        view[pix_cid.axis] = slice(None)
+        return tuple(view)
+
     def update_profile(self, update_limits=True):
 
         if self._profile_cache is not None:
@@ -484,13 +515,10 @@ class ProfileLayerState(MatplotlibLayerState, HubListener):
             subset_state = None
 
         if self.viewer_state.function == 'slice':
-            view = list(self.viewer_state.slices or ())
-            if len(view) != data.ndim:
-                view = [0] * data.ndim
-            view[pix_cid.axis] = slice(None)
-            profile_values = data.get_data(self.attribute, view=tuple(view))
+            view = self.slice_view(data, pix_cid)
+            profile_values = data.get_data(self.attribute, view=view)
             if subset_state is not None:
-                mask = data.get_mask(subset_state, view=tuple(view))
+                mask = data.get_mask(subset_state, view=view)
                 profile_values = np.where(mask, profile_values, np.nan)
         else:
             profile_values = data.compute_statistic(self.viewer_state.function, self.attribute, axis=axes, subset_state=subset_state)

--- a/glue/viewers/profile/state.py
+++ b/glue/viewers/profile/state.py
@@ -526,8 +526,11 @@ class ProfileLayerState(MatplotlibLayerState, HubListener):
         if np.all(np.isnan(profile_values)):
             self._profile_cache = [], []
         else:
-            axis_view = [0] * data.ndim
-            axis_view[pix_cid.axis] = slice(None)
+            if self.viewer_state.function == 'slice':
+                axis_view = view
+            else:
+                axis_view = [0] * data.ndim
+                axis_view[pix_cid.axis] = slice(None)
             axis_values = data[self.viewer_state.x_att, tuple(axis_view)]
 
             converter = UnitConverter()

--- a/glue/viewers/profile/tests/test_python_export.py
+++ b/glue/viewers/profile/tests/test_python_export.py
@@ -96,3 +96,26 @@ class TestExportPython(BaseTestExportPython):
     def test_profile_att(self, tmpdir):
         self.viewer.layers[0].state.attribute = self.data.id['y']
         self.assert_same(tmpdir)
+
+
+class TestExportPythonWCSAxes(TestExportPython):
+
+    # Run all the export tests again with a WCSAxes-based viewer, where the
+    # profile is plotted in pixel coordinates and the WCS formats the ticks
+
+    def setup_method(self, method):
+
+        self.data = Data(label='d1')
+        self.data.coords = SimpleCoordinates()
+        with NumpyRNGContext(12345):
+            self.data['x'] = random_with_nan(48, 5).reshape((6, 4, 2))
+            self.data['y'] = random_with_nan(48, 12).reshape((6, 4, 2))
+        self.data_collection = DataCollection([self.data])
+        self.app = Application(self.data_collection)
+        self.viewer = SimpleProfileViewer(self.app.session, wcs=True)
+        self.viewer.register_to_hub(self.app.session.hub)
+        self.viewer.add_data(self.data)
+        # Make legend location deterministic
+        self.viewer.state.legend.location = 'lower left'
+
+        assert self.viewer.state.wcsaxes_active

--- a/glue/viewers/profile/tests/test_python_export.py
+++ b/glue/viewers/profile/tests/test_python_export.py
@@ -68,8 +68,9 @@ class TestExportPython(BaseTestExportPython):
         self.assert_same(tmpdir)
 
     def test_slice_subset(self, tmpdir):
+        # The subset mask is deliberately partial along the profile axis
         self.viewer.state.function = 'slice'
-        self.data_collection.new_subset_group('mysubset', self.data.id['x'] > 0.25)
+        self.data_collection.new_subset_group('mysubset', self.data.pixel_component_ids[0] > 0.5)
         self.assert_same(tmpdir)
 
     def test_normalization(self, tmpdir):

--- a/glue/viewers/profile/tests/test_python_export.py
+++ b/glue/viewers/profile/tests/test_python_export.py
@@ -62,6 +62,16 @@ class TestExportPython(BaseTestExportPython):
         self.viewer.state.function = 'sum'
         self.assert_same(tmpdir)
 
+    def test_slice(self, tmpdir):
+        self.viewer.state.function = 'slice'
+        self.viewer.state.slices = (0, 2, 1)
+        self.assert_same(tmpdir)
+
+    def test_slice_subset(self, tmpdir):
+        self.viewer.state.function = 'slice'
+        self.data_collection.new_subset_group('mysubset', self.data.id['x'] > 0.25)
+        self.assert_same(tmpdir)
+
     def test_normalization(self, tmpdir):
         self.viewer.state.normalize = True
         self.assert_same(tmpdir)

--- a/glue/viewers/profile/tests/test_python_export.py
+++ b/glue/viewers/profile/tests/test_python_export.py
@@ -1,10 +1,43 @@
 from astropy.utils import NumpyRNGContext
+from astropy.wcs import WCS
+import numpy as np
+import pytest
+import matplotlib.pyplot as plt
+from numpy.testing import assert_allclose
 
 from glue.core import Data, DataCollection
 from glue.core.application_base import Application
 from glue.viewers.profile.viewer import SimpleProfileViewer
 from glue.viewers.matplotlib.tests.test_python_export import BaseTestExportPython, random_with_nan
 from glue.viewers.profile.tests.test_state import SimpleCoordinates
+from glue.viewers.profile.python_export import python_export_profile_layer
+
+
+@pytest.mark.parametrize('subset', [False, True])
+def test_slice_world_coordinate_export(subset, request):
+    wcs = WCS(naxis=2)
+    wcs.wcs.ctype = ['WAVE', 'LINEAR']
+    wcs.wcs.cunit = ['m', '']
+    wcs.wcs.crpix = [1, 1]
+    wcs.wcs.crval = [1, 0]
+    wcs.wcs.pc = [[1, 10], [0, 1]]
+    data = Data(flux=np.arange(12).reshape(3, 4), coords=wcs)
+    app = Application(DataCollection([data]))
+    viewer = app.new_data_viewer(SimpleProfileViewer)
+    request.addfinalizer(lambda: plt.close(viewer.figure))
+    viewer.add_data(data)
+    viewer.state.x_att = data.world_component_ids[1]
+    viewer.state.function = 'slice'
+    viewer.state.slices = (2, 0)
+    if subset:
+        app.data_collection.new_subset_group('selected', data.id['flux'] > 8)
+    artist = viewer.layers[-1]
+    imports, script = python_export_profile_layer(artist)
+    namespace = dict(layer_data=artist.state.layer, ax=viewer.axes,
+                     legend_handles=[], legend_labels=[])
+    exec('\n'.join(imports) + '\n' + script, namespace)  # noqa: S102 - test the trusted exporter output
+    assert_allclose(namespace['profile_x_values'], [21, 22, 23, 24])
+    assert_allclose(namespace['profile_values'], [np.nan if subset else 8, 9, 10, 11])
 
 
 class TestExportPython(BaseTestExportPython):

--- a/glue/viewers/profile/tests/test_state.py
+++ b/glue/viewers/profile/tests/test_state.py
@@ -196,6 +196,71 @@ class TestProfileViewerState:
         assert_allclose(y, [3.5, 11.5, 19.5])
 
 
+def test_slice_function_linked():
+
+    # Slices are defined on the reference data and must be translated into
+    # the pixel frame of other linked layers
+
+    from glue.core.link_helpers import LinkSame
+
+    data1 = Data(x=np.arange(24).reshape((3, 4, 2)).astype(float), label='d1')
+    data2 = Data(y=np.arange(24).reshape((4, 3, 2)).astype(float), label='d2')
+
+    dc = DataCollection([data1, data2])
+    p1 = data1.pixel_component_ids
+    p2 = data2.pixel_component_ids
+    # data2's first two axes are swapped relative to data1
+    dc.add_link(LinkSame(p1[0], p2[1]))
+    dc.add_link(LinkSame(p1[1], p2[0]))
+    dc.add_link(LinkSame(p1[2], p2[2]))
+
+    viewer_state = ProfileViewerState()
+    layer1 = ProfileLayerState(viewer_state=viewer_state, layer=data1)
+    viewer_state.layers.append(layer1)
+    layer2 = ProfileLayerState(viewer_state=viewer_state, layer=data2)
+    viewer_state.layers.append(layer2)
+    viewer_state.reference_data = data1
+    viewer_state.function = 'slice'
+    viewer_state.slices = (0, 2, 1)
+
+    _, y = layer1.profile
+    assert_allclose(y, data1['x'][:, 2, 1])
+
+    _, y = layer2.profile
+    assert_allclose(y, data2['y'][2, :, 1])
+
+
+def test_slice_function_out_of_bounds():
+
+    # A slice point that falls outside a linked layer raises
+    # IncompatibleDataException instead of silently plotting wrong values
+
+    from glue.core.exceptions import IncompatibleDataException
+    from glue.core.link_helpers import LinkSame
+
+    data1 = Data(x=np.arange(24).reshape((3, 4, 2)).astype(float), label='d1')
+    data2 = Data(y=np.arange(12).reshape((3, 2, 2)).astype(float), label='d2')
+
+    dc = DataCollection([data1, data2])
+    for cid1, cid2 in zip(data1.pixel_component_ids, data2.pixel_component_ids):
+        dc.add_link(LinkSame(cid1, cid2))
+
+    viewer_state = ProfileViewerState()
+    layer1 = ProfileLayerState(viewer_state=viewer_state, layer=data1)
+    viewer_state.layers.append(layer1)
+    layer2 = ProfileLayerState(viewer_state=viewer_state, layer=data2)
+    viewer_state.layers.append(layer2)
+    viewer_state.reference_data = data1
+    viewer_state.function = 'slice'
+    viewer_state.slices = (0, 3, 1)
+
+    _, y = layer1.profile
+    assert_allclose(y, data1['x'][:, 3, 1])
+
+    with pytest.raises(IncompatibleDataException):
+        layer2.profile
+
+
 def test_slice_function_1d():
 
     # For 1D data the slice function should just return the data itself

--- a/glue/viewers/profile/tests/test_state.py
+++ b/glue/viewers/profile/tests/test_state.py
@@ -95,6 +95,38 @@ class TestProfileViewerState:
         _x, y = self.layer_state.profile
         assert_allclose(y, [3.5, 11.5, 19.5])
 
+    def test_slice_function(self):
+
+        self.viewer_state.function = 'slice'
+
+        # Default slices are all zero
+        assert self.viewer_state.slices == (0, 0, 0)
+        x, y = self.layer_state.profile
+        assert_allclose(x, [0, 2, 4])
+        assert_allclose(y, self.data['x'][:, 0, 0])
+
+        self.viewer_state.slices = (0, 2, 1)
+        x, y = self.layer_state.profile
+        assert_allclose(y, self.data['x'][:, 2, 1])
+
+        self.viewer_state.x_att = self.data.pixel_component_ids[1]
+        x, y = self.layer_state.profile
+        assert_allclose(x, [0, 1, 2, 3])
+        assert_allclose(y, self.data['x'][0, :, 1])
+
+    def test_slice_function_subset(self):
+
+        self.viewer_state.function = 'slice'
+
+        subset = self.data.new_subset()
+        subset.subset_state = self.data.id['x'] > 10
+
+        self.layer_state.layer = subset
+
+        x, y = self.layer_state.profile
+        assert_allclose(x, [0, 2, 4])
+        assert_allclose(y, [np.nan, np.nan, 16])
+
     def test_subset(self):
 
         subset = self.data.new_subset()
@@ -162,6 +194,23 @@ class TestProfileViewerState:
         x, y = self.layer_state.profile
         assert_allclose(x, [0, 2, 4])
         assert_allclose(y, [3.5, 11.5, 19.5])
+
+
+def test_slice_function_1d():
+
+    # For 1D data the slice function should just return the data itself
+
+    data = Data(y=[1., 2., 3.], label='d1')
+    DataCollection([data])
+
+    viewer_state = ProfileViewerState()
+    layer_state = ProfileLayerState(viewer_state=viewer_state, layer=data)
+    viewer_state.layers.append(layer_state)
+    viewer_state.function = 'slice'
+
+    x, y = layer_state.profile
+    assert_allclose(x, [0, 1, 2])
+    assert_allclose(y, [1, 2, 3])
 
 
 @pytest.mark.parametrize(('value', 'limits'),

--- a/glue/viewers/profile/tests/test_state.py
+++ b/glue/viewers/profile/tests/test_state.py
@@ -196,6 +196,43 @@ class TestProfileViewerState:
         assert_allclose(y, [3.5, 11.5, 19.5])
 
 
+@pytest.mark.parametrize('display_unit', [None, 'cm'])
+@pytest.mark.parametrize('linked', [False, True])
+def test_slice_world_coordinates(display_unit, linked):
+    from astropy.wcs import WCS
+    from glue.core.link_helpers import LinkSame
+
+    wcs = WCS(naxis=2)
+    wcs.wcs.ctype = ['WAVE', 'LINEAR']
+    wcs.wcs.cunit = ['m', '']
+    wcs.wcs.crpix = [1, 1]
+    wcs.wcs.crval = [1, 0]
+    wcs.wcs.pc = [[1, 10], [0, 1]]
+    data = Data(flux=np.arange(12).reshape(3, 4), coords=wcs)
+    dc = DataCollection([data])
+    state = ProfileViewerState()
+    layer = ProfileLayerState(viewer_state=state, layer=data)
+    state.layers.append(layer)
+    if linked:
+        target = Data(flux=data['flux'].T)
+        dc.append(target)
+        for axis in range(2):
+            dc.add_link(LinkSame(data.pixel_component_ids[axis], target.pixel_component_ids[1 - axis]))
+        layer = ProfileLayerState(viewer_state=state, layer=target)
+        state.layers.append(layer)
+    state.reference_data = data
+    state.x_att = data.world_component_ids[1]
+    state.function = 'slice'
+    state.x_display_unit = display_unit
+    scale = 100 if display_unit == 'cm' else 1
+
+    for row in (2, 1):
+        state.slices = (row, 0)
+        x, y = layer.profile
+        assert_allclose(x, (1 + 10 * row + np.arange(4)) * scale)
+        assert_allclose(y, data['flux'][row, :])
+
+
 def test_slice_function_linked():
 
     # Slices are defined on the reference data and must be translated into

--- a/glue/viewers/profile/tests/test_viewer.py
+++ b/glue/viewers/profile/tests/test_viewer.py
@@ -196,6 +196,119 @@ def test_unit_conversion_slice():
     assert_allclose(y, [1000, 2000, 3000])
 
 
+def _wcsaxes_viewer(app, data):
+    viewer = SimpleProfileViewer(app.session, wcs=True)
+    viewer.register_to_hub(app.session.hub)
+    viewer.add_data(data)
+    return viewer
+
+
+def test_wcsaxes_profile():
+
+    from astropy.visualization.wcsaxes.frame import RectangularFrame1D
+
+    settings.UNIT_CONVERTER = 'test-spectral2'
+
+    wcs1 = WCS(naxis=1)
+    wcs1.wcs.ctype = ['FREQ']
+    wcs1.wcs.crval = [1]
+    wcs1.wcs.cdelt = [1]
+    wcs1.wcs.crpix = [1]
+    wcs1.wcs.cunit = ['GHz']
+
+    d1 = Data(f1=[1., 2., 3.], label='d1')
+    d1.coords = wcs1
+
+    app = Application()
+    app.data_collection.append(d1)
+
+    viewer = _wcsaxes_viewer(app, d1)
+
+    # With world coordinates in native units, WCSAxes formats the ticks and
+    # the profile is plotted in pixel coordinates
+    assert viewer.state.wcsaxes
+    assert viewer.state.wcsaxes_active
+    assert isinstance(viewer.axes.coords.frame, RectangularFrame1D)
+    assert viewer.axes.wcs is d1.coords
+
+    x, y = viewer.state.layers[0].profile
+    assert_allclose(x, [0, 1, 2])
+    assert_allclose(y, [1, 2, 3])
+    assert_allclose((viewer.state.x_min, viewer.state.x_max), (-0.5, 2.5))
+
+    # ROIs are applied in pixel coordinates to the pixel component
+    roi = XRangeROI(0.5, 2.2)
+    viewer.apply_roi(roi)
+    assert len(d1.subsets) == 1
+    assert d1.subsets[0].subset_state.att == d1.pixel_component_ids[0]
+    assert_equal(d1.subsets[0].to_mask(), [0, 1, 1])
+
+    # A display unit override switches back to plain numeric world values
+    viewer.state.x_display_unit = 'GHz'
+    assert not viewer.state.wcsaxes_active
+    x, y = viewer.state.layers[0].profile
+    assert_allclose(x, [1, 2, 3])
+    assert_allclose((viewer.state.x_min, viewer.state.x_max), (1, 3))
+    assert viewer.axes.wcs is not d1.coords
+
+    # And going back to native units restores WCSAxes formatting
+    viewer.state.x_display_unit = 'Hz'
+    assert viewer.state.wcsaxes_active
+    x, y = viewer.state.layers[0].profile
+    assert_allclose(x, [0, 1, 2])
+    assert_allclose((viewer.state.x_min, viewer.state.x_max), (-0.5, 2.5))
+    assert viewer.axes.wcs is d1.coords
+
+
+def test_wcsaxes_identity_fallback():
+
+    # Without real coords the axes fall back to an identity WCS, which
+    # behaves like a plain numeric axis
+
+    data = Data(y=[1., 2., 3.], label='d1')
+
+    app = Application()
+    app.data_collection.append(data)
+
+    viewer = _wcsaxes_viewer(app, data)
+
+    assert viewer.state.wcsaxes
+    assert not viewer.state.wcsaxes_active
+    assert viewer.axes.wcs.pixel_n_dim == 1
+
+    x, y = viewer.state.layers[0].profile
+    assert_allclose(x, [0, 1, 2])
+    assert_allclose(y, [1, 2, 3])
+
+
+def test_wcsaxes_slices():
+
+    # For ndim > 1 the WCS is sliced along the non-profile axes
+
+    from glue.viewers.profile.tests.test_state import SimpleCoordinates
+
+    data = Data(label='d1')
+    data.coords = SimpleCoordinates()
+    data['x'] = np.arange(24).reshape((3, 4, 2)).astype(float)
+
+    app = Application()
+    app.data_collection.append(data)
+
+    viewer = _wcsaxes_viewer(app, data)
+
+    assert viewer.state.wcsaxes_active
+    assert viewer.state.wcsaxes_slice == (0, 0, 'x')
+
+    x, _ = viewer.state.layers[0].profile
+    assert_allclose(x, [0, 1, 2])
+
+    viewer.state.slices = (0, 2, 1)
+    assert viewer.state.wcsaxes_slice == (1, 2, 'x')
+
+    viewer.state.x_att = data.world_component_ids[1]
+    assert viewer.state.wcsaxes_slice == (1, 'x', 0)
+
+
 def test_indexed_data():
 
     # Make sure that the profile viewer works properly with IndexedData objects

--- a/glue/viewers/profile/tests/test_viewer.py
+++ b/glue/viewers/profile/tests/test_viewer.py
@@ -174,6 +174,28 @@ def test_unit_conversion():
     viewer.state.y_display_unit = 'mJy'
 
 
+def test_unit_conversion_slice():
+
+    # The slice function should apply display unit conversion like the others
+
+    settings.UNIT_CONVERTER = 'test-spectral2'
+
+    d1 = Data(f1=[1., 2., 3.])
+    d1.get_component('f1').units = 'Jy'
+
+    app = Application()
+    app.session.data_collection.append(d1)
+
+    viewer = app.new_data_viewer(SimpleProfileViewer)
+    viewer.add_data(d1)
+    viewer.state.function = 'slice'
+    viewer.state.y_display_unit = 'mJy'
+
+    x, y = viewer.state.layers[0].profile
+    assert_allclose(x, [0, 1, 2])
+    assert_allclose(y, [1000, 2000, 3000])
+
+
 def test_indexed_data():
 
     # Make sure that the profile viewer works properly with IndexedData objects

--- a/glue/viewers/profile/tests/test_viewer.py
+++ b/glue/viewers/profile/tests/test_viewer.py
@@ -246,6 +246,7 @@ def test_wcsaxes_profile():
     # A display unit override switches back to plain numeric world values
     viewer.state.x_display_unit = 'GHz'
     assert not viewer.state.wcsaxes_active
+    assert not viewer.state.x_limits_pixel
     x, y = viewer.state.layers[0].profile
     assert_allclose(x, [1, 2, 3])
     assert_allclose((viewer.state.x_min, viewer.state.x_max), (1, 3))
@@ -254,10 +255,43 @@ def test_wcsaxes_profile():
     # And going back to native units restores WCSAxes formatting
     viewer.state.x_display_unit = 'Hz'
     assert viewer.state.wcsaxes_active
+    assert viewer.state.x_limits_pixel
     x, y = viewer.state.layers[0].profile
     assert_allclose(x, [0, 1, 2])
     assert_allclose((viewer.state.x_min, viewer.state.x_max), (-0.5, 2.5))
     assert viewer.axes.wcs is d1.coords
+
+
+def test_wcsaxes_limits_mode_mismatch():
+
+    # x limits from a session saved in the other mode (e.g. world values from
+    # a plain-axes viewer restored into a WCSAxes viewer) cannot be
+    # reinterpreted and should be reset
+
+    wcs1 = WCS(naxis=1)
+    wcs1.wcs.ctype = ['FREQ']
+    wcs1.wcs.cunit = ['GHz']
+    wcs1.wcs.set()
+
+    d1 = Data(f1=[1., 2., 3.], label='d1')
+    d1.coords = wcs1
+
+    app = Application()
+    app.data_collection.append(d1)
+
+    viewer = _wcsaxes_viewer(app, d1)
+    assert viewer.state.x_limits_pixel
+
+    # Simulate a state restored from a plain-axes session, which stored
+    # world values as the x limits
+    viewer.state.x_min = 1.e9
+    viewer.state.x_max = 3.e9
+    viewer.state.x_limits_pixel = False
+
+    viewer._set_wcs()
+
+    assert viewer.state.x_limits_pixel
+    assert_allclose((viewer.state.x_min, viewer.state.x_max), (-0.5, 2.5))
 
 
 def test_wcsaxes_identity_fallback():

--- a/glue/viewers/profile/viewer.py
+++ b/glue/viewers/profile/viewer.py
@@ -1,9 +1,12 @@
 import numpy as np
 
+from astropy.visualization.wcsaxes.frame import RectangularFrame1D
+
 from glue.core.units import UnitConverter
 from glue.core.subset import roi_to_subset_state
 
 from glue.viewers.matplotlib.viewer import SimpleMatplotlibViewer
+from glue.viewers.image.viewer import get_identity_wcs
 from glue.viewers.profile.state import ProfileViewerState
 from glue.viewers.profile.layer_artist import ProfileLayerArtist
 
@@ -13,9 +16,17 @@ __all__ = ['MatplotlibProfileMixin', 'SimpleProfileViewer']
 class MatplotlibProfileMixin(object):
 
     def setup_callbacks(self):
+        # Viewers whose axes are WCSAxes get world tick labels formatted by
+        # the reference data's WCS (viewers with plain axes are unaffected)
+        self.state.wcsaxes = hasattr(self.axes, 'reset_wcs')
         self.state.add_callback('x_att', self._update_axes)
         self.state.add_callback('normalize', self._update_axes)
         self.state.add_callback('y_display_unit', self._update_axes)
+        self.state.add_callback('x_att', self._set_wcs)
+        self.state.add_callback('reference_data', self._set_wcs, echo_old=True)
+        self.state.add_callback('x_display_unit', self._set_wcs)
+        self.state.add_callback('slices', self._set_wcs)
+        self._set_wcs()
 
     def _update_axes(self, *args):
 
@@ -32,6 +43,73 @@ class MatplotlibProfileMixin(object):
 
         self.axes.figure.canvas.draw_idle()
 
+    def _set_wcs(self, before=None, after=None):
+
+        if not self.state.wcsaxes:
+            return
+
+        if self.state.reference_data is None or self.state.x_att_pixel is None:
+            return
+
+        # A callback event for reference_data is triggered if the choices change
+        # but the actual selection doesn't - so we avoid resetting the WCS in
+        # this case.
+        if after is not None and before is after:
+            return
+
+        if self.state.wcsaxes_active:
+            wcs = self.state.reference_data.coords
+            slices = self.state.wcsaxes_slice
+        else:
+            # A plain numeric axis - the profile x values are plotted directly
+            wcs = get_identity_wcs(1)
+            slices = ('x',)
+
+        # Avoid needless WCS resets, e.g. for unit changes within a mode
+        wcs_key = (self.state.wcsaxes_active,
+                   id(wcs) if self.state.wcsaxes_active else None, slices)
+        if getattr(self, '_last_wcs_key', None) == wcs_key:
+            return
+        self._last_wcs_key = wcs_key
+
+        self.axes.frame_class = RectangularFrame1D
+        self.axes.reset_wcs(slices=slices, wcs=wcs)
+
+        # The y axis is a plain matplotlib axis, which WCSAxes hid when the
+        # axes were created with the default 2D frame - unhide it
+        self.axes.yaxis.set_visible(True)
+
+        # Reset the axis labels to match the fact that the new axes have no
+        # labels, so that _update_axes re-applies them
+        self.state.x_axislabel = ''
+        self.state.y_axislabel = ''
+
+        self._update_appearance_from_settings()
+        self._update_axes()
+
+        self.update_x_ticklabel()
+        self.update_y_ticklabel()
+
+    def update_x_ticklabel(self, *event):
+        if not self.state.wcsaxes:
+            return super().update_x_ticklabel(*event)
+        # tick_params silently does nothing on a 1D-frame WCSAxes, so use the
+        # coordinate helper of the world axis correlated with the profile
+        # dimension (ax.coords is in WCS axis order)
+        if self.state.wcsaxes_active and self.state.x_att_pixel is not None:
+            axis = self.state.reference_data.ndim - self.state.x_att_pixel.axis - 1
+        else:
+            axis = 0
+        self.axes.coords[axis].set_ticklabel(size=self.state.x_ticklabel_size)
+        self.redraw()
+
+    def update_y_ticklabel(self, *event):
+        if not self.state.wcsaxes:
+            return super().update_y_ticklabel(*event)
+        self.axes.yaxis.set_tick_params(labelsize=self.state.y_ticklabel_size)
+        self.axes.yaxis.get_offset_text().set_fontsize(self.state.y_ticklabel_size)
+        self.redraw()
+
     def apply_roi(self, roi, override_mode=None):
 
         # Force redraw to get rid of ROI. We do this because applying the
@@ -44,21 +122,77 @@ class MatplotlibProfileMixin(object):
         if len(self.layers) == 0:
             return
 
-        # Apply inverse unit conversion, converting from display to native units
-        converter = UnitConverter()
-        cmin, cmax = converter.to_native(self.state.reference_data,
-                                         self.state.x_att, np.array([roi.min, roi.max]),
-                                         self.state.x_display_unit)
+        if self.state.wcsaxes_active:
+            # The profile is plotted in pixel coordinates
+            subset_state = roi_to_subset_state(roi, x_att=self.state.x_att_pixel)
+        else:
+            # Apply inverse unit conversion, converting from display to native units
+            converter = UnitConverter()
+            cmin, cmax = converter.to_native(self.state.reference_data,
+                                             self.state.x_att, np.array([roi.min, roi.max]),
+                                             self.state.x_display_unit)
 
-        # Sometimes unit conversions can cause the min/max to be swapped
-        if cmin > cmax:
-            cmin, cmax = cmax, cmin
+            # Sometimes unit conversions can cause the min/max to be swapped
+            if cmin > cmax:
+                cmin, cmax = cmax, cmin
 
-        roi.min = cmin
-        roi.max = cmax
+            roi.min = cmin
+            roi.max = cmax
 
-        subset_state = roi_to_subset_state(roi, x_att=self.state.x_att)
+            subset_state = roi_to_subset_state(roi, x_att=self.state.x_att)
+
         self.apply_subset_state(subset_state, override_mode=override_mode)
+
+    def _script_header(self):
+
+        if not self.state.wcsaxes:
+            return super()._script_header()
+
+        imports = ['import matplotlib.pyplot as plt',
+                   'from glue.viewers.matplotlib.mpl_axes import init_mpl',
+                   'from glue.viewers.matplotlib.mpl_axes import set_figure_colors',
+                   'from astropy.visualization.wcsaxes.frame import RectangularFrame1D']
+
+        script = ""
+        script += "fig, ax = init_mpl(wcs=True)\n"
+        script += "ax.frame_class = RectangularFrame1D\n"
+
+        if self.state.wcsaxes_active:
+            dindex = self.session.data_collection.index(self.state.reference_data)
+            script += f"ref_data = data_collection[{dindex}]\n"
+            ref_wcs = "ref_data.coords"
+            slices = self.state.wcsaxes_slice
+        else:
+            imports.append('from glue.viewers.image.viewer import get_identity_wcs')
+            ref_wcs = "get_identity_wcs(1)"
+            slices = ('x',)
+
+        script += f"ax.reset_wcs(slices={slices}, wcs={ref_wcs})\n"
+        script += "ax.yaxis.set_visible(True)\n\n"
+
+        script += "# for the legend\n"
+        script += "legend_handles = []\n"
+        script += "legend_labels = []\n"
+        script += "legend_handler_dict = dict()\n\n"
+
+        return imports, script
+
+    def _script_footer(self):
+
+        imports, script = super()._script_footer()
+
+        if not self.state.wcsaxes:
+            return imports, script
+
+        # tick_params in the generic footer does nothing on a 1D-frame WCSAxes
+        if self.state.wcsaxes_active and self.state.x_att_pixel is not None:
+            axis = self.state.reference_data.ndim - self.state.x_att_pixel.axis - 1
+        else:
+            axis = 0
+        extra = (f"ax.coords[{axis}].set_ticklabel(size={self.state.x_ticklabel_size})\n"
+                 f"ax.yaxis.set_tick_params(labelsize={self.state.y_ticklabel_size})\n\n")
+
+        return imports, extra + script
 
 
 class SimpleProfileViewer(MatplotlibProfileMixin, SimpleMatplotlibViewer):

--- a/glue/viewers/profile/viewer.py
+++ b/glue/viewers/profile/viewer.py
@@ -45,9 +45,6 @@ class MatplotlibProfileMixin(object):
 
     def _set_wcs(self, before=None, after=None):
 
-        if not self.state.wcsaxes:
-            return
-
         if self.state.reference_data is None or self.state.x_att_pixel is None:
             return
 
@@ -55,6 +52,16 @@ class MatplotlibProfileMixin(object):
         # but the actual selection doesn't - so we avoid resetting the WCS in
         # this case.
         if after is not None and before is after:
+            return
+
+        # x limits saved in the other mode (world/display values vs pixel
+        # coordinates) cannot be reinterpreted - reset them. This matters for
+        # sessions restored into a viewer whose mode differs from the one
+        # they were saved in.
+        if self.state.x_limits_pixel != self.state.wcsaxes_active:
+            self.state._reset_x_limits()
+
+        if not self.state.wcsaxes:
             return
 
         if self.state.wcsaxes_active:


### PR DESCRIPTION
Stacked on #2596 (first two commits).

With `wcs=True` (the image viewer's mechanism) and world coordinates shown in their native unit, the profile axes are reset to the reference data's WCS sliced to 1D (`RectangularFrame1D`), so tick labels are WCS-formatted. In that mode the profile, x limits and ROIs are in pixel coordinates, as in the image viewer. A display-unit override, or data without real coords, falls back to the existing plain-axes behaviour unchanged. `x_limits_pixel` records which kind of limits a session saved, so a viewer restored in the other mode does not open blank.

Off by default: `SimpleProfileViewer` keeps plain axes unless `wcs=True`; glue-qt is unaffected until its viewer passes it (separate, feature-gated PR).

Salvaged from #2248 with its defects fixed (reference_data guard, slice indices from `slices`, no state mutation in getters, hidden y axis restored); #2248 is closed in favour of this.

Label: enhancement.
