### PR TITLE
Add vertical line mode to profile viewer

### DIFF
--- a/glue/viewers/profile/layer_artist.py
+++ b/glue/viewers/profile/layer_artist.py
@@ -62,7 +62,10 @@ class ProfileLayerArtist(MatplotlibLayerArtist):
         except (IncompatibleAttribute, IndexError):
             self.vline_collection.set_segments(np.zeros((0, 2, 2)))
             self.redraw()
-            self.disable_invalid_attributes(self._viewer_state.x_att)
+            if isinstance(self.state.layer, BaseData):
+                self.disable_invalid_attributes(self._viewer_state.x_att)
+            else:
+                self.disable_incompatible_subset()
             return
         self.enable()
         self.vline_collection.set_segments(values_to_segments(positions))

--- a/glue/viewers/profile/layer_artist.py
+++ b/glue/viewers/profile/layer_artist.py
@@ -55,22 +55,6 @@ class ProfileLayerArtist(MatplotlibLayerArtist):
 
         self.mpl_artists = [self.plot_artist, self.vline_collection]
 
-        self._display_mode_auto_checked = False
-
-    def _auto_switch_display_mode(self):
-        # If, the first time the profile fails to compute, the position values
-        # can still be resolved, the only meaningful way to show the layer is
-        # as vertical lines, so we switch to that mode. This is done only once
-        # so that users can subsequently change the mode without it being
-        # overridden on every update.
-        if self._display_mode_auto_checked:
-            return False
-        self._display_mode_auto_checked = True
-        if self.state.display_mode != 'Vertical lines':
-            self.state.display_mode = 'Vertical lines'
-            return True
-        return False
-
     @defer_draw
     def _update_positions(self):
         try:
@@ -151,18 +135,22 @@ class ProfileLayerArtist(MatplotlibLayerArtist):
         self.plot_artist.set_visible(False)
         self.notify_end_computation()
         if issubclass(exc[0], (IncompatibleAttribute, IncompatibleDataException)):
-            # Even if the profile itself cannot be computed, the layer can
-            # still be shown as vertical lines if the position values along
-            # the x axis can be resolved, so switch mode (once) if so.
+            # If the profile cannot be computed but the position values along
+            # the x axis can be resolved, the only way to show the layer is as
+            # vertical lines, so we switch to that mode rather than disabling
+            # the layer (which would also hide the layer options, making it
+            # impossible to switch mode). Disabling only happens if neither
+            # the profile nor the positions are available.
             try:
                 self.state.compute_line_positions()
             except (IncompatibleAttribute, IndexError):
                 pass
             else:
-                if self._auto_switch_display_mode():
+                if self.state.display_mode != 'Vertical lines':
                     # Changing the display mode retriggers an update, which
                     # will render the positions.
-                    return
+                    self.state.display_mode = 'Vertical lines'
+                return
         self.redraw()
         if issubclass(exc[0], IncompatibleAttribute):
             if isinstance(self.state.layer, BaseData):

--- a/glue/viewers/profile/layer_artist.py
+++ b/glue/viewers/profile/layer_artist.py
@@ -134,23 +134,6 @@ class ProfileLayerArtist(MatplotlibLayerArtist):
     def _calculate_profile_error(self, exc):
         self.plot_artist.set_visible(False)
         self.notify_end_computation()
-        if issubclass(exc[0], (IncompatibleAttribute, IncompatibleDataException)):
-            # If the profile cannot be computed but the position values along
-            # the x axis can be resolved, the only way to show the layer is as
-            # vertical lines, so we switch to that mode rather than disabling
-            # the layer (which would also hide the layer options, making it
-            # impossible to switch mode). Disabling only happens if neither
-            # the profile nor the positions are available.
-            try:
-                self.state.compute_line_positions()
-            except (IncompatibleAttribute, IndexError):
-                pass
-            else:
-                if self.state.display_mode != 'Vertical lines':
-                    # Changing the display mode retriggers an update, which
-                    # will render the positions.
-                    self.state.display_mode = 'Vertical lines'
-                return
         self.redraw()
         if issubclass(exc[0], IncompatibleAttribute):
             if isinstance(self.state.layer, BaseData):
@@ -183,6 +166,11 @@ class ProfileLayerArtist(MatplotlibLayerArtist):
         self.redraw()
 
     def _update_profile(self, force=False, **kwargs):
+
+        # Remove the profile mode from the choices if no profile can be
+        # computed for the layer. If the current mode is no longer offered,
+        # this also changes the mode, which retriggers this method.
+        self.state.update_display_mode_choices()
 
         if (self._viewer_state.x_att is None or
                 self.state.layer is None or

--- a/glue/viewers/profile/layer_artist.py
+++ b/glue/viewers/profile/layer_artist.py
@@ -1,7 +1,10 @@
 import sys
 import warnings
 
+import numpy as np
+
 from matplotlib.lines import Line2D
+from matplotlib.collections import LineCollection
 
 
 from glue.core import BaseData
@@ -10,6 +13,19 @@ from glue.viewers.profile.state import ProfileLayerState
 from glue.viewers.matplotlib.layer_artist import MatplotlibLayerArtist
 from glue.core.exceptions import IncompatibleAttribute, IncompatibleDataException
 from glue.viewers.profile.python_export import python_export_profile_layer
+
+
+def values_to_segments(values):
+    """
+    Construct segments for a `~matplotlib.collections.LineCollection` with one
+    full-height vertical line per value, where the direction along the lines
+    is in axes fraction coordinates (0 to 1).
+    """
+    segments = np.zeros((len(values), 2, 2))
+    segments[:, 0, 0] = values
+    segments[:, 1, 0] = values
+    segments[:, 1, 1] = 1
+    return segments
 
 
 class ProfileLayerArtist(MatplotlibLayerArtist):
@@ -30,7 +46,40 @@ class ProfileLayerArtist(MatplotlibLayerArtist):
         drawstyle = 'steps-mid' if self.state.as_steps else 'default'
         self.plot_artist = self.axes.plot([1, 2, 3], [3, 4, 5], 'k-', drawstyle=drawstyle)[0]
 
-        self.mpl_artists = [self.plot_artist]
+        # The vertical line collection uses a blended transform so that the
+        # lines always span the full height of the axes regardless of the
+        # y limits.
+        self.vline_collection = LineCollection(np.zeros((0, 2, 2)),
+                                               transform=self.axes.get_xaxis_transform())
+        self.axes.add_collection(self.vline_collection)
+
+        self.mpl_artists = [self.plot_artist, self.vline_collection]
+
+        self._line_mode_auto_checked = False
+
+    def _auto_enable_line_mode(self):
+        # If, the first time the profile fails to compute, the position values
+        # can still be resolved, the only meaningful way to show the layer is
+        # as vertical lines, so we enable that mode. This is done only once so
+        # that users can subsequently turn the lines off without them coming
+        # back on every update.
+        if self._line_mode_auto_checked:
+            return
+        self._line_mode_auto_checked = True
+        if not self.state.vline_visible:
+            self.state.vline_visible = True
+
+    def _update_vlines(self):
+        positions = None
+        if self.state.vline_visible:
+            try:
+                positions = self.state.compute_line_positions()
+            except (IncompatibleAttribute, IndexError):
+                pass
+        if positions is None:
+            self.vline_collection.set_segments(np.zeros((0, 2, 2)))
+        else:
+            self.vline_collection.set_segments(values_to_segments(positions))
 
     @defer_draw
     def _calculate_profile(self, reset=False):
@@ -89,12 +138,29 @@ class ProfileLayerArtist(MatplotlibLayerArtist):
             # passing an empty list to plot_artist
             self.plot_artist.set_data([0.], [0.])
 
+        self._update_vlines()
+
         self.redraw()
 
     @defer_draw
     def _calculate_profile_error(self, exc):
         self.plot_artist.set_visible(False)
         self.notify_end_computation()
+        if issubclass(exc[0], (IncompatibleAttribute, IncompatibleDataException)):
+            # Even if the profile itself cannot be computed, the layer can
+            # still be shown as vertical lines if the position values along
+            # the x axis can be resolved.
+            try:
+                positions = self.state.compute_line_positions()
+            except (IncompatibleAttribute, IndexError):
+                positions = None
+            if positions is not None:
+                self.plot_artist.set_data([0.], [0.])
+                self.enable()
+                self._auto_enable_line_mode()
+                self._update_vlines()
+                self.redraw()
+                return
         self.redraw()
         if issubclass(exc[0], IncompatibleAttribute):
             if isinstance(self.state.layer, BaseData):
@@ -116,7 +182,8 @@ class ProfileLayerArtist(MatplotlibLayerArtist):
             mpl_artist.set_color(self.state.color)
             mpl_artist.set_alpha(self.state.alpha)
             mpl_artist.set_linewidth(self.state.linewidth)
-            mpl_artist.set_drawstyle('steps-mid' if self.state.as_steps else 'default')
+
+        self.plot_artist.set_drawstyle('steps-mid' if self.state.as_steps else 'default')
 
         self.redraw()
 
@@ -132,7 +199,8 @@ class ProfileLayerArtist(MatplotlibLayerArtist):
         changed = self.pop_changed_properties()
 
         if force or any(prop in changed for prop in ('layer', 'x_att', 'attribute', 'function', 'normalize',
-                                                     'v_min', 'v_max', 'visible', 'x_display_unit', 'y_display_unit')):
+                                                     'v_min', 'v_max', 'visible', 'x_display_unit', 'y_display_unit',
+                                                     'vline_visible')):
             self._calculate_profile(reset=force)
             force = True
 

--- a/glue/viewers/profile/layer_artist.py
+++ b/glue/viewers/profile/layer_artist.py
@@ -55,34 +55,40 @@ class ProfileLayerArtist(MatplotlibLayerArtist):
 
         self.mpl_artists = [self.plot_artist, self.vline_collection]
 
-        self._line_mode_auto_checked = False
+        self._display_mode_auto_checked = False
 
-    def _auto_enable_line_mode(self):
+    def _auto_switch_display_mode(self):
         # If, the first time the profile fails to compute, the position values
         # can still be resolved, the only meaningful way to show the layer is
-        # as vertical lines, so we enable that mode. This is done only once so
-        # that users can subsequently turn the lines off without them coming
-        # back on every update.
-        if self._line_mode_auto_checked:
-            return
-        self._line_mode_auto_checked = True
-        if not self.state.vline_visible:
-            self.state.vline_visible = True
+        # as vertical lines, so we switch to that mode. This is done only once
+        # so that users can subsequently change the mode without it being
+        # overridden on every update.
+        if self._display_mode_auto_checked:
+            return False
+        self._display_mode_auto_checked = True
+        if self.state.display_mode != 'Vertical lines':
+            self.state.display_mode = 'Vertical lines'
+            return True
+        return False
 
-    def _update_vlines(self):
-        positions = None
-        if self.state.vline_visible:
-            try:
-                positions = self.state.compute_line_positions()
-            except (IncompatibleAttribute, IndexError):
-                pass
-        if positions is None:
+    @defer_draw
+    def _update_positions(self):
+        try:
+            positions = self.state.compute_line_positions()
+        except (IncompatibleAttribute, IndexError):
             self.vline_collection.set_segments(np.zeros((0, 2, 2)))
-        else:
-            self.vline_collection.set_segments(values_to_segments(positions))
+            self.redraw()
+            self.disable_invalid_attributes(self._viewer_state.x_att)
+            return
+        self.enable()
+        self.vline_collection.set_segments(values_to_segments(positions))
+        self.redraw()
 
     @defer_draw
     def _calculate_profile(self, reset=False):
+        if self.state.display_mode == 'Vertical lines':
+            self._update_positions()
+            return
         try:
             self.notify_start_computation()
             self._calculate_profile_thread(reset=reset)
@@ -138,8 +144,6 @@ class ProfileLayerArtist(MatplotlibLayerArtist):
             # passing an empty list to plot_artist
             self.plot_artist.set_data([0.], [0.])
 
-        self._update_vlines()
-
         self.redraw()
 
     @defer_draw
@@ -149,18 +153,16 @@ class ProfileLayerArtist(MatplotlibLayerArtist):
         if issubclass(exc[0], (IncompatibleAttribute, IncompatibleDataException)):
             # Even if the profile itself cannot be computed, the layer can
             # still be shown as vertical lines if the position values along
-            # the x axis can be resolved.
+            # the x axis can be resolved, so switch mode (once) if so.
             try:
-                positions = self.state.compute_line_positions()
+                self.state.compute_line_positions()
             except (IncompatibleAttribute, IndexError):
-                positions = None
-            if positions is not None:
-                self.plot_artist.set_data([0.], [0.])
-                self.enable()
-                self._auto_enable_line_mode()
-                self._update_vlines()
-                self.redraw()
-                return
+                pass
+            else:
+                if self._auto_switch_display_mode():
+                    # Changing the display mode retriggers an update, which
+                    # will render the positions.
+                    return
         self.redraw()
         if issubclass(exc[0], IncompatibleAttribute):
             if isinstance(self.state.layer, BaseData):
@@ -177,11 +179,16 @@ class ProfileLayerArtist(MatplotlibLayerArtist):
             return
 
         for mpl_artist in self.mpl_artists:
-            mpl_artist.set_visible(self.state.visible)
             mpl_artist.set_zorder(self.state.zorder)
             mpl_artist.set_color(self.state.color)
             mpl_artist.set_alpha(self.state.alpha)
             mpl_artist.set_linewidth(self.state.linewidth)
+
+        # The profile and the vertical lines are alternative representations
+        # of the layer, so only one of the two is ever visible.
+        vline_mode = self.state.display_mode == 'Vertical lines'
+        self.plot_artist.set_visible(self.state.visible and not vline_mode)
+        self.vline_collection.set_visible(self.state.visible and vline_mode)
 
         self.plot_artist.set_drawstyle('steps-mid' if self.state.as_steps else 'default')
 
@@ -190,8 +197,8 @@ class ProfileLayerArtist(MatplotlibLayerArtist):
     def _update_profile(self, force=False, **kwargs):
 
         if (self._viewer_state.x_att is None or
-                self.state.attribute is None or
-                self.state.layer is None):
+                self.state.layer is None or
+                (self.state.attribute is None and self.state.display_mode != 'Vertical lines')):
             return
 
         # NOTE: we need to evaluate this even if force=True so that the cache
@@ -200,11 +207,12 @@ class ProfileLayerArtist(MatplotlibLayerArtist):
 
         if force or any(prop in changed for prop in ('layer', 'x_att', 'attribute', 'function', 'normalize',
                                                      'v_min', 'v_max', 'visible', 'x_display_unit', 'y_display_unit',
-                                                     'vline_visible')):
+                                                     'display_mode')):
             self._calculate_profile(reset=force)
             force = True
 
-        if force or any(prop in changed for prop in ('alpha', 'color', 'zorder', 'linewidth', 'as_steps')):
+        if force or any(prop in changed for prop in ('alpha', 'color', 'zorder', 'linewidth', 'as_steps',
+                                                     'display_mode')):
             self._update_visual_attributes()
 
     @defer_draw

--- a/glue/viewers/profile/python_export.py
+++ b/glue/viewers/profile/python_export.py
@@ -1,4 +1,4 @@
-from glue.viewers.common.python_export import serialize_options
+from glue.viewers.common.python_export import code, serialize_options
 from glue.core import Subset
 
 
@@ -7,8 +7,38 @@ def python_export_profile_layer(layer, *args):
     if len(layer.mpl_artists) == 0 or not layer.enabled or not layer.visible:
         return [], None
 
+    try:
+        layer.state.profile
+    except Exception:
+        profile_available = False
+    else:
+        profile_available = True
+
     script = ""
     imports = ["import numpy as np"]
+
+    if layer.state.vline_visible:
+
+        options = dict(colors=layer.state.color,
+                       linewidth=layer.state.linewidth,
+                       alpha=layer.state.alpha,
+                       zorder=layer.state.zorder,
+                       transform=code('ax.get_xaxis_transform()'))
+
+        script += "# Plot vertical lines at the positions along the x axis\n"
+        script += "positions = np.unique(layer_data['{0}'])\n".format(layer._viewer_state.x_att.label)
+        script += "positions = positions[~np.isnan(positions)]\n"
+        script += "vline_artist = ax.vlines(positions, 0, 1, {0})\n".format(serialize_options(options))
+        if not profile_available:
+            script += "legend_handles.append(vline_artist)\n"
+            script += "legend_labels.append(layer_data.label)\n"
+        script += "\n"
+
+    if not profile_available:
+        if script:
+            return imports, script.strip()
+        else:
+            return [], None
 
     script += "# Calculate the profile of the data\n"
     script += "profile_axis = {0}\n".format(layer._viewer_state.x_att_pixel.axis)

--- a/glue/viewers/profile/python_export.py
+++ b/glue/viewers/profile/python_export.py
@@ -7,17 +7,10 @@ def python_export_profile_layer(layer, *args):
     if len(layer.mpl_artists) == 0 or not layer.enabled or not layer.visible:
         return [], None
 
-    try:
-        layer.state.profile
-    except Exception:
-        profile_available = False
-    else:
-        profile_available = True
-
     script = ""
     imports = ["import numpy as np"]
 
-    if layer.state.vline_visible:
+    if layer.state.display_mode == 'Vertical lines':
 
         options = dict(colors=layer.state.color,
                        linewidth=layer.state.linewidth,
@@ -29,16 +22,10 @@ def python_export_profile_layer(layer, *args):
         script += "positions = np.unique(layer_data['{0}'])\n".format(layer._viewer_state.x_att.label)
         script += "positions = positions[~np.isnan(positions)]\n"
         script += "vline_artist = ax.vlines(positions, 0, 1, {0})\n".format(serialize_options(options))
-        if not profile_available:
-            script += "legend_handles.append(vline_artist)\n"
-            script += "legend_labels.append(layer_data.label)\n"
-        script += "\n"
+        script += "legend_handles.append(vline_artist)\n"
+        script += "legend_labels.append(layer_data.label)\n"
 
-    if not profile_available:
-        if script:
-            return imports, script.strip()
-        else:
-            return [], None
+        return imports, script.strip()
 
     script += "# Calculate the profile of the data\n"
     script += "profile_axis = {0}\n".format(layer._viewer_state.x_att_pixel.axis)

--- a/glue/viewers/profile/state.py
+++ b/glue/viewers/profile/state.py
@@ -506,6 +506,26 @@ class ProfileLayerState(MatplotlibLayerState, HubListener):
                 self.v_min = np.nanmin(self._profile_cache[1])
                 self.v_max = np.nanmax(self._profile_cache[1])
 
+    def update_display_mode_choices(self):
+        """
+        Only offer the profile display mode if the profile can in principle
+        be computed for the layer, that is if the viewer x axis can be
+        related to a single pixel axis of the layer. This does not depend on
+        the selected attribute, so if the profile mode is not offered, no
+        attribute selection could have made it work.
+        """
+        if (self.viewer_state is None or self.viewer_state.x_att_pixel is None
+                or self.layer is None):
+            return
+        if is_convertible_to_single_pixel_cid(self.layer, self.viewer_state.x_att_pixel) is None:
+            choices = ['Vertical lines']
+        else:
+            choices = ['Profile', 'Vertical lines']
+        if ProfileLayerState.display_mode.get_choices(self) != choices:
+            # If the current mode is no longer offered, this also switches
+            # the selection to the first remaining choice.
+            ProfileLayerState.display_mode.set_choices(self, choices)
+
     def compute_line_positions(self):
         """
         The unique values of the viewer x attribute for the layer, converted

--- a/glue/viewers/profile/state.py
+++ b/glue/viewers/profile/state.py
@@ -10,7 +10,7 @@ from glue.viewers.matplotlib.state import (MatplotlibDataViewerState,
                                            DeferredDrawCallbackProperty as DDCProperty,
                                            DeferredDrawSelectionCallbackProperty as DDSCProperty)
 from glue.core.data_combo_helper import ManualDataComboHelper, ComponentIDComboHelper
-from glue.utils import defer_draw, avoid_circular
+from glue.utils import defer_draw, avoid_circular, ensure_numerical
 from glue.core.link_manager import is_convertible_to_single_pixel_cid
 from glue.core.exceptions import IncompatibleDataException
 from glue.core.message import SubsetUpdateMessage
@@ -356,6 +356,9 @@ class ProfileLayerState(MatplotlibLayerState, HubListener):
 
     as_steps = DDCProperty(True, docstring='Whether to display the profile as steps')
 
+    vline_visible = DDCProperty(False, docstring='Whether to show full-height vertical '
+                                                 'lines at each position along the x axis')
+
     _viewer_callbacks_set = False
     _layer_subset_updates_subscribed = False
     _profile_cache = None
@@ -498,3 +501,15 @@ class ProfileLayerState(MatplotlibLayerState, HubListener):
             if self._profile_cache is not None and len(self._profile_cache[1]) > 0:
                 self.v_min = np.nanmin(self._profile_cache[1])
                 self.v_max = np.nanmax(self._profile_cache[1])
+
+    def compute_line_positions(self):
+        """
+        The unique values of the viewer x attribute for the layer, converted
+        to the x display units, to be shown as full-height vertical lines.
+        """
+        values = ensure_numerical(self.layer[self.viewer_state.x_att].ravel())
+        converter = UnitConverter()
+        values = converter.to_unit(self.viewer_state.reference_data,
+                                   self.viewer_state.x_att, values,
+                                   self.viewer_state.x_display_unit)
+        return np.unique(values[~np.isnan(values)])

--- a/glue/viewers/profile/state.py
+++ b/glue/viewers/profile/state.py
@@ -356,8 +356,10 @@ class ProfileLayerState(MatplotlibLayerState, HubListener):
 
     as_steps = DDCProperty(True, docstring='Whether to display the profile as steps')
 
-    vline_visible = DDCProperty(False, docstring='Whether to show full-height vertical '
-                                                 'lines at each position along the x axis')
+    display_mode = DDSCProperty(default_index=0, docstring='Whether to display the layer '
+                                                           'as a collapsed profile or as '
+                                                           'full-height vertical lines at '
+                                                           'each position along the x axis')
 
     _viewer_callbacks_set = False
     _layer_subset_updates_subscribed = False
@@ -376,6 +378,8 @@ class ProfileLayerState(MatplotlibLayerState, HubListener):
                               95: '95%',
                               90: '90%',
                               'Custom': 'Custom'}
+
+        ProfileLayerState.display_mode.set_choices(self, ['Profile', 'Vertical lines'])
 
         ProfileLayerState.percentile.set_choices(self, [100, 99.5, 99, 95, 90, 'Custom'])
         ProfileLayerState.percentile.set_display_func(self, percentile_display.get)

--- a/glue/viewers/profile/tests/test_python_export.py
+++ b/glue/viewers/profile/tests/test_python_export.py
@@ -85,3 +85,16 @@ class TestExportPython(BaseTestExportPython):
     def test_profile_att(self, tmpdir):
         self.viewer.layers[0].state.attribute = self.data.id['y']
         self.assert_same(tmpdir)
+
+    def test_vline(self, tmpdir):
+        self.viewer.state.layers[0].vline_visible = True
+        self.assert_same(tmpdir)
+
+    def test_vline_only_layer(self, tmpdir):
+        from glue.core.link_helpers import LinkSame
+        lines = Data(position=[1.5, 2.5], label='lines')
+        self.data_collection.append(lines)
+        self.data_collection.add_link(LinkSame(lines.id['position'],
+                                               self.data.pixel_component_ids[0]))
+        self.viewer.add_data(lines)
+        self.assert_same(tmpdir)

--- a/glue/viewers/profile/tests/test_python_export.py
+++ b/glue/viewers/profile/tests/test_python_export.py
@@ -87,7 +87,7 @@ class TestExportPython(BaseTestExportPython):
         self.assert_same(tmpdir)
 
     def test_vline(self, tmpdir):
-        self.viewer.state.layers[0].vline_visible = True
+        self.viewer.state.layers[0].display_mode = 'Vertical lines'
         self.assert_same(tmpdir)
 
     def test_vline_only_layer(self, tmpdir):

--- a/glue/viewers/profile/tests/test_viewer.py
+++ b/glue/viewers/profile/tests/test_viewer.py
@@ -310,3 +310,52 @@ def test_vertical_lines_normal_layer():
     artist.state.display_mode = 'Profile'
     assert artist.plot_artist.get_visible()
     assert not artist.vline_collection.get_visible()
+
+
+def test_vertical_lines_unit_conversion():
+
+    # The vertical line positions should follow the x display units
+
+    from glue.core.link_helpers import LinkSame
+
+    previous_converter = settings.UNIT_CONVERTER
+    settings.UNIT_CONVERTER = 'test-spectral2'
+
+    try:
+
+        wcs = WCS(naxis=1)
+        wcs.wcs.ctype = ['FREQ']
+        wcs.wcs.crval = [1]
+        wcs.wcs.cdelt = [1]
+        wcs.wcs.crpix = [1]
+        wcs.wcs.cunit = ['GHz']
+
+        # World coordinate values are in SI units (Hz), so the line
+        # positions need to be too
+        spectrum = Data(flux=np.random.random(10), label='spectrum', coords=wcs)
+        lines = Data(position=[1.e9, 2.e9, 3.e9], label='lines')
+
+        app = Application()
+        app.data_collection.append(spectrum)
+        app.data_collection.append(lines)
+        app.data_collection.add_link(LinkSame(lines.id['position'], spectrum.world_component_ids[0]))
+
+        viewer = app.new_data_viewer(SimpleProfileViewer)
+        viewer.add_data(spectrum)
+        viewer.state.x_att = spectrum.world_component_ids[0]
+        viewer.add_data(lines)
+        artist = viewer.layers[1]
+
+        assert artist.enabled
+        assert artist.state.display_mode == 'Vertical lines'
+
+        segments = artist.vline_collection.get_segments()
+        assert_allclose([s[0][0] for s in segments], [1.e9, 2.e9, 3.e9])
+
+        viewer.state.x_display_unit = 'GHz'
+
+        segments = artist.vline_collection.get_segments()
+        assert_allclose([s[0][0] for s in segments], [1, 2, 3])
+
+    finally:
+        settings.UNIT_CONVERTER = previous_converter

--- a/glue/viewers/profile/tests/test_viewer.py
+++ b/glue/viewers/profile/tests/test_viewer.py
@@ -198,3 +198,100 @@ def test_indexed_data():
     viewer.add_data(data_2d)
 
     assert viewer.state.x_att is data_2d.world_component_ids[0]
+
+
+def test_vertical_lines():
+
+    # A layer for which no profile can be computed but for which the positions
+    # along the x axis can be resolved via links should be shown as full-height
+    # vertical lines rather than being disabled.
+
+    from glue.core.link_helpers import LinkSame
+
+    spectrum = Data(flux=np.random.random(50), label='spectrum')
+    lines = Data(position=[10., 20., 30.], label='lines')
+
+    app = Application()
+    app.data_collection.append(spectrum)
+    app.data_collection.append(lines)
+
+    viewer = app.new_data_viewer(SimpleProfileViewer)
+    viewer.add_data(spectrum)
+    viewer.add_data(lines)
+    artist = viewer.layers[1]
+
+    # Without any links the layer cannot be shown at all
+    assert not artist.enabled
+    assert not artist.state.vline_visible
+
+    # Linking the line positions to the x attribute should enable the layer
+    # and automatically turn on the vertical line mode
+    app.data_collection.add_link(LinkSame(lines.id['position'], spectrum.pixel_component_ids[0]))
+    artist.update()
+
+    assert artist.enabled
+    assert artist.state.vline_visible
+
+    segments = artist.vline_collection.get_segments()
+    assert len(segments) == 3
+    assert_allclose(segments[0], [[10, 0], [10, 1]])
+
+    # The lines span the full height of the axes independently of the y limits
+    assert artist.vline_collection.get_transform() is artist.axes.get_xaxis_transform()
+
+    # The vertical line mode is only enabled automatically once, so it should
+    # stay off if turned off explicitly
+    artist.state.vline_visible = False
+    assert len(artist.vline_collection.get_segments()) == 0
+    artist.update()
+    assert not artist.state.vline_visible
+
+
+def test_vertical_lines_subset():
+
+    # Subsets of a line list should be shown as the matching subset of lines
+
+    from glue.core.link_helpers import LinkSame
+
+    spectrum = Data(flux=np.random.random(50), label='spectrum')
+    lines = Data(position=[10., 20., 30.], label='lines')
+
+    app = Application()
+    app.data_collection.append(spectrum)
+    app.data_collection.append(lines)
+    app.data_collection.add_link(LinkSame(lines.id['position'], spectrum.pixel_component_ids[0]))
+
+    viewer = app.new_data_viewer(SimpleProfileViewer)
+    viewer.add_data(spectrum)
+    viewer.add_data(lines)
+
+    app.data_collection.new_subset_group(label='high', subset_state=lines.id['position'] > 15)
+
+    subset_artist = viewer.layers[-1]
+    assert subset_artist.enabled
+    assert subset_artist.state.vline_visible
+    assert len(subset_artist.vline_collection.get_segments()) == 2
+
+
+def test_vertical_lines_normal_layer():
+
+    # The vertical line mode can also be enabled manually on a layer that has
+    # a normal profile, in which case a line is drawn at each unique position
+
+    data = Data(flux=np.random.random(10), label='spectrum')
+
+    app = Application()
+    app.data_collection.append(data)
+
+    viewer = app.new_data_viewer(SimpleProfileViewer)
+    viewer.add_data(data)
+    artist = viewer.layers[0]
+
+    assert artist.enabled
+    assert not artist.state.vline_visible
+
+    artist.state.vline_visible = True
+    assert len(artist.vline_collection.get_segments()) == 10
+
+    artist.state.vline_visible = False
+    assert len(artist.vline_collection.get_segments()) == 0

--- a/glue/viewers/profile/tests/test_viewer.py
+++ b/glue/viewers/profile/tests/test_viewer.py
@@ -241,13 +241,14 @@ def test_vertical_lines():
     # The lines span the full height of the axes independently of the y limits
     assert artist.vline_collection.get_transform() is artist.axes.get_xaxis_transform()
 
-    # The display mode is only switched automatically once, so it should stay
-    # on the profile mode if changed back explicitly (even though in this case
-    # the profile cannot be shown)
+    # Selecting the profile mode explicitly is not possible for this layer
+    # since no profile can be computed, so the mode snaps back to vertical
+    # lines and the layer stays enabled (disabling it would also hide the
+    # layer options, making it impossible to change the mode back)
     artist.state.display_mode = 'Profile'
-    artist.update()
-    assert artist.state.display_mode == 'Profile'
-    assert not artist.enabled
+    assert artist.state.display_mode == 'Vertical lines'
+    assert artist.enabled
+    assert len(artist.vline_collection.get_segments()) == 3
 
 
 def test_vertical_lines_subset():

--- a/glue/viewers/profile/tests/test_viewer.py
+++ b/glue/viewers/profile/tests/test_viewer.py
@@ -1,6 +1,8 @@
 from astropy import units as u
 from astropy.wcs import WCS
 
+import pytest
+
 import numpy as np
 from numpy.testing import assert_equal, assert_allclose
 
@@ -220,12 +222,14 @@ def test_vertical_lines():
     viewer.add_data(lines)
     artist = viewer.layers[1]
 
-    # Without any links the layer cannot be shown at all
+    # Without any links the layer cannot be shown at all, and since no
+    # profile can be computed only the vertical line mode is offered
     assert not artist.enabled
-    assert artist.state.display_mode == 'Profile'
+    assert artist.state.display_mode == 'Vertical lines'
+    assert type(artist.state).display_mode.get_choices(artist.state) == ['Vertical lines']
 
-    # Linking the line positions to the x attribute should enable the layer
-    # and automatically switch to the vertical line mode
+    # Linking the line positions to the x attribute should enable the layer,
+    # still showing vertical lines
     app.data_collection.add_link(LinkSame(lines.id['position'], spectrum.pixel_component_ids[0]))
     artist.update()
 
@@ -241,14 +245,14 @@ def test_vertical_lines():
     # The lines span the full height of the axes independently of the y limits
     assert artist.vline_collection.get_transform() is artist.axes.get_xaxis_transform()
 
-    # Selecting the profile mode explicitly is not possible for this layer
-    # since no profile can be computed, so the mode snaps back to vertical
-    # lines and the layer stays enabled (disabling it would also hide the
-    # layer options, making it impossible to change the mode back)
-    artist.state.display_mode = 'Profile'
+    # The profile mode is not offered for this layer since no profile can
+    # be computed (whatever the attribute selection), so it also cannot be
+    # selected programmatically
+    assert type(artist.state).display_mode.get_choices(artist.state) == ['Vertical lines']
+    with pytest.raises(ValueError):
+        artist.state.display_mode = 'Profile'
     assert artist.state.display_mode == 'Vertical lines'
     assert artist.enabled
-    assert len(artist.vline_collection.get_segments()) == 3
 
 
 def test_vertical_lines_subset():
@@ -294,6 +298,7 @@ def test_vertical_lines_normal_layer():
 
     assert artist.enabled
     assert artist.state.display_mode == 'Profile'
+    assert type(artist.state).display_mode.get_choices(artist.state) == ['Profile', 'Vertical lines']
     assert artist.plot_artist.get_visible()
     assert not artist.vline_collection.get_visible()
 

--- a/glue/viewers/profile/tests/test_viewer.py
+++ b/glue/viewers/profile/tests/test_viewer.py
@@ -222,15 +222,17 @@ def test_vertical_lines():
 
     # Without any links the layer cannot be shown at all
     assert not artist.enabled
-    assert not artist.state.vline_visible
+    assert artist.state.display_mode == 'Profile'
 
     # Linking the line positions to the x attribute should enable the layer
-    # and automatically turn on the vertical line mode
+    # and automatically switch to the vertical line mode
     app.data_collection.add_link(LinkSame(lines.id['position'], spectrum.pixel_component_ids[0]))
     artist.update()
 
     assert artist.enabled
-    assert artist.state.vline_visible
+    assert artist.state.display_mode == 'Vertical lines'
+    assert artist.vline_collection.get_visible()
+    assert not artist.plot_artist.get_visible()
 
     segments = artist.vline_collection.get_segments()
     assert len(segments) == 3
@@ -239,12 +241,13 @@ def test_vertical_lines():
     # The lines span the full height of the axes independently of the y limits
     assert artist.vline_collection.get_transform() is artist.axes.get_xaxis_transform()
 
-    # The vertical line mode is only enabled automatically once, so it should
-    # stay off if turned off explicitly
-    artist.state.vline_visible = False
-    assert len(artist.vline_collection.get_segments()) == 0
+    # The display mode is only switched automatically once, so it should stay
+    # on the profile mode if changed back explicitly (even though in this case
+    # the profile cannot be shown)
+    artist.state.display_mode = 'Profile'
     artist.update()
-    assert not artist.state.vline_visible
+    assert artist.state.display_mode == 'Profile'
+    assert not artist.enabled
 
 
 def test_vertical_lines_subset():
@@ -269,14 +272,15 @@ def test_vertical_lines_subset():
 
     subset_artist = viewer.layers[-1]
     assert subset_artist.enabled
-    assert subset_artist.state.vline_visible
+    assert subset_artist.state.display_mode == 'Vertical lines'
     assert len(subset_artist.vline_collection.get_segments()) == 2
 
 
 def test_vertical_lines_normal_layer():
 
-    # The vertical line mode can also be enabled manually on a layer that has
+    # The vertical line mode can also be selected manually on a layer that has
     # a normal profile, in which case a line is drawn at each unique position
+    # and the profile is hidden
 
     data = Data(flux=np.random.random(10), label='spectrum')
 
@@ -288,10 +292,15 @@ def test_vertical_lines_normal_layer():
     artist = viewer.layers[0]
 
     assert artist.enabled
-    assert not artist.state.vline_visible
+    assert artist.state.display_mode == 'Profile'
+    assert artist.plot_artist.get_visible()
+    assert not artist.vline_collection.get_visible()
 
-    artist.state.vline_visible = True
+    artist.state.display_mode = 'Vertical lines'
     assert len(artist.vline_collection.get_segments()) == 10
+    assert artist.vline_collection.get_visible()
+    assert not artist.plot_artist.get_visible()
 
-    artist.state.vline_visible = False
-    assert len(artist.vline_collection.get_segments()) == 0
+    artist.state.display_mode = 'Profile'
+    assert artist.plot_artist.get_visible()
+    assert not artist.vline_collection.get_visible()


### PR DESCRIPTION
This makes it possible to show a dataset in the profile viewer solely as vertical lines, which can be useful for datasets where there is no y value as such (e.g. a catalog of spectral lines). It is analogous  to https://github.com/glue-viz/glue/pull/2590 which is for the scatter viewer.